### PR TITLE
Filter consultations by read state

### DIFF
--- a/backend/application/services/consultation-inquiry.service.ts
+++ b/backend/application/services/consultation-inquiry.service.ts
@@ -77,6 +77,7 @@ export class ConsultationInquiryService {
         const limit = query.limit ?? 20;
         const search = query.search?.trim() || undefined;
         const status = query.status || "all";
+        const readState = query.readState || "all";
 
         const result = await this.repository.findManyByBranch({
             branchId,
@@ -84,6 +85,7 @@ export class ConsultationInquiryService {
             limit,
             search,
             status,
+            readState,
         });
 
         return {

--- a/backend/domain/repositories/consultation-inquiry.repository.interface.ts
+++ b/backend/domain/repositories/consultation-inquiry.repository.interface.ts
@@ -9,6 +9,7 @@ export interface ConsultationInquiryListParams {
     limit: number;
     search?: string;
     status?: string;
+    readState?: string;
 }
 
 export interface ConsultationInquiryListResult {

--- a/backend/infrastructure/database/repositories/sb.consultation-inquiry.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.consultation-inquiry.repository.ts
@@ -114,6 +114,12 @@ export class SbConsultationInquiryRepository implements IConsultationInquiryRepo
             where.status = params.status;
         }
 
+        if (params.readState === "read") {
+            where.readAt = { not: null };
+        } else if (params.readState === "unread") {
+            where.readAt = null;
+        }
+
         if (params.search) {
             where.OR = [
                 { motherName: { contains: params.search } },

--- a/backend/interface/dto/consultation-inquiry.dto.ts
+++ b/backend/interface/dto/consultation-inquiry.dto.ts
@@ -89,4 +89,9 @@ export class ConsultationInquiryListQueryDto {
     @IsOptional()
     @IsIn(["all", ...CONSULTATION_INQUIRY_STATUSES])
     status?: string;
+
+    @IsString()
+    @IsOptional()
+    @IsIn(["all", "read", "unread"])
+    readState?: string;
 }

--- a/backend/test/services/consultation-inquiry.service.spec.ts
+++ b/backend/test/services/consultation-inquiry.service.spec.ts
@@ -136,6 +136,7 @@ describe("ConsultationInquiryService", () => {
             limit: 20,
             search: undefined,
             status: "all",
+            readState: "all",
         });
         expect(result).toEqual({
             data: [inquiry],

--- a/frontend/src/app/(protected)/consultations/page.tsx
+++ b/frontend/src/app/(protected)/consultations/page.tsx
@@ -21,11 +21,10 @@ import { useConsultationInquiries, useMarkConsultationInquiryRead } from "@/hook
 import { cn } from "@/lib/utils";
 import type { ConsultationInquiry } from "@/services/api";
 
-const STATUS_TABS = [
+const READ_TABS = [
     { label: "전체", value: "all" },
-    { label: "신규", value: "new" },
-    { label: "연락 완료", value: "contacted" },
-    { label: "종료", value: "closed" },
+    { label: "읽음", value: "read" },
+    { label: "읽지 않음", value: "unread" },
 ];
 
 function formatDate(value: string): string {
@@ -61,7 +60,7 @@ function getReadVariant(readAt: string | null): "neutral" | "warning" {
 }
 
 export default function ConsultationsPage() {
-    const [activeStatus, setActiveStatus] = useState("all");
+    const [activeReadState, setActiveReadState] = useState("all");
     const [search, setSearch] = useState("");
     const [selectedInquiry, setSelectedInquiry] = useState<ConsultationInquiry | null>(null);
 
@@ -69,10 +68,10 @@ export default function ConsultationsPage() {
         () => ({
             page: 1,
             limit: 50,
-            status: activeStatus,
+            readState: activeReadState,
             search: search.trim() || undefined,
         }),
-        [activeStatus, search],
+        [activeReadState, search],
     );
 
     const { data, isLoading } = useConsultationInquiries(queryParams);
@@ -108,10 +107,10 @@ export default function ConsultationsPage() {
             <SplitLayout hasSelection={!!activeInquiry} onBack={() => setSelectedInquiry(null)}>
                 <ListPanel
                     title="상담 문의"
-                    tabs={STATUS_TABS}
-                    activeTab={activeStatus}
+                    tabs={READ_TABS}
+                    activeTab={activeReadState}
                     onTabChange={(value) => {
-                        setActiveStatus(value);
+                        setActiveReadState(value);
                         setSelectedInquiry(null);
                     }}
                     searchValue={search}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -295,6 +295,7 @@ export interface ConsultationInquiryListParams {
     limit?: number;
     search?: string;
     status?: string;
+    readState?: string;
 }
 
 export const settingsApi = {


### PR DESCRIPTION
## Summary
- Replace 상담 list filters with 전체, 읽음, 읽지 않음
- Add backend readState filtering for consultation inquiries

## Test Plan
- pnpm --dir backend build
- pnpm --dir backend test -- consultation-inquiry.service.spec.ts
- pnpm --dir frontend build