### PR TITLE
fix: resolve preview deployment build errors

### DIFF
--- a/frontend/src/app/eformsign/webhook/route.ts
+++ b/frontend/src/app/eformsign/webhook/route.ts
@@ -1,1 +1,3 @@
-export { POST, runtime } from "@/app/api/eformsign/webhook/route";
+export const runtime = "nodejs";
+
+export { POST } from "@/app/api/eformsign/webhook/route";

--- a/frontend/src/components/app/documents/document-dropzone.tsx
+++ b/frontend/src/components/app/documents/document-dropzone.tsx
@@ -107,7 +107,7 @@ export function DocumentDropzone({
   );
 
   const handleDragOver = useCallback(
-    (e: React.DragEvent<HTMLDivElement>) => {
+    (e: React.DragEvent<HTMLLabelElement>) => {
       e.preventDefault();
       e.stopPropagation();
       if (!isLoading) {
@@ -117,14 +117,14 @@ export function DocumentDropzone({
     [isLoading]
   );
 
-  const handleDragLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+  const handleDragLeave = useCallback((e: React.DragEvent<HTMLLabelElement>) => {
     e.preventDefault();
     e.stopPropagation();
     setIsDragOver(false);
   }, []);
 
   const handleDrop = useCallback(
-    (e: React.DragEvent<HTMLDivElement>) => {
+    (e: React.DragEvent<HTMLLabelElement>) => {
       e.preventDefault();
       e.stopPropagation();
       setIsDragOver(false);


### PR DESCRIPTION
## Summary
- stop re-exporting Next.js route runtime from the eformsign webhook route
- fix document dropzone drag handler element typings for production TypeScript build
- restore successful frontend production build for preview deployment
