### PR TITLE
[codex] fix contract stats cache on empty list

### DIFF
--- a/frontend/src/app/(protected)/contracts/page.tsx
+++ b/frontend/src/app/(protected)/contracts/page.tsx
@@ -380,7 +380,7 @@ export default function ContractsPage() {
   const [statsDocuments, setStatsDocuments] = useState<EformsignDocument[]>([]);
 
   useEffect(() => {
-    if (filterType === null && allDocuments.length > 0) {
+    if (filterType === null) {
       setStatsDocuments(allDocuments);
     }
   }, [allDocuments, filterType]);


### PR DESCRIPTION
## Summary
- Update contract stats cache even when the all-documents result becomes empty.
- Addresses the Codex review feedback from PR #119 about stale non-zero stats after deleting or refreshing down to zero documents.

## Validation
- `pnpm --filter babyjamjam-staff exec eslint 'src/app/(protected)/contracts/page.tsx'` passed.

## Notes
- This is intentionally a one-line follow-up to merged PR #119.
