### PR TITLE
fix: PWA UX improvements

### DIFF
--- a/frontend/src/app/(components)/nav-bar/NavBar.tsx
+++ b/frontend/src/app/(components)/nav-bar/NavBar.tsx
@@ -18,12 +18,24 @@ interface NavBarProps {
     onClose: () => void;
 }
 
+function isEformsignAuthenticated(): boolean {
+    if (typeof window === "undefined") return false;
+    const authTimeStr = sessionStorage.getItem("eformsign_auth_time");
+    if (!authTimeStr) return false;
+    const authTime = parseInt(authTimeStr, 10);
+    const tokenExpiryMs = 60 * 60 * 1000;
+    const bufferMs = 5 * 60 * 1000;
+    return Date.now() - authTime < tokenExpiryMs - bufferMs;
+}
+
 export const NavBar = ({ onClose }: NavBarProps) => {
     const locale = useLocale();
     const pathname = usePathname();
     const queryClient = useQueryClient();
 
     useEffect(() => {
+        if (!isEformsignAuthenticated()) return;
+        
         queryClient.prefetchQuery({
             queryKey: eformsignQueryKeys.allDocuments(),
             queryFn: () => eformsignApi.getAllDocuments(),

--- a/frontend/src/app/(components)/splash/SplashScreen.tsx
+++ b/frontend/src/app/(components)/splash/SplashScreen.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import { useServiceWorkerUpdate } from "@/app/hooks/useServiceWorkerUpdate";
 
 const MIN_SPLASH_TIME = 1500;
+const SPLASH_SHOWN_KEY = "pwa_splash_shown";
 
 function isPWAStandalone(): boolean {
   if (typeof window === "undefined") return false;
@@ -16,22 +17,41 @@ function isPWAStandalone(): boolean {
   return isStandalone || isIOSStandalone;
 }
 
+function wasSplashAlreadyShown(): boolean {
+  if (typeof window === "undefined") return false;
+  return sessionStorage.getItem(SPLASH_SHOWN_KEY) === "true";
+}
+
+function markSplashAsShown(): void {
+  if (typeof window === "undefined") return;
+  sessionStorage.setItem(SPLASH_SHOWN_KEY, "true");
+}
+
 export default function SplashScreen() {
   const [isPWA, setIsPWA] = useState(false);
   const [minTimeElapsed, setMinTimeElapsed] = useState(false);
+  const [alreadyShown, setAlreadyShown] = useState(false);
   const { isUpdating } = useServiceWorkerUpdate();
 
   useEffect(() => {
-    setIsPWA(isPWAStandalone());
+    const pwaMode = isPWAStandalone();
+    setIsPWA(pwaMode);
+    
+    if (pwaMode && wasSplashAlreadyShown()) {
+      setAlreadyShown(true);
+    }
   }, []);
 
   useEffect(() => {
-    if (!isPWA) return;
-    const timer = setTimeout(() => setMinTimeElapsed(true), MIN_SPLASH_TIME);
+    if (!isPWA || alreadyShown) return;
+    const timer = setTimeout(() => {
+      setMinTimeElapsed(true);
+      markSplashAsShown();
+    }, MIN_SPLASH_TIME);
     return () => clearTimeout(timer);
-  }, [isPWA]);
+  }, [isPWA, alreadyShown]);
 
-  const shouldShow = isPWA && (!minTimeElapsed || isUpdating);
+  const shouldShow = isPWA && !alreadyShown && (!minTimeElapsed || isUpdating);
 
   return (
     <AnimatePresence>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -19,6 +19,10 @@
   }
 }
 
+html, body {
+  overscroll-behavior: none;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);


### PR DESCRIPTION
## Summary

- **Fix splash screen on refresh**: Use sessionStorage to track if splash was already shown in this PWA session. Splash only shows on initial app launch, not on page refreshes.
- **Fix eFormSign API first-try error**: Add auth check before prefetching documents in NavBar. Prefetch only runs if eformsign auth token exists in sessionStorage.
- **Disable pull-to-refresh**: Add `overscroll-behavior: none` to prevent accidental page refresh when pulling down on mobile.

## Changes

| File | Change |
|------|--------|
| `SplashScreen.tsx` | Track splash shown state in sessionStorage |
| `NavBar.tsx` | Check eformsign auth before prefetch |
| `globals.css` | Add overscroll-behavior: none |