### PR TITLE
feat(eformsign): two-phase contract support for 서비스제공기록지

### DIFF
--- a/backend/app.module.ts
+++ b/backend/app.module.ts
@@ -17,6 +17,7 @@ import { ClientModule } from "module/client.module";
 import { EmployeeScheduleModule } from "module/employee-schedule.module";
 import { EformsignDocModule } from "module/eformsign-doc.module";
 import { EformsignWebhookModule } from "module/eformsign-webhook.module";
+import { DailyRecordModule } from "module/daily-record.module";
 import { AreaTemplateModule } from "module/area-template.module";
 import { DocumentModule } from "module/document.module";
 import { DatabaseModule } from "infrastructure/database/database.module";
@@ -60,6 +61,7 @@ const ENV_FILE_PATHS = [
         EmployeeScheduleModule,
         EformsignDocModule,
         EformsignWebhookModule,
+        DailyRecordModule,
         AreaTemplateModule,
         DocumentModule,
         TenantModule,

--- a/backend/application/services/daily-record.service.ts
+++ b/backend/application/services/daily-record.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from "@nestjs/common";
+import { DailyRecordEntryEntity } from "domain/entities/daily-record-entry.entity";
+import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
+import {
+    SubmitDailyRecordEntryUsecase,
+    SubmitDailyRecordEntryParams,
+} from "application/usecases/eformsign-doc/submit-daily-record-entry.usecase";
+import {
+    ListDailyRecordEntriesUsecase,
+    ListDailyRecordEntriesResult,
+} from "application/usecases/eformsign-doc/list-daily-record-entries.usecase";
+import {
+    FinalizeServiceRecordUsecase,
+    FinalizeServiceRecordParams,
+    FinalizeServiceRecordResult,
+} from "application/usecases/eformsign-doc/finalize-service-record.usecase";
+
+@Injectable()
+export class DailyRecordService {
+    constructor(
+        private readonly submitEntryUsecase: SubmitDailyRecordEntryUsecase,
+        private readonly listEntriesUsecase: ListDailyRecordEntriesUsecase,
+        private readonly finalizeUsecase: FinalizeServiceRecordUsecase,
+    ) {}
+
+    submitEntry(
+        organizationid: string,
+        params: SubmitDailyRecordEntryParams,
+    ): Promise<DailyRecordEntryEntity> {
+        return this.submitEntryUsecase.execute(organizationid, params);
+    }
+
+    listEntries(
+        organizationid: string,
+        eformsignDocId: number,
+    ): Promise<ListDailyRecordEntriesResult> {
+        return this.listEntriesUsecase.execute(organizationid, eformsignDocId);
+    }
+
+    finalize(
+        organizationid: string,
+        params: FinalizeServiceRecordParams,
+    ): Promise<FinalizeServiceRecordResult> {
+        return this.finalizeUsecase.execute(organizationid, params);
+    }
+}

--- a/backend/application/services/eformsign-webhook.service.ts
+++ b/backend/application/services/eformsign-webhook.service.ts
@@ -1,12 +1,22 @@
 import { Injectable, Logger, Inject } from "@nestjs/common";
 import { UpdateEformsignDocStatusUsecase } from "application/usecases/eformsign-doc/update-eformsign-doc-status.usecase";
 import { LinkDocumentToClientUsecase } from "application/usecases/eformsign-doc/link-document-to-client.usecase";
+import { StartDailyRecordCollectionUsecase } from "application/usecases/eformsign-doc/start-daily-record-collection.usecase";
 import { EformsignWebhookPayloadDto } from "interface/dto/eformsign-webhook.dto";
 import { AlimtalkService } from "./alimtalk.service";
 import { CLIENT_REPOSITORY, IClientRepository } from "domain/repositories/client.repository.interface";
 import { EFORMSIGN_DOC_REPOSITORY, IEformsignDocRepository } from "domain/repositories/eformsign-doc.repository.interface";
 import { EMPLOYEE_SCHEDULE_REPOSITORY, IEmployeeScheduleRepository } from "domain/repositories/employee-schedule.repository.interface";
 import { EMPLOYEE_REPOSITORY, IEmployeeRepository } from "domain/repositories/employee.repository.interface";
+
+/**
+ * Names (or name fragments) that identify 서비스제공기록지 documents.
+ * Matched against webhook `template_name` or `document_title`.
+ */
+const SERVICE_PROVISION_RECORD_NAME_PATTERNS = [
+    "서비스제공기록지",
+    "서비스 제공 기록지",
+];
 
 /**
  * Eformsign document status codes (from document.status field)
@@ -53,6 +63,7 @@ export class EformsignWebhookService {
     constructor(
         private readonly updateStatusUsecase: UpdateEformsignDocStatusUsecase,
         private readonly linkDocumentUsecase: LinkDocumentToClientUsecase,
+        private readonly startDailyRecordCollectionUsecase: StartDailyRecordCollectionUsecase,
         private readonly alimtalkService: AlimtalkService,
         @Inject(CLIENT_REPOSITORY)
         private readonly clientRepository: IClientRepository,
@@ -63,6 +74,16 @@ export class EformsignWebhookService {
         @Inject(EMPLOYEE_REPOSITORY)
         private readonly employeeRepository: IEmployeeRepository,
     ) {}
+
+    /**
+     * Detects 서비스제공기록지 (service provision record) documents by name.
+     * Matched against any of: template_name, document_title, workflow_name.
+     */
+    private isServiceProvisionRecord(names: (string | undefined)[]): boolean {
+        return names.some(name =>
+            name && SERVICE_PROVISION_RECORD_NAME_PATTERNS.some(pattern => name.includes(pattern))
+        );
+    }
 
     async processWebhook(organizationid: string, payload: EformsignWebhookPayloadDto): Promise<void> {
         const { event_type, webhook_id, document, ready_document_pdf, document_action } = payload;
@@ -99,12 +120,32 @@ export class EformsignWebhookService {
         organizationid: string,
         pdfEvent: NonNullable<EformsignWebhookPayloadDto["ready_document_pdf"]>
     ): Promise<void> {
-        const { document_id: documentId, document_status: status, workflow_seq, workflow_name } = pdfEvent;
+        const {
+            document_id: documentId,
+            document_status: status,
+            document_title,
+            template_name,
+            workflow_seq,
+            workflow_name,
+        } = pdfEvent;
 
         this.logger.log(`PDF ready event: ${documentId} -> status=${status}, workflow=${workflow_name}`);
 
+        // For doc_complete on 서비스제공기록지, status type is 070 (collecting) instead of 050.
+        const isRecordDoc =
+            status === DOCUMENT_STATUS.DOC_COMPLETE &&
+            this.isServiceProvisionRecord([template_name, document_title, workflow_name]);
+
+        // If we already set this document to 070 via a prior document event, do NOT downgrade it
+        // back to 050 via the PDF event. Check current state first.
+        const existing = await this.eformsignDocRepository.findByDocumentId(organizationid, documentId);
+        const alreadyCollecting = existing?.statusType === "070";
+
         // Map status to Korean detail and determine status type
-        const { statusType, statusDetail } = this.mapStatus(status);
+        const { statusType, statusDetail } =
+            isRecordDoc || alreadyCollecting
+                ? { statusType: "070", statusDetail: "일일기록 수집 중" }
+                : this.mapStatus(status);
 
         // Update document status in DB
         try {
@@ -118,7 +159,7 @@ export class EformsignWebhookService {
                 expired: false,
             });
 
-            this.logger.log(`Document ${documentId} status updated from PDF event: ${status} -> ${statusDetail}`);
+            this.logger.log(`Document ${documentId} status updated from PDF event: ${status} -> ${statusDetail}${isRecordDoc || alreadyCollecting ? " (서비스제공기록지 Phase 1)" : ""}`);
         } catch (error) {
             // Document not found - frontend must create record first
             this.logger.warn(
@@ -128,9 +169,17 @@ export class EformsignWebhookService {
             return;
         }
 
-        if (status === DOCUMENT_STATUS.DOC_COMPLETE) {
-            this.logger.log(`Document ${documentId} completed (from PDF event), linking to client`);
+        if (status === DOCUMENT_STATUS.DOC_COMPLETE && !alreadyCollecting) {
+            // Phase 1 chain — only runs once. If the document event already handled it
+            // (alreadyCollecting), the collection window was initialized and we don't re-run.
+            this.logger.log(`Document ${documentId} completed (from PDF event), running Phase 1 chain`);
             try {
+                if (isRecordDoc) {
+                    await this.startDailyRecordCollectionUsecase.execute(organizationid, {
+                        documentId,
+                    });
+                }
+
                 await this.linkDocumentUsecase.execute(organizationid, documentId);
                 this.logger.log(`Document ${documentId} successfully linked to client`);
 
@@ -140,7 +189,7 @@ export class EformsignWebhookService {
                     workflow_name
                 );
             } catch (error) {
-                this.logger.error(`Failed to link document ${documentId} to client: ${error}`);
+                this.logger.error(`Failed Phase 1 chain for document ${documentId} (PDF event): ${error}`);
             }
         }
     }
@@ -186,12 +235,19 @@ export class EformsignWebhookService {
         organizationid: string,
         document: NonNullable<EformsignWebhookPayloadDto["document"]>
     ): Promise<void> {
-        const { id: documentId, status, document_title, workflow_seq, workflow_name } = document;
+        const { id: documentId, status, document_title, template_name, workflow_seq, workflow_name } = document;
 
         this.logger.log(`Document event: ${documentId} -> status=${status}, title=${document_title}`);
 
+        // For doc_complete on 서비스제공기록지, the final status is 070 (collecting) instead of 050 (completed)
+        const isRecordDoc =
+            status === DOCUMENT_STATUS.DOC_COMPLETE &&
+            this.isServiceProvisionRecord([template_name, document_title, workflow_name]);
+
         // Map status to Korean detail and determine status type
-        const { statusType, statusDetail } = this.mapStatus(status);
+        const { statusType, statusDetail } = isRecordDoc
+            ? { statusType: "070", statusDetail: "일일기록 수집 중" }
+            : this.mapStatus(status);
 
         // Update document status in DB
         try {
@@ -205,7 +261,7 @@ export class EformsignWebhookService {
                 expired: false,
             });
 
-            this.logger.log(`Document ${documentId} status updated: ${status} -> ${statusDetail}`);
+            this.logger.log(`Document ${documentId} status updated: ${status} -> ${statusDetail}${isRecordDoc ? " (서비스제공기록지 Phase 1)" : ""}`);
         } catch (error) {
             // Document might not exist in our DB - frontend must create it first
             this.logger.warn(
@@ -216,8 +272,18 @@ export class EformsignWebhookService {
         }
 
         if (status === DOCUMENT_STATUS.DOC_COMPLETE) {
-            this.logger.log(`Document ${documentId} completed, linking to client`);
+            // Phase 1 chain runs for BOTH record and non-record documents.
+            // For record docs, this is Phase 1 of two phases; the document remains in status 070
+            // and requires finalize() later to reach 050.
+            this.logger.log(`Document ${documentId} completed, running Phase 1 chain`);
             try {
+                if (isRecordDoc) {
+                    // Initialize collection window for Phase 2
+                    await this.startDailyRecordCollectionUsecase.execute(organizationid, {
+                        documentId,
+                    });
+                }
+
                 await this.linkDocumentUsecase.execute(organizationid, documentId);
                 this.logger.log(`Document ${documentId} successfully linked to client`);
 
@@ -227,7 +293,7 @@ export class EformsignWebhookService {
                     workflow_name
                 );
             } catch (error) {
-                this.logger.error(`Failed to link document ${documentId} to client: ${error}`);
+                this.logger.error(`Failed Phase 1 chain for document ${documentId}: ${error}`);
             }
         }
     }

--- a/backend/application/usecases/eformsign-doc/finalize-service-record.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/finalize-service-record.usecase.ts
@@ -1,0 +1,101 @@
+import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
+import { EFORMSIGN_DOC_REPOSITORY, IEformsignDocRepository } from "domain/repositories/eformsign-doc.repository.interface";
+import { ListDailyRecordEntriesUsecase } from "./list-daily-record-entries.usecase";
+
+export interface FinalizeServiceRecordParams {
+    eformsignDocId: number;
+    force: boolean;
+}
+
+export interface FinalizeServiceRecordResult {
+    doc: EformsignDocEntity;
+    missingDates: string[]; // empty if all entries filled
+    forced: boolean;
+}
+
+/**
+ * Phase 2 completion.
+ * Flips statusType from "070" (collecting) to "050" (completed), sets finalizedAt.
+ * Does NOT re-run LinkDocumentToClientUsecase (already ran at Phase 1).
+ * Does NOT re-send the contract-signed alimtalk (already sent at Phase 1).
+ * No new alimtalk at Phase 2 (intentional — see PRD v0.2.0).
+ *
+ * If force=false and there are missing dates, throws BadRequestException with the list.
+ * If force=true, proceeds even with gaps and returns them in the result for the caller to surface.
+ */
+@Injectable()
+export class FinalizeServiceRecordUsecase {
+    private readonly logger = new Logger(FinalizeServiceRecordUsecase.name);
+
+    constructor(
+        @Inject(EFORMSIGN_DOC_REPOSITORY)
+        private readonly eformsignDocRepository: IEformsignDocRepository,
+        private readonly listEntriesUsecase: ListDailyRecordEntriesUsecase,
+    ) {}
+
+    async execute(
+        organizationid: string,
+        params: FinalizeServiceRecordParams,
+    ): Promise<FinalizeServiceRecordResult> {
+        const doc = await this.eformsignDocRepository.findById(organizationid, params.eformsignDocId);
+        if (!doc) {
+            throw new NotFoundException(
+                `EformsignDoc with id ${params.eformsignDocId} not found`,
+            );
+        }
+
+        if (doc.statusType !== "070") {
+            throw new BadRequestException(
+                `Cannot finalize: document status is ${doc.statusType}, expected 070 (collecting)`,
+            );
+        }
+
+        const { missingDates } = await this.listEntriesUsecase.execute(
+            organizationid,
+            params.eformsignDocId,
+        );
+
+        if (missingDates.length > 0 && !params.force) {
+            throw new BadRequestException({
+                message: "Daily records are incomplete. Use force=true to finalize anyway.",
+                missingDates,
+            });
+        }
+
+        const updated = EformsignDocEntity.reconstitute({
+            id: doc.id,
+            documentId: doc.documentId,
+            createdDate: doc.createdDate,
+            updatedDate: new Date(),
+            statusType: "050",
+            statusDetail: "완료",
+            stepType: doc.stepType,
+            stepIndex: doc.stepIndex,
+            stepName: doc.stepName,
+            stepRecipientType: doc.stepRecipientType,
+            stepRecipientName: doc.stepRecipientName,
+            stepRecipientSms: doc.stepRecipientSms,
+            expiredDate: doc.expiredDate,
+            expired: doc.expired,
+            clientId: doc.clientId,
+            collectionStartDate: doc.collectionStartDate,
+            collectionEndDate: doc.collectionEndDate,
+            collectionPeriodDays: doc.collectionPeriodDays,
+            finalizedAt: new Date(),
+            forceFinalize: params.force && missingDates.length > 0,
+        });
+
+        const saved = await this.eformsignDocRepository.update(organizationid, updated);
+
+        this.logger.log(
+            `Finalized service record doc ${doc.documentId} (id=${doc.id}): force=${params.force}, missing=${missingDates.length}`,
+        );
+
+        return {
+            doc: saved,
+            missingDates,
+            forced: params.force && missingDates.length > 0,
+        };
+    }
+}

--- a/backend/application/usecases/eformsign-doc/index.ts
+++ b/backend/application/usecases/eformsign-doc/index.ts
@@ -19,5 +19,11 @@ export * from "./fetch-eformsign-doc-from-api.usecase";
 // Contract creation
 export * from "./create-and-send-contract.usecase";
 
+// Two-phase service provision records (서비스제공기록지)
+export * from "./start-daily-record-collection.usecase";
+export * from "./submit-daily-record-entry.usecase";
+export * from "./list-daily-record-entries.usecase";
+export * from "./finalize-service-record.usecase";
+
 
 

--- a/backend/application/usecases/eformsign-doc/list-daily-record-entries.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/list-daily-record-entries.usecase.ts
@@ -1,0 +1,89 @@
+import { Inject, Injectable, NotFoundException } from "@nestjs/common";
+import { DailyRecordEntryEntity } from "domain/entities/daily-record-entry.entity";
+import { DAILY_RECORD_ENTRY_REPOSITORY, IDailyRecordEntryRepository } from "domain/repositories/daily-record-entry.repository.interface";
+import { EFORMSIGN_DOC_REPOSITORY, IEformsignDocRepository } from "domain/repositories/eformsign-doc.repository.interface";
+
+export interface ListDailyRecordEntriesResult {
+    entries: DailyRecordEntryEntity[];
+    missingDates: string[]; // ISO YYYY-MM-DD
+    collectionStartDate: string | null;
+    collectionEndDate: string | null;
+    collectionPeriodDays: number | null;
+}
+
+@Injectable()
+export class ListDailyRecordEntriesUsecase {
+    constructor(
+        @Inject(DAILY_RECORD_ENTRY_REPOSITORY)
+        private readonly entryRepository: IDailyRecordEntryRepository,
+        @Inject(EFORMSIGN_DOC_REPOSITORY)
+        private readonly eformsignDocRepository: IEformsignDocRepository,
+    ) {}
+
+    async execute(
+        organizationid: string,
+        eformsignDocId: number,
+    ): Promise<ListDailyRecordEntriesResult> {
+        const doc = await this.eformsignDocRepository.findById(organizationid, eformsignDocId);
+        if (!doc) {
+            throw new NotFoundException(
+                `EformsignDoc with id ${eformsignDocId} not found`,
+            );
+        }
+
+        const entries = await this.entryRepository.findByEformsignDocId(
+            organizationid,
+            eformsignDocId,
+        );
+
+        const missingDates = this.computeMissingDates(
+            doc.collectionStartDate,
+            doc.collectionEndDate,
+            entries.map(e => this.toDateOnly(e.recordDate)),
+        );
+
+        return {
+            entries,
+            missingDates,
+            collectionStartDate: doc.collectionStartDate
+                ? this.formatDate(doc.collectionStartDate)
+                : null,
+            collectionEndDate: doc.collectionEndDate
+                ? this.formatDate(doc.collectionEndDate)
+                : null,
+            collectionPeriodDays: doc.collectionPeriodDays,
+        };
+    }
+
+    private computeMissingDates(
+        startDate: Date | null,
+        endDate: Date | null,
+        submittedDates: Date[],
+    ): string[] {
+        if (!startDate || !endDate) return [];
+
+        const submitted = new Set(submittedDates.map(d => this.formatDate(d)));
+        const missing: string[] = [];
+
+        const cursor = this.toDateOnly(startDate);
+        const end = this.toDateOnly(endDate);
+
+        while (cursor <= end) {
+            const key = this.formatDate(cursor);
+            if (!submitted.has(key)) {
+                missing.push(key);
+            }
+            cursor.setDate(cursor.getDate() + 1);
+        }
+
+        return missing;
+    }
+
+    private toDateOnly(d: Date): Date {
+        return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+    }
+
+    private formatDate(d: Date): string {
+        return d.toISOString().slice(0, 10);
+    }
+}

--- a/backend/application/usecases/eformsign-doc/start-daily-record-collection.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/start-daily-record-collection.usecase.ts
@@ -1,0 +1,76 @@
+import { Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
+import { EFORMSIGN_DOC_REPOSITORY, IEformsignDocRepository } from "domain/repositories/eformsign-doc.repository.interface";
+
+export interface StartDailyRecordCollectionParams {
+    documentId: string;
+    collectionPeriodDays?: number;
+    startDate?: Date;
+}
+
+const DEFAULT_COLLECTION_PERIOD_DAYS = 30;
+
+/**
+ * Phase 1 → Phase 2 transition helper.
+ * Initializes the collection window on an eformsign_doc after it enters status "070".
+ * Does NOT change the status itself — that happens in UpdateEformsignDocStatusUsecase
+ * as part of the webhook branching. This usecase only sets the collection metadata.
+ */
+@Injectable()
+export class StartDailyRecordCollectionUsecase {
+    private readonly logger = new Logger(StartDailyRecordCollectionUsecase.name);
+
+    constructor(
+        @Inject(EFORMSIGN_DOC_REPOSITORY)
+        private readonly eformsignDocRepository: IEformsignDocRepository,
+    ) {}
+
+    async execute(
+        organizationid: string,
+        params: StartDailyRecordCollectionParams,
+    ): Promise<EformsignDocEntity> {
+        const existing = await this.eformsignDocRepository.findByDocumentId(
+            organizationid,
+            params.documentId,
+        );
+        if (!existing) {
+            throw new NotFoundException(
+                `EformsignDoc with documentId ${params.documentId} not found`,
+            );
+        }
+
+        const periodDays = params.collectionPeriodDays ?? DEFAULT_COLLECTION_PERIOD_DAYS;
+        const startDate = params.startDate ?? new Date();
+        const endDate = new Date(startDate);
+        endDate.setDate(endDate.getDate() + periodDays);
+
+        const updated = EformsignDocEntity.reconstitute({
+            id: existing.id,
+            documentId: existing.documentId,
+            createdDate: existing.createdDate,
+            updatedDate: new Date(),
+            statusType: existing.statusType,
+            statusDetail: existing.statusDetail,
+            stepType: existing.stepType,
+            stepIndex: existing.stepIndex,
+            stepName: existing.stepName,
+            stepRecipientType: existing.stepRecipientType,
+            stepRecipientName: existing.stepRecipientName,
+            stepRecipientSms: existing.stepRecipientSms,
+            expiredDate: existing.expiredDate,
+            expired: existing.expired,
+            clientId: existing.clientId,
+            collectionStartDate: startDate,
+            collectionEndDate: endDate,
+            collectionPeriodDays: periodDays,
+            finalizedAt: existing.finalizedAt,
+            forceFinalize: existing.forceFinalize,
+        });
+
+        const saved = await this.eformsignDocRepository.update(organizationid, updated);
+        this.logger.log(
+            `Started daily record collection for ${params.documentId}: ${periodDays} days, ${startDate.toISOString().slice(0, 10)} → ${endDate.toISOString().slice(0, 10)}`,
+        );
+        return saved;
+    }
+}

--- a/backend/application/usecases/eformsign-doc/submit-daily-record-entry.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/submit-daily-record-entry.usecase.ts
@@ -1,0 +1,84 @@
+import { BadRequestException, ConflictException, Inject, Injectable, NotFoundException } from "@nestjs/common";
+import { DailyRecordEntryEntity } from "domain/entities/daily-record-entry.entity";
+import { DAILY_RECORD_ENTRY_REPOSITORY, IDailyRecordEntryRepository } from "domain/repositories/daily-record-entry.repository.interface";
+import { EFORMSIGN_DOC_REPOSITORY, IEformsignDocRepository } from "domain/repositories/eformsign-doc.repository.interface";
+
+export interface SubmitDailyRecordEntryParams {
+    eformsignDocId: number;
+    recordDate: Date;
+    content?: string | null;
+    submittedBy?: string | null;
+}
+
+@Injectable()
+export class SubmitDailyRecordEntryUsecase {
+    constructor(
+        @Inject(DAILY_RECORD_ENTRY_REPOSITORY)
+        private readonly entryRepository: IDailyRecordEntryRepository,
+        @Inject(EFORMSIGN_DOC_REPOSITORY)
+        private readonly eformsignDocRepository: IEformsignDocRepository,
+    ) {}
+
+    async execute(
+        organizationid: string,
+        params: SubmitDailyRecordEntryParams,
+    ): Promise<DailyRecordEntryEntity> {
+        const doc = await this.eformsignDocRepository.findById(organizationid, params.eformsignDocId);
+        if (!doc) {
+            throw new NotFoundException(
+                `EformsignDoc with id ${params.eformsignDocId} not found`,
+            );
+        }
+
+        if (doc.statusType !== "070") {
+            throw new BadRequestException(
+                `Cannot submit entries: document status is ${doc.statusType}, expected 070 (collecting)`,
+            );
+        }
+
+        if (!doc.collectionStartDate || !doc.collectionEndDate) {
+            throw new BadRequestException(
+                "Collection window is not initialized on this document",
+            );
+        }
+
+        const recordDateOnly = this.toDateOnly(params.recordDate);
+        const startDateOnly = this.toDateOnly(doc.collectionStartDate);
+        const endDateOnly = this.toDateOnly(doc.collectionEndDate);
+
+        if (recordDateOnly < startDateOnly || recordDateOnly > endDateOnly) {
+            throw new BadRequestException(
+                `Record date ${this.formatDate(recordDateOnly)} is outside collection window [${this.formatDate(startDateOnly)}, ${this.formatDate(endDateOnly)}]`,
+            );
+        }
+
+        const existing = await this.entryRepository.findByEformsignDocIdAndDate(
+            organizationid,
+            params.eformsignDocId,
+            recordDateOnly,
+        );
+        if (existing) {
+            throw new ConflictException(
+                `Daily record entry for ${this.formatDate(recordDateOnly)} already exists on document ${params.eformsignDocId}`,
+            );
+        }
+
+        const entry = DailyRecordEntryEntity.create({
+            eformsignDocId: params.eformsignDocId,
+            recordDate: recordDateOnly,
+            content: params.content ?? null,
+            submittedBy: params.submittedBy ?? null,
+            organizationId: organizationid,
+        });
+
+        return this.entryRepository.create(organizationid, entry);
+    }
+
+    private toDateOnly(d: Date): Date {
+        return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+    }
+
+    private formatDate(d: Date): string {
+        return d.toISOString().slice(0, 10);
+    }
+}

--- a/backend/application/usecases/eformsign-doc/update-eformsign-doc-status.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/update-eformsign-doc-status.usecase.ts
@@ -31,7 +31,7 @@ export class UpdateEformsignDocStatusUsecase {
             throw new NotFoundException(`EformsignDoc with documentId ${params.documentId} not found`);
         }
 
-        // Reconstitute entity with updated fields
+        // Reconstitute entity with updated fields (preserve two-phase metadata)
         const updated = EformsignDocEntity.reconstitute({
             id: existing.id,
             documentId: existing.documentId,
@@ -48,6 +48,11 @@ export class UpdateEformsignDocStatusUsecase {
             expiredDate: existing.expiredDate,
             expired: params.expired ?? existing.expired,
             clientId: existing.clientId,
+            collectionStartDate: existing.collectionStartDate,
+            collectionEndDate: existing.collectionEndDate,
+            collectionPeriodDays: existing.collectionPeriodDays,
+            finalizedAt: existing.finalizedAt,
+            forceFinalize: existing.forceFinalize,
         });
 
         return this.eformsignDocRepository.update(organizationid, updated);

--- a/backend/domain/entities/daily-record-entry.entity.ts
+++ b/backend/domain/entities/daily-record-entry.entity.ts
@@ -1,0 +1,66 @@
+interface DailyRecordEntryProps {
+    id?: string;
+    eformsignDocId: number;
+    recordDate: Date;
+    content: string | null;
+    submittedBy: string | null;
+    submittedAt: Date;
+    organizationId: string | null;
+    createdAt: Date;
+}
+
+export class DailyRecordEntryEntity {
+    private readonly props: DailyRecordEntryProps;
+
+    constructor(props: DailyRecordEntryProps) {
+        this.props = { ...props };
+        this.assertInvariants();
+    }
+
+    private assertInvariants(): void {
+        if (typeof this.props.eformsignDocId !== "number" || this.props.eformsignDocId <= 0) {
+            throw new Error("DailyRecordEntryEntity: eformsignDocId must be a positive number");
+        }
+        if (!(this.props.recordDate instanceof Date) || Number.isNaN(this.props.recordDate.getTime())) {
+            throw new Error("DailyRecordEntryEntity: recordDate must be a valid Date");
+        }
+        if (!(this.props.submittedAt instanceof Date) || Number.isNaN(this.props.submittedAt.getTime())) {
+            throw new Error("DailyRecordEntryEntity: submittedAt must be a valid Date");
+        }
+        if (!(this.props.createdAt instanceof Date) || Number.isNaN(this.props.createdAt.getTime())) {
+            throw new Error("DailyRecordEntryEntity: createdAt must be a valid Date");
+        }
+    }
+
+    get id(): string | undefined { return this.props.id; }
+    get eformsignDocId(): number { return this.props.eformsignDocId; }
+    get recordDate(): Date { return this.props.recordDate; }
+    get content(): string | null { return this.props.content; }
+    get submittedBy(): string | null { return this.props.submittedBy; }
+    get submittedAt(): Date { return this.props.submittedAt; }
+    get organizationId(): string | null { return this.props.organizationId; }
+    get createdAt(): Date { return this.props.createdAt; }
+
+    /**
+     * Use this when creating a new entry from an incoming request.
+     * id is DB-generated; submittedAt/createdAt default to now.
+     */
+    static create(
+        props: Omit<DailyRecordEntryProps, "id" | "submittedAt" | "createdAt">
+            & Partial<Pick<DailyRecordEntryProps, "submittedAt" | "createdAt">>,
+    ): DailyRecordEntryEntity {
+        const now = new Date();
+        return new DailyRecordEntryEntity({
+            ...props,
+            submittedAt: props.submittedAt ?? now,
+            createdAt: props.createdAt ?? now,
+        });
+    }
+
+    /**
+     * Reconstitute an entity from persistence data (used by Mapper).
+     */
+    static reconstitute(props: DailyRecordEntryProps): DailyRecordEntryEntity {
+        return new DailyRecordEntryEntity(props);
+    }
+}

--- a/backend/domain/entities/eformsign-doc.entity.ts
+++ b/backend/domain/entities/eformsign-doc.entity.ts
@@ -3,9 +3,9 @@ interface EformsignDocProps {
     documentId: string;
     createdDate: Date;
     updatedDate: Date;
-    // doc status code example: 060 = pending, 050 = completed, 080 = rejected
+    // doc status code example: 060 = pending, 050 = completed, 070 = collecting daily records, 080 = rejected
     statusType: string;
-    // doc status detail example: "대기", "완료", "거부"
+    // doc status detail example: "대기", "완료", "일일기록 수집 중", "거부"
     statusDetail: string;
     // step type example: "05" = participant, "06" = reviewer
     stepType: string;
@@ -25,6 +25,13 @@ interface EformsignDocProps {
     expired: boolean;
     // FK to client
     clientId: number;
+    // Two-phase (서비스제공기록지) collection window — null for non-record docs
+    collectionStartDate?: Date | null;
+    collectionEndDate?: Date | null;
+    collectionPeriodDays?: number | null;
+    // Phase 2 finalization metadata
+    finalizedAt?: Date | null;
+    forceFinalize?: boolean;
 }
 
 export class EformsignDocEntity {
@@ -93,6 +100,11 @@ export class EformsignDocEntity {
     get expiredDate(): Date { return this.props.expiredDate; }
     get expired(): boolean { return this.props.expired; }
     get clientId(): number { return this.props.clientId; }
+    get collectionStartDate(): Date | null { return this.props.collectionStartDate ?? null; }
+    get collectionEndDate(): Date | null { return this.props.collectionEndDate ?? null; }
+    get collectionPeriodDays(): number | null { return this.props.collectionPeriodDays ?? null; }
+    get finalizedAt(): Date | null { return this.props.finalizedAt ?? null; }
+    get forceFinalize(): boolean { return this.props.forceFinalize ?? false; }
 
     /**
      * Use this for "API JSON → select fields → create entity".

--- a/backend/domain/repositories/daily-record-entry.repository.interface.ts
+++ b/backend/domain/repositories/daily-record-entry.repository.interface.ts
@@ -1,0 +1,15 @@
+import { DailyRecordEntryEntity } from "domain/entities/daily-record-entry.entity";
+
+export interface IDailyRecordEntryRepository {
+    findById(organizationid: string, id: string): Promise<DailyRecordEntryEntity | null>;
+    findByEformsignDocId(organizationid: string, eformsignDocId: number): Promise<DailyRecordEntryEntity[]>;
+    findByEformsignDocIdAndDate(
+        organizationid: string,
+        eformsignDocId: number,
+        recordDate: Date,
+    ): Promise<DailyRecordEntryEntity | null>;
+    create(organizationid: string, entry: DailyRecordEntryEntity): Promise<DailyRecordEntryEntity>;
+    delete(organizationid: string, id: string): Promise<void>;
+}
+
+export const DAILY_RECORD_ENTRY_REPOSITORY = "DAILY_RECORD_ENTRY_REPOSITORY";

--- a/backend/infrastructure/database/mapper/daily-record-entry.mapper.ts
+++ b/backend/infrastructure/database/mapper/daily-record-entry.mapper.ts
@@ -1,0 +1,37 @@
+import { DailyRecordEntryEntity } from "domain/entities/daily-record-entry.entity";
+
+type DailyRecordEntryRow = {
+    id: string;
+    eformsignDocId: number;
+    recordDate: Date;
+    content: string | null;
+    submittedBy: string | null;
+    submittedAt: Date;
+    organizationId: string | null;
+    createdAt: Date;
+};
+
+export class DailyRecordEntryMapper {
+    static toDomain(row: DailyRecordEntryRow): DailyRecordEntryEntity {
+        return DailyRecordEntryEntity.reconstitute({
+            id: row.id,
+            eformsignDocId: row.eformsignDocId,
+            recordDate: row.recordDate,
+            content: row.content,
+            submittedBy: row.submittedBy,
+            submittedAt: row.submittedAt,
+            organizationId: row.organizationId,
+            createdAt: row.createdAt,
+        });
+    }
+
+    static toPrismaCreate(entity: DailyRecordEntryEntity) {
+        return {
+            eformsignDocId: entity.eformsignDocId,
+            recordDate: entity.recordDate,
+            content: entity.content,
+            submittedBy: entity.submittedBy,
+            submittedAt: entity.submittedAt,
+        };
+    }
+}

--- a/backend/infrastructure/database/mapper/eformsign-doc.mapper.ts
+++ b/backend/infrastructure/database/mapper/eformsign-doc.mapper.ts
@@ -16,6 +16,11 @@ type EformsignDocRow = {
     expiredDate: Date;
     expired: boolean;
     clientId: number;
+    collectionStartDate?: Date | null;
+    collectionEndDate?: Date | null;
+    collectionPeriodDays?: number | null;
+    finalizedAt?: Date | null;
+    forceFinalize?: boolean;
 };
 
 export class EformsignDocMapper {
@@ -36,6 +41,11 @@ export class EformsignDocMapper {
             expiredDate: row.expiredDate,
             expired: row.expired,
             clientId: row.clientId,
+            collectionStartDate: row.collectionStartDate ?? null,
+            collectionEndDate: row.collectionEndDate ?? null,
+            collectionPeriodDays: row.collectionPeriodDays ?? null,
+            finalizedAt: row.finalizedAt ?? null,
+            forceFinalize: row.forceFinalize ?? false,
         });
     }
 
@@ -55,6 +65,11 @@ export class EformsignDocMapper {
             expiredDate: entity.expiredDate,
             expired: entity.expired,
             clientId: entity.clientId,
+            collectionStartDate: entity.collectionStartDate,
+            collectionEndDate: entity.collectionEndDate,
+            collectionPeriodDays: entity.collectionPeriodDays,
+            finalizedAt: entity.finalizedAt,
+            forceFinalize: entity.forceFinalize,
         };
     }
 
@@ -74,6 +89,11 @@ export class EformsignDocMapper {
             expiredDate: entity.expiredDate,
             expired: entity.expired,
             clientId: entity.clientId,
+            collectionStartDate: entity.collectionStartDate,
+            collectionEndDate: entity.collectionEndDate,
+            collectionPeriodDays: entity.collectionPeriodDays,
+            finalizedAt: entity.finalizedAt,
+            forceFinalize: entity.forceFinalize,
         };
     }
 }

--- a/backend/infrastructure/database/repositories/sb.daily-record-entry.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.daily-record-entry.repository.ts
@@ -1,0 +1,62 @@
+import { Injectable } from "@nestjs/common";
+import { DailyRecordEntryEntity } from "domain/entities/daily-record-entry.entity";
+import { IDailyRecordEntryRepository } from "domain/repositories/daily-record-entry.repository.interface";
+import { PrismaService } from "infrastructure/database/prisma.service";
+import { DailyRecordEntryMapper } from "infrastructure/database/mapper/daily-record-entry.mapper";
+
+@Injectable()
+export class SbDailyRecordEntryRepository implements IDailyRecordEntryRepository {
+    constructor(private readonly prismaService: PrismaService) {}
+
+    async findById(organizationid: string, id: string): Promise<DailyRecordEntryEntity | null> {
+        const row = await this.prismaService.daily_record_entry.findFirst({
+            where: { id, organizationId: organizationid },
+        });
+        return row ? DailyRecordEntryMapper.toDomain(row) : null;
+    }
+
+    async findByEformsignDocId(
+        organizationid: string,
+        eformsignDocId: number,
+    ): Promise<DailyRecordEntryEntity[]> {
+        const rows = await this.prismaService.daily_record_entry.findMany({
+            where: { eformsignDocId, organizationId: organizationid },
+            orderBy: { recordDate: "asc" },
+        });
+        return rows.map(DailyRecordEntryMapper.toDomain);
+    }
+
+    async findByEformsignDocIdAndDate(
+        organizationid: string,
+        eformsignDocId: number,
+        recordDate: Date,
+    ): Promise<DailyRecordEntryEntity | null> {
+        const row = await this.prismaService.daily_record_entry.findFirst({
+            where: {
+                eformsignDocId,
+                recordDate,
+                organizationId: organizationid,
+            },
+        });
+        return row ? DailyRecordEntryMapper.toDomain(row) : null;
+    }
+
+    async create(
+        organizationid: string,
+        entry: DailyRecordEntryEntity,
+    ): Promise<DailyRecordEntryEntity> {
+        const created = await this.prismaService.daily_record_entry.create({
+            data: {
+                ...DailyRecordEntryMapper.toPrismaCreate(entry),
+                organizationId: organizationid,
+            },
+        });
+        return DailyRecordEntryMapper.toDomain(created);
+    }
+
+    async delete(organizationid: string, id: string): Promise<void> {
+        await this.prismaService.daily_record_entry.deleteMany({
+            where: { id, organizationId: organizationid },
+        });
+    }
+}

--- a/backend/interface/controllers/daily-record.controller.ts
+++ b/backend/interface/controllers/daily-record.controller.ts
@@ -1,0 +1,86 @@
+import { Body, Controller, Get, Param, Post, UseGuards } from "@nestjs/common";
+import { DailyRecordService } from "application/services/daily-record.service";
+import {
+    FinalizeServiceRecordDto,
+    FinalizeServiceRecordResponseDto,
+    ListDailyRecordEntriesResponseDto,
+    SubmitDailyRecordEntryDto,
+    DailyRecordEntryResponseDto,
+} from "interface/dto/daily-record.dto";
+import { JwtGuard } from "infrastructure/auth/jwt.guard";
+import { CurrentTenant, TenantGuard } from "infrastructure/tenant";
+import { DailyRecordEntryEntity } from "domain/entities/daily-record-entry.entity";
+import { FinalizeServiceRecordResult } from "application/usecases/eformsign-doc/finalize-service-record.usecase";
+
+@Controller("daily-records")
+@UseGuards(JwtGuard, TenantGuard)
+export class DailyRecordController {
+    constructor(private readonly dailyRecordService: DailyRecordService) {}
+
+    @Post(":eformsignDocId/entries")
+    async submitEntry(
+        @CurrentTenant() tenant: { organizationId?: string },
+        @Param("eformsignDocId") eformsignDocId: string,
+        @Body() dto: SubmitDailyRecordEntryDto,
+    ): Promise<DailyRecordEntryResponseDto> {
+        const entry = await this.dailyRecordService.submitEntry(tenant.organizationId ?? "", {
+            eformsignDocId: Number(eformsignDocId),
+            recordDate: new Date(dto.recordDate),
+            content: dto.content ?? null,
+            submittedBy: dto.submittedBy ?? null,
+        });
+        return this.toResponseDto(entry);
+    }
+
+    @Get(":eformsignDocId/entries")
+    async listEntries(
+        @CurrentTenant() tenant: { organizationId?: string },
+        @Param("eformsignDocId") eformsignDocId: string,
+    ): Promise<ListDailyRecordEntriesResponseDto> {
+        const result = await this.dailyRecordService.listEntries(
+            tenant.organizationId ?? "",
+            Number(eformsignDocId),
+        );
+        return {
+            entries: result.entries.map(e => this.toResponseDto(e)),
+            missingDates: result.missingDates,
+            collectionStartDate: result.collectionStartDate,
+            collectionEndDate: result.collectionEndDate,
+            collectionPeriodDays: result.collectionPeriodDays,
+        };
+    }
+
+    @Post(":eformsignDocId/finalize")
+    async finalize(
+        @CurrentTenant() tenant: { organizationId?: string },
+        @Param("eformsignDocId") eformsignDocId: string,
+        @Body() dto: FinalizeServiceRecordDto,
+    ): Promise<FinalizeServiceRecordResponseDto> {
+        const result: FinalizeServiceRecordResult = await this.dailyRecordService.finalize(
+            tenant.organizationId ?? "",
+            {
+                eformsignDocId: Number(eformsignDocId),
+                force: dto.force ?? false,
+            },
+        );
+        return {
+            documentId: result.doc.documentId,
+            statusType: result.doc.statusType,
+            finalizedAt: result.doc.finalizedAt ? result.doc.finalizedAt.toISOString() : null,
+            forced: result.forced,
+            missingDates: result.missingDates,
+        };
+    }
+
+    private toResponseDto(entry: DailyRecordEntryEntity): DailyRecordEntryResponseDto {
+        return {
+            id: entry.id ?? "",
+            eformsignDocId: entry.eformsignDocId,
+            recordDate: entry.recordDate.toISOString().slice(0, 10),
+            content: entry.content,
+            submittedBy: entry.submittedBy,
+            submittedAt: entry.submittedAt.toISOString(),
+            createdAt: entry.createdAt.toISOString(),
+        };
+    }
+}

--- a/backend/interface/dto/daily-record.dto.ts
+++ b/backend/interface/dto/daily-record.dto.ts
@@ -1,0 +1,46 @@
+import { IsBoolean, IsDateString, IsOptional, IsString } from "class-validator";
+
+export class SubmitDailyRecordEntryDto {
+    @IsDateString()
+    recordDate!: string; // ISO date string, e.g. "2026-04-17"
+
+    @IsOptional()
+    @IsString()
+    content?: string | null;
+
+    @IsOptional()
+    @IsString()
+    submittedBy?: string | null; // employee UUID (optional; can default to current user)
+}
+
+export class FinalizeServiceRecordDto {
+    @IsOptional()
+    @IsBoolean()
+    force?: boolean; // if true, finalize even with missing dates
+}
+
+export class DailyRecordEntryResponseDto {
+    id!: string;
+    eformsignDocId!: number;
+    recordDate!: string;
+    content!: string | null;
+    submittedBy!: string | null;
+    submittedAt!: string;
+    createdAt!: string;
+}
+
+export class ListDailyRecordEntriesResponseDto {
+    entries!: DailyRecordEntryResponseDto[];
+    missingDates!: string[]; // ISO YYYY-MM-DD
+    collectionStartDate!: string | null;
+    collectionEndDate!: string | null;
+    collectionPeriodDays!: number | null;
+}
+
+export class FinalizeServiceRecordResponseDto {
+    documentId!: string;
+    statusType!: string;
+    finalizedAt!: string | null;
+    forced!: boolean;
+    missingDates!: string[];
+}

--- a/backend/module/daily-record.module.ts
+++ b/backend/module/daily-record.module.ts
@@ -1,0 +1,33 @@
+import { Module } from "@nestjs/common";
+import { DailyRecordController } from "interface/controllers/daily-record.controller";
+import { DailyRecordService } from "application/services/daily-record.service";
+import {
+    SubmitDailyRecordEntryUsecase,
+    ListDailyRecordEntriesUsecase,
+    FinalizeServiceRecordUsecase,
+} from "application/usecases/eformsign-doc";
+import { DAILY_RECORD_ENTRY_REPOSITORY } from "domain/repositories/daily-record-entry.repository.interface";
+import { EFORMSIGN_DOC_REPOSITORY } from "domain/repositories/eformsign-doc.repository.interface";
+import { SbDailyRecordEntryRepository } from "infrastructure/database/repositories/sb.daily-record-entry.repository";
+import { SbEformsignDocRepository } from "infrastructure/database/repositories/sb.eformsign-doc.repository";
+import { DatabaseModule } from "infrastructure/database/database.module";
+
+@Module({
+    imports: [DatabaseModule],
+    controllers: [DailyRecordController],
+    providers: [
+        DailyRecordService,
+        SubmitDailyRecordEntryUsecase,
+        ListDailyRecordEntriesUsecase,
+        FinalizeServiceRecordUsecase,
+        {
+            provide: DAILY_RECORD_ENTRY_REPOSITORY,
+            useClass: SbDailyRecordEntryRepository,
+        },
+        {
+            provide: EFORMSIGN_DOC_REPOSITORY,
+            useClass: SbEformsignDocRepository,
+        },
+    ],
+})
+export class DailyRecordModule {}

--- a/backend/module/eformsign-webhook.module.ts
+++ b/backend/module/eformsign-webhook.module.ts
@@ -4,6 +4,7 @@ import { EformsignWebhookService } from "application/services/eformsign-webhook.
 import {
     UpdateEformsignDocStatusUsecase,
     LinkDocumentToClientUsecase,
+    StartDailyRecordCollectionUsecase,
 } from "application/usecases/eformsign-doc";
 import { EFORMSIGN_DOC_REPOSITORY } from "domain/repositories/eformsign-doc.repository.interface";
 import { CLIENT_REPOSITORY } from "domain/repositories/client.repository.interface";
@@ -25,6 +26,7 @@ import { AlimtalkModule } from "./alimtalk.module";
         EformsignWebhookService,
         UpdateEformsignDocStatusUsecase,
         LinkDocumentToClientUsecase,
+        StartDailyRecordCollectionUsecase,
         {
             provide: EFORMSIGN_DOC_REPOSITORY,
             useClass: SbEformsignDocRepository,

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -75,30 +75,30 @@ model chat_session {
 }
 
 model client {
-  id                                            Int                 @id @default(autoincrement())
-  name                                          String
-  address                                       String?
-  phone                                         String?
-  type                                          String?
-  duration                                      Int?                @db.SmallInt
-  fullPrice                                     String?             @map("full_price")
-  grant                                         String?
-  actualPrice                                   String?             @map("actual_price")
-  startDate                                     DateTime?           @map("start_date") @db.Date
-  endDate                                       DateTime?           @map("end_date") @db.Date
-  careCenter                                    Boolean             @map("care_center")
-  voucherClient                                 Boolean             @map("voucher_client")
-  birthday                                      String?             @db.VarChar(6)
-  breastPump                                    Boolean             @default(false) @map("breast_pump")
-  serviceStatus                                 String?             @map("service_status")
-  eDocId                                        String?             @unique @map("e_doc_id")
-  dueDate                                       DateTime?           @map("due_date") @db.Date
-  createdAt                                     DateTime            @default(now()) @map("created_at") @db.Timestamptz(6)
-  organizationId                                String?             @map("organization_id") @db.Uuid
-  eformsignDocByEDocId                          eformsign_doc?      @relation("client_e_doc_idToeformsign_doc", fields: [eDocId], references: [documentId], onUpdate: NoAction)
-  organization                                  organization?       @relation(fields: [organizationId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  eformsignDocs                                 eformsign_doc[]     @relation("eformsign_doc_client_idToclient")
-  employeeSchedules                             employee_schedule[]
+  id                   Int                 @id @default(autoincrement())
+  name                 String
+  address              String?
+  phone                String?
+  type                 String?
+  duration             Int?                @db.SmallInt
+  fullPrice            String?             @map("full_price")
+  grant                String?
+  actualPrice          String?             @map("actual_price")
+  startDate            DateTime?           @map("start_date") @db.Date
+  endDate              DateTime?           @map("end_date") @db.Date
+  careCenter           Boolean             @map("care_center")
+  voucherClient        Boolean             @map("voucher_client")
+  birthday             String?             @db.VarChar(6)
+  breastPump           Boolean             @default(false) @map("breast_pump")
+  serviceStatus        String?             @map("service_status")
+  eDocId               String?             @unique @map("e_doc_id")
+  dueDate              DateTime?           @map("due_date") @db.Date
+  createdAt            DateTime            @default(now()) @map("created_at") @db.Timestamptz(6)
+  organizationId       String?             @map("organization_id") @db.Uuid
+  eformsignDocByEDocId eformsign_doc?      @relation("client_e_doc_idToeformsign_doc", fields: [eDocId], references: [documentId], onUpdate: NoAction)
+  organization         organization?       @relation(fields: [organizationId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  eformsignDocs        eformsign_doc[]     @relation("eformsign_doc_client_idToclient")
+  employeeSchedules    employee_schedule[]
 
   @@index([organizationId], map: "idx_client_organization")
   @@index([createdAt], map: "idx_client_created_at")
@@ -151,41 +151,64 @@ model document_category {
 }
 
 model eformsign_doc {
-  id                                     Int           @id @default(autoincrement())
-  documentId                             String        @unique @map("document_id")
-  createdDate                            DateTime      @map("created_date") @db.Timestamptz(6)
-  updatedDate                            DateTime      @map("updated_date") @db.Timestamptz(6)
-  statusType                             String        @map("status_type")
-  statusDetail                           String        @map("status_detail")
-  stepType                               String        @map("step_type")
-  stepIndex                              String        @map("step_index")
-  stepName                               String        @map("step_name")
-  stepRecipientType                      String        @map("step_recipient_type")
-  stepRecipientName                      String        @map("step_recipient_name")
-  stepRecipientSms                       String        @map("step_recipient_sms")
-  expiredDate                            DateTime      @map("expired_date") @db.Timestamptz(6)
-  expired                                Boolean       @default(false)
-  clientId                               Int           @map("client_id")
-  organizationId                         String?       @map("organization_id") @db.Uuid
-  clientByEDocId                         client?       @relation("client_e_doc_idToeformsign_doc")
-  client                                 client        @relation("eformsign_doc_client_idToclient", fields: [clientId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  organization                           organization? @relation(fields: [organizationId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  id                   Int                  @id @default(autoincrement())
+  documentId           String               @unique @map("document_id")
+  createdDate          DateTime             @map("created_date") @db.Timestamptz(6)
+  updatedDate          DateTime             @map("updated_date") @db.Timestamptz(6)
+  statusType           String               @map("status_type")
+  statusDetail         String               @map("status_detail")
+  stepType             String               @map("step_type")
+  stepIndex            String               @map("step_index")
+  stepName             String               @map("step_name")
+  stepRecipientType    String               @map("step_recipient_type")
+  stepRecipientName    String               @map("step_recipient_name")
+  stepRecipientSms     String               @map("step_recipient_sms")
+  expiredDate          DateTime             @map("expired_date") @db.Timestamptz(6)
+  expired              Boolean              @default(false)
+  clientId             Int                  @map("client_id")
+  organizationId       String?              @map("organization_id") @db.Uuid
+  collectionStartDate  DateTime?            @map("collection_start_date") @db.Date
+  collectionEndDate    DateTime?            @map("collection_end_date") @db.Date
+  collectionPeriodDays Int?                 @map("collection_period_days")
+  finalizedAt          DateTime?            @map("finalized_at") @db.Timestamptz(6)
+  forceFinalize        Boolean              @default(false) @map("force_finalize")
+  clientByEDocId       client?              @relation("client_e_doc_idToeformsign_doc")
+  client               client               @relation("eformsign_doc_client_idToclient", fields: [clientId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  organization         organization?        @relation(fields: [organizationId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  dailyRecordEntries   daily_record_entry[]
 
   @@index([organizationId], map: "idx_eformsign_doc_organization")
 }
 
+model daily_record_entry {
+  id             String        @id @default(dbgenerated("(gen_random_uuid())::text"))
+  eformsignDocId Int           @map("eformsign_doc_id")
+  recordDate     DateTime      @map("record_date") @db.Date
+  content        String?
+  submittedBy    String?       @map("submitted_by") @db.Uuid
+  submittedAt    DateTime      @default(now()) @map("submitted_at") @db.Timestamptz(6)
+  organizationId String?       @map("organization_id") @db.Uuid
+  createdAt      DateTime      @default(now()) @map("created_at") @db.Timestamptz(6)
+  eformsignDoc   eformsign_doc @relation(fields: [eformsignDocId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  organization   organization? @relation(fields: [organizationId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@unique([eformsignDocId, recordDate], map: "uniq_daily_record_entry_doc_date")
+  @@index([organizationId], map: "idx_daily_record_entry_organization")
+  @@index([eformsignDocId, recordDate], map: "idx_daily_record_entry_doc_date")
+}
+
 model employee {
-  id                            Int                 @id @db.SmallInt
-  name                          String
-  workArea                      String[]            @map("work_area")
-  phone                         String              @unique
-  grade                         String
-  openToNextWork                Boolean             @default(true) @map("open_to_next_work")
-  companyRegisteredDate         DateTime?           @map("company_registered_date") @db.Date
-  organizationId                String?             @map("organization_id") @db.Uuid
-  organization                  organization?       @relation(fields: [organizationId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  primaryEmployeeSchedules      employee_schedule[] @relation("employee_schedule_primary_employee_idToemployee")
-  secondaryEmployeeSchedules    employee_schedule[] @relation("employee_schedule_secondary_employee_idToemployee")
+  id                         Int                 @id @db.SmallInt
+  name                       String
+  workArea                   String[]            @map("work_area")
+  phone                      String              @unique
+  grade                      String
+  openToNextWork             Boolean             @default(true) @map("open_to_next_work")
+  companyRegisteredDate      DateTime?           @map("company_registered_date") @db.Date
+  organizationId             String?             @map("organization_id") @db.Uuid
+  organization               organization?       @relation(fields: [organizationId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  primaryEmployeeSchedules   employee_schedule[] @relation("employee_schedule_primary_employee_idToemployee")
+  secondaryEmployeeSchedules employee_schedule[] @relation("employee_schedule_secondary_employee_idToemployee")
 
   @@index([organizationId], map: "idx_employee_organization")
 }
@@ -251,35 +274,36 @@ model notification {
 }
 
 model organization {
-  id                 String              @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  name               String
-  slug               String              @unique
-  phone              String?
-  address            String?
-  email              String?
-  description        String?
-  isActive           Boolean?            @default(true) @map("is_active")
-  smsSenderPhone     String?             @map("sms_sender_phone") @db.VarChar(20)
-  smsSenderApprovalStatus String         @default("not_requested") @map("sms_sender_approval_status") @db.VarChar(20)
-  smsSenderApprovalRequestedAt DateTime? @map("sms_sender_approval_requested_at") @db.Timestamptz(6)
-  smsSenderApprovalRequestedBy String?   @map("sms_sender_approval_requested_by") @db.Uuid
-  smsSenderApprovalApprovedAt DateTime?  @map("sms_sender_approval_approved_at") @db.Timestamptz(6)
-  smsSenderApprovalApprovedBy String?    @map("sms_sender_approval_approved_by") @db.Uuid
-  createdAt          DateTime?           @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt          DateTime?           @default(now()) @map("updated_at") @db.Timestamptz(6)
-  ownerId            String              @map("owner_id") @db.Uuid
-  areas              area[]
-  clients            client[]
-  documents          document[]
-  documentCategories document_category[]
-  eformsignDocs      eformsign_doc[]
-  employees          employee[]
-  employeeSchedules  employee_schedule[]
-  messages           message[]
-  messageTemplates   message_template[]
-  notifications      notification[]
-  owner              user                @relation(fields: [ownerId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  userOrganizations  user_organization[]
+  id                           String               @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name                         String
+  slug                         String               @unique
+  phone                        String?
+  address                      String?
+  email                        String?
+  description                  String?
+  isActive                     Boolean?             @default(true) @map("is_active")
+  smsSenderPhone               String?              @map("sms_sender_phone") @db.VarChar(20)
+  smsSenderApprovalStatus      String               @default("not_requested") @map("sms_sender_approval_status") @db.VarChar(20)
+  smsSenderApprovalRequestedAt DateTime?            @map("sms_sender_approval_requested_at") @db.Timestamptz(6)
+  smsSenderApprovalRequestedBy String?              @map("sms_sender_approval_requested_by") @db.Uuid
+  smsSenderApprovalApprovedAt  DateTime?            @map("sms_sender_approval_approved_at") @db.Timestamptz(6)
+  smsSenderApprovalApprovedBy  String?              @map("sms_sender_approval_approved_by") @db.Uuid
+  createdAt                    DateTime?            @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt                    DateTime?            @default(now()) @map("updated_at") @db.Timestamptz(6)
+  ownerId                      String               @map("owner_id") @db.Uuid
+  areas                        area[]
+  clients                      client[]
+  dailyRecordEntries           daily_record_entry[]
+  documents                    document[]
+  documentCategories           document_category[]
+  eformsignDocs                eformsign_doc[]
+  employees                    employee[]
+  employeeSchedules            employee_schedule[]
+  messages                     message[]
+  messageTemplates             message_template[]
+  notifications                notification[]
+  owner                        user                 @relation(fields: [ownerId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  userOrganizations            user_organization[]
 
   @@index([isActive], map: "idx_organization_is_active")
   @@index([ownerId], map: "idx_organization_owner")
@@ -330,26 +354,26 @@ model system_template_version {
 }
 
 model user {
-  id                String              @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  email             String?             @unique @db.VarChar
-  name              String?             @db.VarChar
-  phone             String?             @db.VarChar
-  birthDate         String?             @map("birth_date") @db.VarChar
-  profileImage      String?             @map("profile_image") @db.VarChar
-  role              String?             @db.VarChar
-  createdAt         DateTime            @default(now()) @map("created_at") @db.Timestamp(6)
-  kakaoId           String?             @unique(map: "user_kakaoId_key") @map("kakao_id") @db.VarChar
-  passwordHash      String?             @map("password_hash") @db.VarChar
-  emailVerified     Boolean             @default(false) @map("email_verified")
-  emailVerifiedAt   DateTime?           @map("email_verified_at") @db.Timestamptz(6)
-  authProvider      String              @default("kakao") @map("auth_provider")
-  chatFeedback      chat_feedback[]
-  chatSessions      chat_session[]
-  notifications     notification[]
+  id                 String              @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  email              String?             @unique @db.VarChar
+  name               String?             @db.VarChar
+  phone              String?             @db.VarChar
+  birthDate          String?             @map("birth_date") @db.VarChar
+  profileImage       String?             @map("profile_image") @db.VarChar
+  role               String?             @db.VarChar
+  createdAt          DateTime            @default(now()) @map("created_at") @db.Timestamp(6)
+  kakaoId            String?             @unique(map: "user_kakaoId_key") @map("kakao_id") @db.VarChar
+  passwordHash       String?             @map("password_hash") @db.VarChar
+  emailVerified      Boolean             @default(false) @map("email_verified")
+  emailVerifiedAt    DateTime?           @map("email_verified_at") @db.Timestamptz(6)
+  authProvider       String              @default("kakao") @map("auth_provider")
+  chatFeedback       chat_feedback[]
+  chatSessions       chat_session[]
+  notifications      notification[]
   ownedOrganizations organization[]
-  pushSubscriptions push_subscription[]
-  userOrganizations user_organization[]
-  authTokens        auth_token[]
+  pushSubscriptions  push_subscription[]
+  userOrganizations  user_organization[]
+  authTokens         auth_token[]
 }
 
 model user_organization {
@@ -395,7 +419,7 @@ model auth_token {
   id        String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   userId    String    @map("user_id") @db.Uuid
   token     String    @unique
-  type      String    // "email_verification" | "password_reset"
+  type      String // "email_verification" | "password_reset"
   expiresAt DateTime  @map("expires_at") @db.Timestamptz(6)
   createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   usedAt    DateTime? @map("used_at") @db.Timestamptz(6)
@@ -427,7 +451,7 @@ model auth_flow_state {
 model alimtalk_log {
   id             Int       @id @default(autoincrement())
   organizationId String?   @map("organization_id") @db.Uuid
-  provider       String    // "aligo" | "channeltalk"
+  provider       String // "aligo" | "channeltalk"
   templateKey    String    @map("template_key")
   triggerJobId   String?   @map("trigger_job_id")
   receiver       String
@@ -452,17 +476,17 @@ model alimtalk_log {
 }
 
 model alimtalk_trigger_rule {
-  id             String    @id @default(dbgenerated("gen_random_uuid()::text"))
-  organizationId String?   @map("organization_id") @db.Uuid
+  id             String   @id @default(dbgenerated("gen_random_uuid()::text"))
+  organizationId String?  @map("organization_id") @db.Uuid
   name           String
-  isActive       Boolean   @default(true) @map("is_active")
-  eventType      String    @map("event_type")
-  offsetType     String    @map("offset_type")
-  offsetDays     Int       @default(0) @map("offset_days")
-  recipientType  String    @map("recipient_type")
-  templateKey    String    @map("template_key")
-  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt      DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
+  isActive       Boolean  @default(true) @map("is_active")
+  eventType      String   @map("event_type")
+  offsetType     String   @map("offset_type")
+  offsetDays     Int      @default(0) @map("offset_days")
+  recipientType  String   @map("recipient_type")
+  templateKey    String   @map("template_key")
+  createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt      DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   @@index([organizationId], map: "idx_alimtalk_trigger_rule_organization")
   @@index([organizationId, isActive], map: "idx_alimtalk_trigger_rule_active")
@@ -470,23 +494,23 @@ model alimtalk_trigger_rule {
 }
 
 model alimtalk_trigger_job {
-  id               String    @id @default(dbgenerated("gen_random_uuid()::text"))
-  organizationId   String?   @map("organization_id") @db.Uuid
-  ruleId           String    @map("rule_id")
-  status           String    @default("pending")
-  scheduledFor     DateTime  @map("scheduled_for") @db.Timestamptz(6)
-  sentAt           DateTime? @map("sent_at") @db.Timestamptz(6)
-  canceledAt       DateTime? @map("canceled_at") @db.Timestamptz(6)
-  cancelReason     String?   @map("cancel_reason")
-  clientId         Int?      @map("client_id")
-  employeeScheduleId Int?    @map("employee_schedule_id")
-  recipientType    String    @map("recipient_type")
-  recipientPhone   String?   @map("recipient_phone")
-  templateKey      String    @map("template_key")
-  dedupeKey        String    @unique @map("dedupe_key")
-  payload          Json      @default("{}")
-  createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt        DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
+  id                 String    @id @default(dbgenerated("gen_random_uuid()::text"))
+  organizationId     String?   @map("organization_id") @db.Uuid
+  ruleId             String    @map("rule_id")
+  status             String    @default("pending")
+  scheduledFor       DateTime  @map("scheduled_for") @db.Timestamptz(6)
+  sentAt             DateTime? @map("sent_at") @db.Timestamptz(6)
+  canceledAt         DateTime? @map("canceled_at") @db.Timestamptz(6)
+  cancelReason       String?   @map("cancel_reason")
+  clientId           Int?      @map("client_id")
+  employeeScheduleId Int?      @map("employee_schedule_id")
+  recipientType      String    @map("recipient_type")
+  recipientPhone     String?   @map("recipient_phone")
+  templateKey        String    @map("template_key")
+  dedupeKey          String    @unique @map("dedupe_key")
+  payload            Json      @default("{}")
+  createdAt          DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt          DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   @@index([organizationId], map: "idx_alimtalk_trigger_job_organization")
   @@index([ruleId], map: "idx_alimtalk_trigger_job_rule_id")

--- a/docs/plans/eformsign/ISSUE.md
+++ b/docs/plans/eformsign/ISSUE.md
@@ -1,0 +1,53 @@
+# [Feature] Two-phase contract support for 서비스제공기록지 (deferred submission)
+
+## Summary
+
+서비스제공기록지 (service provision records) are 10–30 day daily-record documents. Currently, when the customer signs them in eformsign the backend immediately completes the document (status `050`) and activates the client. This prevents the intended workflow: records must accumulate daily over the period and only then should the document be considered complete.
+
+This issue tracks adding **two-phase contract support** in the backend:
+
+- **Phase 1 — Customer signing (계약 체결)**: unchanged customer experience. The customer signs, the existing `LinkDocumentToClientUsecase` and `sendContractSignedAlimtalk` chain runs as today. The only difference is the backend writes `statusType = "070"` (NEW: 일일기록 수집 중) instead of `050`, keeping the document open for Phase 2.
+- **Phase 2 — Service provision records (서비스 제공 기록)**: employees submit daily entries via new backend endpoints. When all entries are filled (or force-finalized with missing dates in the response), the backend flips `statusType = "050"` and sets `finalizedAt`. No customer alimtalk at Phase 2.
+
+The employee frontend (mobile app) is a separate future project; endpoints will be ready when it arrives.
+
+## Architecture Decision: A2 (babyjamjam-staff handles deferral)
+
+eformsign signing is unchanged. Deferral is purely backend state-machine + new endpoints. No new eformsign API calls. No new env vars. No new alimtalk templates.
+
+## Acceptance Criteria
+
+- [ ] Signing a 서비스제공기록지 produces `eformsign_doc.statusType = "070"` with `collectionStartDate`, `collectionEndDate`, `collectionPeriodDays` populated
+- [ ] Phase 1 chain (link to client + contract-signed alimtalk) runs unchanged
+- [ ] Non-record documents continue to complete at `statusType = "050"` with no behavioral change
+- [ ] `POST /daily-records/:docId/entries` accepts daily entries; rejects out-of-range dates (`400`) and duplicates (`409`)
+- [ ] `GET /daily-records/:docId/entries` returns entries + computed `missingDates: string[]`
+- [ ] `POST /daily-records/:docId/finalize` with `{ force: false }` rejects with missing-dates payload if gaps exist
+- [ ] `POST /daily-records/:docId/finalize` with `{ force: true }` succeeds with missing-dates payload in response; sets `statusType = "050"`, `finalizedAt`
+- [ ] All endpoints scoped by `TenantGuard` (cross-tenant access blocked)
+- [ ] `pnpm --filter imirae-incheon-backend build` and `lint` pass
+
+## Implementation Plan
+
+Full plan at `docs/plans/eformsign/deferred-submission-service-record.md` in this branch.
+
+## Out of Scope
+
+- Employee mobile app frontend (future project)
+- Alimtalk changes (Phase 2 customer notification intentionally not sent; staff notifications will come from the future app)
+- Provider-role auth guard (use standard `JwtGuard + TenantGuard` for now)
+- Auto-finalization on cron (manual trigger only in v1)
+- Prisma migration rollback or data migration of existing in-flight docs (additive only)
+
+## Verification
+
+Manual smoke after deploy:
+1. Sign a 서비스제공기록지 in eformsign sandbox → check `statusType = "070"` and collection fields set
+2. Submit daily entry via `POST /daily-records/:docId/entries`
+3. Finalize with `force=false` (expect missing-dates 400 if gaps) or `force=true` (expect 200 with missing-dates in body)
+4. Verify regular contracts still complete at `statusType = "050"` unchanged
+
+## Related
+
+Branch: `feature/eformsign-deferred-submission`
+Worktree: `babyjamjam-staff/feat-eformsign-deferred-submission`

--- a/docs/plans/eformsign/deferred-submission-service-record.md
+++ b/docs/plans/eformsign/deferred-submission-service-record.md
@@ -1,0 +1,156 @@
+---
+plan_id: efsi-2026-001
+feature: deferred-submission-service-record
+status: approved
+swagger_base: https://api.eformsign.com/v2.0
+agent_version: v0.2.0
+created_at: 2026-04-15T00:00:00Z
+approved_at: 2026-04-17T00:00:00Z
+content_hash: null
+depends_on: []
+---
+
+# Summary
+
+Add **two-phase contract support** for 서비스제공기록지 in babyjamjam-staff. A single eformsign document has two completion phases tracked in the backend:
+
+- **Phase 1 — Customer signing (계약 체결)**: Customer signs in eformsign → webhook fires → document persisted → client service activated → customer receives existing `sendContractSignedAlimtalk`. This reuses the existing chain unchanged. The only difference from today is that `statusType` goes to `070` (collecting) instead of `050` (completed) so the document stays open for Phase 2.
+- **Phase 2 — Service provision records (서비스 제공 기록)**: Employees submit daily entries over a 10–30 day period via backend endpoints (consumer app comes later). When all entries are filled or force-finalized, `statusType` flips to `050`. No customer alimtalk at Phase 2.
+
+eformsign signing is unchanged — Phase 2 deferral is purely babyjamjam-staff side (Architecture A2). No new eformsign API calls, no new env vars, no alimtalk changes.
+
+# Requirements
+
+## Goals
+- On customer signing of a 서비스제공기록지 document: preserve the existing Phase 1 chain (`LinkDocumentToClientUsecase` + `sendContractSignedAlimtalk`), but write `statusType = "070"` instead of `050`
+- Initialize collection period fields (`collectionStartDate`, `collectionEndDate`, `collectionPeriodDays`) at Phase 1 completion
+- Provide backend endpoints for daily-record entry submission, listing (with computed missing dates), and finalization (with `force` flag)
+- Finalize path: flip `statusType = "050"`, set `finalizedAt`; do NOT re-run `LinkDocumentToClientUsecase` (already ran at Phase 1) or re-send the signed alimtalk
+- Support force-finalize with missing dates: return the missing dates in the response (no customer alimtalk)
+- Do not break non-record document flows (conditional branching on template type)
+
+## Non-goals
+- Modifying eformsign's signing flow
+- Building the employee frontend (app is a future project)
+- New alimtalk templates or AlimtalkService changes (Phase 2 customer notification is intentionally not sent)
+- Provider-specific auth guard (use standard JwtGuard + TenantGuard for now)
+- Migration of existing in-flight documents (additive only)
+- Auto-finalization on cron (manual trigger only for v1)
+
+# Technical Design
+
+## Existing Behavior (baseline)
+Webhook `doc_complete` for ANY document:
+1. `UpdateEformsignDocStatusUsecase` sets `statusType = "050"`, `statusDetail = "완료"`
+2. `LinkDocumentToClientUsecase` activates the client service
+3. `sendContractSignedAlimtalk` notifies the customer
+
+## Proposed Behavior
+Webhook `doc_complete` for 서비스제공기록지 (detected by template lookup):
+1. `UpdateEformsignDocStatusUsecase` sets `statusType = "070"`, `statusDetail = "일일기록 수집 중"` (NEW status code)
+2. `StartDailyRecordCollectionUsecase` sets `collectionStartDate = today`, `collectionEndDate = today + collectionPeriodDays`, `collectionPeriodDays` (from client record or default 30)
+3. `LinkDocumentToClientUsecase` runs as today (preserved)
+4. `sendContractSignedAlimtalk` runs as today (preserved)
+
+Webhook `doc_complete` for other templates: unchanged.
+
+`POST /daily-records/:docId/entries` (guarded by JwtGuard + TenantGuard):
+- Validates date within `[collectionStartDate, collectionEndDate]`
+- Dedupes via unique `(eformsignDocId, recordDate)` constraint
+- Persists the entry
+
+`GET /daily-records/:docId/entries`:
+- Returns entries + computed missing dates list
+
+`POST /daily-records/:docId/finalize` with body `{ force: boolean }`:
+- If `force === false` and gaps exist: returns 400 with `{ missingDates: [...] }`
+- If `force === true` or complete: sets `statusType = "050"`, `finalizedAt = now()`, `forceFinalize = force`
+- Does NOT re-run Phase 1 chain
+
+## eformsign Layer Touchpoints
+
+- **Affected usecases** (`application/usecases/eformsign-doc/`):
+  - MODIFY `update-eformsign-doc-status.usecase.ts` — no code change needed; already accepts any statusType/statusDetail as params
+  - NEW `start-daily-record-collection.usecase.ts`
+  - NEW `submit-daily-record-entry.usecase.ts`
+  - NEW `list-daily-record-entries.usecase.ts`
+  - NEW `finalize-service-record.usecase.ts`
+
+- **Services / controllers / modules**:
+  - MODIFY `application/services/eformsign-webhook.service.ts` — branch `handleDocumentEvent` and `handleReadyDocumentPdfEvent` on 서비스제공기록지 detection
+  - NEW `application/services/daily-record.service.ts` — orchestrates usecases
+  - NEW `interface/controllers/daily-record.controller.ts` — JwtGuard + TenantGuard
+  - NEW `module/daily-record.module.ts` — registers everything
+  - MODIFY `app.module.ts` — import DailyRecordModule
+  - MODIFY `module/eformsign-webhook.module.ts` — inject AreaTemplateService for template detection
+
+- **`EformsignApiClient`**: no changes
+
+- **DTOs/mappers** (`interface/dto/`, `infrastructure/database/mapper/`):
+  - NEW `interface/dto/daily-record.dto.ts`
+  - NEW `infrastructure/database/mapper/daily-record-entry.mapper.ts`
+
+- **Domain** (`domain/`):
+  - NEW `domain/entities/daily-record-entry.entity.ts`
+  - NEW `domain/repositories/daily-record-entry.repository.interface.ts`
+  - NEW `infrastructure/database/repositories/sb.daily-record-entry.repository.ts`
+
+- **Prisma schema deltas** (`backend/prisma/schema.prisma`):
+  - NEW model `daily_record_entry`
+  - MODIFY `eformsign_doc` — add `collectionStartDate`, `collectionEndDate`, `collectionPeriodDays`, `finalizedAt`, `forceFinalize`
+  - MODIFY `organization` — add reverse relation
+
+- **Env vars**: none
+
+- **Webhook event types affected**: `document` and `ready_document_pdf` handlers (only `doc_complete` status case adds branching)
+
+- **Template detection helper**: add method to `AreaTemplateService` (e.g., `isServiceProvisionRecordTemplate`) using `doc_template` table lookup by templateId or templateName
+
+## Status Vocabulary (post-change)
+Existing: `010` (created), `020` (in-progress), `050` (completed), `060` (pending), `080` (rejected), `090` (revoked), `099` (deleted)
+NEW: `070` (일일기록 수집 중 / COLLECTING_DAILY_RECORDS)
+
+# Task Breakdown
+
+Vertical slices, each ≤400 LOC:
+
+1. **Prisma schema + migration** (~60 LOC) — add model + fields, run `prisma migrate dev --name add_daily_record_entry` + `prisma generate`
+2. **Domain + repository** (~200 LOC) — entity, interface+token, mapper, Supabase impl
+3. **Usecases** (~300 LOC) — 4 new usecases under `application/usecases/eformsign-doc/`, export from `index.ts`
+4. **Webhook branching** (~120 LOC) — modify `eformsign-webhook.service.ts`, add template detection to `AreaTemplateService`, update `mapStatus` to accept new `070`
+5. **Controller + DTOs + service + module** (~350 LOC) — controller, DTOs, service, module, register in app.module
+6. **Build + lint verification** — run `pnpm build`, `pnpm lint` on backend filter
+
+# Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Webhook branching breaks existing non-record flows | Medium | High | Branch strictly on `isServiceProvisionRecordTemplate(templateId)`; fallback to existing path on any error; add smoke test |
+| Template detection returns false negative (record doc treated as normal) | Medium | Medium | Use `doc_template` table lookup with explicit `templateName` contains match (`서비스제공기록지`); log warning on ambiguous matches |
+| No consumer yet → endpoints have no real-world validation | High | Low | Acceptable; document that integration will happen with employee app project |
+| Timezone bug on `recordDate` submissions near midnight | Low | Medium | Use `@db.Date` (date-only) and reject invalid date ranges explicitly |
+| `collectionPeriodDays` defaulting wrong | Low | Low | Default 30 if unset; allow override via DTO or client record in future |
+
+# Testing Strategy
+
+- **Unit** (stubbed, no Jest run required for this PR per babyjamjam-staff convention):
+  - `submit-daily-record-entry.usecase` — valid date, out-of-range date, duplicate date
+  - `finalize-service-record.usecase` — complete path, force path with gaps, non-force with gaps
+  - Webhook branching — record template vs non-record template routes
+- **Manual smoke** (see Verification)
+
+# Verification
+
+1. `pnpm --filter imirae-incheon-backend build` — passes (type check)
+2. `pnpm --filter imirae-incheon-backend lint` — passes
+3. `pnpm --filter imirae-incheon-backend prisma migrate dev --name add_daily_record_entry` — migration applies
+4. `pnpm --filter imirae-incheon-backend prisma generate` — client regenerates
+5. Grep codebase for `statusType === "050"` or `statusType: "050"` to confirm no existing logic is broken by record-type docs entering `070` instead
+6. **Phase 1 smoke (manual)**: sign a 서비스제공기록지 in eformsign sandbox → verify `statusType = "070"`, collection fields set, client linked, contract-signed alimtalk sent
+7. **Phase 2 entry smoke**: `POST /daily-records/:docId/entries` → 201 Created; duplicate date → 409 Conflict
+8. **Phase 2 finalize complete**: all entries filled → `POST /daily-records/:docId/finalize` with `force=false` → 200 OK, `statusType = "050"`, no additional alimtalk
+9. **Phase 2 finalize force**: `POST /daily-records/:docId/finalize` with `force=true` and gaps → 200 OK with `missingDates: [...]` in response
+10. **Cross-tenant**: submit entry with a JWT from a different organization → 403 or empty (TenantGuard blocks)
+11. **Non-record doc regression**: sign a regular contract → existing flow unchanged (statusType = "050", client linked, alimtalk sent)
+
+Rollout: N/A — additive. Rollback: revert the branch; schema additions are nullable and safe to leave.


### PR DESCRIPTION
## Summary

- Adds deferred-submission support so multi-day 서비스제공기록지 documents don't auto-complete on customer signing. Phase 1 (customer signs) preserves the existing chain but writes `statusType = "070"` (COLLECTING_DAILY_RECORDS); Phase 2 (daily record collection) has new REST endpoints and a finalize flow that flips status to `"050"` with `finalizedAt` recorded.
- No alimtalk changes (existing Phase 1 `sendContractSignedAlimtalk` stays; Phase 2 has no customer notification by design — staff notifications deferred to the future employee app).
- No new eformsign API calls, no new env vars, no ProviderAppGuard (employee app deferred).

Closes #113

## Test plan

- [ ] Run `pnpm --filter babyjamjam-staff-backend exec prisma migrate dev --name add_daily_record_entry` in dev env (DB migration not run from the feature worktree)
- [ ] `pnpm --filter babyjamjam-staff-backend exec prisma generate` (already done locally)
- [ ] `pnpm --filter babyjamjam-staff-backend build` passes (verified locally)
- [ ] Phase 1 smoke: sign a 서비스제공기록지 in eformsign sandbox → verify `eformsign_doc.statusType = "070"`, `collectionStartDate/EndDate/PeriodDays` set, client linked (via existing `LinkDocumentToClientUsecase`), contract-signed alimtalk sent
- [ ] Non-record regression: sign a regular contract → existing flow unchanged (`statusType = "050"`, client linked, alimtalk sent)
- [ ] `POST /daily-records/:docId/entries` with JWT + tenant → 201 Created
- [ ] Duplicate date → 409 Conflict
- [ ] Date outside collection window → 400 Bad Request
- [ ] `GET /daily-records/:docId/entries` returns entries + computed `missingDates`
- [ ] `POST /daily-records/:docId/finalize` with `force=false` and gaps → 400 with `missingDates` payload
- [ ] `POST /daily-records/:docId/finalize` with `force=true` and gaps → 200, `statusType = "050"`, `missingDates` in response
- [ ] `POST /daily-records/:docId/finalize` when all entries filled → 200, `statusType = "050"`, no missing dates
- [ ] Cross-tenant: JWT from different org attempting access → blocked by TenantGuard
- [ ] Webhook ordering: `document` event then `ready_document_pdf` event → PDF event does NOT downgrade status from `070` back to `050`

## Out of scope

- Employee mobile app frontend (future project)
- Phase 2 customer notification (intentional — no alimtalk change)
- Auto-finalization on cron (manual trigger only in v1)
- Prisma migration rollback or data migration of existing in-flight docs (additive only)

## Related

- Spec: \`docs/plans/eformsign/deferred-submission-service-record.md\`
- Issue body: \`docs/plans/eformsign/ISSUE.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)