### PR TITLE
[codex] refine consultation history and auth routing

### DIFF
--- a/backend/infrastructure/database/repositories/sb.consultation-inquiry.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.consultation-inquiry.repository.ts
@@ -40,6 +40,29 @@ function toEntity(row: InquiryWithBranch): ConsultationInquiryEntity {
     };
 }
 
+export function getConsultationPhoneSearchVariants(phone: string): string[] {
+    const trimmed = phone.trim();
+    if (!trimmed) {
+        return [];
+    }
+
+    const digits = trimmed.replace(/\D/g, "");
+    const variants = new Set([trimmed]);
+
+    if (digits.length >= 10 && digits.length <= 11 && digits.startsWith("01")) {
+        const prefix = digits.slice(0, 3);
+        const middle = digits.slice(3, -4);
+        const last = digits.slice(-4);
+
+        variants.add(digits);
+        variants.add(`${prefix}-${middle}-${last}`);
+        variants.add(`${prefix}-${middle}${last}`);
+        variants.add(`${prefix}${middle}-${last}`);
+    }
+
+    return Array.from(variants);
+}
+
 @Injectable()
 export class SbConsultationInquiryRepository implements IConsultationInquiryRepository {
     constructor(private readonly prisma: PrismaService) {}
@@ -121,7 +144,10 @@ export class SbConsultationInquiryRepository implements IConsultationInquiryRepo
         }
 
         if (params.phone) {
-            where.phone = params.phone;
+            const phoneSearchVariants = getConsultationPhoneSearchVariants(params.phone);
+            if (phoneSearchVariants.length > 0) {
+                where.phone = { in: phoneSearchVariants };
+            }
         }
 
         if (params.search) {

--- a/backend/test/repositories/sb.consultation-inquiry.repository.spec.ts
+++ b/backend/test/repositories/sb.consultation-inquiry.repository.spec.ts
@@ -1,0 +1,16 @@
+import { getConsultationPhoneSearchVariants } from "infrastructure/database/repositories/sb.consultation-inquiry.repository";
+
+describe("getConsultationPhoneSearchVariants", () => {
+    it("should include hyphenated and digit-only variants for mobile numbers", () => {
+        expect(getConsultationPhoneSearchVariants("010-9641-1878")).toEqual([
+            "010-9641-1878",
+            "01096411878",
+            "010-96411878",
+            "0109641-1878",
+        ]);
+    });
+
+    it("should preserve exact trimmed value for unsupported formats", () => {
+        expect(getConsultationPhoneSearchVariants(" 1661-2386 ")).toEqual(["1661-2386"]);
+    });
+});

--- a/frontend/src/app/(auth)/callback/actions.ts
+++ b/frontend/src/app/(auth)/callback/actions.ts
@@ -15,6 +15,7 @@ interface TokenExchangeSuccessResponse {
     accessToken: string;
     refreshToken: string;
     requiresBranchSelection?: boolean;
+    requiresOrgSelection?: boolean;
 }
 
 interface TokenExchangePendingSignupResponse {
@@ -115,7 +116,10 @@ export async function exchangeToken(
         cookieStore.delete(PENDING_KAKAO_SIGNUP_COOKIE);
         cookieStore.delete(PENDING_ACCOUNT_ONBOARDING_COOKIE);
 
-        return { success: true, requiresBranchSelection: data.requiresBranchSelection || false };
+        return {
+            success: true,
+            requiresBranchSelection: Boolean(data.requiresBranchSelection || data.requiresOrgSelection),
+        };
     } catch (error) {
         console.error("[Server Action] Token Exchange Error:", error);
 

--- a/frontend/src/app/(auth)/kakao/onboarding/actions.ts
+++ b/frontend/src/app/(auth)/kakao/onboarding/actions.ts
@@ -16,6 +16,7 @@ interface CompleteKakaoOnboardingSuccessResponse {
     accessToken: string;
     refreshToken: string;
     requiresBranchSelection?: boolean;
+    requiresOrgSelection?: boolean;
 }
 
 const PENDING_KAKAO_SIGNUP_COOKIE = "pending_kakao_signup";
@@ -37,7 +38,10 @@ export async function completeKakaoOnboarding(
     try {
         const response = await serverAPIClient.post<CompleteKakaoOnboardingSuccessResponse>(
             "/auth/kakao/complete-signup",
-            input,
+            {
+                ...input,
+                organizationId: input.branchId,
+            },
             {
                 headers: {
                     [PENDING_KAKAO_SIGNUP_TOKEN_HEADER]: pendingSignupToken,
@@ -69,7 +73,7 @@ export async function completeKakaoOnboarding(
 
         return {
             success: true,
-            requiresBranchSelection: response.data.requiresBranchSelection || false,
+            requiresBranchSelection: Boolean(response.data.requiresBranchSelection || response.data.requiresOrgSelection),
         };
     } catch (error) {
         if (error instanceof AxiosError) {

--- a/frontend/src/app/(auth)/login/actions.ts
+++ b/frontend/src/app/(auth)/login/actions.ts
@@ -2,7 +2,7 @@
 
 import { cookies } from "next/headers";
 import { serverAPIClient } from "@/lib/api/server";
-import { AxiosError } from "axios";
+import axios, { AxiosError } from "axios";
 import { clearAuthSessionCookies, setAuthSessionCookies } from "@/lib/auth/session-cookies";
 
 interface APIErrorResponse {
@@ -25,6 +25,7 @@ interface LoginSuccessResponse {
     accessToken: string;
     refreshToken: string;
     requiresBranchSelection?: boolean;
+    requiresOrgSelection?: boolean;
 }
 
 interface LoginOnboardingResponse {
@@ -41,9 +42,26 @@ type LoginResponsePayload = LoginSuccessResponse | LoginOnboardingResponse | {
 
 const PENDING_ACCOUNT_ONBOARDING_COOKIE = "pending_account_onboarding";
 const PENDING_KAKAO_SIGNUP_COOKIE = "pending_kakao_signup";
+const NETWORK_ERROR_CODES = new Set([
+    "ECONNABORTED",
+    "ECONNREFUSED",
+    "ECONNRESET",
+    "EHOSTUNREACH",
+    "ENOTFOUND",
+    "ETIMEDOUT",
+    "EAI_AGAIN",
+]);
 
 function isLoginOnboardingResponse(data: LoginResponsePayload): data is LoginOnboardingResponse {
     return typeof data === "object" && !!data && "onboardingRequired" in data && data.onboardingRequired === true;
+}
+
+function isBackendConnectionError(error: AxiosError): boolean {
+    return (
+        !error.response ||
+        error.message === "Network Error" ||
+        (typeof error.code === "string" && NETWORK_ERROR_CODES.has(error.code))
+    );
 }
 
 export async function loginWithEmail(email: string, password: string, autoLogin = true): Promise<LoginResult> {
@@ -96,21 +114,25 @@ export async function loginWithEmail(email: string, password: string, autoLogin 
         cookieStore.delete(PENDING_ACCOUNT_ONBOARDING_COOKIE);
         cookieStore.delete(PENDING_KAKAO_SIGNUP_COOKIE);
 
-        // Use requiresBranchSelection from backend response
-        return { success: true, requiresBranchSelection: loginData.requiresBranchSelection || false };
+        return {
+            success: true,
+            requiresBranchSelection: Boolean(
+                loginData.requiresBranchSelection || loginData.requiresOrgSelection,
+            ),
+        };
     } catch (error) {
         console.error("[Server Action] Email Login Error:", error);
 
-        if (error instanceof AxiosError) {
-            const axiosError = error as AxiosError<APIErrorResponse>;
+        if (axios.isAxiosError<APIErrorResponse>(error)) {
+            const axiosError = error;
             console.error("[Server Action] Axios Error:", {
                 message: axiosError.message,
                 code: axiosError.code,
                 status: axiosError.response?.status,
             });
 
-            if (axiosError.code === 'ECONNABORTED' || axiosError.message === 'Network Error') {
-                return { success: false, error: "서버에 연결할 수 없습니다. 다시 시도해 주세요." };
+            if (isBackendConnectionError(axiosError)) {
+                return { success: false, error: "로그인 서버에 연결할 수 없습니다. 백엔드 서버를 확인해 주세요." };
             }
 
             return {

--- a/frontend/src/app/(auth)/onboarding/actions.ts
+++ b/frontend/src/app/(auth)/onboarding/actions.ts
@@ -16,6 +16,7 @@ interface CompleteAccountOnboardingSuccessResponse {
     accessToken: string;
     refreshToken: string;
     requiresBranchSelection?: boolean;
+    requiresOrgSelection?: boolean;
 }
 
 const PENDING_ACCOUNT_ONBOARDING_COOKIE = "pending_account_onboarding";
@@ -37,7 +38,10 @@ export async function completeAccountOnboarding(
     try {
         const response = await serverAPIClient.post<CompleteAccountOnboardingSuccessResponse>(
             "/auth/onboarding/complete",
-            input,
+            {
+                ...input,
+                organizationId: input.branchId,
+            },
             {
                 headers: {
                     [PENDING_ONBOARDING_TOKEN_HEADER]: pendingOnboardingToken,
@@ -69,7 +73,7 @@ export async function completeAccountOnboarding(
 
         return {
             success: true,
-            requiresBranchSelection: response.data.requiresBranchSelection || false,
+            requiresBranchSelection: Boolean(response.data.requiresBranchSelection || response.data.requiresOrgSelection),
         };
     } catch (error) {
         if (error instanceof AxiosError) {

--- a/frontend/src/app/(protected)/consultations/page.tsx
+++ b/frontend/src/app/(protected)/consultations/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { CalendarClock, ChevronDown, Headset, MapPin, Phone, Search, UserRound } from "lucide-react";
+import { CalendarClock, Headset, MapPin, Phone, Search, UserRound } from "lucide-react";
 
 import {
     AnimatedSlotList,
@@ -22,9 +22,8 @@ import { cn } from "@/lib/utils";
 import type { ConsultationInquiry } from "@/services/api";
 
 const READ_TABS = [
-    { label: "전체", value: "all" },
-    { label: "읽음", value: "read" },
     { label: "읽지 않음", value: "unread" },
+    { label: "읽음", value: "read" },
 ];
 
 function formatDate(value: string): string {
@@ -36,16 +35,6 @@ function formatDate(value: string): string {
         month: "2-digit",
         day: "2-digit",
     });
-}
-
-function formatCompactDate(value: string): string {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return "-";
-
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
-    return `${year}.${month}.${day}`;
 }
 
 function formatDateTime(value: string): string {
@@ -61,6 +50,30 @@ function formatDateTime(value: string): string {
     });
 }
 
+function getInquirySourceLabel(source: string): string {
+    if (source === "website") return "홈페이지";
+    return source || "-";
+}
+
+function getConsultationIdentityKey(inquiry: ConsultationInquiry): string {
+    return `${inquiry.motherName.trim().toLowerCase()}::${inquiry.phone.replace(/\D/g, "")}`;
+}
+
+function getLatestUniqueConsultationInquiries(inquiries: ConsultationInquiry[]): ConsultationInquiry[] {
+    return Array.from(
+        inquiries.reduce((uniqueMap, inquiry) => {
+            const key = getConsultationIdentityKey(inquiry);
+            const current = uniqueMap.get(key);
+
+            if (!current || new Date(inquiry.createdAt).getTime() > new Date(current.createdAt).getTime()) {
+                uniqueMap.set(key, inquiry);
+            }
+
+            return uniqueMap;
+        }, new Map<string, ConsultationInquiry>()).values(),
+    );
+}
+
 function getReadLabel(readAt: string | null): string {
     return readAt ? "읽음" : "읽지 않음";
 }
@@ -70,10 +83,9 @@ function getReadVariant(readAt: string | null): "neutral" | "warning" {
 }
 
 export default function ConsultationsPage() {
-    const [activeReadState, setActiveReadState] = useState("all");
+    const [activeReadState, setActiveReadState] = useState("unread");
     const [search, setSearch] = useState("");
     const [selectedInquiry, setSelectedInquiry] = useState<ConsultationInquiry | null>(null);
-    const [phoneHistoryOpen, setPhoneHistoryOpen] = useState(false);
 
     const queryParams = useMemo(
         () => ({
@@ -85,9 +97,21 @@ export default function ConsultationsPage() {
         [activeReadState, search],
     );
 
+    const statsQueryParams = useMemo(
+        () => ({
+            page: 1,
+            limit: 100,
+            readState: "all",
+        }),
+        [],
+    );
+
     const { data, isLoading } = useConsultationInquiries(queryParams);
+    const { data: statsData, isLoading: isStatsLoading } = useConsultationInquiries(statsQueryParams);
     const markRead = useMarkConsultationInquiryRead();
     const inquiries = useMemo(() => data?.data ?? [], [data?.data]);
+    const statsInquiries = useMemo(() => statsData?.data ?? [], [statsData?.data]);
+    const visibleInquiries = useMemo(() => getLatestUniqueConsultationInquiries(inquiries), [inquiries]);
     const activeInquiry = selectedInquiry
         ? inquiries.find((item) => item.id === selectedInquiry.id) ?? selectedInquiry
         : null;
@@ -103,27 +127,45 @@ export default function ConsultationsPage() {
     const { data: phoneHistoryData, isLoading: isPhoneHistoryLoading } =
         useConsultationInquiries(phoneHistoryParams, Boolean(activeInquiry?.phone));
     const phoneHistoryItems = useMemo(
-        () => (phoneHistoryData?.data ?? []).filter((item) => item.id !== activeInquiry?.id),
-        [activeInquiry?.id, phoneHistoryData?.data],
+        () => (phoneHistoryData?.data ?? []).filter((item) => {
+            if (!activeInquiry) return false;
+            const activeInquiryIdentityKey = getConsultationIdentityKey(activeInquiry);
+            if (!activeInquiryIdentityKey) return false;
+            return item.id !== activeInquiry?.id && getConsultationIdentityKey(item) === activeInquiryIdentityKey;
+        }),
+        [activeInquiry, phoneHistoryData?.data],
     );
+    const previousConsultationDates = useMemo(() => {
+        if (isPhoneHistoryLoading) return [];
+        return phoneHistoryItems.map((item) => formatDateTime(item.createdAt));
+    }, [isPhoneHistoryLoading, phoneHistoryItems]);
 
     const stats = useMemo(() => {
+        const now = new Date();
+        const currentYear = now.getFullYear();
+        const currentMonth = now.getMonth();
+
         return {
-            total: data?.total ?? 0,
-            unreadCount: inquiries.filter((item) => !item.readAt).length,
-            newCount: inquiries.filter((item) => item.status === "new").length,
-            contactedCount: inquiries.filter((item) => item.status === "contacted").length,
-            closedCount: inquiries.filter((item) => item.status === "closed").length,
+            currentMonthTotal: statsInquiries.filter((item) => {
+                const createdAt = new Date(item.createdAt);
+                if (Number.isNaN(createdAt.getTime())) return false;
+
+                return createdAt.getFullYear() === currentYear && createdAt.getMonth() === currentMonth;
+            }).length,
+            unreadCount: statsInquiries.filter((item) => !item.readAt).length,
+            newCount: statsInquiries.filter((item) => item.status === "new").length,
+            contactedCount: statsInquiries.filter((item) => item.status === "contacted").length,
+            closedCount: statsInquiries.filter((item) => item.status === "closed").length,
         };
-    }, [data?.total, inquiries]);
+    }, [statsInquiries]);
 
     return (
         <PageSection name="consultations">
             <StatsBar
                 name="consultations"
-                isLoading={isLoading}
+                isLoading={isLoading || isStatsLoading}
                 items={[
-                    { icon: Headset, value: stats.total, label: "전체 상담", counter: "건" },
+                    { icon: Headset, value: stats.currentMonthTotal, label: "이번달 전체 상담", counter: "건" },
                     { icon: CalendarClock, value: stats.unreadCount, label: "읽지 않음", counter: "건", colorIndex: 1 },
                     { icon: Phone, value: stats.contactedCount, label: "연락 완료", counter: "건", colorIndex: 2 },
                     { icon: Search, value: stats.closedCount, label: "종료", counter: "건", colorIndex: 3 },
@@ -134,7 +176,6 @@ export default function ConsultationsPage() {
                 hasSelection={!!activeInquiry}
                 onBack={() => {
                     setSelectedInquiry(null);
-                    setPhoneHistoryOpen(false);
                 }}
             >
                 <ListPanel
@@ -144,24 +185,20 @@ export default function ConsultationsPage() {
                     onTabChange={(value) => {
                         setActiveReadState(value);
                         setSelectedInquiry(null);
-                        setPhoneHistoryOpen(false);
                     }}
                     searchValue={search}
-                    onSearchChange={(value) => {
-                        setSearch(value);
-                        setPhoneHistoryOpen(false);
-                    }}
+                    onSearchChange={setSearch}
                     searchPlaceholder="이름, 연락처, 주소 검색..."
                     isLoading={isLoading}
                 >
-                    {!isLoading && inquiries.length === 0 ? (
+                    {!isLoading && visibleInquiries.length === 0 ? (
                         <ListEmptyState
                             name="consultations-empty"
                             message={search ? "검색 결과가 없습니다" : "상담 문의가 없습니다"}
                         />
                     ) : (
                         <AnimatedSlotList<ConsultationInquiry>
-                            items={inquiries}
+                            items={visibleInquiries}
                             isLoading={isLoading}
                             loadingCount={6}
                             className="space-y-2"
@@ -179,7 +216,6 @@ export default function ConsultationsPage() {
                             }}
                             onSlotClick={(inquiry) => {
                                 setSelectedInquiry(inquiry);
-                                setPhoneHistoryOpen(false);
                                 if (!inquiry.readAt) {
                                     markRead.mutate(inquiry.id);
                                 }
@@ -189,7 +225,7 @@ export default function ConsultationsPage() {
                                     return (
                                         <>
                                             <Skeleton className="h-11 w-11 shrink-0 rounded-[14px] bg-v3-dim-white" />
-                                            <div className="min-w-0 flex-1">
+                                            <div data-component="consultations-list-item-skeleton-content" className="min-w-0 flex-1">
                                                 <Skeleton className="mb-2 h-4 w-28 bg-v3-dim-white" />
                                                 <Skeleton className="h-3 w-44 bg-v3-dim-white" />
                                             </div>
@@ -202,11 +238,11 @@ export default function ConsultationsPage() {
 
                                 return (
                                     <>
-                                        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[14px] bg-v3-primary text-white shadow-md">
+                                        <div data-component="consultations-list-item-icon" className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[14px] bg-v3-primary text-white shadow-md">
                                             <Headset className="h-5 w-5" />
                                         </div>
-                                        <div className="min-w-0 flex-1">
-                                            <div className="mb-1 flex items-center gap-2">
+                                        <div data-component="consultations-list-item-content" className="min-w-0 flex-1">
+                                            <div data-component="consultations-list-item-title-row" className="mb-1 flex items-center gap-2">
                                                 <span className="truncate text-[0.86rem] font-bold text-v3-dark">
                                                     {item.motherName}
                                                 </span>
@@ -214,7 +250,7 @@ export default function ConsultationsPage() {
                                                     {getReadLabel(item.readAt)}
                                                 </StatusPill>
                                             </div>
-                                            <div className="flex min-w-0 items-center gap-2 text-[0.72rem] text-v3-text-muted">
+                                            <div data-component="consultations-list-item-meta-row" className="flex min-w-0 items-center gap-2 text-[0.72rem] text-v3-text-muted">
                                                 <Phone className="h-3.5 w-3.5 shrink-0" />
                                                 <span className="shrink-0">{item.phone}</span>
                                                 <span className="truncate">{item.address}</span>
@@ -230,7 +266,7 @@ export default function ConsultationsPage() {
                 {activeInquiry ? (
                     <DetailPanel
                         avatar={
-                            <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-[20px] bg-v3-primary text-white shadow-lg">
+                            <div data-component="consultations-detail-avatar" className="flex h-16 w-16 shrink-0 items-center justify-center rounded-[20px] bg-v3-primary text-white shadow-lg">
                                 <UserRound className="h-7 w-7" />
                             </div>
                         }
@@ -244,85 +280,32 @@ export default function ConsultationsPage() {
                     >
                         <div data-component="consultations-detail" className="space-y-4">
                             <div data-component="consultations-detail-basic-grid" className="grid grid-cols-2 gap-4">
-                                <InfoCard title="상담자 정보" className="col-start-1 row-start-1 row-end-3">
+                                <InfoCard title="상담자 정보" className="col-start-1 row-start-1">
                                     <InfoRow label="이름" value={activeInquiry.motherName} />
                                     <InfoRow label="연락처" value={activeInquiry.phone} />
-                                    <div data-component="consultations-phone-history" className="relative flex items-start gap-4 py-2.5 border-b border-v3-border">
-                                        <span className="shrink-0 text-[0.8rem] text-v3-text-muted">이전 상담</span>
-                                        <div className="ml-auto min-w-0 flex-1 text-right">
-                                            <button
-                                                type="button"
-                                                className="inline-flex items-center gap-1.5 text-[0.8rem] font-semibold text-v3-dark px-3 py-1.5 rounded-[10px] border border-v3-border hover:bg-v3-dim-white transition-colors"
-                                                onClick={() => setPhoneHistoryOpen((current) => !current)}
-                                            >
-                                                전체
-                                                <ChevronDown
-                                                    className={cn(
-                                                        "w-3.5 h-3.5 text-v3-text-muted transition-transform",
-                                                        phoneHistoryOpen && "rotate-180",
-                                                    )}
-                                                />
-                                            </button>
-                                            {phoneHistoryOpen ? (
-                                                <div className="absolute right-0 top-[calc(100%-4px)] z-20 mt-1 w-[260px] rounded-[14px] border border-v3-border bg-white py-1 text-left shadow-v3">
-                                                    {isPhoneHistoryLoading ? (
-                                                        <div className="px-4 py-3 text-[0.76rem] font-medium text-v3-text-muted">
-                                                            불러오는 중...
-                                                        </div>
-                                                    ) : phoneHistoryItems.length === 0 ? (
-                                                        <div className="px-4 py-3 text-[0.76rem] font-medium text-v3-text-muted">
-                                                            같은 번호의 이전 상담이 없습니다.
-                                                        </div>
-                                                    ) : (
-                                                        phoneHistoryItems.map((item) => (
-                                                            <button
-                                                                type="button"
-                                                                key={item.id}
-                                                                className="flex w-full items-start justify-between gap-3 px-4 py-2 text-left transition-colors hover:bg-v3-dim-white"
-                                                                onClick={() => {
-                                                                    setSelectedInquiry(item);
-                                                                    setPhoneHistoryOpen(false);
-                                                                    if (!item.readAt) {
-                                                                        markRead.mutate(item.id);
-                                                                    }
-                                                                }}
-                                                            >
-                                                                <span className="min-w-0">
-                                                                    <span className="block truncate text-[0.8rem] font-semibold text-v3-dark">
-                                                                        {item.motherName}
-                                                                    </span>
-                                                                    <span className="mt-0.5 block truncate text-[0.72rem] text-v3-text-muted">
-                                                                        {item.branchName ?? "현재 지점"}
-                                                                    </span>
-                                                                </span>
-                                                                <span className="shrink-0 text-[0.72rem] font-semibold text-v3-text-muted">
-                                                                    {formatCompactDate(item.createdAt)}
-                                                                </span>
-                                                            </button>
-                                                        ))
-                                                    )}
-                                                </div>
-                                            ) : null}
-                                        </div>
-                                    </div>
                                     <InfoRow label="주소" value={activeInquiry.address} />
                                     <InfoRow label="출산 예정일" value={formatDate(activeInquiry.dueDate)} />
                                     <InfoRow label="출산 경험" value={activeInquiry.birthExperience} />
                                 </InfoCard>
 
-                                <InfoCard title="처리 정보" className="col-start-1 row-start-3 row-end-5">
-                                    <InfoRow label="읽음 상태" value={getReadLabel(activeInquiry.readAt)} />
-                                    <InfoRow label="상담 접수" value={formatDateTime(activeInquiry.createdAt)} />
-                                    <InfoRow label="개인정보 동의" value={formatDateTime(activeInquiry.privacyAcceptedAt)} />
-                                </InfoCard>
-
-                                <InfoCard title="신청 정보" className="col-start-2 row-start-1 row-end-5">
+                                <InfoCard title="신청 정보" className="col-start-2 row-start-1">
                                     <InfoRow label="바우처 유형" value={activeInquiry.voucherType || "-"} />
                                     <InfoRow label="희망 관리사" value={activeInquiry.preferredCaregiverName || "-"} />
                                     <InfoRow label="유입 경로" value={activeInquiry.referralSource} />
-                                    <InfoRow label="신청 경로" value={activeInquiry.source} />
+                                    <InfoRow label="신청 경로" value={getInquirySourceLabel(activeInquiry.source)} />
                                     <InfoRow label="담당 지점" value={activeInquiry.branchName ?? "-"} />
-                                    <InfoRow label="공개 지점 ID" value={activeInquiry.publicBranchSlug} />
+                                    {previousConsultationDates.length > 0 ? (
+                                        <div data-component="consultations-phone-history" className="flex items-start gap-4 py-2.5 border-b border-v3-border last:border-b-0">
+                                            <span className="shrink-0 text-[0.8rem] text-v3-text-muted">이전 상담</span>
+                                            <span data-component="consultations-phone-history-values" className="ml-auto min-w-0 flex-1 text-[0.8rem] font-semibold text-v3-dark text-right">
+                                                {previousConsultationDates.map((date) => (
+                                                    <span key={date} className="block">
+                                                        {date}
+                                                    </span>
+                                                ))}
+                                            </span>
+                                        </div>
+                                    ) : null}
                                 </InfoCard>
                             </div>
                         </div>

--- a/frontend/src/app/(protected)/select-branch/actions.ts
+++ b/frontend/src/app/(protected)/select-branch/actions.ts
@@ -23,6 +23,16 @@ function getAuthHeaders(token: string | null): Record<string, string> {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
+function normalizeBranchRecord(record: Partial<Branch>): Branch {
+  return {
+    id: record.id ?? "",
+    name: record.name ?? "",
+    slug: record.slug ?? record.id ?? "",
+    description: record.description ?? null,
+    role: record.role ?? "member",
+  };
+}
+
 export async function getUserBranches(): Promise<{
   success: boolean;
   branches?: Branch[];
@@ -32,13 +42,36 @@ export async function getUserBranches(): Promise<{
     const cookieStore = await cookies();
     const token = cookieStore.get("auth_token")?.value || null;
 
-    const { data } = await serverAPIClient.get("/auth/branches", {
+    const response = await serverAPIClient.get("/auth/branches", {
       headers: getAuthHeaders(token),
     });
 
+    if (response.status === 404) {
+      const { data } = await serverAPIClient.get("/auth/organizations", {
+        headers: getAuthHeaders(token),
+      });
+
+      return {
+        success: true,
+        branches: (data.organizations ?? []).map((organization: Partial<Branch>) =>
+          normalizeBranchRecord(organization)
+        ),
+      };
+    }
+
+    if (response.status >= 400) {
+      const message = typeof response.data === "object" && response.data && "message" in response.data
+        ? String(response.data.message)
+        : "지점 목록을 불러오는데 실패했습니다.";
+
+      return { success: false, error: message };
+    }
+
     return {
       success: true,
-      branches: data.branches,
+      branches: (response.data.branches ?? []).map((branch: Partial<Branch>) =>
+        normalizeBranchRecord(branch)
+      ),
     };
   } catch (error) {
     console.error("[Server Action] Error fetching branches:", error);
@@ -69,11 +102,29 @@ export async function setCurrentBranch(branchId: string): Promise<{
     const autoLoginCookie = cookieStore.get("auto_login")?.value;
     const autoLogin = autoLoginCookie !== "0" && autoLoginCookie !== "false";
 
-    const { data } = await serverAPIClient.post("/auth/select-branch", {
+    let response = await serverAPIClient.post("/auth/select-branch", {
       branchId,
     }, {
       headers: getAuthHeaders(token),
     });
+
+    if (response.status === 404 || response.status === 400) {
+      response = await serverAPIClient.post("/auth/select-organization", {
+        organizationId: branchId,
+      }, {
+        headers: getAuthHeaders(token),
+      });
+    }
+
+    if (response.status >= 400) {
+      const message = typeof response.data === "object" && response.data && "message" in response.data
+        ? String(response.data.message)
+        : "지점 선택에 실패했습니다.";
+
+      return { success: false, error: message };
+    }
+
+    const { data } = response;
 
     setAuthSessionCookies(cookieStore, {
       accessToken: data.accessToken,
@@ -82,6 +133,13 @@ export async function setCurrentBranch(branchId: string): Promise<{
     });
 
     cookieStore.set("selected_branch_id", branchId, {
+      httpOnly: false,
+      secure: isSecureCookie,
+      sameSite: "lax",
+      path: "/",
+      maxAge: 30 * 24 * 60 * 60,
+    });
+    cookieStore.set("selected_organization_id", branchId, {
       httpOnly: false,
       secure: isSecureCookie,
       sameSite: "lax",

--- a/frontend/src/app/api/auth/kakao/route.ts
+++ b/frontend/src/app/api/auth/kakao/route.ts
@@ -1,8 +1,29 @@
 import { redirect } from "next/navigation";
 
 const isProduction = process.env.NODE_ENV === "production" || process.env.VERCEL_ENV === "preview";
-const API_URL = isProduction ? process.env.NEXT_PUBLIC_API_BASE_URL : process.env.DEVELOPMENT_API_BASE_URL;
+const DEFAULT_DEVELOPMENT_API_URL = "http://localhost:3001";
+
+function normalizeBaseUrl(value: string | undefined): string | undefined {
+    const trimmed = value?.trim();
+    if (!trimmed || trimmed === "undefined") {
+        return undefined;
+    }
+
+    return trimmed.replace(/\/+$/, "");
+}
+
+function resolveKakaoAuthBaseUrl(): string {
+    if (isProduction) {
+        return normalizeBaseUrl(process.env.NEXT_PUBLIC_API_BASE_URL) ?? DEFAULT_DEVELOPMENT_API_URL;
+    }
+
+    return (
+        normalizeBaseUrl(process.env.DEVELOPMENT_API_BASE_URL) ??
+        normalizeBaseUrl(process.env.NEXT_PUBLIC_API_BASE_URL) ??
+        DEFAULT_DEVELOPMENT_API_URL
+    );
+}
 
 export async function GET() {
-    redirect(`${API_URL}/auth/kakao`);
+    redirect(`${resolveKakaoAuthBaseUrl()}/auth/kakao`);
 }

--- a/frontend/src/app/api/auth/login/route.ts
+++ b/frontend/src/app/api/auth/login/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({
             success: true,
             message: "로그인 성공",
-            requiresBranchSelection: data.requiresBranchSelection,
+            requiresBranchSelection: Boolean(data.requiresBranchSelection || data.requiresOrgSelection),
         }, { status: 200 });
     } catch (error) {
         console.error("[Auth Login] Error:", error);

--- a/frontend/src/app/api/auth/token/route.ts
+++ b/frontend/src/app/api/auth/token/route.ts
@@ -14,6 +14,7 @@ interface TokenExchangeSuccessResponse {
     accessToken: string;
     refreshToken: string;
     requiresBranchSelection?: boolean;
+    requiresOrgSelection?: boolean;
 }
 
 interface TokenExchangePendingSignupResponse {
@@ -110,7 +111,10 @@ export async function POST(request: NextRequest) {
         cookieStore.delete(PENDING_KAKAO_SIGNUP_COOKIE);
         cookieStore.delete(PENDING_ACCOUNT_ONBOARDING_COOKIE);
 
-        return NextResponse.json({ message: "Success", requiresBranchSelection: data.requiresBranchSelection || false }, { status: 200 });
+        return NextResponse.json({
+            message: "Success",
+            requiresBranchSelection: Boolean(data.requiresBranchSelection || data.requiresOrgSelection),
+        }, { status: 200 });
     } catch (error) {
         console.error("Token Exchange Error:", error);
         console.error("Backend URL:", serverAPIClient.defaults.baseURL);

--- a/frontend/src/app/api/consultation-inquiries/route.ts
+++ b/frontend/src/app/api/consultation-inquiries/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
         const searchParams = request.nextUrl.searchParams;
         const params: Record<string, string> = {};
 
-        for (const key of ["page", "limit", "search", "status"]) {
+        for (const key of ["page", "limit", "search", "phone", "status", "readState"]) {
             const value = searchParams.get(key);
             if (value) params[key] = value;
         }

--- a/frontend/src/components/app/root/mobile-bottom-nav.tsx
+++ b/frontend/src/components/app/root/mobile-bottom-nav.tsx
@@ -50,6 +50,7 @@ export function MobileBottomNav() {
           <Link
             key={item.href}
             href={item.href}
+            prefetch={false}
             data-component={
               item.kind === "chat"
                 ? "mobile-bottom-nav-chat"

--- a/frontend/src/components/app/v3/V3Sidebar.tsx
+++ b/frontend/src/components/app/v3/V3Sidebar.tsx
@@ -26,6 +26,7 @@ import { t } from "@/lib/i18n/translations";
 import { ROLES } from "@/lib/constants/roles";
 import { SidebarNotifications } from "@/components/app/v3/SidebarNotifications";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { useConsultationInquiries } from "@/hooks/useConsultationInquiries";
 
 interface NavItem {
   label: string;
@@ -84,8 +85,20 @@ export const V3Sidebar = () => {
   const user = useInitialUser();
   const locale = useLocale();
   const isOwner = user?.role === ROLES.owner;
+  const isExcluded = isLayoutExcluded(pathname);
   const [isNavScrolling, setIsNavScrolling] = React.useState(false);
   const scrollResetTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const consultationUnreadParams = React.useMemo(
+    () => ({ page: 1, limit: 1, readState: "unread" }),
+    []
+  );
+  const { data: consultationUnreadData } = useConsultationInquiries(
+    consultationUnreadParams,
+    Boolean(user) && !isExcluded
+  );
+  const consultationUnreadCount = consultationUnreadData?.total ?? 0;
+  const consultationUnreadBadge =
+    consultationUnreadCount > 99 ? "99+" : consultationUnreadCount > 0 ? String(consultationUnreadCount) : null;
 
   const getNavItemName = (href: string) => {
     const segment = href.split("/").filter(Boolean).pop() || "";
@@ -138,7 +151,7 @@ export const V3Sidebar = () => {
     }, 450);
   };
 
-  if (isLayoutExcluded(pathname)) {
+  if (isExcluded) {
     return null;
   }
 
@@ -185,10 +198,12 @@ export const V3Sidebar = () => {
             <ul className="space-y-1">
               {section.items.map((item) => {
                 const active = isActive(item.href);
+                const badge = item.href === "/consultations" ? consultationUnreadBadge : item.badge;
                 return (
                   <li key={item.href}>
                     <Link
                       href={item.href}
+                      prefetch={false}
                       data-component={`sidebar-nav-${getNavItemName(item.href)}`}
                       className={`
                         relative group flex items-center gap-3 px-4 py-2.5 rounded-2xl transition-all duration-200 overflow-hidden
@@ -206,9 +221,15 @@ export const V3Sidebar = () => {
                         {item.label}
                       </span>
 
-                      {item.badge && (
-                        <span className="ml-auto text-[0.65rem] px-2 py-0.5 rounded-full bg-v3-primary-light text-v3-primary font-bold">
-                          {item.badge}
+                      {badge && (
+	                        <span
+	                          data-component={`sidebar-nav-${getNavItemName(item.href)}-badge`}
+	                          className={`
+	                            ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full px-2 text-center text-[0.65rem] font-bold leading-none
+	                            bg-v3-burgundy text-white
+	                          `}
+	                        >
+                          {badge}
                         </span>
                       )}
                     </Link>

--- a/frontend/src/components/auth/oauth-buttons.tsx
+++ b/frontend/src/components/auth/oauth-buttons.tsx
@@ -4,8 +4,6 @@ import { Button } from "@/components/ui/button";
 import { RiKakaoTalkFill } from "react-icons/ri";
 import { cn } from "@/lib/utils";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
-
 // Google Icon Component (since MUI icons won't be used)
 function GoogleIcon({ className }: { className?: string }) {
   return (
@@ -29,11 +27,11 @@ interface OAuthButtonsProps {
 
 export function OAuthButtons({ disabled, className }: OAuthButtonsProps) {
   const handleKakaoLogin = () => {
-    window.location.href = `${API_BASE_URL}/auth/kakao`;
+    window.location.href = "/api/auth/kakao";
   };
 
   const handleGoogleLogin = () => {
-    window.location.href = `${API_BASE_URL}/auth/google`;
+    window.location.href = "/api/auth/google";
   };
 
   return (

--- a/frontend/src/features/auth/login/shared/use-login-page-controller.ts
+++ b/frontend/src/features/auth/login/shared/use-login-page-controller.ts
@@ -8,8 +8,6 @@ import { loginSchema, type LoginFormData } from "@/lib/validations/auth";
 import { safeStorageGetItem, safeStorageRemoveItem, safeStorageSetItem } from "@/lib/safe-storage";
 import { loginWithEmail } from "@/app/(auth)/login/actions";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
-
 export function useLoginPageController() {
   const router = useRouter();
   const [autoLogin, setAutoLogin] = useState(false);
@@ -141,8 +139,8 @@ export function useLoginPageController() {
     }
   };
 
-  const kakaoLoginUrl = useMemo(() => `${API_BASE_URL}/auth/kakao`, []);
-  const googleLoginUrl = useMemo(() => `${API_BASE_URL}/auth/google`, []);
+  const kakaoLoginUrl = useMemo(() => "/api/auth/kakao", []);
+  const googleLoginUrl = useMemo(() => "/api/auth/google", []);
 
   return {
     autoLogin,

--- a/frontend/src/hooks/use-toast.test.tsx
+++ b/frontend/src/hooks/use-toast.test.tsx
@@ -1,0 +1,42 @@
+import { act, render, screen } from "@testing-library/react";
+
+import { toast, useToast } from "./use-toast";
+
+function ToastCounter() {
+  const { toasts } = useToast();
+
+  return <div data-testid="toast-count">{toasts.length}</div>;
+}
+
+describe("toast", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("auto-dismisses toasts after the configured duration", () => {
+    render(<ToastCounter />);
+
+    act(() => {
+      toast({ title: "문서 삭제 완료", duration: 50 });
+    });
+
+    expect(screen.getByTestId("toast-count")).toHaveTextContent("1");
+
+    act(() => {
+      jest.advanceTimersByTime(49);
+    });
+
+    expect(screen.getByTestId("toast-count")).toHaveTextContent("1");
+
+    act(() => {
+      jest.advanceTimersByTime(301);
+    });
+
+    expect(screen.getByTestId("toast-count")).toHaveTextContent("0");
+  });
+});

--- a/frontend/src/hooks/use-toast.ts
+++ b/frontend/src/hooks/use-toast.ts
@@ -3,7 +3,8 @@
 import * as React from "react";
 
 const TOAST_LIMIT = 1;
-const TOAST_REMOVE_DELAY = 1000000;
+const DEFAULT_TOAST_DURATION = 4000;
+const TOAST_REMOVE_DELAY = 300;
 
 type ToasterToast = {
   id: string;
@@ -11,6 +12,7 @@ type ToasterToast = {
   description?: string;
   action?: React.ReactNode;
   variant?: "default" | "destructive";
+  duration?: number;
 };
 
 let count = 0;
@@ -43,6 +45,42 @@ interface State {
 }
 
 const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+const toastAutoDismissTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+const clearToastTimers = (toastId: string) => {
+  const removeTimeout = toastTimeouts.get(toastId);
+  if (removeTimeout) {
+    clearTimeout(removeTimeout);
+    toastTimeouts.delete(toastId);
+  }
+
+  const autoDismissTimeout = toastAutoDismissTimeouts.get(toastId);
+  if (autoDismissTimeout) {
+    clearTimeout(autoDismissTimeout);
+    toastAutoDismissTimeouts.delete(toastId);
+  }
+};
+
+const addToAutoDismissQueue = (toastId: string, duration = DEFAULT_TOAST_DURATION) => {
+  if (!Number.isFinite(duration) || duration <= 0) {
+    return;
+  }
+
+  const existingTimeout = toastAutoDismissTimeouts.get(toastId);
+  if (existingTimeout) {
+    clearTimeout(existingTimeout);
+  }
+
+  const timeout = setTimeout(() => {
+    toastAutoDismissTimeouts.delete(toastId);
+    dispatch({
+      type: "DISMISS_TOAST",
+      toastId,
+    });
+  }, duration);
+
+  toastAutoDismissTimeouts.set(toastId, timeout);
+};
 
 const addToRemoveQueue = (toastId: string) => {
   if (toastTimeouts.has(toastId)) {
@@ -80,9 +118,19 @@ export const reducer = (state: State, action: Action): State => {
       const { toastId } = action;
 
       if (toastId) {
+        const autoDismissTimeout = toastAutoDismissTimeouts.get(toastId);
+        if (autoDismissTimeout) {
+          clearTimeout(autoDismissTimeout);
+          toastAutoDismissTimeouts.delete(toastId);
+        }
         addToRemoveQueue(toastId);
       } else {
         state.toasts.forEach((toast) => {
+          const autoDismissTimeout = toastAutoDismissTimeouts.get(toast.id);
+          if (autoDismissTimeout) {
+            clearTimeout(autoDismissTimeout);
+            toastAutoDismissTimeouts.delete(toast.id);
+          }
           addToRemoveQueue(toast.id);
         });
       }
@@ -100,11 +148,15 @@ export const reducer = (state: State, action: Action): State => {
     }
     case "REMOVE_TOAST":
       if (action.toastId === undefined) {
+        for (const toast of state.toasts) {
+          clearToastTimers(toast.id);
+        }
         return {
           ...state,
           toasts: [],
         };
       }
+      clearToastTimers(action.toastId);
       return {
         ...state,
         toasts: state.toasts.filter((t) => t.id !== action.toastId),
@@ -142,6 +194,7 @@ function toast({ ...props }: Toast) {
       id,
     },
   });
+  addToAutoDismissQueue(id, props.duration);
 
   return {
     id: id,

--- a/frontend/src/lib/auth/cookies.ts
+++ b/frontend/src/lib/auth/cookies.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { cache } from "react";
 import { jwtDecode } from "jwt-decode";
 import axios from "axios";
+import type { AuthUser } from "@/hooks/useGetAuthUser";
 
 interface TokenPayload {
   sub: string;
@@ -10,8 +11,14 @@ interface TokenPayload {
   branchId?: string;
   branchRole?: string;
   organizationId?: string;
+  orgRole?: string;
   type: "access" | "refresh";
 }
+
+type CurrentUserResponse = AuthUser & {
+  branchName?: string | null;
+  organizationName?: string | null;
+};
 
 // React cache()를 사용하여 같은 request cycle 내에서 중복 호출 방지
 // Next.js의 Request Memoization은 native fetch에만 적용되므로
@@ -37,7 +44,11 @@ export const getCurrentUser = cache(async () => {
       return null;
     }
 
-    return res.data;
+    const user = res.data as CurrentUserResponse;
+    return {
+      ...user,
+      branchName: user.branchName ?? user.organizationName ?? null,
+    };
   } catch (error: unknown) {
     if (axios.isAxiosError(error)) {
       console.error("[getCurrentUser] Failed to fetch user:", error.message);

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -7,6 +7,8 @@ interface TokenPayload {
   role: string | null;
   branchId?: string;
   branchRole?: string;
+  organizationId?: string;
+  orgRole?: string;
   type: "access" | "refresh";
 }
 
@@ -59,7 +61,7 @@ export function proxy(request: NextRequest) {
     const decoded = jwtDecode<TokenPayload>(authToken);
 
     // No branch selected - redirect to select-branch
-    if (!decoded.branchId) {
+    if (!decoded.branchId && !decoded.organizationId) {
       const selectBranchUrl = new URL("/select-branch", request.url);
       return NextResponse.redirect(selectBranchUrl);
     }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -27,8 +27,7 @@ export interface EformsignAuthStatusResponse {
 // Auth API
 export const authApi = {
     kakaoLogin: () => {
-        const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3001";
-        window.location.href = `${API_BASE_URL}/auth/kakao`;
+        window.location.href = "/api/auth/kakao";
     },
 
     // Email authentication


### PR DESCRIPTION
## Summary
- Refine staff 상담 list/detail behavior around same-name and same-phone inquiry history.
- Add unread 상담 count badge to the sidebar 상담 nav item.
- Harden local auth routing against missing API base URLs and branch/organization naming drift during the branch migration.
- Fix app toasts so success/error notifications auto-dismiss instead of lingering indefinitely.

## Changes
- Collapse 상담 list items by normalized `motherName + phone`, while showing all older matching inquiries in the detail `이전 상담` row.
- Move 상담 detail fields to the requested cards, remove 처리 정보/public branch id, localize `website` to `홈페이지`, and keep stats independent from read-state tabs.
- Add backend phone-history matching across hyphenated/digit-only phone variants.
- Route Kakao login through `/api/auth/kakao` and add local fallback to `http://localhost:3001`.
- Accept both branch and organization response/token names in auth and selection paths while the migration finishes.
- Add `prefetch={false}` on shared nav links to reduce noisy current-route prefetching in dev.
- Auto-dismiss toasts after a default duration and cover the behavior with a focused unit test.

## Test Plan
- `pnpm --dir frontend exec eslint 'src/app/(auth)/callback/actions.ts' 'src/app/(auth)/kakao/onboarding/actions.ts' 'src/app/(auth)/login/actions.ts' 'src/app/(auth)/onboarding/actions.ts' 'src/app/(protected)/consultations/page.tsx' 'src/app/(protected)/select-branch/actions.ts' 'src/app/api/auth/kakao/route.ts' 'src/app/api/auth/login/route.ts' 'src/app/api/auth/token/route.ts' 'src/app/api/consultation-inquiries/route.ts' 'src/components/app/root/mobile-bottom-nav.tsx' 'src/components/app/v3/V3Sidebar.tsx' 'src/components/auth/oauth-buttons.tsx' 'src/features/auth/login/shared/use-login-page-controller.ts' 'src/lib/auth/cookies.ts' 'src/proxy.ts' 'src/services/api.ts'`
- `pnpm --dir backend test -- --runTestsByPath test/services/consultation-inquiry.service.spec.ts test/repositories/sb.consultation-inquiry.repository.spec.ts`
- `pnpm --dir frontend test -- --runTestsByPath src/hooks/use-toast.test.tsx`
- `pnpm --dir frontend build`
- Playwright local checks for consultation list dedupe/history, read-state tabs, stats stability, sidebar badge, and Kakao login route.

## Notes
- Full `pnpm --dir frontend lint` is still blocked by the pre-existing `frontend/src/app/website-admin/page.tsx:46` `react-hooks/set-state-in-effect` error.
- Dummy local DB rows were added for manual testing only; no seed/migration was committed.
