### PR TITLE
Add consultation read state and notifications

### DIFF
--- a/backend/application/services/consultation-inquiry.service.ts
+++ b/backend/application/services/consultation-inquiry.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
 
 import {
     ConsultationInquiryEntity,
@@ -12,6 +12,7 @@ import {
     ConsultationInquiryListQueryDto,
     CreatePublicConsultationInquiryDto,
 } from "interface/dto/consultation-inquiry.dto";
+import { NotificationService } from "application/services/notification.service";
 
 export interface PaginatedConsultationInquiries {
     data: ConsultationInquiryEntity[];
@@ -23,9 +24,12 @@ export interface PaginatedConsultationInquiries {
 
 @Injectable()
 export class ConsultationInquiryService {
+    private readonly logger = new Logger(ConsultationInquiryService.name);
+
     constructor(
         @Inject(CONSULTATION_INQUIRY_REPOSITORY)
         private readonly repository: IConsultationInquiryRepository,
+        private readonly notificationService: NotificationService,
     ) {}
 
     async createPublicInquiry(dto: CreatePublicConsultationInquiryDto): Promise<ConsultationInquiryEntity> {
@@ -54,7 +58,15 @@ export class ConsultationInquiryService {
             status: "new",
         };
 
-        return this.repository.create(params);
+        const inquiry = await this.repository.create(params);
+        this.notifyBranchUsers(inquiry).catch((error) => {
+            this.logger.error(
+                `Failed to create consultation notification for inquiry ${inquiry.id}`,
+                error instanceof Error ? error.stack : String(error),
+            );
+        });
+
+        return inquiry;
     }
 
     async listForBranch(
@@ -81,5 +93,31 @@ export class ConsultationInquiryService {
             limit,
             totalPages: Math.max(1, Math.ceil(result.total / limit)),
         };
+    }
+
+    async markRead(branchId: string, id: string): Promise<ConsultationInquiryEntity> {
+        return this.repository.markRead(branchId, id);
+    }
+
+    private async notifyBranchUsers(inquiry: ConsultationInquiryEntity): Promise<void> {
+        const userIds = await this.repository.findNotificationRecipientUserIds(inquiry.branchId);
+        if (userIds.length === 0) {
+            return;
+        }
+
+        await Promise.all(userIds.map((userId) =>
+            this.notificationService.sendNotification(
+                inquiry.branchId,
+                userId,
+                "새 상담 문의",
+                `${inquiry.motherName}님 상담 문의가 접수되었습니다.`,
+                {
+                    url: "/consultations",
+                    type: "consultation-inquiry",
+                    inquiryId: inquiry.id,
+                    branchSlug: inquiry.publicBranchSlug,
+                },
+            )
+        ));
     }
 }

--- a/backend/domain/entities/consultation-inquiry.entity.ts
+++ b/backend/domain/entities/consultation-inquiry.entity.ts
@@ -16,6 +16,7 @@ export interface CreateConsultationInquiryParams {
     privacyAcceptedAt: Date;
     source: string;
     status: ConsultationInquiryStatus;
+    readAt?: Date | null;
 }
 
 export interface ConsultationInquiryEntity {
@@ -33,6 +34,7 @@ export interface ConsultationInquiryEntity {
     privacyAcceptedAt: Date;
     source: string;
     status: string;
+    readAt: Date | null;
     createdAt: Date;
     updatedAt: Date;
     branchName?: string;

--- a/backend/domain/repositories/consultation-inquiry.repository.interface.ts
+++ b/backend/domain/repositories/consultation-inquiry.repository.interface.ts
@@ -24,8 +24,10 @@ export interface ConsultationInquiryBranchLookup {
 
 export interface IConsultationInquiryRepository {
     findActiveBranchBySlug(slug: string): Promise<ConsultationInquiryBranchLookup | null>;
+    findNotificationRecipientUserIds(branchId: string): Promise<string[]>;
     create(params: CreateConsultationInquiryParams): Promise<ConsultationInquiryEntity>;
     findManyByBranch(params: ConsultationInquiryListParams): Promise<ConsultationInquiryListResult>;
+    markRead(branchId: string, id: string): Promise<ConsultationInquiryEntity>;
 }
 
 export const CONSULTATION_INQUIRY_REPOSITORY = "CONSULTATION_INQUIRY_REPOSITORY";

--- a/backend/infrastructure/database/repositories/sb.consultation-inquiry.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.consultation-inquiry.repository.ts
@@ -33,6 +33,7 @@ function toEntity(row: InquiryWithBranch): ConsultationInquiryEntity {
         privacyAcceptedAt: row.privacyAcceptedAt,
         source: row.source,
         status: row.status,
+        readAt: row.readAt,
         createdAt: row.createdAt,
         updatedAt: row.updatedAt,
         branchName: row.branch.name,
@@ -57,6 +58,27 @@ export class SbConsultationInquiryRepository implements IConsultationInquiryRepo
         });
     }
 
+    async findNotificationRecipientUserIds(branchId: string): Promise<string[]> {
+        const branch = await this.prisma.branch.findUnique({
+            where: { id: branchId },
+            select: {
+                ownerId: true,
+                userBranches: {
+                    select: { userId: true },
+                },
+            },
+        });
+
+        if (!branch) {
+            return [];
+        }
+
+        return Array.from(new Set([
+            branch.ownerId,
+            ...branch.userBranches.map((membership) => membership.userId),
+        ]));
+    }
+
     async create(params: CreateConsultationInquiryParams): Promise<ConsultationInquiryEntity> {
         const row = await this.prisma.consultation_inquiry.create({
             data: {
@@ -73,6 +95,7 @@ export class SbConsultationInquiryRepository implements IConsultationInquiryRepo
                 privacyAcceptedAt: params.privacyAcceptedAt,
                 source: params.source,
                 status: params.status,
+                readAt: params.readAt ?? null,
             },
             include: {
                 branch: { select: { name: true } },
@@ -116,5 +139,31 @@ export class SbConsultationInquiryRepository implements IConsultationInquiryRepo
             data: data.map(toEntity),
             total,
         };
+    }
+
+    async markRead(branchId: string, id: string): Promise<ConsultationInquiryEntity> {
+        await this.prisma.consultation_inquiry.updateMany({
+            where: {
+                id,
+                branchId,
+                readAt: null,
+            },
+            data: {
+                readAt: new Date(),
+            },
+        });
+
+        const row = await this.prisma.consultation_inquiry.findFirst({
+            where: { id, branchId },
+            include: {
+                branch: { select: { name: true } },
+            },
+        });
+
+        if (!row) {
+            throw new Error("Consultation inquiry not found for branch");
+        }
+
+        return toEntity(row);
     }
 }

--- a/backend/interface/controllers/consultation-inquiry.controller.ts
+++ b/backend/interface/controllers/consultation-inquiry.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Query, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, Param, Patch, Post, Query, UseGuards } from "@nestjs/common";
 
 import { ConsultationInquiryService } from "application/services/consultation-inquiry.service";
 import { JwtGuard } from "infrastructure/auth/jwt.guard";
@@ -31,5 +31,13 @@ export class ConsultationInquiryController {
         @Query() query: ConsultationInquiryListQueryDto,
     ) {
         return this.service.listForBranch(tenant.branchId ?? "", query);
+    }
+
+    @Patch(":id/read")
+    markRead(
+        @CurrentTenant() tenant: { branchId?: string },
+        @Param("id") id: string,
+    ) {
+        return this.service.markRead(tenant.branchId ?? "", id);
     }
 }

--- a/backend/module/consultation-inquiry.module.ts
+++ b/backend/module/consultation-inquiry.module.ts
@@ -9,9 +9,10 @@ import {
     ConsultationInquiryController,
     PublicConsultationInquiryController,
 } from "interface/controllers/consultation-inquiry.controller";
+import { NotificationModule } from "module/notification.module";
 
 @Module({
-    imports: [DatabaseModule],
+    imports: [DatabaseModule, NotificationModule],
     controllers: [PublicConsultationInquiryController, ConsultationInquiryController],
     providers: [
         { provide: CONSULTATION_INQUIRY_REPOSITORY, useClass: SbConsultationInquiryRepository },

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -373,26 +373,28 @@ model user_branch {
 }
 
 model consultation_inquiry {
-  id                     String   @id @default(dbgenerated("gen_random_uuid()::text"))
-  branchId               String   @map("branch_id") @db.Uuid
-  publicBranchSlug       String   @map("public_branch_slug")
-  motherName             String   @map("mother_name")
+  id                     String    @id @default(dbgenerated("gen_random_uuid()::text"))
+  branchId               String    @map("branch_id") @db.Uuid
+  publicBranchSlug       String    @map("public_branch_slug")
+  motherName             String    @map("mother_name")
   phone                  String
   address                String
-  dueDate                DateTime @map("due_date") @db.Date
-  birthExperience        String   @map("birth_experience")
-  voucherType            String?  @map("voucher_type")
-  preferredCaregiverName String?  @map("preferred_caregiver_name")
-  referralSource         String   @map("referral_source")
-  privacyAcceptedAt      DateTime @map("privacy_accepted_at") @db.Timestamptz(6)
-  source                 String   @default("website")
-  status                 String   @default("new")
-  createdAt              DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt              DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
-  branch                 branch   @relation(fields: [branchId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  dueDate                DateTime  @map("due_date") @db.Date
+  birthExperience        String    @map("birth_experience")
+  voucherType            String?   @map("voucher_type")
+  preferredCaregiverName String?   @map("preferred_caregiver_name")
+  referralSource         String    @map("referral_source")
+  privacyAcceptedAt      DateTime  @map("privacy_accepted_at") @db.Timestamptz(6)
+  source                 String    @default("website")
+  status                 String    @default("new")
+  readAt                 DateTime? @map("read_at") @db.Timestamptz(6)
+  createdAt              DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt              DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
+  branch                 branch    @relation(fields: [branchId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
   @@index([branchId, createdAt], map: "idx_consultation_inquiry_branch_created")
   @@index([branchId, status], map: "idx_consultation_inquiry_branch_status")
+  @@index([branchId, readAt], map: "idx_consultation_inquiry_branch_read_at")
   @@index([phone], map: "idx_consultation_inquiry_phone")
   @@index([publicBranchSlug], map: "idx_consultation_inquiry_public_branch_slug")
 }

--- a/backend/prisma/scripts/branch-rename-and-consultation-schema.sql
+++ b/backend/prisma/scripts/branch-rename-and-consultation-schema.sql
@@ -93,6 +93,7 @@ CREATE TABLE IF NOT EXISTS "consultation_inquiry" (
   "privacy_accepted_at" TIMESTAMPTZ(6) NOT NULL,
   "source" TEXT NOT NULL DEFAULT 'website',
   "status" TEXT NOT NULL DEFAULT 'new',
+  "read_at" TIMESTAMPTZ(6),
   "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT NOW(),
   "updated_at" TIMESTAMPTZ(6) NOT NULL DEFAULT NOW(),
   CONSTRAINT "consultation_inquiry_branch_id_fkey"
@@ -100,12 +101,17 @@ CREATE TABLE IF NOT EXISTS "consultation_inquiry" (
     ON DELETE NO ACTION ON UPDATE NO ACTION
 );
 
+ALTER TABLE "consultation_inquiry"
+  ADD COLUMN IF NOT EXISTS "read_at" TIMESTAMPTZ(6);
+
 CREATE INDEX IF NOT EXISTS "idx_branch_region"
   ON "branch" ("region");
 CREATE INDEX IF NOT EXISTS "idx_consultation_inquiry_branch_created"
   ON "consultation_inquiry" ("branch_id", "created_at");
 CREATE INDEX IF NOT EXISTS "idx_consultation_inquiry_branch_status"
   ON "consultation_inquiry" ("branch_id", "status");
+CREATE INDEX IF NOT EXISTS "idx_consultation_inquiry_branch_read_at"
+  ON "consultation_inquiry" ("branch_id", "read_at");
 CREATE INDEX IF NOT EXISTS "idx_consultation_inquiry_phone"
   ON "consultation_inquiry" ("phone");
 CREATE INDEX IF NOT EXISTS "idx_consultation_inquiry_public_branch_slug"

--- a/backend/test/services/consultation-inquiry.service.spec.ts
+++ b/backend/test/services/consultation-inquiry.service.spec.ts
@@ -3,12 +3,19 @@ import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { ConsultationInquiryService } from "application/services/consultation-inquiry.service";
 import { ConsultationInquiryEntity } from "domain/entities/consultation-inquiry.entity";
 import { IConsultationInquiryRepository } from "domain/repositories/consultation-inquiry.repository.interface";
+import { NotificationService } from "application/services/notification.service";
 
 describe("ConsultationInquiryService", () => {
     const createRepository = (): jest.Mocked<IConsultationInquiryRepository> => ({
         findActiveBranchBySlug: jest.fn(),
+        findNotificationRecipientUserIds: jest.fn(),
         create: jest.fn(),
         findManyByBranch: jest.fn(),
+        markRead: jest.fn(),
+    });
+
+    const createNotificationService = (): jest.Mocked<Pick<NotificationService, "sendNotification">> => ({
+        sendNotification: jest.fn().mockResolvedValue({}),
     });
 
     const createInquiry = (): ConsultationInquiryEntity => ({
@@ -26,17 +33,23 @@ describe("ConsultationInquiryService", () => {
         privacyAcceptedAt: new Date("2026-04-21T00:00:00.000Z"),
         source: "website",
         status: "new",
+        readAt: null,
         createdAt: new Date("2026-04-21T00:00:00.000Z"),
         updatedAt: new Date("2026-04-21T00:00:00.000Z"),
         branchName: "인천 연수구점",
     });
 
     let repository: jest.Mocked<IConsultationInquiryRepository>;
+    let notificationService: jest.Mocked<Pick<NotificationService, "sendNotification">>;
     let service: ConsultationInquiryService;
 
     beforeEach(() => {
         repository = createRepository();
-        service = new ConsultationInquiryService(repository);
+        notificationService = createNotificationService();
+        service = new ConsultationInquiryService(
+            repository,
+            notificationService as unknown as NotificationService,
+        );
     });
 
     it("should create public inquiry when branch exists and privacy is accepted", async () => {
@@ -47,6 +60,7 @@ describe("ConsultationInquiryService", () => {
             slug: "incheon-yeonsu",
         });
         repository.create.mockResolvedValue(inquiry);
+        repository.findNotificationRecipientUserIds.mockResolvedValue(["user-1", "user-2"]);
 
         const result = await service.createPublicInquiry({
             branchSlug: "incheon-yeonsu",
@@ -67,6 +81,19 @@ describe("ConsultationInquiryService", () => {
             status: "new",
             source: "website",
         }));
+        await new Promise(process.nextTick);
+        expect(notificationService.sendNotification).toHaveBeenCalledTimes(2);
+        expect(notificationService.sendNotification).toHaveBeenCalledWith(
+            "branch-1",
+            "user-1",
+            "새 상담 문의",
+            "김지은님 상담 문의가 접수되었습니다.",
+            expect.objectContaining({
+                url: "/consultations",
+                type: "consultation-inquiry",
+                inquiryId: "inq-1",
+            }),
+        );
     });
 
     it("should reject public inquiry when privacy is not accepted", async () => {
@@ -117,5 +144,15 @@ describe("ConsultationInquiryService", () => {
             limit: 20,
             totalPages: 1,
         });
+    });
+
+    it("should mark inquiry as read", async () => {
+        const inquiry = { ...createInquiry(), readAt: new Date("2026-04-22T00:00:00.000Z") };
+        repository.markRead.mockResolvedValue(inquiry);
+
+        const result = await service.markRead("branch-1", "inq-1");
+
+        expect(repository.markRead).toHaveBeenCalledWith("branch-1", "inq-1");
+        expect(result.readAt).toEqual(inquiry.readAt);
     });
 });

--- a/frontend/src/app/(protected)/consultations/page.tsx
+++ b/frontend/src/app/(protected)/consultations/page.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/app/v3";
 import { StatusPill } from "@/components/app/ui/status-badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useConsultationInquiries } from "@/hooks/useConsultationInquiries";
+import { useConsultationInquiries, useMarkConsultationInquiryRead } from "@/hooks/useConsultationInquiries";
 import { cn } from "@/lib/utils";
 import type { ConsultationInquiry } from "@/services/api";
 
@@ -72,6 +72,14 @@ function getStatusVariant(status: string): "warning" | "success" | "neutral" {
     return STATUS_VARIANT[status] ?? "neutral";
 }
 
+function getReadLabel(readAt: string | null): string {
+    return readAt ? "읽음" : "읽지 않음";
+}
+
+function getReadVariant(readAt: string | null): "neutral" | "warning" {
+    return readAt ? "neutral" : "warning";
+}
+
 export default function ConsultationsPage() {
     const [activeStatus, setActiveStatus] = useState("all");
     const [search, setSearch] = useState("");
@@ -88,14 +96,16 @@ export default function ConsultationsPage() {
     );
 
     const { data, isLoading } = useConsultationInquiries(queryParams);
+    const markRead = useMarkConsultationInquiryRead();
     const inquiries = useMemo(() => data?.data ?? [], [data?.data]);
-    const activeInquiry = selectedInquiry && inquiries.some((item) => item.id === selectedInquiry.id)
-        ? selectedInquiry
+    const activeInquiry = selectedInquiry
+        ? inquiries.find((item) => item.id === selectedInquiry.id) ?? selectedInquiry
         : null;
 
     const stats = useMemo(() => {
         return {
             total: data?.total ?? 0,
+            unreadCount: inquiries.filter((item) => !item.readAt).length,
             newCount: inquiries.filter((item) => item.status === "new").length,
             contactedCount: inquiries.filter((item) => item.status === "contacted").length,
             closedCount: inquiries.filter((item) => item.status === "closed").length,
@@ -109,7 +119,7 @@ export default function ConsultationsPage() {
                 isLoading={isLoading}
                 items={[
                     { icon: Headset, value: stats.total, label: "전체 상담", counter: "건" },
-                    { icon: CalendarClock, value: stats.newCount, label: "신규", counter: "건", colorIndex: 1 },
+                    { icon: CalendarClock, value: stats.unreadCount, label: "읽지 않음", counter: "건", colorIndex: 1 },
                     { icon: Phone, value: stats.contactedCount, label: "연락 완료", counter: "건", colorIndex: 2 },
                     { icon: Search, value: stats.closedCount, label: "종료", counter: "건", colorIndex: 3 },
                 ]}
@@ -153,7 +163,12 @@ export default function ConsultationsPage() {
                                         : !slotLoading && "hover:bg-v3-primary-light/50 hover:border-v3-primary/30",
                                 );
                             }}
-                            onSlotClick={(inquiry) => setSelectedInquiry(inquiry)}
+                            onSlotClick={(inquiry) => {
+                                setSelectedInquiry(inquiry);
+                                if (!inquiry.readAt) {
+                                    markRead.mutate(inquiry.id);
+                                }
+                            }}
                             render={({ item, isLoading: slotLoading }) => {
                                 if (slotLoading) {
                                     return (
@@ -183,6 +198,9 @@ export default function ConsultationsPage() {
                                                 <StatusPill variant={getStatusVariant(item.status)} size="sm">
                                                     {getStatusLabel(item.status)}
                                                 </StatusPill>
+                                                <StatusPill variant={getReadVariant(item.readAt)} size="sm">
+                                                    {getReadLabel(item.readAt)}
+                                                </StatusPill>
                                             </div>
                                             <div className="flex min-w-0 items-center gap-2 text-[0.72rem] text-v3-text-muted">
                                                 <Phone className="h-3.5 w-3.5 shrink-0" />
@@ -207,9 +225,14 @@ export default function ConsultationsPage() {
                         title={activeInquiry.motherName}
                         subtitle={`${activeInquiry.branchName ?? "현재 지점"} · ${formatDateTime(activeInquiry.createdAt)}`}
                         badges={
-                            <StatusPill variant={getStatusVariant(activeInquiry.status)} size="sm">
-                                {getStatusLabel(activeInquiry.status)}
-                            </StatusPill>
+                            <>
+                                <StatusPill variant={getStatusVariant(activeInquiry.status)} size="sm">
+                                    {getStatusLabel(activeInquiry.status)}
+                                </StatusPill>
+                                <StatusPill variant={getReadVariant(activeInquiry.readAt)} size="sm">
+                                    {getReadLabel(activeInquiry.readAt)}
+                                </StatusPill>
+                            </>
                         }
                     >
                         <div data-component="consultations-detail" className="space-y-4">
@@ -226,6 +249,7 @@ export default function ConsultationsPage() {
                                 <InfoRow label="희망 관리사" value={activeInquiry.preferredCaregiverName || "-"} />
                                 <InfoRow label="신청 경로" value={activeInquiry.source} />
                                 <InfoRow label="개인정보 동의" value={formatDateTime(activeInquiry.privacyAcceptedAt)} />
+                                <InfoRow label="읽음 상태" value={getReadLabel(activeInquiry.readAt)} />
                             </InfoCard>
 
                             <InfoCard title="지점">

--- a/frontend/src/app/api/consultation-inquiries/[id]/read/route.ts
+++ b/frontend/src/app/api/consultation-inquiries/[id]/read/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { errorResponse, getAuthHeaders, getAuthToken } from "@/lib/api/route-utils";
+import { serverAPIClient } from "@/lib/api/server";
+
+export async function PATCH(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    try {
+        const token = getAuthToken(request);
+        if (!token) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const { id } = await params;
+        const response = await serverAPIClient.patch(`/consultation-inquiries/${id}/read`, {}, {
+            headers: getAuthHeaders(token),
+        });
+
+        return NextResponse.json(response.data, { status: response.status });
+    } catch (error) {
+        return errorResponse(error, "mark consultation inquiry read");
+    }
+}

--- a/frontend/src/app/api/notifications/[id]/read/route.ts
+++ b/frontend/src/app/api/notifications/[id]/read/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { errorResponse, getAuthHeaders, getAuthToken } from "@/lib/api/route-utils";
+import { serverAPIClient } from "@/lib/api/server";
+
+export async function PATCH(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    try {
+        const token = getAuthToken(request);
+        if (!token) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const { id } = await params;
+        const response = await serverAPIClient.patch(`/notifications/${id}/read`, {}, {
+            headers: getAuthHeaders(token),
+        });
+
+        return NextResponse.json(response.data, { status: response.status });
+    } catch (error) {
+        return errorResponse(error, "mark notification as read");
+    }
+}

--- a/frontend/src/components/app/v3/SidebarNotifications.tsx
+++ b/frontend/src/components/app/v3/SidebarNotifications.tsx
@@ -2,9 +2,11 @@
 
 import * as React from "react";
 import { createPortal } from "react-dom";
-import { Bell, Clock3, X } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Bell, Clock3, Headset, X } from "lucide-react";
 
 import { useClientAlerts } from "@/hooks/useClientAlerts";
+import { useMarkAsRead, useNotifications, type Notification } from "@/hooks/usePushNotification";
 import { PanelTitleGroup } from "@/components/app/v3/PanelTitleGroup";
 import { useScrollActivity } from "@/components/app/v3/useScrollActivity";
 import { Button } from "@/components/ui/button";
@@ -12,16 +14,16 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";
 
 interface SidebarNotificationItem {
-  id: string;
-  client: {
-    id: number;
+    id: string;
     name: string;
     createdAt: string | null;
-  };
-  message: string;
-  timeLabel: string;
-  unread: boolean;
-  tone: "default" | "warning";
+    notificationId?: number;
+    message: string;
+    url?: string;
+    timeLabel: string;
+    unread: boolean;
+    tone: "default" | "warning";
+    icon: "client" | "consultation";
 }
 
 const SIDEBAR_NOTIFICATIONS_MODAL_WIDTH = 352;
@@ -52,6 +54,11 @@ const getClientInitials = (name: string) => {
   }
 
   return normalized.slice(0, 2).toUpperCase();
+};
+
+const getNotificationUrl = (notification: Notification): string | undefined => {
+  const url = notification.data?.url;
+  return typeof url === "string" ? url : undefined;
 };
 
 const formatNotificationTime = (value: string | Date | null | undefined) => {
@@ -95,14 +102,17 @@ const formatNotificationTime = (value: string | Date | null | undefined) => {
 };
 
 export function SidebarNotifications() {
+  const router = useRouter();
   const [open, setOpen] = React.useState(false);
   const [modalPosition, setModalPosition] = React.useState<{ top: number; left: number } | null>(null);
   const triggerRef = React.useRef<HTMLButtonElement | null>(null);
   const { isScrollActive, handleScroll } = useScrollActivity();
   const { data: alerts = [] } = useClientAlerts(3);
+  const { data: savedNotifications = [] } = useNotifications(5, 0, true);
+  const markAsRead = useMarkAsRead();
 
   const notifications = React.useMemo<SidebarNotificationItem[]>(() => {
-    return alerts.map((alert) => {
+    const actionItems: SidebarNotificationItem[] = alerts.map((alert) => {
       const message = alert.reason === "교체 요청"
         ? "교체 요청이 접수되었습니다."
         : alert.reason === "서명 필요"
@@ -111,20 +121,51 @@ export function SidebarNotifications() {
 
       return {
         id: `action-${alert.id}`,
-        client: {
-          id: alert.id,
-          name: alert.name,
-          createdAt: alert.createdAt,
-        },
+        name: alert.name,
+        createdAt: alert.createdAt,
         message,
         timeLabel: formatNotificationTime(alert.createdAt),
         unread: true,
         tone: alert.priority === 1 ? "warning" : "default",
+        icon: "client" as const,
       };
     });
-  }, [alerts]);
+
+    const notificationItems: SidebarNotificationItem[] = savedNotifications.map((notification) => {
+      const url = getNotificationUrl(notification);
+      const isConsultation = notification.data?.type === "consultation-inquiry";
+
+      return {
+        id: `notification-${notification.id}`,
+        notificationId: notification.id,
+        name: notification.title,
+        createdAt: notification.sentAt,
+        message: notification.body,
+        url,
+        timeLabel: formatNotificationTime(notification.sentAt),
+        unread: !notification.isRead,
+        tone: isConsultation ? "warning" : "default",
+        icon: isConsultation ? "consultation" as const : "client" as const,
+      };
+    });
+
+    return [...notificationItems, ...actionItems]
+      .sort((a, b) => new Date(b.createdAt ?? 0).getTime() - new Date(a.createdAt ?? 0).getTime())
+      .slice(0, 6);
+  }, [alerts, savedNotifications]);
 
   const unreadCount = notifications.filter((item) => item.unread).length;
+
+  const handleNotificationClick = (notification: SidebarNotificationItem) => {
+    if (notification.notificationId && notification.unread) {
+      markAsRead.mutate(notification.notificationId);
+    }
+
+    if (notification.url) {
+      setOpen(false);
+      router.push(notification.url);
+    }
+  };
 
   React.useEffect(() => {
     if (!open) {
@@ -216,23 +257,43 @@ export function SidebarNotifications() {
                       <div
                         key={notification.id}
                         data-component="sidebar-notifications-item"
-                        className="rounded-[18px] border border-v3-border/70 bg-white px-3 py-3"
+                        role={notification.url ? "button" : undefined}
+                        tabIndex={notification.url ? 0 : undefined}
+                        onClick={() => handleNotificationClick(notification)}
+                        onKeyDown={(event) => {
+                          if (!notification.url) return;
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            handleNotificationClick(notification);
+                          }
+                        }}
+                        className={cn(
+                          "rounded-[18px] border border-v3-border/70 bg-white px-3 py-3",
+                          notification.url && "cursor-pointer transition-colors hover:bg-v3-primary-light/45",
+                          notification.unread && "border-v3-primary/20 bg-v3-primary-light/20",
+                        )}
                       >
                         <div className="flex items-start gap-3">
                           <Avatar className="mt-0.5 h-8 w-8 shrink-0 shadow-sm">
                             <AvatarFallback
                               className={cn(
                                 "text-[0.65rem] font-bold text-white",
-                                getClientAvatarGradient(notification.client.name)
+                                notification.icon === "consultation"
+                                  ? "bg-v3-primary"
+                                  : getClientAvatarGradient(notification.name)
                               )}
                             >
-                              {getClientInitials(notification.client.name)}
+                              {notification.icon === "consultation" ? (
+                                <Headset className="h-4 w-4" />
+                              ) : (
+                                getClientInitials(notification.name)
+                              )}
                             </AvatarFallback>
                           </Avatar>
 
                           <div className="min-w-0 flex-1">
                             <div className="flex items-start justify-between gap-2">
-                              <p className="text-[0.8rem] font-semibold text-v3-dark">{notification.client.name}</p>
+                              <p className="text-[0.8rem] font-semibold text-v3-dark">{notification.name}</p>
                               <span className="inline-flex items-center gap-1 whitespace-nowrap text-[0.68rem] font-medium text-v3-text-muted">
                                 <Clock3 className="h-3.5 w-3.5" />
                                 {notification.timeLabel}

--- a/frontend/src/components/app/v3/V3Sidebar.tsx
+++ b/frontend/src/components/app/v3/V3Sidebar.tsx
@@ -50,8 +50,8 @@ const BASE_NAV_SECTIONS: NavSection[] = [
   {
     title: "지점 관리",
     items: [
-      { label: "고객", href: "/clients", icon: Users },
       { label: "상담", href: "/consultations", icon: Headset },
+      { label: "고객", href: "/clients", icon: Users },
       { label: "직원", href: "/employees", icon: UserCheck },
       // { label: "통계", href: "/analytics", icon: BarChart3 },
     ],

--- a/frontend/src/hooks/useConsultationInquiries.ts
+++ b/frontend/src/hooks/useConsultationInquiries.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
     consultationInquiriesApi,
@@ -19,5 +19,16 @@ export function useConsultationInquiries(params: ConsultationInquiryListParams) 
         queryKey: consultationInquiryQueryKeys.list(params),
         queryFn: () => consultationInquiriesApi.list(params),
         staleTime: 1000 * 60,
+    });
+}
+
+export function useMarkConsultationInquiryRead() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (id: string) => consultationInquiriesApi.markRead(id),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: consultationInquiryQueryKeys.all });
+        },
     });
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -276,6 +276,7 @@ export interface ConsultationInquiry {
     privacyAcceptedAt: string;
     source: string;
     status: string;
+    readAt: string | null;
     createdAt: string;
     updatedAt: string;
     branchName?: string;
@@ -326,6 +327,10 @@ export const settingsApi = {
 export const consultationInquiriesApi = {
     list: async (params: ConsultationInquiryListParams = {}): Promise<ConsultationInquiryListResponse> => {
         const { data } = await api.get("/consultation-inquiries", { params });
+        return data;
+    },
+    markRead: async (id: string): Promise<ConsultationInquiry> => {
+        const { data } = await api.patch(`/consultation-inquiries/${id}/read`);
         return data;
     },
 };


### PR DESCRIPTION
## Summary
- Add read/unread state for consultation inquiries and mark-read support
- Create branch-user notifications when a public consultation arrives
- Include saved notifications in the sidebar notification list
- Move 상담 above 고객 in the branch management sidebar section

## Test Plan
- pnpm --dir backend exec prisma validate
- pnpm --dir backend build
- pnpm --dir backend test -- consultation-inquiry.service.spec.ts auth.service.branch.spec.ts tenant.guard.spec.ts
- pnpm --dir frontend build

## Notes
- Applied `consultation_inquiry.read_at` to the connected dev DB for local testing.