### PR TITLE
perf(auth): defer auth-shell hydration + align password validation

### DIFF
--- a/backend/application/services/auth.service.ts
+++ b/backend/application/services/auth.service.ts
@@ -1132,16 +1132,13 @@ export class AuthService {
 
     /**
      * Validate password strength
-     * Requirements: min 8 chars, uppercase, lowercase, number, special char
+     * Requirements: min 8 chars, lowercase, number, special char
      */
     validatePasswordStrength(password: string): PasswordValidationResult {
         const errors: string[] = [];
 
         if (password.length < 8) {
             errors.push('비밀번호는 최소 8자 이상이어야 합니다.');
-        }
-        if (!/[A-Z]/.test(password)) {
-            errors.push('비밀번호에 대문자가 포함되어야 합니다.');
         }
         if (!/[a-z]/.test(password)) {
             errors.push('비밀번호에 소문자가 포함되어야 합니다.');

--- a/backend/test/unit/auth.service.branch.spec.ts
+++ b/backend/test/unit/auth.service.branch.spec.ts
@@ -447,6 +447,15 @@ describe("AuthService - Multi-Tenancy Enhancement", () => {
     // registerWithEmail Tests
     // ============================================
     describe("registerWithEmail", () => {
+        it("should allow passwords without uppercase letters when other requirements pass", async () => {
+            const result = service.validatePasswordStrength("password1!");
+
+            expect(result).toEqual({
+                valid: true,
+                errors: [],
+            });
+        });
+
         it("should preserve the submitted branch role on membership creation", async () => {
             prismaService.branch.findUnique.mockResolvedValue(mockBranch);
             prismaService.user.findUnique
@@ -464,7 +473,7 @@ describe("AuthService - Multi-Tenancy Enhancement", () => {
 
             await service.registerWithEmail(
                 "manager@example.com",
-                "Password1!",
+                "password1!",
                 "Manager User",
                 "010-1234-5678",
                 "1990-01-01",

--- a/frontend/src/app/(auth)/callback/page.tsx
+++ b/frontend/src/app/(auth)/callback/page.tsx
@@ -1,11 +1,29 @@
 "use client";
 
+import { Suspense } from "react";
+
 import { CallbackPageDesktop } from "@/features/auth/callback/desktop/callback-page-desktop";
 import { CallbackPageMobile } from "@/features/auth/callback/mobile/callback-page-mobile";
 import { useAuthShellVariant } from "@/features/auth/shared/use-auth-shell-variant";
 
 export default function AuthCallbackPage() {
-  const shellVariant = useAuthShellVariant();
+  return (
+    <Suspense fallback={<AuthCallbackLoading />}>
+      <AuthCallbackContent />
+    </Suspense>
+  );
+}
+
+function AuthCallbackContent() {
+  const shellVariant = useAuthShellVariant({ deferUntilMounted: true });
+
+  if (!shellVariant) {
+    return <AuthCallbackLoading />;
+  }
 
   return shellVariant === "mobile" ? <CallbackPageMobile /> : <CallbackPageDesktop />;
+}
+
+function AuthCallbackLoading() {
+  return <div data-component="auth-callback-loading" className="min-h-screen" />;
 }

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,11 +1,38 @@
 "use client";
 
-import { LoginPageDesktop } from "@/features/auth/login/desktop/login-page-desktop";
-import { LoginPageMobile } from "@/features/auth/login/mobile/login-page-mobile";
+import { Suspense } from "react";
+import dynamic from "next/dynamic";
+
 import { useAuthShellVariant } from "@/features/auth/shared/use-auth-shell-variant";
 
+const LoginPageDesktop = dynamic(
+  () => import("@/features/auth/login/desktop/login-page-desktop").then((mod) => mod.LoginPageDesktop),
+  { ssr: false },
+);
+
+const LoginPageMobile = dynamic(
+  () => import("@/features/auth/login/mobile/login-page-mobile").then((mod) => mod.LoginPageMobile),
+  { ssr: false },
+);
+
 export default function LoginPage() {
-  const shellVariant = useAuthShellVariant();
+  return (
+    <Suspense fallback={<AuthLoginLoading />}>
+      <LoginPageContent />
+    </Suspense>
+  );
+}
+
+function LoginPageContent() {
+  const shellVariant = useAuthShellVariant({ deferUntilMounted: true });
+
+  if (!shellVariant) {
+    return <AuthLoginLoading />;
+  }
 
   return shellVariant === "mobile" ? <LoginPageMobile /> : <LoginPageDesktop />;
+}
+
+function AuthLoginLoading() {
+  return <div data-component="auth-login-loading" className="min-h-screen" />;
 }

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -5,14 +5,18 @@ import dynamic from "next/dynamic";
 
 import { useAuthShellVariant } from "@/features/auth/shared/use-auth-shell-variant";
 
+function AuthLoginLoading() {
+  return <div data-component="auth-login-loading" className="min-h-screen" />;
+}
+
 const LoginPageDesktop = dynamic(
   () => import("@/features/auth/login/desktop/login-page-desktop").then((mod) => mod.LoginPageDesktop),
-  { ssr: false },
+  { ssr: false, loading: AuthLoginLoading },
 );
 
 const LoginPageMobile = dynamic(
   () => import("@/features/auth/login/mobile/login-page-mobile").then((mod) => mod.LoginPageMobile),
-  { ssr: false },
+  { ssr: false, loading: AuthLoginLoading },
 );
 
 export default function LoginPage() {
@@ -31,8 +35,4 @@ function LoginPageContent() {
   }
 
   return shellVariant === "mobile" ? <LoginPageMobile /> : <LoginPageDesktop />;
-}
-
-function AuthLoginLoading() {
-  return <div data-component="auth-login-loading" className="min-h-screen" />;
 }

--- a/frontend/src/app/(auth)/reset-password/page.tsx
+++ b/frontend/src/app/(auth)/reset-password/page.tsx
@@ -1,11 +1,29 @@
 "use client";
 
+import { Suspense } from "react";
+
 import { ResetPasswordPageDesktop } from "@/features/auth/reset-password/desktop/reset-password-page-desktop";
 import { ResetPasswordPageMobile } from "@/features/auth/reset-password/mobile/reset-password-page-mobile";
 import { useAuthShellVariant } from "@/features/auth/shared/use-auth-shell-variant";
 
 export default function ResetPasswordPage() {
-  const shellVariant = useAuthShellVariant();
+  return (
+    <Suspense fallback={<ResetPasswordLoading />}>
+      <ResetPasswordContent />
+    </Suspense>
+  );
+}
+
+function ResetPasswordContent() {
+  const shellVariant = useAuthShellVariant({ deferUntilMounted: true });
+
+  if (!shellVariant) {
+    return <ResetPasswordLoading />;
+  }
 
   return shellVariant === "mobile" ? <ResetPasswordPageMobile /> : <ResetPasswordPageDesktop />;
+}
+
+function ResetPasswordLoading() {
+  return <div data-component="auth-reset-password-loading" className="min-h-screen" />;
 }

--- a/frontend/src/app/(auth)/verify-email/page.tsx
+++ b/frontend/src/app/(auth)/verify-email/page.tsx
@@ -1,11 +1,29 @@
 "use client";
 
+import { Suspense } from "react";
+
 import { VerifyEmailPageDesktop } from "@/features/auth/verify-email/desktop/verify-email-page-desktop";
 import { VerifyEmailPageMobile } from "@/features/auth/verify-email/mobile/verify-email-page-mobile";
 import { useAuthShellVariant } from "@/features/auth/shared/use-auth-shell-variant";
 
 export default function VerifyEmailPage() {
-  const shellVariant = useAuthShellVariant();
+  return (
+    <Suspense fallback={<VerifyEmailLoading />}>
+      <VerifyEmailContent />
+    </Suspense>
+  );
+}
+
+function VerifyEmailContent() {
+  const shellVariant = useAuthShellVariant({ deferUntilMounted: true });
+
+  if (!shellVariant) {
+    return <VerifyEmailLoading />;
+  }
 
   return shellVariant === "mobile" ? <VerifyEmailPageMobile /> : <VerifyEmailPageDesktop />;
+}
+
+function VerifyEmailLoading() {
+  return <div data-component="auth-verify-email-loading" className="min-h-screen" />;
 }

--- a/frontend/src/features/auth/login/shared/use-login-page-controller.ts
+++ b/frontend/src/features/auth/login/shared/use-login-page-controller.ts
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 
-import { authApi } from "@/services/api";
+import { resendVerificationEmail } from "@/features/auth/shared/auth-api";
 import { loginSchema, type LoginFormData } from "@/lib/validations/auth";
 import { safeStorageGetItem, safeStorageRemoveItem, safeStorageSetItem } from "@/lib/safe-storage";
 import { loginWithEmail } from "@/app/(auth)/login/actions";
@@ -123,7 +123,7 @@ export function useLoginPageController() {
 
     setIsResendingVerification(true);
     try {
-      const response = await authApi.resendVerification(targetEmail);
+      const response = await resendVerificationEmail(targetEmail);
       if (response.success) {
         safeStorageSetItem("local", "auth:verificationEmail", targetEmail);
       }

--- a/frontend/src/features/auth/shared/auth-api.ts
+++ b/frontend/src/features/auth/shared/auth-api.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { api } from "@/lib/api/client";
+
+export interface AuthActionResponse {
+  success: boolean;
+  message?: string;
+  code?: string;
+  hasKakaoAccount?: boolean;
+  errors?: string[];
+}
+
+export async function resendVerificationEmail(email: string): Promise<AuthActionResponse> {
+  const { data } = await api.post("/auth/resend-verification", { email });
+  return data;
+}

--- a/frontend/src/features/auth/shared/use-auth-shell-variant.ts
+++ b/frontend/src/features/auth/shared/use-auth-shell-variant.ts
@@ -1,8 +1,21 @@
 "use client";
 
+import { useSyncExternalStore } from "react";
+
 import { useIsMobile } from "@/hooks/useIsMobile";
 
-export function useAuthShellVariant(): "desktop" | "mobile" {
+type AuthShellVariant = "desktop" | "mobile";
+const subscribe = () => () => {};
+
+export function useAuthShellVariant(): AuthShellVariant;
+export function useAuthShellVariant(opts: { deferUntilMounted: true }): AuthShellVariant | null;
+export function useAuthShellVariant(opts?: { deferUntilMounted?: boolean }): AuthShellVariant | null {
+  const mounted = useSyncExternalStore(subscribe, () => true, () => false);
   const isMobile = useIsMobile();
+
+  if (opts?.deferUntilMounted && !mounted) {
+    return null;
+  }
+
   return isMobile ? "mobile" : "desktop";
 }


### PR DESCRIPTION
## Summary
- Reimplementation of the stale `perf/preview-ko-login` branch on current dev. The original branch's auth-route paths no longer exist after dev's refactor; this is a targeted re-port of the still-relevant pieces.
- New `deferUntilMounted` overload on `useAuthShellVariant()` (backed by `useSyncExternalStore`) lets login/callback/reset-password/verify-email pages render a stable SSR shell and defer client-shell hydration to the first mount. Outer Suspense + dynamic-imported desktop/mobile shells.
- Backend password validator no longer requires uppercase letters, matching the frontend strength check (min 8 + lowercase + digit + special). Test coverage added.
- New tiny helper `frontend/src/features/auth/shared/auth-api.ts` exposes `resendVerificationEmail()` so `useLoginPageController` doesn't reach for the full `authApi` surface.

## What was deliberately skipped
The original perf commit hardcoded `lang="ko"` at the root layout and relocated `LocaleProvider`/`QueryProvider`/`Toaster` to a Korean-only `(auth)` layout. We kept dev's dynamic `getLocale()` at the root because the i18n strategy depends on it. The perf gain we keep is deferred shell hydration, not a Korean-only assumption.

## Backwards compatibility
Callers of `useAuthShellVariant()` with no args (`register`, `forgot-password`) keep the non-null `"desktop" | "mobile"` return via overload signature — no caller breakage.

## Test plan
- [x] `pnpm --dir backend exec jest test/unit/auth.service.branch.spec.ts` — 27/27 pass (new lowercase-only password test included)
- [x] `pnpm --dir backend exec nest build` — clean
- [x] `pnpm lint -- src/features/auth src/app/\(auth\)` — clean
- [x] `pnpm exec next build --webpack` — clean (Turbopack flagged the symlinked `node_modules` in the temp worktree; CI uses real install)
- [ ] Real-browser smoke after deploy: load `/login`, watch network — desktop/mobile shell should not render until after hydration; no CLS flash; password reset email still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)