### PR TITLE
fix(consultations): route Incheon inquiries to main branch

### DIFF
--- a/backend/application/services/auth.service.ts
+++ b/backend/application/services/auth.service.ts
@@ -7,6 +7,7 @@ import { EMAIL_PORT, EmailPort } from "../../domain/ports/email.port";
 import { AUTH_TOKEN_REPOSITORY, IAuthTokenRepository } from "../../domain/repositories/auth-token.repository.interface";
 import { AuthTokenEntity } from "../../domain/entities/auth-token.entity";
 import { getAuthTokenExpiresIn } from "./auth-token-policy";
+import { isVisibleStaffBranchSlug } from "domain/constants/branch-routing.constants";
 
 export interface KakaoData {
     kakaoId: string;
@@ -91,6 +92,15 @@ export interface PasswordValidationResult {
     errors: string[];
 }
 
+type UserBranchSelection = {
+    branchId: string;
+    role: string | null;
+    branch?: {
+        slug: string | null;
+        isActive: boolean | null;
+    };
+};
+
 export interface RegistrationResult {
     success: boolean;
     message: string;
@@ -158,7 +168,7 @@ export class AuthService {
             birthDate: string | null;
             role: string | null;
         },
-        userOrgs: Array<{ branchId: string; role: string | null }>,
+        userOrgs: UserBranchSelection[],
     ): PendingAccountOnboardingProfile | null {
         const [firstOrg] = userOrgs;
 
@@ -183,6 +193,19 @@ export class AuthService {
         };
     }
 
+    private filterSelectableUserBranches<TUserBranch extends UserBranchSelection>(
+        userBranches: TUserBranch[],
+    ): TUserBranch[] {
+        return userBranches.filter((userBranch) => {
+            if (!userBranch.branch) {
+                return true;
+            }
+
+            return userBranch.branch.isActive === true
+                && isVisibleStaffBranchSlug(userBranch.branch.slug ?? "");
+        });
+    }
+
     private async createLoginResultForUser(user: {
         id: string;
         email: string | null;
@@ -192,13 +215,19 @@ export class AuthService {
         birthDate: string | null;
         role: string | null;
     }): Promise<UserValidationResult | PendingAccountOnboardingValidationResult> {
-        const userOrgs = await this.prisma.user_branch.findMany({
+        const userOrgs = this.filterSelectableUserBranches(await this.prisma.user_branch.findMany({
             where: { userId: user.id },
             select: {
                 branchId: true,
                 role: true,
+                branch: {
+                    select: {
+                        slug: true,
+                        isActive: true,
+                    },
+                },
             },
-        });
+        }));
 
         const pendingAccountOnboardingProfile = user.role === "owner"
             ? null
@@ -332,6 +361,14 @@ export class AuthService {
         return this.createLoginResultForUser(user);
     }
 
+    private isSelectableBranch(branch: { slug?: string | null; isActive?: boolean | null } | null | undefined): boolean {
+        if (!branch) {
+            return true;
+        }
+
+        return branch.isActive === true && isVisibleStaffBranchSlug(branch.slug ?? "");
+    }
+
     async selectBranch(userid: string, branchid: string): Promise<{ accessToken: string; refreshToken: string }> {
         const user = await this.prisma.user.findUnique({ where: { id: userid } });
         if (!user) {
@@ -342,9 +379,9 @@ export class AuthService {
         if (user.role === 'owner') {
             const org = await this.prisma.branch.findUnique({
                 where: { id: branchid },
-                select: { id: true },
+                select: { id: true, slug: true, isActive: true },
             });
-            if (!org) {
+            if (!org || !this.isSelectableBranch(org)) {
                 throw new ForbiddenException("Branch not found");
             }
             return this.issueBranchTokens(user, branchid, 'owner');
@@ -352,9 +389,17 @@ export class AuthService {
 
         // Regular users must be linked to the branch
         const userOrg = await this.prisma.user_branch.findFirst({
-            where: { userId: userid, branchId: branchid }
+            where: { userId: userid, branchId: branchid },
+            include: {
+                branch: {
+                    select: {
+                        slug: true,
+                        isActive: true,
+                    },
+                },
+            },
         });
-        if (!userOrg) {
+        if (!userOrg || !this.isSelectableBranch(userOrg.branch)) {
             throw new ForbiddenException("User does not belong to this branch");
         }
 
@@ -375,9 +420,9 @@ export class AuthService {
         if (user.role === 'owner') {
             const org = await this.prisma.branch.findUnique({
                 where: { id: newbranchid },
-                select: { id: true },
+                select: { id: true, slug: true, isActive: true },
             });
-            if (!org) {
+            if (!org || !this.isSelectableBranch(org)) {
                 throw new ForbiddenException("Branch not found");
             }
             return this.issueBranchTokens(user, newbranchid, 'owner');
@@ -385,9 +430,17 @@ export class AuthService {
 
         // Regular users must be linked to the branch
         const userOrg = await this.prisma.user_branch.findFirst({
-            where: { userId: userid, branchId: newbranchid }
+            where: { userId: userid, branchId: newbranchid },
+            include: {
+                branch: {
+                    select: {
+                        slug: true,
+                        isActive: true,
+                    },
+                },
+            },
         });
-        if (!userOrg) {
+        if (!userOrg || !this.isSelectableBranch(userOrg.branch)) {
             throw new ForbiddenException("User does not belong to target branch");
         }
 
@@ -417,7 +470,7 @@ export class AuthService {
 
             this.logger.log(`[getUserBranches] Owner access - found ${allOrgs.length} active branches`);
 
-            return allOrgs.map(org => ({
+            return allOrgs.filter((org) => isVisibleStaffBranchSlug(org.slug)).map(org => ({
                 id: org.id,
                 name: org.name,
                 slug: org.slug,
@@ -435,7 +488,7 @@ export class AuthService {
             return [];
         }
 
-        return userOrgs.map(userOrg => ({
+        return userOrgs.filter((userOrg) => isVisibleStaffBranchSlug(userOrg.branch.slug)).map(userOrg => ({
             id: userOrg.branch.id,
             name: userOrg.branch.name,
             slug: userOrg.branch.slug,
@@ -720,13 +773,19 @@ export class AuthService {
             throw new UnauthorizedException("Pending account onboarding user not found");
         }
 
-        const userOrgs = await this.prisma.user_branch.findMany({
+        const userOrgs = this.filterSelectableUserBranches(await this.prisma.user_branch.findMany({
             where: { userId: user.id },
             select: {
                 branchId: true,
                 role: true,
+                branch: {
+                    select: {
+                        slug: true,
+                        isActive: true,
+                    },
+                },
             },
-        });
+        }));
 
         return this.getPendingAccountOnboardingProfile(user, userOrgs) ?? {
             email: user.email ?? undefined,

--- a/backend/application/services/consultation-inquiry.service.ts
+++ b/backend/application/services/consultation-inquiry.service.ts
@@ -5,6 +5,7 @@ import {
     ConsultationSelectedServices,
     CreateConsultationInquiryParams,
 } from "domain/entities/consultation-inquiry.entity";
+import { getStaffBranchSlugForPublicInquiry } from "domain/constants/branch-routing.constants";
 import {
     CONSULTATION_INQUIRY_REPOSITORY,
     IConsultationInquiryRepository,
@@ -64,14 +65,16 @@ export class ConsultationInquiryService {
             throw new BadRequestException("개인정보 수집 및 이용 동의가 필요합니다.");
         }
 
-        const branch = await this.repository.findActiveBranchBySlug(dto.branchSlug);
+        const publicBranchSlug = dto.branchSlug.trim();
+        const staffBranchSlug = getStaffBranchSlugForPublicInquiry(publicBranchSlug);
+        const branch = await this.repository.findActiveBranchBySlug(staffBranchSlug);
         if (!branch) {
             throw new NotFoundException("상담 가능한 지점을 찾을 수 없습니다.");
         }
 
         const params: CreateConsultationInquiryParams = {
             branchId: branch.id,
-            publicBranchSlug: branch.slug,
+            publicBranchSlug,
             motherName: dto.motherName,
             phone: dto.phone,
             address: dto.address,

--- a/backend/domain/constants/branch-routing.constants.ts
+++ b/backend/domain/constants/branch-routing.constants.ts
@@ -1,0 +1,29 @@
+export const INCHEON_STAFF_BRANCH_SLUG = "incheon";
+
+const INCHEON_PUBLIC_BRANCH_SLUG_PREFIX = `${INCHEON_STAFF_BRANCH_SLUG}-`;
+
+export const INCHEON_PUBLIC_DISTRICT_BRANCH_SLUGS = [
+    "incheon-junggu",
+    "incheon-donggu",
+    "incheon-michuhol",
+    "incheon-yeonsu",
+    "incheon-namdong",
+    "incheon-bupyeong",
+    "incheon-gyeyang",
+    "incheon-seogu",
+] as const;
+
+export function getStaffBranchSlugForPublicInquiry(publicBranchSlug: string): string {
+    const branchSlug = publicBranchSlug.trim();
+
+    if (branchSlug.startsWith(INCHEON_PUBLIC_BRANCH_SLUG_PREFIX)) {
+        return INCHEON_STAFF_BRANCH_SLUG;
+    }
+
+    return branchSlug;
+}
+
+export function isVisibleStaffBranchSlug(branchSlug: string): boolean {
+    return branchSlug === INCHEON_STAFF_BRANCH_SLUG
+        || !branchSlug.startsWith(INCHEON_PUBLIC_BRANCH_SLUG_PREFIX);
+}

--- a/backend/infrastructure/database/repositories/sb.branch.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.branch.repository.ts
@@ -1,15 +1,20 @@
 import { Injectable } from "@nestjs/common";
 import { PrismaService } from "infrastructure/database/prisma.service";
 import { IBranchRepository } from "domain/repositories/branch.repository.interface";
+import { isVisibleStaffBranchSlug } from "domain/constants/branch-routing.constants";
 
 @Injectable()
 export class SbBranchRepository implements IBranchRepository {
     constructor(private readonly prisma: PrismaService) {}
 
     async findAllActive(): Promise<{ id: string; name: string }[]> {
-        return this.prisma.branch.findMany({
+        const branches = await this.prisma.branch.findMany({
             where: { isActive: true },
-            select: { id: true, name: true },
+            select: { id: true, name: true, slug: true },
         });
+
+        return branches
+            .filter((branch) => isVisibleStaffBranchSlug(branch.slug))
+            .map(({ id, name }) => ({ id, name }));
     }
 }

--- a/backend/interface/controllers/auth.controller.ts
+++ b/backend/interface/controllers/auth.controller.ts
@@ -19,6 +19,7 @@ import {
 } from "interface/dto/email-auth.dto";
 import { SelectBranchDto, SwitchBranchDto } from "interface/dto/branch-auth.dto";
 import { CompleteKakaoOnboardingDto } from "interface/dto/kakao-onboarding.dto";
+import { isVisibleStaffBranchSlug } from "domain/constants/branch-routing.constants";
 
 @Controller("auth")
 export class AuthController {
@@ -344,10 +345,12 @@ export class AuthController {
     async getAllActiveBranches() {
         const branches = await this.prisma.branch.findMany({
             where: { isActive: true },
-            select: { id: true, name: true },
+            select: { id: true, name: true, slug: true },
             orderBy: { name: 'asc' },
         });
-        return branches;
+        return branches
+            .filter((branch) => isVisibleStaffBranchSlug(branch.slug))
+            .map(({ id, name }) => ({ id, name }));
     }
 
     @Post("select-branch")

--- a/backend/prisma/scripts/seed-public-branches.ts
+++ b/backend/prisma/scripts/seed-public-branches.ts
@@ -1,95 +1,20 @@
 import { PrismaClient } from "@prisma/client";
 
+import { INCHEON_STAFF_BRANCH_SLUG } from "../../domain/constants/branch-routing.constants";
+
 const prisma = new PrismaClient();
 
 const PUBLIC_BRANCHES = [
     {
-        slug: "incheon-junggu",
-        name: "인천 중구점",
+        slug: INCHEON_STAFF_BRANCH_SLUG,
+        name: "인천지점",
         region: "인천",
-        district: "중구",
+        district: "인천",
         branchType: "direct",
-        address: "인천광역시 중구 신포로 27, 4층",
+        address: "",
         phone: "1661-2386",
         businessHours: "평일 09:00 – 18:00",
-        description: "인천 중구·영종 지역 전담. 신포역 인근.",
-    },
-    {
-        slug: "incheon-donggu",
-        name: "인천 동구점",
-        region: "인천",
-        district: "동구",
-        branchType: "direct",
-        address: "인천광역시 동구 솔빛로 105, 3층",
-        phone: "1661-2386",
-        businessHours: "평일 09:00 – 18:00",
-        description: "인천 동구 전담. 동인천역 도보 3분.",
-    },
-    {
-        slug: "incheon-michuhol",
-        name: "인천 미추홀구점",
-        region: "인천",
-        district: "미추홀구",
-        branchType: "direct",
-        address: "인천광역시 미추홀구 경인로 229, 5층",
-        phone: "1661-2386",
-        businessHours: "평일 09:00 – 18:00",
-        description: "미추홀구 전담. 주안역 인근.",
-    },
-    {
-        slug: "incheon-yeonsu",
-        name: "인천 연수구점",
-        region: "인천",
-        district: "연수구",
-        branchType: "direct",
-        address: "인천광역시 연수구 컨벤시아대로 165, 6층",
-        phone: "1661-2386",
-        businessHours: "평일 09:00 – 18:00",
-        description: "연수·송도 지역 전담. 센트럴파크역 인근.",
-    },
-    {
-        slug: "incheon-namdong",
-        name: "인천 남동구점",
-        region: "인천",
-        district: "남동구",
-        branchType: "direct",
-        address: "인천광역시 남동구 인주대로 552, 3층",
-        phone: "1661-2386",
-        businessHours: "평일 09:00 – 18:00",
-        description: "남동구 전담. 남동인더스파크역 인근.",
-    },
-    {
-        slug: "incheon-bupyeong",
-        name: "인천 부평구점",
-        region: "인천",
-        district: "부평구",
-        branchType: "direct",
-        address: "인천광역시 부평구 부평대로 283, 4층",
-        phone: "1661-2386",
-        businessHours: "평일 09:00 – 18:00",
-        description: "부평구 전담. 부평역 도보 5분.",
-    },
-    {
-        slug: "incheon-gyeyang",
-        name: "인천 계양구점",
-        region: "인천",
-        district: "계양구",
-        branchType: "direct",
-        address: "인천광역시 계양구 계양대로 145, 3층",
-        phone: "1661-2386",
-        businessHours: "평일 09:00 – 18:00",
-        description: "계양구 전담. 계양역 인근.",
-    },
-    {
-        slug: "incheon-seogu",
-        name: "인천 서구점",
-        region: "인천",
-        district: "서구",
-        branchType: "direct",
-        address: "인천광역시 서구 청라대로 229, 5층",
-        phone: "1661-2386",
-        businessHours: "평일 09:00 – 18:00",
-        description: "서구·청라 지역 전담. 검암역 인근.",
+        description: "인천 전 지역 상담 접수 지점.",
     },
     {
         slug: "gyeongsan",
@@ -176,7 +101,23 @@ async function main(): Promise<void> {
         });
     }
 
-    console.log(`Seeded ${PUBLIC_BRANCHES.length} public branches for ${owner.email}.`);
+    const deactivatedIncheonDistrictBranches = await prisma.branch.updateMany({
+        where: {
+            slug: { not: INCHEON_STAFF_BRANCH_SLUG },
+            OR: [
+                { region: "인천" },
+                { slug: { startsWith: `${INCHEON_STAFF_BRANCH_SLUG}-` } },
+            ],
+        },
+        data: {
+            isActive: false,
+        },
+    });
+
+    console.log(
+        `Seeded ${PUBLIC_BRANCHES.length} public branches for ${owner.email}; ` +
+        `deactivated ${deactivatedIncheonDistrictBranches.count} Incheon district branches.`,
+    );
 }
 
 main()

--- a/backend/test/services/consultation-inquiry.service.spec.ts
+++ b/backend/test/services/consultation-inquiry.service.spec.ts
@@ -53,12 +53,12 @@ describe("ConsultationInquiryService", () => {
         );
     });
 
-    it("should create public inquiry when branch exists and privacy is accepted", async () => {
+    it("should route Incheon district public inquiry to the canonical Incheon branch", async () => {
         const inquiry = createInquiry();
         repository.findActiveBranchBySlug.mockResolvedValue({
             id: "branch-1",
-            name: "인천 연수구점",
-            slug: "incheon-yeonsu",
+            name: "인천지점",
+            slug: "incheon",
         });
         repository.create.mockResolvedValue(inquiry);
         repository.findNotificationRecipientUserIds.mockResolvedValue(["user-1", "user-2"]);
@@ -75,6 +75,7 @@ describe("ConsultationInquiryService", () => {
         });
 
         expect(result).toBe(inquiry);
+        expect(repository.findActiveBranchBySlug).toHaveBeenCalledWith("incheon");
         expect(repository.create).toHaveBeenCalledWith(expect.objectContaining({
             branchId: "branch-1",
             publicBranchSlug: "incheon-yeonsu",
@@ -138,8 +139,43 @@ describe("ConsultationInquiryService", () => {
                 url: "/consultations",
                 type: "consultation-inquiry",
                 inquiryId: "inq-1",
+                branchSlug: "incheon-yeonsu",
             }),
         );
+    });
+
+    it("should route non-Incheon public inquiry to its matching branch", async () => {
+        const inquiry = {
+            ...createInquiry(),
+            branchId: "branch-bucheon",
+            publicBranchSlug: "bucheon",
+            branchName: "부천점",
+        };
+        repository.findActiveBranchBySlug.mockResolvedValue({
+            id: "branch-bucheon",
+            name: "부천점",
+            slug: "bucheon",
+        });
+        repository.create.mockResolvedValue(inquiry);
+        repository.findNotificationRecipientUserIds.mockResolvedValue([]);
+
+        const result = await service.createPublicInquiry({
+            branchSlug: "bucheon",
+            motherName: "김지은",
+            phone: "010-1234-5678",
+            address: "경기도 부천시",
+            dueDate: "2026-05-01",
+            birthExperience: "초산",
+            referralSource: "검색",
+            privacyAccepted: true,
+        });
+
+        expect(result).toBe(inquiry);
+        expect(repository.findActiveBranchBySlug).toHaveBeenCalledWith("bucheon");
+        expect(repository.create).toHaveBeenCalledWith(expect.objectContaining({
+            branchId: "branch-bucheon",
+            publicBranchSlug: "bucheon",
+        }));
     });
 
     it("should reject public inquiry when privacy is not accepted", async () => {

--- a/backend/test/unit/auth.service.branch.spec.ts
+++ b/backend/test/unit/auth.service.branch.spec.ts
@@ -22,6 +22,7 @@ describe("AuthService - Multi-Tenancy Enhancement", () => {
         },
         branch: {
             findUnique: jest.fn(),
+            findMany: jest.fn(),
         },
     });
 
@@ -216,6 +217,42 @@ describe("AuthService - Multi-Tenancy Enhancement", () => {
                 expect(jwtService.signAsync).not.toHaveBeenCalled();
             });
         });
+
+        describe("given user only has a hidden Incheon district branch", () => {
+            it("should not auto-select the hidden branch", async () => {
+                const kakaoData = {
+                    kakaoId: "kakao-12345",
+                    email: "test@example.com",
+                    name: "Test User",
+                };
+                const hiddenIncheonDistrictBranch = {
+                    id: "incheon-bupyeong-id",
+                    name: "인천 부평구점",
+                    slug: "incheon-bupyeong",
+                    isActive: true,
+                };
+
+                prismaService.user.findFirst.mockResolvedValue(mockUser);
+                prismaService.user_branch.findMany.mockResolvedValue([
+                    {
+                        ...mockUserBranch,
+                        branchId: hiddenIncheonDistrictBranch.id,
+                        branch: hiddenIncheonDistrictBranch,
+                    },
+                ]);
+
+                const result = await service.validateKakaoUser(kakaoData);
+
+                expect(result).toMatchObject({
+                    onboardingRequired: true,
+                    onboardingKind: "account_completion",
+                    prefill: expect.objectContaining({
+                        branchId: undefined,
+                    }),
+                });
+                expect(jwtService.signAsync).not.toHaveBeenCalled();
+            });
+        });
     });
 
     // ============================================
@@ -256,6 +293,30 @@ describe("AuthService - Multi-Tenancy Enhancement", () => {
                 const action = () => service.selectBranch(userId, invalidOrgId);
 
                 // #then
+                await expect(action).rejects.toThrow(ForbiddenException);
+                await expect(action).rejects.toThrow("User does not belong to this branch");
+            });
+        });
+
+        describe("given user belongs to a hidden Incheon district branch", () => {
+            it("should throw ForbiddenException", async () => {
+                const hiddenIncheonDistrictBranch = {
+                    id: "incheon-bupyeong-id",
+                    name: "인천 부평구점",
+                    slug: "incheon-bupyeong",
+                    isActive: true,
+                };
+                const hiddenMembership = {
+                    ...mockUserBranch,
+                    branchId: hiddenIncheonDistrictBranch.id,
+                    branch: hiddenIncheonDistrictBranch,
+                };
+
+                prismaService.user.findUnique.mockResolvedValue(mockUser);
+                prismaService.user_branch.findFirst.mockResolvedValue(hiddenMembership);
+
+                const action = () => service.selectBranch(mockUser.id, hiddenIncheonDistrictBranch.id);
+
                 await expect(action).rejects.toThrow(ForbiddenException);
                 await expect(action).rejects.toThrow("User does not belong to this branch");
             });
@@ -545,6 +606,81 @@ describe("AuthService - Multi-Tenancy Enhancement", () => {
                     slug: mockBranch2.slug,
                     role: "member",
                 });
+            });
+
+            it("should hide Incheon district branches from regular user branch list", async () => {
+                const userId = mockUser.id;
+                const hiddenIncheonDistrictBranch = {
+                    id: "incheon-bupyeong-id",
+                    name: "인천 부평구점",
+                    slug: "incheon-bupyeong",
+                    isActive: true,
+                };
+                const canonicalIncheonBranch = {
+                    id: "incheon-id",
+                    name: "인천지점",
+                    slug: "incheon",
+                    isActive: true,
+                };
+
+                prismaService.user.findUnique.mockResolvedValue({ role: "user" });
+                prismaService.user_branch.findMany.mockResolvedValue([
+                    { ...mockUserBranch, branch: hiddenIncheonDistrictBranch },
+                    { ...mockUserBranch2, branch: canonicalIncheonBranch },
+                ]);
+
+                const result = await service.getUserBranches(userId);
+
+                expect(result).toEqual([
+                    {
+                        id: canonicalIncheonBranch.id,
+                        name: canonicalIncheonBranch.name,
+                        slug: canonicalIncheonBranch.slug,
+                        role: "member",
+                    },
+                ]);
+            });
+        });
+
+        describe("given owner user", () => {
+            it("should hide Incheon district branches from owner branch list", async () => {
+                const userId = mockUser.id;
+                const hiddenIncheonDistrictBranch = {
+                    id: "incheon-yeonsu-id",
+                    name: "인천 연수구점",
+                    slug: "incheon-yeonsu",
+                    isActive: true,
+                };
+                const canonicalIncheonBranch = {
+                    id: "incheon-id",
+                    name: "인천지점",
+                    slug: "incheon",
+                    isActive: true,
+                };
+
+                prismaService.user.findUnique.mockResolvedValue({ role: "owner" });
+                prismaService.branch.findMany.mockResolvedValue([
+                    hiddenIncheonDistrictBranch,
+                    canonicalIncheonBranch,
+                    mockBranch,
+                ]);
+
+                const result = await service.getUserBranches(userId);
+
+                expect(result).toEqual([
+                    {
+                        id: canonicalIncheonBranch.id,
+                        name: canonicalIncheonBranch.name,
+                        slug: canonicalIncheonBranch.slug,
+                        role: "owner",
+                    },
+                    {
+                        id: mockBranch.id,
+                        name: mockBranch.name,
+                        slug: mockBranch.slug,
+                        role: "owner",
+                    },
+                ]);
             });
         });
 


### PR DESCRIPTION
## Summary
- Route public Incheon district consultation slugs (`incheon-*`) into the canonical staff branch `인천지점` / `incheon`.
- Preserve the original public branch slug on each inquiry so the website can keep district-level branch selection/display.
- Hide and block stale Incheon district branches in staff branch selection paths, and update public branch seeding to keep only `인천지점` active for Incheon.

## Changes
- Added shared branch-routing constants for Incheon slug canonicalization and staff branch visibility.
- Updated public consultation creation to resolve `incheon-*` to staff slug `incheon` while storing the submitted slug.
- Filtered hidden Incheon district branches from owner/user branch lists and scheduler active-branch lookup.
- Blocked direct select/switch attempts for hidden Incheon district branch IDs.
- Updated `seed-public-branches.ts` to upsert `인천지점` and deactivate existing Incheon district rows.
- Added regression coverage for Incheon routing, non-Incheon routing, hidden membership auto-selection, direct selection rejection, and branch-list filtering.

## Test Plan
- `pnpm --dir backend test -- consultation-inquiry.service.spec.ts auth.service.branch.spec.ts --runInBand` passed: 33 tests.
- `DATABASE_URL='postgresql://user:pass@localhost:5432/db' DIRECT_URL='postgresql://user:pass@localhost:5432/db' pnpm --dir backend exec prisma validate` passed.
- `DATABASE_URL='postgresql://user:pass@localhost:5432/db' DIRECT_URL='postgresql://user:pass@localhost:5432/db' pnpm --dir backend build` passed.
- Focused changed-file security scan found no new secrets or dangerous patterns. `pnpm audit --audit-level high` still fails on existing dependency advisories: 54 total, including 1 critical and 17 high.

## Notes
- Rebased on latest `origin/dev` at `94ed3c55` before opening this PR.
- No live database seed or migration was run by this PR.
