### PR TITLE
[chore] Sync dev into preview (9121bbb5)

### DIFF
--- a/backend/prisma/scripts/migrate-to-multi-tenancy-clean.ts
+++ b/backend/prisma/scripts/migrate-to-multi-tenancy-clean.ts
@@ -24,7 +24,7 @@ async function migrate() {
       org = await prisma.branch.create({
         data: {
           id: crypto.randomUUID(),
-          name: '인천지점',
+          name: '인천점',
           slug: 'incheon',
           description: '기본 지점',
           email: 'incheon@mirae-incheon.com',

--- a/backend/prisma/scripts/route-incheon-consultation-inquiries.sql
+++ b/backend/prisma/scripts/route-incheon-consultation-inquiries.sql
@@ -1,0 +1,89 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION route_incheon_consultation_inquiries_to_main_branch()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  main_branch_id UUID;
+  resolved_branch_slug TEXT;
+BEGIN
+  SELECT id
+  INTO main_branch_id
+  FROM "branch"
+  WHERE "slug" = 'incheon'
+  LIMIT 1;
+
+  IF main_branch_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW."public_branch_slug" LIKE 'incheon-%' THEN
+    NEW."branch_id" = main_branch_id;
+    RETURN NEW;
+  END IF;
+
+  IF NEW."branch_id" IS NOT NULL THEN
+    SELECT "slug"
+    INTO resolved_branch_slug
+    FROM "branch"
+    WHERE "id" = NEW."branch_id";
+
+    IF resolved_branch_slug LIKE 'incheon-%' THEN
+      NEW."branch_id" = main_branch_id;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS consultation_inquiry_route_incheon_to_main_branch
+ON "consultation_inquiry";
+
+CREATE TRIGGER consultation_inquiry_route_incheon_to_main_branch
+BEFORE INSERT OR UPDATE OF "branch_id", "public_branch_slug"
+ON "consultation_inquiry"
+FOR EACH ROW
+EXECUTE FUNCTION route_incheon_consultation_inquiries_to_main_branch();
+
+WITH main_branch AS (
+  SELECT id
+  FROM "branch"
+  WHERE "slug" = 'incheon'
+  LIMIT 1
+),
+district_inquiries AS (
+  SELECT ci.id
+  FROM "consultation_inquiry" ci
+  JOIN "branch" b
+    ON b.id = ci.branch_id
+  WHERE b.slug LIKE 'incheon-%'
+)
+UPDATE "consultation_inquiry" ci
+SET "branch_id" = mb.id
+FROM main_branch mb
+WHERE ci.id IN (SELECT id FROM district_inquiries)
+  AND ci.branch_id <> mb.id;
+
+WITH main_branch AS (
+  SELECT id
+  FROM "branch"
+  WHERE "slug" = 'incheon'
+  LIMIT 1
+),
+district_notification_ids AS (
+  SELECT n.id
+  FROM "notification" n
+  JOIN "branch" b
+    ON b.id = n.branch_id
+  WHERE b.slug LIKE 'incheon-%'
+    AND n.data ->> 'type' = 'consultation-inquiry'
+)
+UPDATE "notification" n
+SET "branch_id" = mb.id
+FROM main_branch mb
+WHERE n.id IN (SELECT id FROM district_notification_ids)
+  AND n.branch_id <> mb.id;
+
+COMMIT;

--- a/backend/prisma/scripts/seed-public-branches.ts
+++ b/backend/prisma/scripts/seed-public-branches.ts
@@ -7,7 +7,7 @@ const prisma = new PrismaClient();
 const PUBLIC_BRANCHES = [
     {
         slug: INCHEON_STAFF_BRANCH_SLUG,
-        name: "인천지점",
+        name: "인천점",
         region: "인천",
         district: "인천",
         branchType: "direct",

--- a/backend/test/services/consultation-inquiry.service.spec.ts
+++ b/backend/test/services/consultation-inquiry.service.spec.ts
@@ -57,7 +57,7 @@ describe("ConsultationInquiryService", () => {
         const inquiry = createInquiry();
         repository.findActiveBranchBySlug.mockResolvedValue({
             id: "branch-1",
-            name: "인천지점",
+            name: "인천점",
             slug: "incheon",
         });
         repository.create.mockResolvedValue(inquiry);

--- a/backend/test/unit/auth.service.branch.spec.ts
+++ b/backend/test/unit/auth.service.branch.spec.ts
@@ -618,7 +618,7 @@ describe("AuthService - Multi-Tenancy Enhancement", () => {
                 };
                 const canonicalIncheonBranch = {
                     id: "incheon-id",
-                    name: "인천지점",
+                    name: "인천점",
                     slug: "incheon",
                     isActive: true,
                 };
@@ -653,7 +653,7 @@ describe("AuthService - Multi-Tenancy Enhancement", () => {
                 };
                 const canonicalIncheonBranch = {
                     id: "incheon-id",
-                    name: "인천지점",
+                    name: "인천점",
                     slug: "incheon",
                     isActive: true,
                 };

--- a/frontend/src/app/(protected)/consultations/list-state.test.ts
+++ b/frontend/src/app/(protected)/consultations/list-state.test.ts
@@ -1,0 +1,101 @@
+import {
+  getDisplayedConsultationInquiries,
+  getLatestUniqueConsultationInquiries,
+} from "./list-state";
+
+import type { ConsultationInquiry } from "@/services/api";
+
+function createInquiry(
+  overrides: Partial<ConsultationInquiry> = {},
+): ConsultationInquiry {
+  return {
+    id: "inquiry-1",
+    branchId: "branch-1",
+    publicBranchSlug: "incheon",
+    motherName: "강감찬",
+    phone: "010-1111-2222",
+    address: "인천",
+    dueDate: "2026-05-01T00:00:00.000Z",
+    birthExperience: "초산",
+    voucherType: null,
+    preferredCaregiverName: null,
+    referralSource: "홈페이지",
+    privacyAcceptedAt: "2026-04-23T00:00:00.000Z",
+    selectedServices: null,
+    source: "website",
+    status: "new",
+    readAt: null,
+    createdAt: "2026-04-23T00:00:00.000Z",
+    updatedAt: "2026-04-23T00:00:00.000Z",
+    branchName: "인천점",
+    ...overrides,
+  };
+}
+
+describe("consultation list state", () => {
+  it("keeps the selected inquiry visible in the unread tab even after refetch removes it", () => {
+    const selectedInquiry = createInquiry({
+      id: "selected",
+      readAt: "2026-04-23T10:03:42.725Z",
+    });
+    const remainingInquiry = createInquiry({
+      id: "remaining",
+      motherName: "이순신",
+      phone: "010-3333-4444",
+    });
+
+    const result = getDisplayedConsultationInquiries({
+      inquiries: [remainingInquiry],
+      selectedInquiry,
+      activeReadState: "unread",
+    });
+
+    expect(result.map((inquiry) => inquiry.id)).toEqual(["selected", "remaining"]);
+  });
+
+  it("does not duplicate the selected inquiry when it is still in the list", () => {
+    const selectedInquiry = createInquiry({ id: "selected" });
+
+    const result = getDisplayedConsultationInquiries({
+      inquiries: [selectedInquiry],
+      selectedInquiry,
+      activeReadState: "unread",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("selected");
+  });
+
+  it("does not pin the selected inquiry outside the unread tab", () => {
+    const selectedInquiry = createInquiry({ id: "selected" });
+    const remainingInquiry = createInquiry({
+      id: "remaining",
+      motherName: "이순신",
+      phone: "010-3333-4444",
+    });
+
+    const result = getDisplayedConsultationInquiries({
+      inquiries: [remainingInquiry],
+      selectedInquiry,
+      activeReadState: "read",
+    });
+
+    expect(result.map((inquiry) => inquiry.id)).toEqual(["remaining"]);
+  });
+
+  it("keeps only the latest inquiry for the same person", () => {
+    const olderInquiry = createInquiry({
+      id: "older",
+      createdAt: "2026-04-22T00:00:00.000Z",
+    });
+    const newerInquiry = createInquiry({
+      id: "newer",
+      createdAt: "2026-04-23T00:00:00.000Z",
+    });
+
+    const result = getLatestUniqueConsultationInquiries([olderInquiry, newerInquiry]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("newer");
+  });
+});

--- a/frontend/src/app/(protected)/consultations/list-state.ts
+++ b/frontend/src/app/(protected)/consultations/list-state.ts
@@ -1,0 +1,47 @@
+import type { ConsultationInquiry } from "@/services/api";
+
+export function getConsultationIdentityKey(inquiry: ConsultationInquiry): string {
+  return `${inquiry.motherName.trim().toLowerCase()}::${inquiry.phone.replace(/\D/g, "")}`;
+}
+
+export function getLatestUniqueConsultationInquiries(
+  inquiries: ConsultationInquiry[],
+): ConsultationInquiry[] {
+  return Array.from(
+    inquiries.reduce((uniqueMap, inquiry) => {
+      const key = getConsultationIdentityKey(inquiry);
+      const current = uniqueMap.get(key);
+
+      if (
+        !current ||
+        new Date(inquiry.createdAt).getTime() > new Date(current.createdAt).getTime()
+      ) {
+        uniqueMap.set(key, inquiry);
+      }
+
+      return uniqueMap;
+    }, new Map<string, ConsultationInquiry>()).values(),
+  );
+}
+
+export function getDisplayedConsultationInquiries({
+  inquiries,
+  selectedInquiry,
+  activeReadState,
+}: {
+  inquiries: ConsultationInquiry[];
+  selectedInquiry: ConsultationInquiry | null;
+  activeReadState: string;
+}): ConsultationInquiry[] {
+  const visibleInquiries = getLatestUniqueConsultationInquiries(inquiries);
+
+  if (activeReadState !== "unread" || !selectedInquiry) {
+    return visibleInquiries;
+  }
+
+  if (visibleInquiries.some((inquiry) => inquiry.id === selectedInquiry.id)) {
+    return visibleInquiries;
+  }
+
+  return [selectedInquiry, ...visibleInquiries];
+}

--- a/frontend/src/app/(protected)/consultations/page.tsx
+++ b/frontend/src/app/(protected)/consultations/page.tsx
@@ -15,6 +15,11 @@ import {
     SplitLayout,
     StatsBar,
 } from "@/components/app/v3";
+import { SelectedServicesCard } from "@/components/app/consultations/SelectedServicesCard";
+import {
+    getDisplayedConsultationInquiries,
+    getConsultationIdentityKey,
+} from "./list-state";
 import { StatusPill } from "@/components/app/ui/status-badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useConsultationInquiries, useMarkConsultationInquiryRead } from "@/hooks/useConsultationInquiries";
@@ -55,63 +60,12 @@ function getInquirySourceLabel(source: string): string {
     return source || "-";
 }
 
-function getConsultationIdentityKey(inquiry: ConsultationInquiry): string {
-    return `${inquiry.motherName.trim().toLowerCase()}::${inquiry.phone.replace(/\D/g, "")}`;
-}
-
-function getLatestUniqueConsultationInquiries(inquiries: ConsultationInquiry[]): ConsultationInquiry[] {
-    return Array.from(
-        inquiries.reduce((uniqueMap, inquiry) => {
-            const key = getConsultationIdentityKey(inquiry);
-            const current = uniqueMap.get(key);
-
-            if (!current || new Date(inquiry.createdAt).getTime() > new Date(current.createdAt).getTime()) {
-                uniqueMap.set(key, inquiry);
-            }
-
-            return uniqueMap;
-        }, new Map<string, ConsultationInquiry>()).values(),
-    );
-}
-
 function getReadLabel(readAt: string | null): string {
     return readAt ? "읽음" : "읽지 않음";
 }
 
 function getReadVariant(readAt: string | null): "neutral" | "warning" {
     return readAt ? "neutral" : "warning";
-}
-
-function SelectedServicesCard({ inquiry }: { inquiry: ConsultationInquiry }) {
-    const selectedServices = inquiry.selectedServices;
-    const hasPlan = Boolean(selectedServices?.plan);
-    const addons = selectedServices?.addons ?? [];
-
-    if (!hasPlan && addons.length === 0) {
-        return (
-            <InfoCard title="선택 서비스">
-                <InfoRow label="서비스" value="선택 서비스 없음" />
-            </InfoCard>
-        );
-    }
-
-    return (
-        <InfoCard title="선택 서비스">
-            {selectedServices?.plan && (
-                <InfoRow
-                    label="플랜"
-                    value={`${selectedServices.plan.name} · ${selectedServices.plan.priceLabel}`}
-                />
-            )}
-            {addons.map((addon) => (
-                <InfoRow
-                    key={addon.id}
-                    label={addon.name}
-                    value={`${addon.priceLabel} · 수량 ${addon.quantity}`}
-                />
-            ))}
-        </InfoCard>
-    );
 }
 
 export default function ConsultationsPage() {
@@ -143,7 +97,14 @@ export default function ConsultationsPage() {
     const markRead = useMarkConsultationInquiryRead();
     const inquiries = useMemo(() => data?.data ?? [], [data?.data]);
     const statsInquiries = useMemo(() => statsData?.data ?? [], [statsData?.data]);
-    const visibleInquiries = useMemo(() => getLatestUniqueConsultationInquiries(inquiries), [inquiries]);
+    const visibleInquiries = useMemo(
+        () => getDisplayedConsultationInquiries({
+            inquiries,
+            selectedInquiry,
+            activeReadState,
+        }),
+        [activeReadState, inquiries, selectedInquiry],
+    );
     const activeInquiry = selectedInquiry
         ? inquiries.find((item) => item.id === selectedInquiry.id) ?? selectedInquiry
         : null;
@@ -249,7 +210,11 @@ export default function ConsultationsPage() {
                             onSlotClick={(inquiry) => {
                                 setSelectedInquiry(inquiry);
                                 if (!inquiry.readAt) {
-                                    markRead.mutate(inquiry.id);
+                                    markRead.mutate(inquiry.id, {
+                                        onSuccess: (updatedInquiry) => {
+                                            setSelectedInquiry(updatedInquiry);
+                                        },
+                                    });
                                 }
                             }}
                             render={({ item, isLoading: slotLoading }) => {
@@ -339,9 +304,9 @@ export default function ConsultationsPage() {
                                         </div>
                                     ) : null}
                                 </InfoCard>
-                            </div>
 
-                            <SelectedServicesCard inquiry={activeInquiry} />
+                                <SelectedServicesCard inquiry={activeInquiry} className="col-span-2" />
+                            </div>
                         </div>
                     </DetailPanel>
                 ) : (

--- a/frontend/src/components/app/consultations/SelectedServicesCard.test.tsx
+++ b/frontend/src/components/app/consultations/SelectedServicesCard.test.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { SelectedServicesCard } from "./SelectedServicesCard";
+
+const baseInquiry = {
+  id: "inquiry-1",
+  branchId: "branch-1",
+  publicBranchSlug: "incheon-namdong",
+  motherName: "강감찬",
+  phone: "010-9641-1878",
+  address: "남동구 논현동",
+  dueDate: "2026-04-23T00:00:00.000Z",
+  birthExperience: "초산",
+  voucherType: "B통합-1형",
+  preferredCaregiverName: "서경자",
+  referralSource: "시군구청",
+  privacyAcceptedAt: "2026-04-23T08:42:36.733Z",
+  source: "website",
+  status: "new",
+  readAt: "2026-04-23T08:50:00.000Z",
+  createdAt: "2026-04-23T08:42:36.733Z",
+  updatedAt: "2026-04-23T08:42:36.733Z",
+  branchName: "인천점",
+};
+
+describe("SelectedServicesCard", () => {
+  it("renders 산후도우미서비스 플랜 and 추가 서비스 rows", () => {
+    render(
+      <SelectedServicesCard
+        inquiry={{
+          ...baseInquiry,
+          selectedServices: {
+            plan: {
+              id: "plan-1",
+              name: "프리미엄",
+              priceLabel: "2,400,000원",
+              durationDays: 15,
+            },
+            addons: [
+              {
+                id: "addon-1",
+                name: "첫만남 이용권",
+                priceLabel: "200,000원",
+                quantity: 2,
+                group: "혜택",
+              },
+              {
+                id: "addon-2",
+                name: "가사 연장",
+                priceLabel: "150,000원",
+                quantity: 1,
+                group: "연장",
+              },
+            ],
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("서비스 정보")).toBeInTheDocument();
+    expect(screen.getByText("산후도우미서비스 플랜")).toBeInTheDocument();
+    expect(screen.getByText("프리미엄 · 2,400,000원")).toBeInTheDocument();
+    expect(screen.getByText("추가 서비스")).toBeInTheDocument();
+    expect(screen.getByText("첫만남 이용권 · 200,000원 · 수량 2")).toBeInTheDocument();
+    expect(screen.getByText("가사 연장 · 150,000원 · 수량 1")).toBeInTheDocument();
+  });
+
+  it("renders an empty fallback when selected services are missing", () => {
+    render(
+      <SelectedServicesCard
+        inquiry={{
+          ...baseInquiry,
+          selectedServices: null,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("서비스 정보")).toBeInTheDocument();
+    expect(screen.getByText("선택 서비스 없음")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/app/consultations/SelectedServicesCard.tsx
+++ b/frontend/src/components/app/consultations/SelectedServicesCard.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { InfoCard, InfoRow } from "@/components/app/v3";
+import type { ConsultationInquiry } from "@/services/api";
+
+interface SelectedServicesCardProps {
+  inquiry: ConsultationInquiry;
+  className?: string;
+}
+
+export function SelectedServicesCard({
+  inquiry,
+  className,
+}: SelectedServicesCardProps) {
+  const selectedServices = inquiry.selectedServices;
+  const hasPlan = Boolean(selectedServices?.plan);
+  const addons = selectedServices?.addons ?? [];
+  const hasAddons = addons.length > 0;
+
+  if (!hasPlan && !hasAddons) {
+    return (
+      <InfoCard title="서비스 정보" className={className}>
+        <InfoRow label="서비스" value="선택 서비스 없음" />
+      </InfoCard>
+    );
+  }
+
+  return (
+    <InfoCard title="서비스 정보" className={className}>
+      {selectedServices?.plan && (
+        <InfoRow
+          label="산후도우미서비스 플랜"
+          value={`${selectedServices.plan.name} · ${selectedServices.plan.priceLabel}`}
+        />
+      )}
+      {hasAddons && (
+        <InfoRow
+          label="추가 서비스"
+          value={addons.map((addon) => (
+            <span key={addon.id} className="block">
+              {`${addon.name} · ${addon.priceLabel} · 수량 ${addon.quantity}`}
+            </span>
+          ))}
+        />
+      )}
+    </InfoCard>
+  );
+}


### PR DESCRIPTION
## Summary
Brings `9121bbb5 fix(consultations): stabilize branch routing and detail state` onto preview.

- New SQL migration: `route-incheon-consultation-inquiries.sql` (Incheon → main backfill, paired with PR #133)
- Frontend refactor: extracts `list-state.ts` + tests, extracts `SelectedServicesCard.tsx` + tests, slims `consultations/page.tsx`

## Test plan
- [ ] CI green on preview after merge
- [ ] Smoke-test consultations list/detail in preview env

🤖 Generated with [Claude Code](https://claude.com/claude-code)