### PR TITLE
[codex] add HWP file previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ frontend/playwright-report/
 # next.js
 **/.next/
 out/
+frontend/public/vendor/rhwp/rhwp_bg.wasm
 
 # production
 build/

--- a/backend/interface/controllers/document.controller.ts
+++ b/backend/interface/controllers/document.controller.ts
@@ -228,14 +228,26 @@ export class DocumentController {
                  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
                  "application/vnd.ms-excel": ".xls",
                  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+                 "application/hwp": ".hwp",
+                 "application/haansofthwp": ".hwp",
+                 "application/vnd.hancom.hwp": ".hwp",
+                 "application/vnd.hancom.hwpx": ".hwpx",
+                 "application/x-hwp": ".hwp",
+                 "application/x-hwpx": ".hwpx",
              };
              return mimeToExt[mimetype] || "";
+         };
+
+         const getStorageExtension = (storagePath: string): string => {
+             const cleanPath = storagePath.split(/[?#]/)[0] ?? "";
+             const extensionMatch = cleanPath.match(/\.([a-z0-9]+)$/i);
+             return extensionMatch?.[1] ? `.${extensionMatch[1].toLowerCase()}` : "";
          };
          
          // Ensure filename has extension
          let filename = doc.name;
          if (!filename.includes(".")) {
-             filename += getExtension(doc.mimetype);
+             filename += getExtension(doc.mimetype) || getStorageExtension(doc.storagepath);
          }
          
          const disposition = attachment === "true" 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,9 @@
     "magi": "./bin/magi"
   },
   "scripts": {
+    "prepare:rhwp": "node ./scripts/copy-rhwp-wasm.mjs",
+    "predev": "pnpm run prepare:rhwp",
+    "prebuild": "pnpm run prepare:rhwp",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
@@ -25,6 +28,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@rhwp/core": "0.7.3",
     "@tanstack/react-query": "^5.90.5",
     "@tanstack/react-query-devtools": "^5.90.2",
     "@types/js-cookie": "^3.0.6",

--- a/frontend/scripts/copy-rhwp-wasm.mjs
+++ b/frontend/scripts/copy-rhwp-wasm.mjs
@@ -1,0 +1,13 @@
+import { copyFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const frontendRoot = resolve(scriptDir, "..");
+const sourcePath = resolve(frontendRoot, "node_modules/@rhwp/core/rhwp_bg.wasm");
+const targetPath = resolve(frontendRoot, "public/vendor/rhwp/rhwp_bg.wasm");
+
+await mkdir(dirname(targetPath), { recursive: true });
+await copyFile(sourcePath, targetPath);
+
+console.log(`Copied rhwp WASM to ${targetPath}`);

--- a/frontend/src/app/(protected)/files/page.tsx
+++ b/frontend/src/app/(protected)/files/page.tsx
@@ -16,6 +16,7 @@ import DocumentPreviewModal from "@/components/app/documents/document-preview-mo
 import { DocumentEditModal } from "@/components/app/documents/document-edit-modal";
 import { AddCategoryModal } from "@/components/app/documents/add-category-modal";
 import { formatDate } from "@/components/app/documents/document-list";
+import { isHangulDocument } from "@/components/app/documents/document-preview-utils";
 import { toast } from "@/hooks/use-toast";
 
 const RECENT_WINDOW_START = Date.now() - 7 * 24 * 60 * 60 * 1000;
@@ -73,9 +74,10 @@ export default function FilesPage() {
     return filteredDocs.find(d => d.id === selectedDocId) ?? null;
   }, [selectedDocId, filteredDocs]);
 
-  function getFileIcon(mimeType: string) {
-    if (mimeType.includes("pdf")) return <FileText className="w-4 h-4 text-v3-burgundy" />;
-    if (mimeType.includes("image")) return <ImageIcon className="w-4 h-4 text-v3-primary" />;
+  function getFileIcon(doc: Document) {
+    if (doc.mimeType.includes("pdf")) return <FileText className="w-4 h-4 text-v3-burgundy" />;
+    if (isHangulDocument(doc)) return <FileText className="w-4 h-4 text-v3-primary" />;
+    if (doc.mimeType.includes("image")) return <ImageIcon className="w-4 h-4 text-v3-primary" />;
     return <File className="w-4 h-4 text-v3-text-muted" />;
   }
 
@@ -204,7 +206,7 @@ export default function FilesPage() {
                 return (
                   <>
                     <div data-component="files-list-item-icon" className="w-9 h-9 rounded-[10px] bg-v3-primary-light flex items-center justify-center shrink-0">
-                      {getFileIcon(doc.mimeType)}
+                      {getFileIcon(doc)}
                     </div>
                     <div data-component="files-list-item-content" className="flex-1 min-w-0">
                       <p className="text-[0.8rem] font-semibold text-v3-dark truncate">{doc.name}</p>
@@ -256,7 +258,7 @@ export default function FilesPage() {
                 파일 업로드
               </DialogTitle>
               <DialogDescription className="mt-2 pt-0 text-[0.82rem] leading-6 text-v3-text-muted">
-                PNG, JPG, PDF 문서를 업로드하고 카테고리와 태그까지 한 번에 정리합니다.
+                PNG, JPG, PDF, HWP/HWPX 문서를 업로드하고 카테고리와 태그까지 한 번에 정리합니다.
               </DialogDescription>
             </div>
           </DialogHeader>

--- a/frontend/src/components/app/documents/__tests__/document-preview-modal.test.tsx
+++ b/frontend/src/components/app/documents/__tests__/document-preview-modal.test.tsx
@@ -3,6 +3,7 @@
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import DocumentPreviewModal from "../document-preview-modal";
+import { getDownloadFileName, getPreviewKind } from "../document-preview-utils";
 import type { Document } from "@/hooks/use-documents";
 import type { DocumentCategory } from "@/hooks/use-document-categories";
 
@@ -20,7 +21,24 @@ type MockNextImageProps = ComponentPropsWithoutRef<"img"> & {
   unoptimized?: boolean;
 };
 
+const mockRhwpInit = jest.fn(() => Promise.resolve({}));
+const mockHwpFree = jest.fn();
+const mockRenderPageSvg = jest.fn((pageNumber: number) => (
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 140"><text>HWP page ${pageNumber + 1}</text></svg>`
+));
+const mockPageCount = jest.fn(() => 2);
+
 jest.mock("@/lib/pdf-config", () => ({}));
+
+jest.mock("@rhwp/core", () => ({
+  __esModule: true,
+  default: mockRhwpInit,
+  HwpDocument: jest.fn().mockImplementation(() => ({
+    free: mockHwpFree,
+    pageCount: mockPageCount,
+    renderPageSvg: mockRenderPageSvg,
+  })),
+}));
 
 jest.mock("next/image", () => ({
   __esModule: true,
@@ -82,8 +100,48 @@ class ResizeObserverMock {
   disconnect() {}
 }
 
+let blobUrlIndex = 0;
+const originalFetch = global.fetch;
+const originalCreateObjectUrl = URL.createObjectURL;
+const originalRevokeObjectUrl = URL.revokeObjectURL;
+
 beforeAll(() => {
   global.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+  global.fetch = jest.fn(async () => ({
+    ok: true,
+    status: 200,
+    arrayBuffer: async () => new ArrayBuffer(8),
+  })) as unknown as typeof fetch;
+
+  Object.defineProperty(URL, "createObjectURL", {
+    configurable: true,
+    value: jest.fn(() => {
+      blobUrlIndex += 1;
+      return `blob:mock-hwp-${blobUrlIndex}`;
+    }),
+  });
+
+  Object.defineProperty(URL, "revokeObjectURL", {
+    configurable: true,
+    value: jest.fn(),
+  });
+});
+
+beforeEach(() => {
+  blobUrlIndex = 0;
+  jest.clearAllMocks();
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+  Object.defineProperty(URL, "createObjectURL", {
+    configurable: true,
+    value: originalCreateObjectUrl,
+  });
+  Object.defineProperty(URL, "revokeObjectURL", {
+    configurable: true,
+    value: originalRevokeObjectUrl,
+  });
 });
 
 describe("DocumentPreviewModal", () => {
@@ -137,5 +195,59 @@ describe("DocumentPreviewModal", () => {
 
     expect(screen.getByText("125%")).toBeInTheDocument();
     expect(image).toHaveStyle({ transform: "scale(1.25)" });
+  });
+
+  it("renders a Hangul document preview from an HWP storage extension", async () => {
+    render(
+      <DocumentPreviewModal
+        open={true}
+        onClose={jest.fn()}
+        doc={{
+          ...baseDocument,
+          id: "hwp-1",
+          name: "산후도우미신청서",
+          mimeType: "application/octet-stream",
+          storagePath: "/documents/hwp-1.hwp",
+        }}
+        categories={categories}
+      />
+    );
+
+    expect(screen.getByText("hwp")).toBeInTheDocument();
+
+    const slider = screen.getByLabelText("한글 문서 미리보기 확대/축소");
+    expect(slider).toHaveValue("100");
+
+    const firstHwpPage = await screen.findByTestId("hwp-page-1");
+    expect(firstHwpPage).toBeInTheDocument();
+    expect(firstHwpPage).not.toHaveClass("rounded-[20px]");
+    expect(screen.getByAltText("산후도우미신청서 1페이지")).toHaveAttribute("src", "blob:mock-hwp-1");
+    expect(screen.queryByText("인쇄")).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockRhwpInit).toHaveBeenCalledWith({ module_or_path: "/vendor/rhwp/rhwp_bg.wasm" });
+      expect(global.fetch).toHaveBeenCalledWith("/api/file-storage/files/hwp-1/download");
+      expect(mockRenderPageSvg).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("detects Hangul preview and download extensions from stored paths", () => {
+    const hwpDoc = {
+      ...baseDocument,
+      name: "신청서",
+      mimeType: "application/octet-stream",
+      storagePath: "/documents/source.hwp",
+    };
+    const hwpxDoc = {
+      ...baseDocument,
+      name: "신청서",
+      mimeType: "application/octet-stream",
+      storagePath: "/documents/source.hwpx",
+    };
+
+    expect(getPreviewKind(hwpDoc)).toBe("hwp");
+    expect(getDownloadFileName(hwpDoc)).toBe("신청서.hwp");
+    expect(getPreviewKind(hwpxDoc)).toBe("hwp");
+    expect(getDownloadFileName(hwpxDoc)).toBe("신청서.hwpx");
   });
 });

--- a/frontend/src/components/app/documents/document-dropzone.tsx
+++ b/frontend/src/components/app/documents/document-dropzone.tsx
@@ -23,6 +23,7 @@ import {
 import { cn } from "@/lib/utils";
 
 const MAX_FILE_SIZE = 25 * 1024 * 1024;
+const HANGUL_DOCUMENT_EXTENSIONS = new Set(["hwp", "hwpx"]);
 const LABEL_CLASS_NAME =
   "text-[0.72rem] font-semibold uppercase tracking-[0.08em] text-v3-text-muted";
 const V3_TEXTAREA_CLASS_NAME =
@@ -195,7 +196,16 @@ export function DocumentDropzone({
     return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
   };
 
+  const isSelectedHangulFile = () => {
+    const extension = selectedFile?.name.split(".").pop()?.toLowerCase();
+    return extension ? HANGUL_DOCUMENT_EXTENSIONS.has(extension) : false;
+  };
+
   const getSelectedFileLabel = () => {
+    if (isSelectedHangulFile()) {
+      return "한글 문서";
+    }
+
     if (selectedFile?.type === "application/pdf") {
       return "PDF 문서";
     }
@@ -208,6 +218,13 @@ export function DocumentDropzone({
   };
 
   const getSelectedFileTone = () => {
+    if (isSelectedHangulFile()) {
+      return {
+        icon: "bg-v3-primary-light text-v3-primary",
+        badge: "border-v3-primary/20 bg-v3-primary-light text-v3-primary",
+      };
+    }
+
     if (selectedFile?.type === "application/pdf") {
       return {
         icon: "bg-v3-burgundy-light text-v3-burgundy",
@@ -229,6 +246,10 @@ export function DocumentDropzone({
   };
 
   const getFileIcon = () => {
+    if (isSelectedHangulFile()) {
+      return <FileText className="h-10 w-10" />;
+    }
+
     if (selectedFile?.type === "application/pdf") {
       return <FileText className="h-10 w-10" />;
     }
@@ -285,7 +306,7 @@ export function DocumentDropzone({
               파일을 끌어다 놓거나 클릭해 선택하세요
             </p>
             <p className="mt-2 text-[0.8rem] leading-6 text-v3-text-muted">
-              문서, 이미지, 압축 파일 등 다양한 형식을 바로 업로드할 수 있습니다.
+              PDF, HWP/HWPX, 이미지, 압축 파일 등 다양한 형식을 바로 업로드할 수 있습니다.
             </p>
           </div>
           <div className="mt-4 flex flex-wrap items-center justify-center gap-2">

--- a/frontend/src/components/app/documents/document-preview-modal.tsx
+++ b/frontend/src/components/app/documents/document-preview-modal.tsx
@@ -12,9 +12,9 @@ import { Badge } from "@/components/ui/badge";
 import { Document, getDownloadUrl } from "@/hooks/use-documents";
 import { DocumentCategory } from "@/hooks/use-document-categories";
 import { formatFileSize, formatDate } from "./document-list";
+import { getDownloadFileName, getFileFormatLabel, getPreviewKind } from "./document-preview-utils";
 import {
   SharedDocumentPreviewDialog,
-  type PreviewKind,
   type PreviewMetaItem,
 } from "./shared-document-preview-dialog";
 
@@ -32,42 +32,6 @@ function getCategoryLabel(categoryId: string, categories: DocumentCategory[]): s
   return category?.label || categoryId;
 }
 
-function getExtensionFromMimeType(mimeType: string): string {
-  const mimeToExt: Record<string, string> = {
-    "application/pdf": ".pdf",
-    "image/jpeg": ".jpg",
-    "image/png": ".png",
-    "image/gif": ".gif",
-    "image/webp": ".webp",
-    "application/msword": ".doc",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
-    "application/vnd.ms-excel": ".xls",
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
-  };
-
-  return mimeToExt[mimeType] || "";
-}
-
-function getDownloadFileName(doc: Document): string {
-  if (doc.name.includes(".")) {
-    return doc.name;
-  }
-
-  return `${doc.name}${getExtensionFromMimeType(doc.mimeType)}`;
-}
-
-function getPreviewKind(mimeType: string): PreviewKind {
-  if (mimeType === "application/pdf") {
-    return "pdf";
-  }
-
-  if (mimeType.startsWith("image/")) {
-    return "image";
-  }
-
-  return "unsupported";
-}
-
 export default function DocumentPreviewModal({
   open,
   onClose,
@@ -80,7 +44,12 @@ export default function DocumentPreviewModal({
     return null;
   }
 
-  const previewKind = getPreviewKind(doc.mimeType);
+  const previewKind = getPreviewKind(doc);
+  const srDescription =
+    previewKind === "hwp"
+      ? "문서 메타데이터와 한글 미리보기를 확인하고 확대, 다운로드를 할 수 있습니다."
+      : "문서 메타데이터와 미리보기를 확인하고 확대, 인쇄, 다운로드를 할 수 있습니다.";
+
   const metaItems: PreviewMetaItem[] = [
     {
       label: "파일 크기",
@@ -94,7 +63,7 @@ export default function DocumentPreviewModal({
       label: "파일 포맷",
       value: (
         <span className="uppercase">
-          {doc.mimeType.split("/")[1]?.replace("jpeg", "jpg").replace("plain", "txt") || "Unknown"}
+          {getFileFormatLabel(doc)}
         </span>
       ),
     },
@@ -157,7 +126,7 @@ export default function DocumentPreviewModal({
           {getCategoryLabel(doc.categoryId, categories)}
         </Badge>,
       ]}
-      srDescription="문서 메타데이터와 미리보기를 확인하고 확대, 인쇄, 다운로드를 할 수 있습니다."
+      srDescription={srDescription}
       metaItems={metaItems}
       metaAction={metaAction}
       metaExtra={metaExtra}

--- a/frontend/src/components/app/documents/document-preview-utils.ts
+++ b/frontend/src/components/app/documents/document-preview-utils.ts
@@ -1,0 +1,90 @@
+import type { Document } from "@/hooks/use-documents";
+
+import type { PreviewKind } from "./shared-document-preview-dialog";
+
+type PreviewableDocument = Pick<Document, "mimeType" | "name" | "storagePath" | "storageUrl">;
+
+const HANGUL_DOCUMENT_EXTENSIONS = new Set(["hwp", "hwpx"]);
+
+const HANGUL_DOCUMENT_MIME_TYPES = new Set([
+  "application/hwp",
+  "application/haansofthwp",
+  "application/vnd.hancom.hwp",
+  "application/vnd.hancom.hwpx",
+  "application/x-hwp",
+  "application/x-hwpx",
+]);
+
+const MIME_TO_EXTENSION: Record<string, string> = {
+  "application/pdf": ".pdf",
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+  "application/msword": ".doc",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+  "application/vnd.ms-excel": ".xls",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+  "application/hwp": ".hwp",
+  "application/haansofthwp": ".hwp",
+  "application/vnd.hancom.hwp": ".hwp",
+  "application/vnd.hancom.hwpx": ".hwpx",
+  "application/x-hwp": ".hwp",
+  "application/x-hwpx": ".hwpx",
+};
+
+function getExtensionFromPath(value?: string | null): string {
+  if (!value) {
+    return "";
+  }
+
+  const cleanValue = value.split(/[?#]/)[0] ?? "";
+  const extensionMatch = cleanValue.match(/\.([a-z0-9]+)$/i);
+  return extensionMatch?.[1]?.toLowerCase() ?? "";
+}
+
+export function getDocumentExtension(doc: PreviewableDocument): string {
+  return getExtensionFromPath(doc.name) || getExtensionFromPath(doc.storagePath) || getExtensionFromPath(doc.storageUrl);
+}
+
+export function getExtensionFromMimeType(mimeType: string): string {
+  return MIME_TO_EXTENSION[mimeType] || "";
+}
+
+export function isHangulDocument(doc: PreviewableDocument): boolean {
+  return HANGUL_DOCUMENT_MIME_TYPES.has(doc.mimeType) || HANGUL_DOCUMENT_EXTENSIONS.has(getDocumentExtension(doc));
+}
+
+export function getPreviewKind(doc: PreviewableDocument): PreviewKind {
+  if (doc.mimeType === "application/pdf") {
+    return "pdf";
+  }
+
+  if (doc.mimeType.startsWith("image/")) {
+    return "image";
+  }
+
+  if (isHangulDocument(doc)) {
+    return "hwp";
+  }
+
+  return "unsupported";
+}
+
+export function getDownloadFileName(doc: PreviewableDocument): string {
+  if (doc.name.includes(".")) {
+    return doc.name;
+  }
+
+  const extension = getExtensionFromMimeType(doc.mimeType) || `.${getDocumentExtension(doc)}`;
+  return extension === "." ? doc.name : `${doc.name}${extension}`;
+}
+
+export function getFileFormatLabel(doc: PreviewableDocument): string {
+  const extension = getDocumentExtension(doc);
+  if (extension) {
+    return extension;
+  }
+
+  return doc.mimeType.split("/")[1]?.replace("jpeg", "jpg").replace("plain", "txt") || "Unknown";
+}

--- a/frontend/src/components/app/documents/hwp-document-preview.tsx
+++ b/frontend/src/components/app/documents/hwp-document-preview.tsx
@@ -1,0 +1,187 @@
+/* eslint-disable @next/next/no-img-element */
+
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Spinner } from "@/components/ui/spinner";
+
+const RHWP_WASM_PATH = "/vendor/rhwp/rhwp_bg.wasm";
+
+interface HwpDocumentPreviewProps {
+  previewUrl: string;
+  previewKey?: string;
+  title: string;
+  pageWidth: number;
+}
+
+interface HwpPage {
+  pageNumber: number;
+  url: string;
+}
+
+interface HwpDocumentInstance {
+  free?: () => void;
+  pageCount: () => number;
+  renderPageSvg: (pageNumber: number) => string;
+}
+
+interface RhwpCoreModule {
+  default: (options: { module_or_path: string }) => Promise<unknown>;
+  HwpDocument: new (bytes: Uint8Array) => HwpDocumentInstance;
+}
+
+type HwpPreviewState =
+  | { status: "loading"; pages: HwpPage[] }
+  | { status: "ready"; pages: HwpPage[] }
+  | { status: "error"; pages: HwpPage[] };
+
+let rhwpCorePromise: Promise<RhwpCoreModule> | null = null;
+
+function ensureMeasureTextWidth(): void {
+  const globalTarget = globalThis as typeof globalThis & {
+    measureTextWidth?: (font: string, text: string) => number;
+  };
+
+  if (globalTarget.measureTextWidth) {
+    return;
+  }
+
+  let context: CanvasRenderingContext2D | null = null;
+  let lastFont = "";
+
+  globalTarget.measureTextWidth = (font, text) => {
+    context ??= document.createElement("canvas").getContext("2d");
+    if (!context) {
+      return text.length * 10;
+    }
+
+    if (font !== lastFont) {
+      context.font = font;
+      lastFont = font;
+    }
+
+    return context.measureText(text).width;
+  };
+}
+
+async function loadRhwpCore(): Promise<RhwpCoreModule> {
+  if (!rhwpCorePromise) {
+    rhwpCorePromise = (async () => {
+      ensureMeasureTextWidth();
+      const rhwpModule = (await import("@rhwp/core")) as unknown as RhwpCoreModule;
+      await rhwpModule.default({ module_or_path: RHWP_WASM_PATH });
+      return rhwpModule;
+    })();
+  }
+
+  return rhwpCorePromise;
+}
+
+export function HwpDocumentPreview({
+  previewUrl,
+  previewKey,
+  title,
+  pageWidth,
+}: HwpDocumentPreviewProps) {
+  const [state, setState] = useState<HwpPreviewState>({ status: "loading", pages: [] });
+
+  useEffect(() => {
+    let isCanceled = false;
+    const pageUrls: string[] = [];
+
+    setState({ status: "loading", pages: [] });
+
+    async function renderDocument(): Promise<void> {
+      try {
+        const [{ HwpDocument }, response] = await Promise.all([
+          loadRhwpCore(),
+          fetch(previewUrl),
+        ]);
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch HWP document: ${response.status}`);
+        }
+
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        const document = new HwpDocument(bytes);
+
+        try {
+          const totalPages = document.pageCount();
+          const pages = Array.from({ length: totalPages }, (_, index) => {
+            const svg = document.renderPageSvg(index);
+            const blob = new Blob([svg], { type: "image/svg+xml" });
+            const url = URL.createObjectURL(blob);
+            pageUrls.push(url);
+
+            return {
+              pageNumber: index + 1,
+              url,
+            };
+          });
+
+          if (isCanceled) {
+            pageUrls.forEach((url) => URL.revokeObjectURL(url));
+            return;
+          }
+
+          setState({ status: "ready", pages });
+        } finally {
+          document.free?.();
+        }
+      } catch {
+        if (!isCanceled) {
+          pageUrls.forEach((url) => URL.revokeObjectURL(url));
+          setState({ status: "error", pages: [] });
+        }
+      }
+    }
+
+    void renderDocument();
+
+    return () => {
+      isCanceled = true;
+      pageUrls.forEach((url) => URL.revokeObjectURL(url));
+    };
+  }, [previewKey, previewUrl]);
+
+  if (state.status === "loading") {
+    return (
+      <div className="flex min-h-full items-center justify-center">
+        <div className="flex items-center gap-3 rounded-2xl bg-white px-5 py-4 text-sm font-medium text-v3-text shadow-sm">
+          <Spinner size="sm" className="text-v3-primary" />
+          한글 문서를 불러오는 중입니다
+        </div>
+      </div>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <div className="flex min-h-full items-center justify-center">
+        <div className="rounded-2xl bg-white px-5 py-4 text-sm font-medium text-v3-burgundy shadow-sm">
+          한글 문서 미리보기를 불러오지 못했습니다.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-full flex-col items-center gap-6">
+      {state.pages.map((page) => (
+        <div
+          key={`${previewKey ?? title}-hwp-page-${page.pageNumber}`}
+          data-testid={`hwp-page-${page.pageNumber}`}
+          className="overflow-hidden bg-white shadow-[0_16px_40px_rgba(15,23,42,0.08)]"
+          style={{ width: pageWidth }}
+        >
+          <img
+            src={page.url}
+            alt={`${title} ${page.pageNumber}페이지`}
+            className="block h-auto w-full"
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/app/documents/shared-document-preview-dialog.tsx
+++ b/frontend/src/components/app/documents/shared-document-preview-dialog.tsx
@@ -9,8 +9,9 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
+import { HwpDocumentPreview } from "./hwp-document-preview";
 
-export type PreviewKind = "pdf" | "image" | "unsupported";
+export type PreviewKind = "pdf" | "image" | "hwp" | "unsupported";
 
 export interface PreviewMetaItem {
   label: string;
@@ -68,13 +69,14 @@ export function SharedDocumentPreviewDialog({
   const [previewWidth, setPreviewWidth] = useState(0);
   const isPdf = previewKind === "pdf";
   const isImage = previewKind === "image";
-  const isZoomablePreview = isPdf || isImage;
+  const isHwp = previewKind === "hwp";
+  const isZoomablePreview = isPdf || isImage || isHwp;
   const zoomScale = zoomPercent / 100;
   const pageWidth = Math.max(previewWidth, 320) * zoomScale;
 
   useEffect(() => {
     const node = previewViewportRef.current;
-    if (!open || !isPdf || !node || typeof ResizeObserver === "undefined") {
+    if (!open || (!isPdf && !isHwp) || !node || typeof ResizeObserver === "undefined") {
       return;
     }
 
@@ -92,7 +94,7 @@ export function SharedDocumentPreviewDialog({
       window.cancelAnimationFrame(frameId);
       observer.disconnect();
     };
-  }, [isPdf, open]);
+  }, [isHwp, isPdf, open]);
 
   const handleClose = () => {
     setZoomPercent(DEFAULT_ZOOM_PERCENT);
@@ -241,7 +243,19 @@ export function SharedDocumentPreviewDialog({
               </div>
             )}
 
-            {!isPdf && !isImage && (
+            {isHwp && (
+              <div ref={previewViewportRef} className="h-full overflow-auto px-6 py-6">
+                <HwpDocumentPreview
+                  key={previewKey}
+                  previewUrl={previewUrl}
+                  previewKey={previewKey}
+                  title={title}
+                  pageWidth={pageWidth}
+                />
+              </div>
+            )}
+
+            {!isPdf && !isImage && !isHwp && (
               <div className="flex h-full items-center justify-center">
                 <div className="text-muted-foreground">{unsupportedMessage}</div>
               </div>
@@ -267,7 +281,7 @@ export function SharedDocumentPreviewDialog({
                   value={zoomPercent}
                   onChange={(event) => setZoomPercent(Number(event.target.value))}
                   className="h-2 w-32 cursor-pointer accent-[hsl(214,100%,34%)]"
-                  aria-label={`${isPdf ? "PDF" : "이미지"} 미리보기 확대/축소`}
+                  aria-label={`${isPdf ? "PDF" : isHwp ? "한글 문서" : "이미지"} 미리보기 확대/축소`}
                 />
                 <div className="min-w-[3.5rem] rounded-full bg-v3-dim-white px-2.5 py-1 text-center text-xs font-semibold text-v3-dark">
                   {zoomPercent}%
@@ -281,10 +295,12 @@ export function SharedDocumentPreviewDialog({
           data-component="contracts-document-preview-footer"
           className="justify-end border-t border-border px-6 py-4"
         >
-          <Button variant="ghost" onClick={handlePrint}>
-            <Printer className="mr-2 h-4 w-4" />
-            인쇄
-          </Button>
+          {!isHwp && (
+            <Button variant="ghost" onClick={handlePrint}>
+              <Printer className="mr-2 h-4 w-4" />
+              인쇄
+            </Button>
+          )}
           {downloadUrl && (
             <Button onClick={handleDownload}>
               <Download className="mr-2 h-4 w-4" />

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -22,6 +22,7 @@ const PUBLIC_ROUTES = [
   "/auth",
   "/api",
   "/_next",
+  "/vendor",
   "/favicon.ico",
   "/manifest.json",
   "/sw.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@rhwp/core':
+        specifier: 0.7.3
+        version: 0.7.3
       '@tanstack/react-query':
         specifier: ^5.90.5
         version: 5.90.21(react@19.2.4)
@@ -879,89 +882,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1215,30 +1234,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.96':
     resolution: {integrity: sha512-UvOi7fii3IE2KDfEfhh8m+LpzSRvhGK7o1eho99M2M0HTik11k3GX+2qgVx9EtujN3/bhFFS1kSO3+vPMaJ0Mg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.96':
     resolution: {integrity: sha512-MBSukhGCQ5nRtf9NbFYWOU080yqkZU1PbuH4o1ROvB4CbPl12fchDR35tU83Wz8gWIM9JTn99lBn9DenPIv7Ig==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.96':
     resolution: {integrity: sha512-I/ccu2SstyKiV3HIeVzyBIWfrJo8cN7+MSQZPnabewWV6hfJ2nY7Df2WqOHmobBRUw84uGR6zfQHsUEio/m5Vg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.96':
     resolution: {integrity: sha512-H3uov7qnTl73GDT4h52lAqpJPsl1tIUyNPWJyhQ6gHakohNqqRq3uf80+NEpzcytKGEOENP1wX3yGwZxhjiWEQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.96':
     resolution: {integrity: sha512-ATp6Y+djOjYtkfV/VRH7CZ8I1MEtkUQBmKUbuWw5zWEHHqfL0cEcInE4Cxgx7zkNAhEdBbnH8HMVrqNp+/gwxA==}
@@ -1372,24 +1396,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -1532,36 +1560,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -2399,6 +2433,9 @@ packages:
       react-redux:
         optional: true
 
+  '@rhwp/core@0.7.3':
+    resolution: {integrity: sha512-nueIqvZbW0v84y0xnRJhwPoYE0kHUZ9gOSiBn33xW4O7VxX/WgfMTbhevXoY8c0ryIH3Zd4ba27nK062l3uW1g==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -2476,24 +2513,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.18':
     resolution: {integrity: sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.18':
     resolution: {integrity: sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.18':
     resolution: {integrity: sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.18':
     resolution: {integrity: sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==}
@@ -2569,24 +2610,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -3024,41 +3069,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -5344,24 +5397,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -9410,6 +9467,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.4
       react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+
+  '@rhwp/core@0.7.3': {}
 
   '@rtsao/scc@1.1.0': {}
 


### PR DESCRIPTION
## Summary
- add HWP/HWPX preview support to the `/files` document preview modal using `@rhwp/core`
- render Hangul document pages client-side through the rhwp WASM parser and SVG output
- copy the rhwp WASM asset into `public/vendor/rhwp` during frontend dev/build and allow that static path through the proxy

## Changes
- detect Hangul documents by MIME type or `.hwp`/`.hwpx` filename/storage extension
- add an HWP preview renderer that fetches the authenticated file URL, converts rendered SVG pages to blob URLs, and avoids raw SVG `innerHTML` injection
- keep HWP preview pages square-cornered, matching the source document canvas
- preserve PDF/image preview behavior and download flow
- extend backend download filename fallback for HWP/HWPX storage paths

## Validation
- `pnpm -C /Users/jaino/Development/babyjamjam-staff/hwp-preview/frontend test -- document-preview-modal`
- `pnpm -C /Users/jaino/Development/babyjamjam-staff/hwp-preview/frontend exec eslint src/proxy.ts src/components/app/documents/hwp-document-preview.tsx src/components/app/documents/document-preview-utils.ts src/components/app/documents/shared-document-preview-dialog.tsx src/components/app/documents/document-preview-modal.tsx src/components/app/documents/document-dropzone.tsx "src/app/(protected)/files/page.tsx" src/components/app/documents/__tests__/document-preview-modal.test.tsx`
- `pnpm -C /Users/jaino/Development/babyjamjam-staff/hwp-preview/backend build`
- `pnpm -C /Users/jaino/Development/babyjamjam-staff/hwp-preview/frontend build`
- `curl -I http://localhost:3002/vendor/rhwp/rhwp_bg.wasm` returned `200 OK` with `application/wasm`

## Notes
- Full frontend lint is still blocked by a pre-existing `frontend/src/app/website-admin/page.tsx:46` `react-hooks/set-state-in-effect` error and existing data-component warnings.
- `pnpm audit --prod --audit-level high` reports existing project advisories in current dependencies, including `next`, `multer`, `effect`, `path-to-regexp`, `picomatch`, `lodash`, and `defu`; no advisory was surfaced for `@rhwp/core`.
