### PR TITLE
feat(stats): branch-scoped inquiries for non-owner + UX polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+@~/.agents/playbook/AGENTS.md

--- a/backend/interface/controllers/auth.controller.ts
+++ b/backend/interface/controllers/auth.controller.ts
@@ -96,14 +96,15 @@ export class AuthController {
         const branchPromise = req.user.branchId
             ? this.prisma.branch.findUnique({
                 where: { id: req.user.branchId },
-                select: { name: true },
+                select: { name: true, slug: true },
             })
             : Promise.resolve(null);
 
         const [user, org] = await Promise.all([userPromise, branchPromise]);
         const branchName = org?.name ?? null;
+        const branchSlug = org?.slug ?? null;
 
-        return { ...user, branchName };
+        return { ...user, branchName, branchSlug };
     }
 
     @Post("token")

--- a/frontend/src/app/(protected)/stats/_components/FunnelBars.tsx
+++ b/frontend/src/app/(protected)/stats/_components/FunnelBars.tsx
@@ -39,7 +39,7 @@ export function FunnelBars({
                   {s.label}
                   {isBiggestDrop ? (
                     <span className="ml-1.5 inline-block rounded bg-red-100 px-1.5 py-0.5 text-[0.6rem] font-semibold text-red-600 align-middle">
-                      누수
+                      이탈
                     </span>
                   ) : null}
                 </div>

--- a/frontend/src/app/(protected)/stats/_components/FunnelBars.tsx
+++ b/frontend/src/app/(protected)/stats/_components/FunnelBars.tsx
@@ -1,0 +1,86 @@
+import type { FunnelStep } from "@/lib/observability/types";
+import { cn } from "@/lib/utils";
+
+interface FunnelBarsProps {
+  steps: FunnelStep[];
+  biggestDropStep?: number | null;
+  /** Compact = overview card; verbose = full /stats/funnel detail page */
+  variant?: "compact" | "verbose";
+}
+
+export function FunnelBars({
+  steps,
+  biggestDropStep,
+  variant = "compact",
+}: FunnelBarsProps) {
+  if (steps.length === 0) {
+    return (
+      <p className="text-[0.78rem] text-v3-text-muted py-4 text-center">
+        펀널 데이터가 아직 없어요.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {steps.map((s, i) => {
+        const isBiggestDrop = biggestDropStep === s.step;
+        const showDropLabel = variant === "verbose" && i > 0;
+        return (
+          <div key={s.step}>
+            <div className="flex items-center gap-3" data-component={`funnel-step-${s.step}`}>
+              <div
+                className={cn(
+                  "shrink-0",
+                  variant === "verbose" ? "w-[200px]" : "w-[150px]"
+                )}
+              >
+                <div className="text-[0.78rem] font-medium text-v3-text leading-tight">
+                  {s.label}
+                  {isBiggestDrop ? (
+                    <span className="ml-1.5 inline-block rounded bg-red-100 px-1.5 py-0.5 text-[0.6rem] font-semibold text-red-600 align-middle">
+                      누수
+                    </span>
+                  ) : null}
+                </div>
+                <div className="text-[0.6rem] font-mono text-v3-text-muted truncate">
+                  {s.event}
+                </div>
+              </div>
+              <div className="flex-1 h-5 rounded-md bg-v3-dim-white overflow-hidden">
+                <div
+                  className={cn(
+                    "h-full rounded-md transition-all",
+                    i === steps.length - 1
+                      ? "bg-gradient-to-r from-green-600 to-green-700"
+                      : isBiggestDrop
+                        ? "bg-gradient-to-r from-red-500 to-red-600"
+                        : "bg-gradient-to-r from-v3-primary to-blue-700"
+                  )}
+                  style={{ width: `${Math.max(s.pct, 1)}%` }}
+                />
+              </div>
+              <div className="w-20 text-right text-[0.78rem] font-semibold text-v3-text tabular-nums">
+                {s.count}
+                <span className="ml-1 text-[0.65rem] font-normal text-v3-text-muted">
+                  {s.pct.toFixed(0)}%
+                </span>
+              </div>
+            </div>
+            {showDropLabel && i > 0 ? (
+              <div
+                className={cn(
+                  "mt-1 text-[0.65rem] tabular-nums",
+                  variant === "verbose" ? "pl-[200px]" : "pl-[150px]",
+                  isBiggestDrop ? "text-red-600 font-semibold" : "text-v3-text-muted"
+                )}
+              >
+                ↓ {Math.round(steps[i - 1].count - s.count)} drop ({s.dropFromPrevPct.toFixed(0)}%)
+              </div>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/stats/_components/FunnelBars.tsx
+++ b/frontend/src/app/(protected)/stats/_components/FunnelBars.tsx
@@ -75,7 +75,7 @@ export function FunnelBars({
                   isBiggestDrop ? "text-red-600 font-semibold" : "text-v3-text-muted"
                 )}
               >
-                ↓ {Math.round(steps[i - 1].count - s.count)} drop ({s.dropFromPrevPct.toFixed(0)}%)
+                ↓ {Math.round(steps[i - 1].count - s.count)}명 감소 ({s.dropFromPrevPct.toFixed(0)}%)
               </div>
             ) : null}
           </div>

--- a/frontend/src/app/(protected)/stats/_components/InfoTooltip.tsx
+++ b/frontend/src/app/(protected)/stats/_components/InfoTooltip.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+interface InfoTooltipProps {
+  /** Plain or multi-paragraph explanation of what the card shows. */
+  text: string;
+  /** Accessible label for screen readers (defaults to "도움말"). */
+  ariaLabel?: string;
+  /** Override Tailwind classes on the trigger. */
+  className?: string;
+  /** Tooltip placement; defaults to "top". */
+  side?: "top" | "right" | "bottom" | "left";
+  /** Optional data-component anchor for E2E selectors. */
+  dataComponent?: string;
+}
+
+/**
+ * Hover-only info icon that surfaces a short explanation of the card it's
+ * placed next to. Self-contains a TooltipProvider so it can be dropped into
+ * any RSC tree without needing a top-level provider.
+ */
+export function InfoTooltip({
+  text,
+  ariaLabel = "도움말",
+  className,
+  side = "top",
+  dataComponent,
+}: InfoTooltipProps) {
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={ariaLabel}
+            data-component={dataComponent}
+            className={cn(
+              "inline-flex items-center justify-center rounded-full text-v3-text-muted hover:text-v3-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-v3-primary/40 transition-colors",
+              className
+            )}
+          >
+            <Info className="w-3.5 h-3.5" strokeWidth={2} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent
+          side={side}
+          align="start"
+          className="max-w-[280px] whitespace-pre-line bg-v3-text/95 text-white border-transparent text-[0.75rem] leading-snug font-medium"
+        >
+          {text}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/frontend/src/app/(protected)/stats/_components/KpiCard.tsx
+++ b/frontend/src/app/(protected)/stats/_components/KpiCard.tsx
@@ -1,5 +1,6 @@
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { InfoTooltip } from "./InfoTooltip";
 
 interface KpiCardProps {
   icon?: LucideIcon;
@@ -12,6 +13,9 @@ interface KpiCardProps {
   tone?: "default" | "warn" | "success";
   dataComponent: string;
   valueSize?: "lg" | "md" | "sm";
+  /** When provided, shows an info (?) icon next to the label that reveals
+   *  this text on hover. */
+  infoText?: string;
 }
 
 const TONE_CLASSES = {
@@ -37,6 +41,7 @@ export function KpiCard({
   tone = "default",
   dataComponent,
   valueSize = "md",
+  infoText,
 }: KpiCardProps) {
   return (
     <div
@@ -50,6 +55,14 @@ export function KpiCard({
           <span className="text-base leading-none">{iconEmoji}</span>
         ) : null}
         <span className="text-[0.7rem] font-medium text-v3-text-muted truncate">{label}</span>
+        {infoText ? (
+          <InfoTooltip
+            text={infoText}
+            ariaLabel={`${label} 도움말`}
+            dataComponent={`${dataComponent}-info`}
+            className="-ml-0.5"
+          />
+        ) : null}
       </div>
       <div className="flex items-baseline gap-1.5">
         <span

--- a/frontend/src/app/(protected)/stats/_components/KpiCard.tsx
+++ b/frontend/src/app/(protected)/stats/_components/KpiCard.tsx
@@ -1,0 +1,83 @@
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface KpiCardProps {
+  icon?: LucideIcon;
+  iconEmoji?: string;
+  label: string;
+  value: string | number;
+  unit?: string;
+  meta?: string;
+  delta?: { label: string; tone: "up" | "down" | "flat" };
+  tone?: "default" | "warn" | "success";
+  dataComponent: string;
+  valueSize?: "lg" | "md" | "sm";
+}
+
+const TONE_CLASSES = {
+  default: "text-v3-text",
+  warn: "text-red-600",
+  success: "text-green-700",
+} as const;
+
+const DELTA_TONE_CLASSES = {
+  up: "bg-green-100 text-green-700",
+  down: "bg-red-100 text-red-700",
+  flat: "bg-v3-dim-white text-v3-text-muted",
+} as const;
+
+export function KpiCard({
+  icon: Icon,
+  iconEmoji,
+  label,
+  value,
+  unit,
+  meta,
+  delta,
+  tone = "default",
+  dataComponent,
+  valueSize = "md",
+}: KpiCardProps) {
+  return (
+    <div
+      data-component={dataComponent}
+      className="bg-white rounded-2xl shadow-v3 p-4.5 px-5 py-5"
+    >
+      <div className="flex items-center gap-2 mb-3">
+        {Icon ? (
+          <Icon className="w-4 h-4 text-v3-text-muted" />
+        ) : iconEmoji ? (
+          <span className="text-base leading-none">{iconEmoji}</span>
+        ) : null}
+        <span className="text-[0.7rem] font-medium text-v3-text-muted truncate">{label}</span>
+      </div>
+      <div className="flex items-baseline gap-1.5">
+        <span
+          className={cn(
+            "font-bold leading-none tabular-nums",
+            valueSize === "lg" ? "text-[1.9rem]" : valueSize === "sm" ? "text-[1.15rem]" : "text-[1.55rem]",
+            TONE_CLASSES[tone]
+          )}
+        >
+          {value}
+        </span>
+        {unit ? (
+          <span className="text-[0.78rem] text-v3-text-muted font-medium">{unit}</span>
+        ) : null}
+        {delta ? (
+          <span
+            className={cn(
+              "ml-auto text-[0.65rem] font-semibold rounded px-1.5 py-0.5 tabular-nums",
+              DELTA_TONE_CLASSES[delta.tone]
+            )}
+          >
+            {delta.label}
+          </span>
+        ) : null}
+      </div>
+      {meta ? (
+        <div className="mt-1.5 text-[0.68rem] text-v3-text-muted leading-tight">{meta}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/stats/_components/MiniBars.tsx
+++ b/frontend/src/app/(protected)/stats/_components/MiniBars.tsx
@@ -1,0 +1,50 @@
+interface MiniBarsProps {
+  values: number[];
+  labels?: string[];
+  highlightLastIndex?: boolean;
+  height?: number;
+  className?: string;
+}
+
+/**
+ * Simple bar chart for showing 7-day trends. The last bar is highlighted by
+ * default. Labels under each bar.
+ */
+export function MiniBars({
+  values,
+  labels,
+  highlightLastIndex = true,
+  height = 56,
+  className,
+}: MiniBarsProps) {
+  const max = Math.max(1, ...values);
+  const lastIndex = values.length - 1;
+
+  return (
+    <div className={className}>
+      <div className="flex items-end gap-1.5" style={{ height }}>
+        {values.map((v, i) => {
+          const isLast = highlightLastIndex && i === lastIndex;
+          const pct = (v / max) * 100;
+          return (
+            <div
+              key={i}
+              className={`flex-1 rounded-t-md ${
+                isLast ? "bg-v3-primary" : "bg-blue-300/60"
+              }`}
+              style={{ height: `${Math.max(pct, 4)}%` }}
+              aria-label={`${labels?.[i] ?? i + 1}: ${v}`}
+            />
+          );
+        })}
+      </div>
+      {labels && labels.length === values.length ? (
+        <div className="mt-1.5 flex justify-between text-[0.6rem] tabular-nums text-v3-text-muted">
+          {labels.map((l, i) => (
+            <span key={i}>{l}</span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/stats/_components/PanelCard.tsx
+++ b/frontend/src/app/(protected)/stats/_components/PanelCard.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface PanelCardProps {
+  title: string;
+  iconEmoji?: string;
+  source?: "Sentry" | "PostHog" | string;
+  detailHref: string;
+  detailLabel?: string;
+  dataComponent: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const SOURCE_PILL: Record<string, string> = {
+  Sentry: "bg-red-100 text-red-700",
+  PostHog: "bg-purple-100 text-purple-700",
+};
+
+/**
+ * Card used in the overview grid. Renders header with title + source pill +
+ * "전체 보기 →" link, then the body.
+ */
+export function PanelCard({
+  title,
+  iconEmoji,
+  source,
+  detailHref,
+  detailLabel = "전체 보기",
+  dataComponent,
+  className,
+  children,
+}: PanelCardProps) {
+  return (
+    <section
+      data-component={dataComponent}
+      className={cn(
+        "bg-white rounded-[28px] shadow-v3 p-6 flex flex-col gap-4 min-h-[280px]",
+        className
+      )}
+    >
+      <header
+        data-component={`${dataComponent}-head`}
+        className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border"
+      >
+        <h3 className="text-[0.95rem] font-bold text-v3-text tracking-tight">
+          {iconEmoji ? <span className="mr-1.5">{iconEmoji}</span> : null}
+          {title}
+        </h3>
+        {source ? (
+          <span
+            className={cn(
+              "text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5",
+              SOURCE_PILL[source] ?? "bg-v3-dim-white text-v3-text-muted"
+            )}
+          >
+            {source}
+          </span>
+        ) : null}
+        <Link
+          href={detailHref}
+          data-component={`${dataComponent}-detail-link`}
+          className="ml-auto inline-flex items-center gap-1 rounded-lg bg-v3-primary-light px-3 py-1.5 text-[0.72rem] font-semibold text-v3-primary hover:bg-v3-primary hover:text-white transition-colors"
+        >
+          <span>{detailLabel}</span>
+          <ArrowRight className="w-3.5 h-3.5" />
+        </Link>
+      </header>
+      <div data-component={`${dataComponent}-body`} className="flex-1 min-h-0 flex flex-col gap-3">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/(protected)/stats/_components/Sparkline.tsx
+++ b/frontend/src/app/(protected)/stats/_components/Sparkline.tsx
@@ -1,0 +1,53 @@
+interface SparklineProps {
+  values: number[];
+  color?: string;
+  height?: number;
+  className?: string;
+}
+
+/**
+ * Pure-SVG sparkline (no client JS needed). Renders the values as a smooth area
+ * + line. Auto-scales to the max value. Empty input renders a flat baseline.
+ */
+export function Sparkline({
+  values,
+  color = "#004aad",
+  height = 40,
+  className,
+}: SparklineProps) {
+  const width = 240;
+  const max = Math.max(1, ...values);
+  const step = values.length > 1 ? width / (values.length - 1) : width;
+  const yFor = (v: number) => height - 6 - (v / max) * (height - 12);
+
+  const points = values.map((v, i) => `${(i * step).toFixed(1)},${yFor(v).toFixed(1)}`);
+  const line = points.length ? `M${points.join(" L")}` : "";
+  const area = points.length
+    ? `M0,${height} L${points.join(" L")} L${width},${height} Z`
+    : "";
+  const lastX = (values.length - 1) * step;
+  const lastY = values.length ? yFor(values[values.length - 1]) : height;
+  const gradId = `spark-${color.replace(/[^a-zA-Z0-9]/g, "")}`;
+
+  return (
+    <svg
+      className={className}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      style={{ width: "100%", height }}
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={color} stopOpacity={0.22} />
+          <stop offset="100%" stopColor={color} stopOpacity={0} />
+        </linearGradient>
+      </defs>
+      {area && <path d={area} fill={`url(#${gradId})`} />}
+      {line && <path d={line} stroke={color} strokeWidth={1.5} fill="none" />}
+      {values.length > 0 && (
+        <circle cx={lastX} cy={lastY} r={3} fill={color} />
+      )}
+    </svg>
+  );
+}

--- a/frontend/src/app/(protected)/stats/_components/StatsHero.tsx
+++ b/frontend/src/app/(protected)/stats/_components/StatsHero.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface StatsHeroProps {
+  title: string;
+  subtitle?: string;
+  rightLabel?: string;
+  rightValue?: string;
+  rightAccent?: "default" | "warn";
+  backHref?: string;
+  backLabel?: string;
+  ariaLabel?: string;
+  dataComponent?: string;
+}
+
+export function StatsHero({
+  title,
+  subtitle = "",
+  rightLabel,
+  rightValue,
+  rightAccent = "default",
+  backHref,
+  backLabel,
+  ariaLabel,
+  dataComponent = "stats-hero",
+}: StatsHeroProps) {
+  return (
+    <div data-component={dataComponent} className="space-y-3">
+      {backHref && backLabel ? (
+        <Link
+          href={backHref}
+          data-component={`${dataComponent}-back-link`}
+          className="inline-flex items-center gap-1 text-[0.78rem] font-medium text-v3-text-muted hover:text-v3-primary transition-colors"
+        >
+          <ArrowLeft className="w-3.5 h-3.5" />
+          <span>{backLabel}</span>
+        </Link>
+      ) : null}
+      <div
+        data-component={`${dataComponent}-banner`}
+        aria-label={ariaLabel}
+        className={cn(
+          "relative overflow-hidden rounded-[24px] p-7",
+          "bg-gradient-to-br from-v3-primary via-v3-primary to-blue-700",
+          "shadow-v3"
+        )}
+      >
+        <div className="absolute -right-10 -top-10 h-40 w-40 rounded-full bg-white/10 blur-2xl" />
+        <div className="absolute -left-10 -bottom-10 h-32 w-32 rounded-full bg-white/5 blur-xl" />
+        <div className="relative z-10 flex items-center justify-between gap-6">
+          <div className="space-y-1.5">
+            <h1
+              data-component={`${dataComponent}-title`}
+              className="text-[1.4rem] font-bold tracking-tight text-white"
+            >
+              {title}
+            </h1>
+            {subtitle ? (
+              <p
+                data-component={`${dataComponent}-subtitle`}
+                className="text-[0.85rem] text-white/75 leading-relaxed"
+              >
+                {subtitle}
+              </p>
+            ) : null}
+          </div>
+          {rightLabel || rightValue ? (
+            <div
+              data-component={`${dataComponent}-meta`}
+              className="text-right shrink-0"
+            >
+              {rightLabel ? (
+                <div className="text-[0.65rem] font-semibold uppercase tracking-[0.15em] text-white/60">
+                  {rightLabel}
+                </div>
+              ) : null}
+              {rightValue ? (
+                <div
+                  className={cn(
+                    "text-base font-semibold tabular-nums",
+                    rightAccent === "warn" ? "text-red-300" : "text-white"
+                  )}
+                >
+                  {rightValue}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/stats/errors/page.tsx
+++ b/frontend/src/app/(protected)/stats/errors/page.tsx
@@ -1,4 +1,7 @@
+import { redirect } from "next/navigation";
 import { Block } from "@/components/app/v3/Block";
+import { getCurrentUser } from "@/lib/auth/cookies";
+import { ROLES } from "@/lib/constants/roles";
 import {
   getSummary as getSentrySummary,
   get24hEventTrend,
@@ -33,6 +36,11 @@ const LEVEL_TEXT_CLASS: Record<string, string> = {
 };
 
 export default async function ErrorsDetailPage() {
+  const user = await getCurrentUser();
+  if (user?.role !== ROLES.owner) {
+    redirect("/stats/inquiries");
+  }
+
   const [summary, trend, issues] = await Promise.all([
     getSentrySummary(),
     get24hEventTrend(),

--- a/frontend/src/app/(protected)/stats/errors/page.tsx
+++ b/frontend/src/app/(protected)/stats/errors/page.tsx
@@ -1,0 +1,298 @@
+import { Block } from "@/components/app/v3/Block";
+import {
+  getSummary as getSentrySummary,
+  get24hEventTrend,
+  getOpenIssues,
+  formatSentryRelativeTime,
+} from "@/lib/observability/sentry";
+import { StatsHero } from "../_components/StatsHero";
+import { KpiCard } from "../_components/KpiCard";
+
+export const metadata = { title: "오류 통계 · 통계" };
+export const revalidate = 60;
+
+const LEVEL_LABEL: Record<string, string> = {
+  fatal: "critical",
+  error: "error",
+  warning: "warning",
+  info: "info",
+};
+
+const LEVEL_DOT_CLASS: Record<string, string> = {
+  fatal: "bg-red-600",
+  error: "bg-red-500",
+  warning: "bg-amber-500",
+  info: "bg-blue-500",
+};
+
+const LEVEL_TEXT_CLASS: Record<string, string> = {
+  fatal: "text-red-700",
+  error: "text-red-600",
+  warning: "text-amber-700",
+  info: "text-blue-700",
+};
+
+export default async function ErrorsDetailPage() {
+  const [summary, trend, issues] = await Promise.all([
+    getSentrySummary(),
+    get24hEventTrend(),
+    getOpenIssues({ limit: 50, statsPeriod: "7d" }),
+  ]);
+
+  // Build chart points from trend (24h, hourly buckets)
+  const maxCount = Math.max(1, ...trend.map((p) => p.count));
+  const chartWidth = 1100;
+  const chartHeight = 180;
+  const chartPadLeft = 36;
+  const chartPadRight = 20;
+  const usableWidth = chartWidth - chartPadLeft - chartPadRight;
+  const yFor = (v: number) =>
+    chartHeight - 24 - (v / maxCount) * (chartHeight - 40);
+  const linePoints = trend.map((p, i) => {
+    const x =
+      chartPadLeft +
+      (trend.length > 1 ? (i / (trend.length - 1)) * usableWidth : 0);
+    return `${x.toFixed(1)},${yFor(p.count).toFixed(1)}`;
+  });
+  const linePath = linePoints.length ? `M${linePoints.join(" L")}` : "";
+  const areaPath = linePoints.length
+    ? `M${chartPadLeft},${chartHeight - 24} L${linePoints.join(" L")} L${
+        chartPadLeft + usableWidth
+      },${chartHeight - 24} Z`
+    : "";
+
+  // Last 3 issues for the "Top events" preview (top by count)
+  const totalIssues = issues.length;
+
+  return (
+    <section data-component="stats-errors" className="flex flex-col gap-6 pb-10">
+      <Block name="stats-errors-hero" className="shrink-0">
+        <StatsHero
+          title="오류 통계"
+          subtitle="Sentry · 미해결 이슈 · 24시간 이내 발생 추이"
+          rightLabel="실시간"
+          rightValue={new Date().toLocaleTimeString("ko-KR", {
+            hour: "2-digit",
+            minute: "2-digit",
+          })}
+          backHref="/stats"
+          backLabel="통계 overview로"
+          dataComponent="stats-errors-hero"
+        />
+      </Block>
+
+      <Block name="stats-errors-kpi" className="shrink-0">
+        <div
+          data-component="stats-errors-kpi-grid"
+          className="grid grid-cols-2 lg:grid-cols-5 gap-3"
+        >
+          <KpiCard
+            iconEmoji="⚠"
+            label="미해결"
+            value={summary.openCount}
+            unit="건"
+            tone={summary.openCount > 0 ? "warn" : "success"}
+            dataComponent="stats-errors-kpi-open"
+          />
+          <KpiCard
+            iconEmoji="+"
+            label="24h 신규"
+            value={summary.newIn24h}
+            unit="건"
+            tone={summary.newIn24h > 0 ? "warn" : "default"}
+            dataComponent="stats-errors-kpi-new"
+          />
+          <KpiCard
+            iconEmoji="∑"
+            label="7일 events"
+            value={summary.totalEvents7d.toLocaleString("ko-KR")}
+            dataComponent="stats-errors-kpi-events"
+          />
+          <KpiCard
+            iconEmoji="👤"
+            label="영향 유저"
+            value={`~${summary.affectedUsers}`}
+            unit="명"
+            dataComponent="stats-errors-kpi-users"
+          />
+          <KpiCard
+            iconEmoji="⏱"
+            label="Last error"
+            value={formatSentryRelativeTime(summary.lastErrorAt)}
+            dataComponent="stats-errors-kpi-last"
+            valueSize="sm"
+          />
+        </div>
+      </Block>
+
+      <Block name="stats-errors-chart">
+        <div
+          data-component="stats-errors-chart-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-4">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">이벤트 추이 (24시간)</h3>
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-red-100 text-red-700">
+              Sentry
+            </span>
+            <span className="ml-auto text-[0.7rem] text-v3-text-muted">
+              총 {trend.reduce((s, p) => s + p.count, 0).toLocaleString("ko-KR")} events
+            </span>
+          </header>
+          {trend.length === 0 ? (
+            <p className="text-center py-8 text-[0.85rem] text-v3-text-muted">
+              지난 24시간 동안 기록된 이벤트가 없어요.
+            </p>
+          ) : (
+            <svg
+              viewBox={`0 0 ${chartWidth} ${chartHeight}`}
+              preserveAspectRatio="none"
+              style={{ width: "100%", height: chartHeight }}
+              aria-label="24시간 이벤트 추이"
+            >
+              <defs>
+                <linearGradient id="errors-chart-grad" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="hsl(0 84% 60%)" stopOpacity={0.28} />
+                  <stop offset="100%" stopColor="hsl(0 84% 60%)" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <line
+                x1={chartPadLeft}
+                y1={chartHeight - 24}
+                x2={chartWidth - chartPadRight}
+                y2={chartHeight - 24}
+                stroke="hsl(214 32% 91%)"
+              />
+              <line
+                x1={chartPadLeft}
+                y1={yFor(maxCount * 0.5)}
+                x2={chartWidth - chartPadRight}
+                y2={yFor(maxCount * 0.5)}
+                stroke="hsl(214 32% 91%)"
+                strokeDasharray="3,3"
+              />
+              <line
+                x1={chartPadLeft}
+                y1={yFor(maxCount)}
+                x2={chartWidth - chartPadRight}
+                y2={yFor(maxCount)}
+                stroke="hsl(214 32% 91%)"
+                strokeDasharray="3,3"
+              />
+              <text x={8} y={yFor(maxCount) + 4} fontSize={10} fill="hsl(215 16% 47%)">
+                {maxCount.toFixed(0)}
+              </text>
+              <text x={8} y={yFor(maxCount * 0.5) + 4} fontSize={10} fill="hsl(215 16% 47%)">
+                {Math.round(maxCount * 0.5)}
+              </text>
+              <text x={8} y={chartHeight - 20} fontSize={10} fill="hsl(215 16% 47%)">
+                0
+              </text>
+              {areaPath && <path d={areaPath} fill="url(#errors-chart-grad)" />}
+              {linePath && (
+                <path d={linePath} stroke="hsl(0 84% 55%)" strokeWidth={2} fill="none" />
+              )}
+              {trend.length > 0 && (() => {
+                const last = trend[trend.length - 1];
+                const x = chartPadLeft + usableWidth;
+                const y = yFor(last.count);
+                return (
+                  <>
+                    <circle cx={x} cy={y} r={4} fill="hsl(0 84% 55%)" />
+                    <text x={x} y={y - 8} fontSize={11} fontWeight={600} fill="hsl(0 84% 55%)" textAnchor="middle">
+                      {last.count}
+                    </text>
+                  </>
+                );
+              })()}
+              <text
+                x={chartPadLeft}
+                y={chartHeight - 6}
+                fontSize={10}
+                fill="hsl(215 16% 47%)"
+              >
+                24h ago
+              </text>
+              <text
+                x={chartPadLeft + usableWidth}
+                y={chartHeight - 6}
+                fontSize={10}
+                fill="hsl(215 16% 47%)"
+                textAnchor="end"
+              >
+                now
+              </text>
+            </svg>
+          )}
+        </div>
+      </Block>
+
+      <Block name="stats-errors-issues">
+        <div
+          data-component="stats-errors-issues-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6 overflow-hidden"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">미해결 이슈 ({totalIssues}건)</h3>
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-red-100 text-red-700">
+              Sentry
+            </span>
+            <span className="ml-auto text-[0.7rem] text-v3-text-muted">최근 발생 순</span>
+          </header>
+          {issues.length === 0 ? (
+            <div className="py-10 text-center text-[0.85rem] text-v3-text-muted">
+              열린 이슈가 없어요 🎉
+            </div>
+          ) : (
+            <table className="w-full text-[0.82rem]">
+              <thead>
+                <tr className="bg-v3-dim-white border-b border-v3-border">
+                  <th className="text-left font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">레벨</th>
+                  <th className="text-left font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">이슈</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">Events</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">유저</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">Last seen</th>
+                </tr>
+              </thead>
+              <tbody>
+                {issues.map((issue) => (
+                  <tr
+                    key={issue.id}
+                    data-component="stats-errors-issue-row"
+                    className="border-b border-v3-border last:border-0 hover:bg-v3-dim-white"
+                  >
+                    <td className="px-3 py-3">
+                      <span className="inline-flex items-center gap-1.5">
+                        <span
+                          className={`inline-block w-2 h-2 rounded-full ${LEVEL_DOT_CLASS[issue.level] ?? "bg-gray-400"}`}
+                        />
+                        <strong className={LEVEL_TEXT_CLASS[issue.level] ?? "text-v3-text"}>
+                          {LEVEL_LABEL[issue.level] ?? issue.level}
+                        </strong>
+                      </span>
+                    </td>
+                    <td className="px-3 py-3">
+                      <div className="font-semibold text-v3-text">{issue.title}</div>
+                      <div className="text-[0.65rem] font-mono text-v3-text-muted truncate max-w-[400px]">
+                        {issue.culprit ?? issue.filename ?? "—"}
+                      </div>
+                    </td>
+                    <td className="px-3 py-3 text-right font-semibold tabular-nums">
+                      {issue.count}
+                    </td>
+                    <td className="px-3 py-3 text-right tabular-nums">
+                      {issue.userCount}
+                    </td>
+                    <td className="px-3 py-3 text-right text-[0.75rem] text-v3-text-muted">
+                      {formatSentryRelativeTime(issue.lastSeen)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </Block>
+    </section>
+  );
+}

--- a/frontend/src/app/(protected)/stats/errors/page.tsx
+++ b/frontend/src/app/(protected)/stats/errors/page.tsx
@@ -104,20 +104,20 @@ export default async function ErrorsDetailPage() {
           />
           <KpiCard
             iconEmoji="∑"
-            label="7일 events"
+            label="7일 발생"
             value={summary.totalEvents7d.toLocaleString("ko-KR")}
             dataComponent="stats-errors-kpi-events"
           />
           <KpiCard
             iconEmoji="👤"
-            label="영향 유저"
+            label="영향받은 사용자"
             value={`~${summary.affectedUsers}`}
             unit="명"
             dataComponent="stats-errors-kpi-users"
           />
           <KpiCard
             iconEmoji="⏱"
-            label="Last error"
+            label="마지막 오류"
             value={formatSentryRelativeTime(summary.lastErrorAt)}
             dataComponent="stats-errors-kpi-last"
             valueSize="sm"
@@ -136,7 +136,7 @@ export default async function ErrorsDetailPage() {
               Sentry
             </span>
             <span className="ml-auto text-[0.7rem] text-v3-text-muted">
-              총 {trend.reduce((s, p) => s + p.count, 0).toLocaleString("ko-KR")} events
+              총 {trend.reduce((s, p) => s + p.count, 0).toLocaleString("ko-KR")}건
             </span>
           </header>
           {trend.length === 0 ? (
@@ -249,9 +249,9 @@ export default async function ErrorsDetailPage() {
                 <tr className="bg-v3-dim-white border-b border-v3-border">
                   <th className="text-left font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">레벨</th>
                   <th className="text-left font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">이슈</th>
-                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">Events</th>
-                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">유저</th>
-                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">Last seen</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">발생 건수</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">영향 사용자</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">최근 발생</th>
                 </tr>
               </thead>
               <tbody>

--- a/frontend/src/app/(protected)/stats/funnel/page.tsx
+++ b/frontend/src/app/(protected)/stats/funnel/page.tsx
@@ -1,4 +1,7 @@
+import { redirect } from "next/navigation";
 import { Block } from "@/components/app/v3/Block";
+import { getCurrentUser } from "@/lib/auth/cookies";
+import { ROLES } from "@/lib/constants/roles";
 import {
   getEntryPages,
   getExitPages,
@@ -16,6 +19,11 @@ export const metadata = { title: "페이지 이동 통계 · 통계" };
 export const revalidate = 60;
 
 export default async function FunnelDetailPage() {
+  const user = await getCurrentUser();
+  if (user?.role !== ROLES.owner) {
+    redirect("/stats/inquiries");
+  }
+
   const [
     navSummary,
     pages,

--- a/frontend/src/app/(protected)/stats/funnel/page.tsx
+++ b/frontend/src/app/(protected)/stats/funnel/page.tsx
@@ -1,9 +1,11 @@
 import { Block } from "@/components/app/v3/Block";
 import {
+  getEntryPages,
+  getExitPages,
   getFunnelSummary,
-  getFunnelTrend,
-  getFunnelByDevice,
-  getFunnelBySource,
+  getPageNavSummary,
+  getPagesDetail,
+  getPageTransitions,
 } from "@/lib/observability/posthog";
 import { StatsHero } from "../_components/StatsHero";
 import { KpiCard } from "../_components/KpiCard";
@@ -14,37 +16,35 @@ export const metadata = { title: "페이지 이동 통계 · 통계" };
 export const revalidate = 60;
 
 export default async function FunnelDetailPage() {
-  const [summary, trend, byDevice, bySource] = await Promise.all([
+  const [
+    navSummary,
+    pages,
+    entryPages,
+    exitPages,
+    transitions,
+    conversionFunnel,
+  ] = await Promise.all([
+    getPageNavSummary(7),
+    getPagesDetail(7, 20),
+    getEntryPages(7, 8),
+    getExitPages(7, 8),
+    getPageTransitions(7, 12),
     getFunnelSummary(7),
-    getFunnelTrend(30),
-    getFunnelByDevice(7),
-    getFunnelBySource(7),
   ]);
 
-  // Conversion-trend line chart geometry (30 days)
-  const trendValues = trend.map((p) => p.conversionRate);
-  const maxConv = Math.max(1, ...trendValues);
-  const chartW = 500;
-  const chartH = 160;
-  const padL = 36;
-  const padR = 16;
-  const usableW = chartW - padL - padR;
-  const yFor = (v: number) => chartH - 22 - (v / maxConv) * (chartH - 40);
-  const points = trend.map((p, i) => {
-    const x = padL + (trend.length > 1 ? (i / (trend.length - 1)) * usableW : 0);
-    return `${x.toFixed(1)},${yFor(p.conversionRate).toFixed(1)}`;
-  });
-  const linePath = points.length ? `M${points.join(" L")}` : "";
+  const maxPv = Math.max(1, ...pages.map((p) => p.pv));
+  const maxEntry = Math.max(1, ...entryPages.map((p) => p.count));
+  const maxExit = Math.max(1, ...exitPages.map((p) => p.count));
+  const maxTransition = Math.max(1, ...transitions.map((t) => t.count));
 
   return (
     <section data-component="stats-funnel" className="flex flex-col gap-6 pb-10">
       <Block name="stats-funnel-hero" className="shrink-0">
         <StatsHero
           title="페이지 이동 통계"
-          subtitle="PostHog · 5단계 전환 분석 + 단계별 drop-off + 세그멘트"
-          rightLabel="전환율"
-          rightValue={`${summary.conversionRate.toFixed(1)}%`}
-          rightAccent={summary.conversionRate < 5 ? "warn" : "default"}
+          subtitle="PostHog · 각 페이지의 트래픽 + 페이지 간 이동 경로"
+          rightLabel="기간"
+          rightValue="최근 7일"
           backHref="/stats"
           backLabel="통계 overview로"
           dataComponent="stats-funnel-hero"
@@ -57,275 +57,306 @@ export default async function FunnelDetailPage() {
           className="grid grid-cols-2 lg:grid-cols-4 gap-3"
         >
           <KpiCard
-            iconEmoji="🔀"
-            label="전체 전환율"
-            value={summary.conversionRate.toFixed(1)}
+            iconEmoji="📄"
+            label="활성 페이지"
+            value={navSummary.activePages}
+            unit="개"
+            dataComponent="stats-funnel-kpi-pages"
+            infoText={
+              "지난 7일 동안 PV가 1회 이상 기록된 고유 경로(pathname) 수."
+            }
+          />
+          <KpiCard
+            iconEmoji="👁"
+            label="총 PV (7일)"
+            value={navSummary.totalPv.toLocaleString("ko-KR")}
+            dataComponent="stats-funnel-kpi-pv"
+            infoText={
+              "지난 7일간 발생한 전체 페이지뷰 이벤트 수.\n중복 사용자도 모두 포함."
+            }
+          />
+          <KpiCard
+            iconEmoji="∅"
+            label="평균 PV/페이지"
+            value={navSummary.avgPvPerPage.toFixed(1)}
+            dataComponent="stats-funnel-kpi-avg"
+            infoText={
+              "총 PV ÷ 활성 페이지 수.\n페이지당 평균 방문 빈도를 나타냅니다."
+            }
+          />
+          <KpiCard
+            iconEmoji="↩"
+            label="평균 이탈률"
+            value={navSummary.avgBouncePct.toFixed(1)}
             unit="%"
-            meta={`100 진입 중 ${summary.completedConversions} 제출`}
-            dataComponent="stats-funnel-kpi-conversion"
+            tone={navSummary.avgBouncePct > 60 ? "warn" : "default"}
+            dataComponent="stats-funnel-kpi-bounce"
             infoText={
-              "가격 페이지에 진입한 사용자 중 상담 신청까지 완료한 비율 (지난 7일).\n공식: 상담 제출 ÷ 가격 페이지 진입 × 100"
-            }
-          />
-          <KpiCard
-            iconEmoji="▼"
-            label="최대 누수"
-            value={summary.biggestDropStep ? `Step ${summary.biggestDropStep}` : "—"}
-            tone={summary.biggestDropStep ? "warn" : "default"}
-            meta={
-              summary.biggestDropStep && summary.steps[summary.biggestDropStep - 1]
-                ? `${summary.steps[summary.biggestDropStep - 1].label} · −${summary.steps[summary.biggestDropStep - 1].dropFromPrevPct.toFixed(0)}%`
-                : "균등 누수"
-            }
-            dataComponent="stats-funnel-kpi-drop"
-            valueSize="sm"
-            infoText={
-              "직전 단계 대비 사용자가 가장 많이 이탈한 단계.\n운영팀이 가장 먼저 점검해야 할 transition 지점을 표시합니다."
-            }
-          />
-          <KpiCard
-            iconEmoji="📥"
-            label="진입 (7일)"
-            value={summary.totalEntries}
-            unit="명"
-            dataComponent="stats-funnel-kpi-entries"
-            infoText={
-              "지난 7일 동안 가격 페이지(/pricing)에 진입한 이벤트 수.\n펀널의 시작 지점 (Step 1)입니다."
-            }
-          />
-          <KpiCard
-            iconEmoji="✓"
-            label="완료된 전환"
-            value={summary.completedConversions}
-            unit="건"
-            tone="success"
-            dataComponent="stats-funnel-kpi-completions"
-            infoText={
-              "지난 7일 동안 상담 신청 폼 제출까지 완료한 건 수.\n펀널의 끝 지점 (Step 5)입니다."
+              "세션당 페이지뷰가 1회뿐인 경우의 비율.\n사용자가 들어와서 다른 페이지를 보지 않고 떠난 정도."
             }
           />
         </div>
       </Block>
 
-      <Block name="stats-funnel-main">
+      {/* Main: per-page detail table */}
+      <Block name="stats-funnel-pages">
         <div
-          data-component="stats-funnel-main-card"
-          className="bg-white rounded-[28px] shadow-v3 p-6"
-        >
-          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-4">
-            <h3 className="text-[0.95rem] font-bold text-v3-text">
-              5단계 페이지 이동 (지난 7일)
-            </h3>
-            <InfoTooltip
-              text={
-                "가격 페이지 진입부터 상담 제출까지 5단계의 사용자 흐름.\n각 단계의 절대 수 + Step 1 대비 비율 + 직전 단계 대비 drop%를 함께 표시합니다."
-              }
-              dataComponent="stats-funnel-main-info"
-            />
-            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
-              PostHog
-            </span>
-          </header>
-          <FunnelBars
-            steps={summary.steps}
-            biggestDropStep={summary.biggestDropStep}
-            variant="verbose"
-          />
-        </div>
-      </Block>
-
-      <Block
-        name="stats-funnel-segments"
-        className="grid grid-cols-1 lg:grid-cols-2 gap-4"
-      >
-        {/* Conversion-rate trend */}
-        <div
-          data-component="stats-funnel-trend-card"
-          className="bg-white rounded-[28px] shadow-v3 p-6"
-        >
-          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-4">
-            <h3 className="text-[0.95rem] font-bold text-v3-text">전환율 추이 (30일)</h3>
-            <InfoTooltip
-              text={
-                "일별 전환율(상담 제출 ÷ 가격 페이지 진입)의 30일 변화.\n전체 트래픽과 별개로 펀널 자체의 quality 추이를 봅니다."
-              }
-              dataComponent="stats-funnel-trend-info"
-            />
-            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
-              PostHog
-            </span>
-          </header>
-          {trend.length === 0 ? (
-            <p className="text-center py-6 text-[0.85rem] text-v3-text-muted">
-              30일간 펀널 데이터가 없어요.
-            </p>
-          ) : (
-            <svg
-              viewBox={`0 0 ${chartW} ${chartH}`}
-              preserveAspectRatio="none"
-              style={{ width: "100%", height: chartH }}
-            >
-              <line x1={padL} y1={chartH - 22} x2={chartW - padR} y2={chartH - 22} stroke="hsl(214 32% 91%)" />
-              <line x1={padL} y1={yFor(maxConv * 0.5)} x2={chartW - padR} y2={yFor(maxConv * 0.5)} stroke="hsl(214 32% 91%)" strokeDasharray="3,3" />
-              <line x1={padL} y1={yFor(maxConv)} x2={chartW - padR} y2={yFor(maxConv)} stroke="hsl(214 32% 91%)" strokeDasharray="3,3" />
-              <text x={8} y={yFor(maxConv) + 4} fontSize={10} fill="hsl(215 16% 47%)">
-                {maxConv.toFixed(0)}%
-              </text>
-              <text x={8} y={yFor(maxConv * 0.5) + 4} fontSize={10} fill="hsl(215 16% 47%)">
-                {(maxConv * 0.5).toFixed(0)}%
-              </text>
-              <text x={8} y={chartH - 18} fontSize={10} fill="hsl(215 16% 47%)">
-                0%
-              </text>
-              {linePath && <path d={linePath} stroke="hsl(214 100% 34%)" strokeWidth={2} fill="none" />}
-              {trend.length > 0 && (() => {
-                const last = trend[trend.length - 1];
-                const x = padL + usableW;
-                const y = yFor(last.conversionRate);
-                return (
-                  <>
-                    <circle cx={x} cy={y} r={4} fill="hsl(214 100% 34%)" />
-                    <text
-                      x={x}
-                      y={y - 8}
-                      fontSize={11}
-                      fontWeight={600}
-                      fill="hsl(214 100% 34%)"
-                      textAnchor="middle"
-                    >
-                      {last.conversionRate.toFixed(1)}%
-                    </text>
-                  </>
-                );
-              })()}
-            </svg>
-          )}
-        </div>
-
-        {/* By device */}
-        <div
-          data-component="stats-funnel-device-card"
-          className="bg-white rounded-[28px] shadow-v3 p-6"
-        >
-          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-4">
-            <h3 className="text-[0.95rem] font-bold text-v3-text">디바이스별 전환율</h3>
-            <InfoTooltip
-              text={
-                "Mobile vs Desktop 사용자의 펀널 완주율 비교 (지난 7일).\n디바이스 특성이 전환에 영향을 주는지 확인할 때 봅니다."
-              }
-              dataComponent="stats-funnel-device-info"
-            />
-            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
-              PostHog
-            </span>
-          </header>
-          {byDevice.length === 0 ? (
-            <p className="text-center py-6 text-[0.85rem] text-v3-text-muted">
-              디바이스별 데이터가 없어요.
-            </p>
-          ) : (
-            <div className="flex flex-col gap-4">
-              {byDevice.slice(0, 4).map((d) => {
-                const isLow = d.conversionRate < 5;
-                return (
-                  <div key={d.device}>
-                    <div className="flex justify-between mb-1.5">
-                      <span className="text-[0.85rem] font-semibold">
-                        {d.device === "Mobile" ? "📱" : d.device === "Desktop" ? "💻" : "📱"}{" "}
-                        {d.device}
-                      </span>
-                      <span
-                        className={`text-[0.85rem] font-bold tabular-nums ${
-                          isLow ? "text-red-600" : "text-green-700"
-                        }`}
-                      >
-                        {d.conversionRate.toFixed(1)}%
-                      </span>
-                    </div>
-                    <div className="h-2.5 rounded-full bg-v3-dim-white overflow-hidden">
-                      <div
-                        className={`h-full rounded-full ${
-                          isLow
-                            ? "bg-gradient-to-r from-red-500 to-red-600"
-                            : "bg-gradient-to-r from-green-600 to-green-700"
-                        }`}
-                        style={{ width: `${Math.min(d.conversionRate * 5, 100)}%` }}
-                      />
-                    </div>
-                    <div className="text-[0.65rem] text-v3-text-muted mt-1">
-                      진입 {d.entries} · 제출 {d.completions}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
-      </Block>
-
-      {/* By source */}
-      <Block name="stats-funnel-source">
-        <div
-          data-component="stats-funnel-source-card"
-          className="bg-white rounded-[28px] shadow-v3 p-6"
+          data-component="stats-funnel-pages-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6 overflow-hidden"
         >
           <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
-            <h3 className="text-[0.95rem] font-bold text-v3-text">유입 소스별 전환율</h3>
+            <h3 className="text-[0.95rem] font-bold text-v3-text">페이지별 상세 (지난 7일)</h3>
             <InfoTooltip
               text={
-                "유입 채널(direct, 네이버, 인스타그램 등)별 5단계 진행 + 최종 전환율 (지난 7일).\n어느 채널이 quality 높은 trafic을 보내는지 비교합니다."
+                "각 페이지의 PV, 유니크 방문자, 진입(entry)으로 사용된 횟수, 이탈(exit)으로 사용된 횟수, 그 페이지에서 시작한 세션 중 한 페이지만 보고 나간 비율(bounce %)을 보여줍니다."
               }
-              dataComponent="stats-funnel-source-info"
+              dataComponent="stats-funnel-pages-info"
             />
             <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
               PostHog
             </span>
+            <span className="ml-auto text-[0.7rem] text-v3-text-muted">
+              총 {pages.length}개 페이지
+            </span>
           </header>
-          {bySource.length === 0 ? (
-            <p className="text-center py-6 text-[0.85rem] text-v3-text-muted">
-              유입 소스 데이터가 없어요.
+          {pages.length === 0 ? (
+            <p className="text-center py-8 text-[0.85rem] text-v3-text-muted">
+              지난 7일간 트래픽이 없어요.
             </p>
           ) : (
             <table className="w-full text-[0.82rem]">
               <thead>
                 <tr className="bg-v3-dim-white border-b border-v3-border">
-                  <th className="text-left font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">유입 소스</th>
+                  <th className="text-left font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">경로</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">PV</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">유니크</th>
                   <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">진입</th>
-                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">견적</th>
-                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">모달</th>
-                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">시작</th>
-                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">제출</th>
-                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">전환율</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">이탈</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">이탈률</th>
+                  <th className="font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">PV 분포</th>
                 </tr>
               </thead>
               <tbody>
-                {bySource.slice(0, 8).map((s, i) => {
-                  const isLow = s.conversionRate < 5;
-                  return (
-                    <tr
-                      key={`${s.source}-${i}`}
-                      data-component="stats-funnel-source-row"
-                      className="border-b border-v3-border last:border-0 hover:bg-v3-dim-white"
+                {pages.map((p, i) => (
+                  <tr
+                    key={`${p.path}-${i}`}
+                    data-component="stats-funnel-page-row"
+                    className="border-b border-v3-border last:border-0 hover:bg-v3-dim-white"
+                  >
+                    <td className="px-3 py-3 font-mono text-v3-text">{p.path}</td>
+                    <td className="px-3 py-3 text-right font-semibold tabular-nums">{p.pv}</td>
+                    <td className="px-3 py-3 text-right tabular-nums">{p.unique}</td>
+                    <td className="px-3 py-3 text-right tabular-nums">{p.entries}</td>
+                    <td className="px-3 py-3 text-right tabular-nums">{p.exits}</td>
+                    <td
+                      className={`px-3 py-3 text-right tabular-nums ${
+                        p.bouncePct > 60 ? "text-red-600 font-semibold" : ""
+                      }`}
                     >
-                      <td className="px-3 py-3 font-semibold">{s.source}</td>
-                      <td className="px-3 py-3 text-right tabular-nums">{s.entries}</td>
-                      <td className="px-3 py-3 text-right tabular-nums">{s.loaded}</td>
-                      <td className="px-3 py-3 text-right tabular-nums">{s.modalOpened}</td>
-                      <td className="px-3 py-3 text-right tabular-nums">{s.started}</td>
-                      <td className="px-3 py-3 text-right tabular-nums">{s.submitted}</td>
-                      <td
-                        className={`px-3 py-3 text-right font-bold tabular-nums ${
-                          isLow ? "text-red-600" : "text-green-700"
-                        }`}
-                      >
-                        {s.conversionRate.toFixed(1)}%
-                      </td>
-                    </tr>
-                  );
-                })}
+                      {p.entries === 0 ? "—" : `${p.bouncePct.toFixed(0)}%`}
+                    </td>
+                    <td className="px-3 py-3">
+                      <div className="h-2 rounded-full bg-v3-dim-white overflow-hidden min-w-[80px]">
+                        <div
+                          className="h-full bg-gradient-to-r from-v3-primary to-blue-700"
+                          style={{ width: `${(p.pv / maxPv) * 100}%` }}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                ))}
               </tbody>
             </table>
           )}
+        </div>
+      </Block>
+
+      {/* Entry & Exit pages */}
+      <Block
+        name="stats-funnel-entry-exit"
+        className="grid grid-cols-1 lg:grid-cols-2 gap-4"
+      >
+        <div
+          data-component="stats-funnel-entry-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">진입 페이지 Top</h3>
+            <InfoTooltip
+              text={
+                "각 세션의 첫 페이지뷰(entry page) 통계.\n사용자가 사이트에 들어왔을 때 가장 자주 보는 페이지를 표시합니다."
+              }
+              dataComponent="stats-funnel-entry-info"
+            />
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+          </header>
+          {entryPages.length === 0 ? (
+            <p className="text-center py-6 text-[0.85rem] text-v3-text-muted">
+              세션 데이터가 아직 없어요.
+            </p>
+          ) : (
+            <div className="space-y-2.5">
+              {entryPages.map((p) => (
+                <div key={p.path} className="flex items-center gap-3">
+                  <span className="w-[130px] truncate text-[0.78rem] font-mono text-v3-text">
+                    {p.path}
+                  </span>
+                  <div className="flex-1 h-5 rounded-md bg-v3-dim-white overflow-hidden">
+                    <div
+                      className="h-full bg-gradient-to-r from-v3-primary to-blue-700"
+                      style={{ width: `${(p.count / maxEntry) * 100}%` }}
+                    />
+                  </div>
+                  <span className="w-20 text-right text-[0.78rem] font-semibold tabular-nums">
+                    {p.count}
+                    <span className="ml-1 text-[0.65rem] font-normal text-v3-text-muted">
+                      {p.pct.toFixed(0)}%
+                    </span>
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div
+          data-component="stats-funnel-exit-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">이탈 페이지 Top</h3>
+            <InfoTooltip
+              text={
+                "각 세션의 마지막 페이지뷰(exit page) 통계.\n사용자가 사이트를 떠나기 직전에 가장 자주 본 페이지를 표시합니다."
+              }
+              dataComponent="stats-funnel-exit-info"
+            />
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+          </header>
+          {exitPages.length === 0 ? (
+            <p className="text-center py-6 text-[0.85rem] text-v3-text-muted">
+              세션 데이터가 아직 없어요.
+            </p>
+          ) : (
+            <div className="space-y-2.5">
+              {exitPages.map((p) => (
+                <div key={p.path} className="flex items-center gap-3">
+                  <span className="w-[130px] truncate text-[0.78rem] font-mono text-v3-text">
+                    {p.path}
+                  </span>
+                  <div className="flex-1 h-5 rounded-md bg-v3-dim-white overflow-hidden">
+                    <div
+                      className="h-full bg-gradient-to-r from-red-500 to-red-600"
+                      style={{ width: `${(p.count / maxExit) * 100}%` }}
+                    />
+                  </div>
+                  <span className="w-20 text-right text-[0.78rem] font-semibold tabular-nums">
+                    {p.count}
+                    <span className="ml-1 text-[0.65rem] font-normal text-v3-text-muted">
+                      {p.pct.toFixed(0)}%
+                    </span>
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </Block>
+
+      {/* Page transitions */}
+      <Block name="stats-funnel-transitions">
+        <div
+          data-component="stats-funnel-transitions-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">주요 페이지 이동 경로</h3>
+            <InfoTooltip
+              text={
+                "한 세션 안에서 사용자가 페이지 A를 본 직후 페이지 B로 이동한 횟수.\n가장 자주 발생한 이동 경로를 통해 자연스러운 네비게이션 흐름을 파악합니다."
+              }
+              dataComponent="stats-funnel-transitions-info"
+            />
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+            <span className="ml-auto text-[0.7rem] text-v3-text-muted">
+              상위 {transitions.length}개
+            </span>
+          </header>
+          {transitions.length === 0 ? (
+            <p className="text-center py-8 text-[0.85rem] text-v3-text-muted">
+              연속된 페이지뷰 데이터가 아직 없어요. (세션당 PV가 2회 이상 발생해야 표시됩니다)
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {transitions.map((t, i) => (
+                <div
+                  key={`${t.fromPath}-${t.toPath}-${i}`}
+                  data-component="stats-funnel-transition-row"
+                  className="flex items-center gap-3 py-2.5 px-3 rounded-lg hover:bg-v3-dim-white"
+                >
+                  <span className="font-mono text-[0.78rem] text-v3-text shrink-0 max-w-[180px] truncate">
+                    {t.fromPath}
+                  </span>
+                  <span className="text-v3-primary text-base shrink-0">→</span>
+                  <span className="font-mono text-[0.78rem] text-v3-text shrink-0 max-w-[180px] truncate">
+                    {t.toPath}
+                  </span>
+                  <div className="flex-1 h-2 rounded-full bg-v3-dim-white overflow-hidden mx-2 min-w-[60px]">
+                    <div
+                      className="h-full bg-gradient-to-r from-v3-primary to-blue-700"
+                      style={{ width: `${(t.count / maxTransition) * 100}%` }}
+                    />
+                  </div>
+                  <span className="text-[0.78rem] font-semibold tabular-nums shrink-0 w-16 text-right">
+                    {t.count}회
+                    <span className="ml-1 text-[0.65rem] font-normal text-v3-text-muted">
+                      {t.pct.toFixed(0)}%
+                    </span>
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </Block>
+
+      {/* Conversion funnel (kept as a featured "주요 전환 펀널") */}
+      <Block name="stats-funnel-conversion">
+        <div
+          data-component="stats-funnel-conversion-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-4">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">
+              핵심 전환 펀널 · 가격 → 상담
+            </h3>
+            <InfoTooltip
+              text={
+                "가격 페이지 진입부터 상담 신청 제출까지 5단계의 사용자 흐름 (지난 7일).\n사이트의 핵심 비즈니스 전환 경로를 별도로 추적합니다."
+              }
+              dataComponent="stats-funnel-conversion-info"
+            />
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+            <span className="ml-auto text-[0.7rem] text-v3-text-muted">
+              전환율{" "}
+              <strong className="text-v3-text">
+                {conversionFunnel.conversionRate.toFixed(1)}%
+              </strong>
+            </span>
+          </header>
+          <FunnelBars
+            steps={conversionFunnel.steps}
+            biggestDropStep={conversionFunnel.biggestDropStep}
+            variant="verbose"
+          />
         </div>
       </Block>
     </section>

--- a/frontend/src/app/(protected)/stats/funnel/page.tsx
+++ b/frontend/src/app/(protected)/stats/funnel/page.tsx
@@ -8,6 +8,7 @@ import {
 import { StatsHero } from "../_components/StatsHero";
 import { KpiCard } from "../_components/KpiCard";
 import { FunnelBars } from "../_components/FunnelBars";
+import { InfoTooltip } from "../_components/InfoTooltip";
 
 export const metadata = { title: "페이지 이동 통계 · 통계" };
 export const revalidate = 60;
@@ -62,6 +63,9 @@ export default async function FunnelDetailPage() {
             unit="%"
             meta={`100 진입 중 ${summary.completedConversions} 제출`}
             dataComponent="stats-funnel-kpi-conversion"
+            infoText={
+              "가격 페이지에 진입한 사용자 중 상담 신청까지 완료한 비율 (지난 7일).\n공식: 상담 제출 ÷ 가격 페이지 진입 × 100"
+            }
           />
           <KpiCard
             iconEmoji="▼"
@@ -75,6 +79,9 @@ export default async function FunnelDetailPage() {
             }
             dataComponent="stats-funnel-kpi-drop"
             valueSize="sm"
+            infoText={
+              "직전 단계 대비 사용자가 가장 많이 이탈한 단계.\n운영팀이 가장 먼저 점검해야 할 transition 지점을 표시합니다."
+            }
           />
           <KpiCard
             iconEmoji="📥"
@@ -82,6 +89,9 @@ export default async function FunnelDetailPage() {
             value={summary.totalEntries}
             unit="명"
             dataComponent="stats-funnel-kpi-entries"
+            infoText={
+              "지난 7일 동안 가격 페이지(/pricing)에 진입한 이벤트 수.\n펀널의 시작 지점 (Step 1)입니다."
+            }
           />
           <KpiCard
             iconEmoji="✓"
@@ -90,6 +100,9 @@ export default async function FunnelDetailPage() {
             unit="건"
             tone="success"
             dataComponent="stats-funnel-kpi-completions"
+            infoText={
+              "지난 7일 동안 상담 신청 폼 제출까지 완료한 건 수.\n펀널의 끝 지점 (Step 5)입니다."
+            }
           />
         </div>
       </Block>
@@ -103,6 +116,12 @@ export default async function FunnelDetailPage() {
             <h3 className="text-[0.95rem] font-bold text-v3-text">
               5단계 페이지 이동 (지난 7일)
             </h3>
+            <InfoTooltip
+              text={
+                "가격 페이지 진입부터 상담 제출까지 5단계의 사용자 흐름.\n각 단계의 절대 수 + Step 1 대비 비율 + 직전 단계 대비 drop%를 함께 표시합니다."
+              }
+              dataComponent="stats-funnel-main-info"
+            />
             <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
               PostHog
             </span>
@@ -126,6 +145,12 @@ export default async function FunnelDetailPage() {
         >
           <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-4">
             <h3 className="text-[0.95rem] font-bold text-v3-text">전환율 추이 (30일)</h3>
+            <InfoTooltip
+              text={
+                "일별 전환율(상담 제출 ÷ 가격 페이지 진입)의 30일 변화.\n전체 트래픽과 별개로 펀널 자체의 quality 추이를 봅니다."
+              }
+              dataComponent="stats-funnel-trend-info"
+            />
             <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
               PostHog
             </span>
@@ -184,6 +209,12 @@ export default async function FunnelDetailPage() {
         >
           <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-4">
             <h3 className="text-[0.95rem] font-bold text-v3-text">디바이스별 전환율</h3>
+            <InfoTooltip
+              text={
+                "Mobile vs Desktop 사용자의 펀널 완주율 비교 (지난 7일).\n디바이스 특성이 전환에 영향을 주는지 확인할 때 봅니다."
+              }
+              dataComponent="stats-funnel-device-info"
+            />
             <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
               PostHog
             </span>
@@ -240,6 +271,12 @@ export default async function FunnelDetailPage() {
         >
           <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
             <h3 className="text-[0.95rem] font-bold text-v3-text">유입 소스별 전환율</h3>
+            <InfoTooltip
+              text={
+                "유입 채널(direct, 네이버, 인스타그램 등)별 5단계 진행 + 최종 전환율 (지난 7일).\n어느 채널이 quality 높은 trafic을 보내는지 비교합니다."
+              }
+              dataComponent="stats-funnel-source-info"
+            />
             <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
               PostHog
             </span>

--- a/frontend/src/app/(protected)/stats/funnel/page.tsx
+++ b/frontend/src/app/(protected)/stats/funnel/page.tsx
@@ -1,0 +1,296 @@
+import { Block } from "@/components/app/v3/Block";
+import {
+  getFunnelSummary,
+  getFunnelTrend,
+  getFunnelByDevice,
+  getFunnelBySource,
+} from "@/lib/observability/posthog";
+import { StatsHero } from "../_components/StatsHero";
+import { KpiCard } from "../_components/KpiCard";
+import { FunnelBars } from "../_components/FunnelBars";
+
+export const metadata = { title: "페이지 이동 통계 · 통계" };
+export const revalidate = 60;
+
+export default async function FunnelDetailPage() {
+  const [summary, trend, byDevice, bySource] = await Promise.all([
+    getFunnelSummary(7),
+    getFunnelTrend(30),
+    getFunnelByDevice(7),
+    getFunnelBySource(7),
+  ]);
+
+  // Conversion-trend line chart geometry (30 days)
+  const trendValues = trend.map((p) => p.conversionRate);
+  const maxConv = Math.max(1, ...trendValues);
+  const chartW = 500;
+  const chartH = 160;
+  const padL = 36;
+  const padR = 16;
+  const usableW = chartW - padL - padR;
+  const yFor = (v: number) => chartH - 22 - (v / maxConv) * (chartH - 40);
+  const points = trend.map((p, i) => {
+    const x = padL + (trend.length > 1 ? (i / (trend.length - 1)) * usableW : 0);
+    return `${x.toFixed(1)},${yFor(p.conversionRate).toFixed(1)}`;
+  });
+  const linePath = points.length ? `M${points.join(" L")}` : "";
+
+  return (
+    <section data-component="stats-funnel" className="flex flex-col gap-6 pb-10">
+      <Block name="stats-funnel-hero" className="shrink-0">
+        <StatsHero
+          title="페이지 이동 통계"
+          subtitle="PostHog · 5단계 전환 분석 + 단계별 drop-off + 세그멘트"
+          rightLabel="전환율"
+          rightValue={`${summary.conversionRate.toFixed(1)}%`}
+          rightAccent={summary.conversionRate < 5 ? "warn" : "default"}
+          backHref="/stats"
+          backLabel="통계 overview로"
+          dataComponent="stats-funnel-hero"
+        />
+      </Block>
+
+      <Block name="stats-funnel-kpi" className="shrink-0">
+        <div
+          data-component="stats-funnel-kpi-grid"
+          className="grid grid-cols-2 lg:grid-cols-4 gap-3"
+        >
+          <KpiCard
+            iconEmoji="🔀"
+            label="전체 전환율"
+            value={summary.conversionRate.toFixed(1)}
+            unit="%"
+            meta={`100 진입 중 ${summary.completedConversions} 제출`}
+            dataComponent="stats-funnel-kpi-conversion"
+          />
+          <KpiCard
+            iconEmoji="▼"
+            label="최대 누수"
+            value={summary.biggestDropStep ? `Step ${summary.biggestDropStep}` : "—"}
+            tone={summary.biggestDropStep ? "warn" : "default"}
+            meta={
+              summary.biggestDropStep && summary.steps[summary.biggestDropStep - 1]
+                ? `${summary.steps[summary.biggestDropStep - 1].label} · −${summary.steps[summary.biggestDropStep - 1].dropFromPrevPct.toFixed(0)}%`
+                : "균등 누수"
+            }
+            dataComponent="stats-funnel-kpi-drop"
+            valueSize="sm"
+          />
+          <KpiCard
+            iconEmoji="📥"
+            label="진입 (7일)"
+            value={summary.totalEntries}
+            unit="명"
+            dataComponent="stats-funnel-kpi-entries"
+          />
+          <KpiCard
+            iconEmoji="✓"
+            label="완료된 전환"
+            value={summary.completedConversions}
+            unit="건"
+            tone="success"
+            dataComponent="stats-funnel-kpi-completions"
+          />
+        </div>
+      </Block>
+
+      <Block name="stats-funnel-main">
+        <div
+          data-component="stats-funnel-main-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-4">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">
+              5단계 페이지 이동 (지난 7일)
+            </h3>
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+          </header>
+          <FunnelBars
+            steps={summary.steps}
+            biggestDropStep={summary.biggestDropStep}
+            variant="verbose"
+          />
+        </div>
+      </Block>
+
+      <Block
+        name="stats-funnel-segments"
+        className="grid grid-cols-1 lg:grid-cols-2 gap-4"
+      >
+        {/* Conversion-rate trend */}
+        <div
+          data-component="stats-funnel-trend-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-4">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">전환율 추이 (30일)</h3>
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+          </header>
+          {trend.length === 0 ? (
+            <p className="text-center py-6 text-[0.85rem] text-v3-text-muted">
+              30일간 펀널 데이터가 없어요.
+            </p>
+          ) : (
+            <svg
+              viewBox={`0 0 ${chartW} ${chartH}`}
+              preserveAspectRatio="none"
+              style={{ width: "100%", height: chartH }}
+            >
+              <line x1={padL} y1={chartH - 22} x2={chartW - padR} y2={chartH - 22} stroke="hsl(214 32% 91%)" />
+              <line x1={padL} y1={yFor(maxConv * 0.5)} x2={chartW - padR} y2={yFor(maxConv * 0.5)} stroke="hsl(214 32% 91%)" strokeDasharray="3,3" />
+              <line x1={padL} y1={yFor(maxConv)} x2={chartW - padR} y2={yFor(maxConv)} stroke="hsl(214 32% 91%)" strokeDasharray="3,3" />
+              <text x={8} y={yFor(maxConv) + 4} fontSize={10} fill="hsl(215 16% 47%)">
+                {maxConv.toFixed(0)}%
+              </text>
+              <text x={8} y={yFor(maxConv * 0.5) + 4} fontSize={10} fill="hsl(215 16% 47%)">
+                {(maxConv * 0.5).toFixed(0)}%
+              </text>
+              <text x={8} y={chartH - 18} fontSize={10} fill="hsl(215 16% 47%)">
+                0%
+              </text>
+              {linePath && <path d={linePath} stroke="hsl(214 100% 34%)" strokeWidth={2} fill="none" />}
+              {trend.length > 0 && (() => {
+                const last = trend[trend.length - 1];
+                const x = padL + usableW;
+                const y = yFor(last.conversionRate);
+                return (
+                  <>
+                    <circle cx={x} cy={y} r={4} fill="hsl(214 100% 34%)" />
+                    <text
+                      x={x}
+                      y={y - 8}
+                      fontSize={11}
+                      fontWeight={600}
+                      fill="hsl(214 100% 34%)"
+                      textAnchor="middle"
+                    >
+                      {last.conversionRate.toFixed(1)}%
+                    </text>
+                  </>
+                );
+              })()}
+            </svg>
+          )}
+        </div>
+
+        {/* By device */}
+        <div
+          data-component="stats-funnel-device-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-4">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">디바이스별 전환율</h3>
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+          </header>
+          {byDevice.length === 0 ? (
+            <p className="text-center py-6 text-[0.85rem] text-v3-text-muted">
+              디바이스별 데이터가 없어요.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-4">
+              {byDevice.slice(0, 4).map((d) => {
+                const isLow = d.conversionRate < 5;
+                return (
+                  <div key={d.device}>
+                    <div className="flex justify-between mb-1.5">
+                      <span className="text-[0.85rem] font-semibold">
+                        {d.device === "Mobile" ? "📱" : d.device === "Desktop" ? "💻" : "📱"}{" "}
+                        {d.device}
+                      </span>
+                      <span
+                        className={`text-[0.85rem] font-bold tabular-nums ${
+                          isLow ? "text-red-600" : "text-green-700"
+                        }`}
+                      >
+                        {d.conversionRate.toFixed(1)}%
+                      </span>
+                    </div>
+                    <div className="h-2.5 rounded-full bg-v3-dim-white overflow-hidden">
+                      <div
+                        className={`h-full rounded-full ${
+                          isLow
+                            ? "bg-gradient-to-r from-red-500 to-red-600"
+                            : "bg-gradient-to-r from-green-600 to-green-700"
+                        }`}
+                        style={{ width: `${Math.min(d.conversionRate * 5, 100)}%` }}
+                      />
+                    </div>
+                    <div className="text-[0.65rem] text-v3-text-muted mt-1">
+                      진입 {d.entries} · 제출 {d.completions}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </Block>
+
+      {/* By source */}
+      <Block name="stats-funnel-source">
+        <div
+          data-component="stats-funnel-source-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">유입 소스별 전환율</h3>
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+          </header>
+          {bySource.length === 0 ? (
+            <p className="text-center py-6 text-[0.85rem] text-v3-text-muted">
+              유입 소스 데이터가 없어요.
+            </p>
+          ) : (
+            <table className="w-full text-[0.82rem]">
+              <thead>
+                <tr className="bg-v3-dim-white border-b border-v3-border">
+                  <th className="text-left font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">유입 소스</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">진입</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">견적</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">모달</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">시작</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">제출</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">전환율</th>
+                </tr>
+              </thead>
+              <tbody>
+                {bySource.slice(0, 8).map((s, i) => {
+                  const isLow = s.conversionRate < 5;
+                  return (
+                    <tr
+                      key={`${s.source}-${i}`}
+                      data-component="stats-funnel-source-row"
+                      className="border-b border-v3-border last:border-0 hover:bg-v3-dim-white"
+                    >
+                      <td className="px-3 py-3 font-semibold">{s.source}</td>
+                      <td className="px-3 py-3 text-right tabular-nums">{s.entries}</td>
+                      <td className="px-3 py-3 text-right tabular-nums">{s.loaded}</td>
+                      <td className="px-3 py-3 text-right tabular-nums">{s.modalOpened}</td>
+                      <td className="px-3 py-3 text-right tabular-nums">{s.started}</td>
+                      <td className="px-3 py-3 text-right tabular-nums">{s.submitted}</td>
+                      <td
+                        className={`px-3 py-3 text-right font-bold tabular-nums ${
+                          isLow ? "text-red-600" : "text-green-700"
+                        }`}
+                      >
+                        {s.conversionRate.toFixed(1)}%
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </Block>
+    </section>
+  );
+}

--- a/frontend/src/app/(protected)/stats/funnel/page.tsx
+++ b/frontend/src/app/(protected)/stats/funnel/page.tsx
@@ -63,25 +63,25 @@ export default async function FunnelDetailPage() {
             unit="개"
             dataComponent="stats-funnel-kpi-pages"
             infoText={
-              "지난 7일 동안 PV가 1회 이상 기록된 고유 경로(pathname) 수."
+              "지난 7일 동안 조회수가 1회 이상 기록된 페이지 수."
             }
           />
           <KpiCard
             iconEmoji="👁"
-            label="총 PV (7일)"
+            label="총 조회수 (7일)"
             value={navSummary.totalPv.toLocaleString("ko-KR")}
             dataComponent="stats-funnel-kpi-pv"
             infoText={
-              "지난 7일간 발생한 전체 페이지뷰 이벤트 수.\n중복 사용자도 모두 포함."
+              "지난 7일간 발생한 전체 페이지 조회 횟수.\n같은 사용자의 반복 방문도 모두 포함."
             }
           />
           <KpiCard
             iconEmoji="∅"
-            label="평균 PV/페이지"
+            label="평균 조회수/페이지"
             value={navSummary.avgPvPerPage.toFixed(1)}
             dataComponent="stats-funnel-kpi-avg"
             infoText={
-              "총 PV ÷ 활성 페이지 수.\n페이지당 평균 방문 빈도를 나타냅니다."
+              "총 조회수 ÷ 활성 페이지 수.\n페이지당 평균 방문 빈도를 나타냅니다."
             }
           />
           <KpiCard
@@ -92,7 +92,7 @@ export default async function FunnelDetailPage() {
             tone={navSummary.avgBouncePct > 60 ? "warn" : "default"}
             dataComponent="stats-funnel-kpi-bounce"
             infoText={
-              "세션당 페이지뷰가 1회뿐인 경우의 비율.\n사용자가 들어와서 다른 페이지를 보지 않고 떠난 정도."
+              "한 방문에서 한 페이지만 보고 떠난 비율.\n다른 페이지로 이동하지 않고 나간 사용자의 비중을 나타냅니다."
             }
           />
         </div>
@@ -108,7 +108,7 @@ export default async function FunnelDetailPage() {
             <h3 className="text-[0.95rem] font-bold text-v3-text">페이지별 상세 (지난 7일)</h3>
             <InfoTooltip
               text={
-                "각 페이지의 PV, 유니크 방문자, 진입(entry)으로 사용된 횟수, 이탈(exit)으로 사용된 횟수, 그 페이지에서 시작한 세션 중 한 페이지만 보고 나간 비율(bounce %)을 보여줍니다."
+                "각 페이지의 조회수, 방문자, 시작 페이지로 쓰인 횟수, 종료 페이지로 쓰인 횟수, 그 페이지에서 시작한 세션 중 한 페이지만 보고 나간 비율(이탈률)을 보여줍니다."
               }
               dataComponent="stats-funnel-pages-info"
             />
@@ -128,12 +128,12 @@ export default async function FunnelDetailPage() {
               <thead>
                 <tr className="bg-v3-dim-white border-b border-v3-border">
                   <th className="text-left font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">경로</th>
-                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">PV</th>
-                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">유니크</th>
-                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">진입</th>
-                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">이탈</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">조회수</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">방문자</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">시작</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">종료</th>
                   <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">이탈률</th>
-                  <th className="font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">PV 분포</th>
+                  <th className="font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">조회수 분포</th>
                 </tr>
               </thead>
               <tbody>
@@ -181,7 +181,7 @@ export default async function FunnelDetailPage() {
           className="bg-white rounded-[28px] shadow-v3 p-6"
         >
           <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
-            <h3 className="text-[0.95rem] font-bold text-v3-text">진입 페이지 Top</h3>
+            <h3 className="text-[0.95rem] font-bold text-v3-text">주요 시작 페이지</h3>
             <InfoTooltip
               text={
                 "각 세션의 첫 페이지뷰(entry page) 통계.\n사용자가 사이트에 들어왔을 때 가장 자주 보는 페이지를 표시합니다."
@@ -226,7 +226,7 @@ export default async function FunnelDetailPage() {
           className="bg-white rounded-[28px] shadow-v3 p-6"
         >
           <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
-            <h3 className="text-[0.95rem] font-bold text-v3-text">이탈 페이지 Top</h3>
+            <h3 className="text-[0.95rem] font-bold text-v3-text">주요 종료 페이지</h3>
             <InfoTooltip
               text={
                 "각 세션의 마지막 페이지뷰(exit page) 통계.\n사용자가 사이트를 떠나기 직전에 가장 자주 본 페이지를 표시합니다."
@@ -290,7 +290,7 @@ export default async function FunnelDetailPage() {
           </header>
           {transitions.length === 0 ? (
             <p className="text-center py-8 text-[0.85rem] text-v3-text-muted">
-              연속된 페이지뷰 데이터가 아직 없어요. (세션당 PV가 2회 이상 발생해야 표시됩니다)
+              연속된 페이지뷰 데이터가 아직 없어요. (한 방문에서 페이지를 2개 이상 발생해야 표시됩니다)
             </p>
           ) : (
             <div className="space-y-2">

--- a/frontend/src/app/(protected)/stats/inquiries/page.tsx
+++ b/frontend/src/app/(protected)/stats/inquiries/page.tsx
@@ -1,0 +1,301 @@
+import { Block } from "@/components/app/v3/Block";
+import {
+  getInquiriesSummary,
+  getInquiriesDailyTrend,
+  getInquiriesHourlyToday,
+  getInquiriesByBranch,
+  getRecentInquiries,
+  formatRelativeKo,
+} from "@/lib/observability/posthog";
+import { StatsHero } from "../_components/StatsHero";
+import { KpiCard } from "../_components/KpiCard";
+
+export const metadata = { title: "상담 신청 · 통계" };
+export const revalidate = 60;
+
+export default async function InquiriesDetailPage() {
+  const [summary, daily, hourly, byBranch, recent] = await Promise.all([
+    getInquiriesSummary(),
+    getInquiriesDailyTrend(30),
+    getInquiriesHourlyToday(),
+    getInquiriesByBranch(7),
+    getRecentInquiries(10),
+  ]);
+
+  // Build last-30-day bar data
+  const dailyMap = new Map(daily.map((p) => [p.day, p.count]));
+  const today = new Date();
+  const last30 = Array.from({ length: 30 }, (_, i) => {
+    const d = new Date(today);
+    d.setDate(d.getDate() - (29 - i));
+    const key = d.toISOString().slice(0, 10);
+    return { date: d, count: dailyMap.get(key) ?? 0 };
+  });
+  const maxDaily = Math.max(1, ...last30.map((p) => p.count));
+
+  const maxHourly = Math.max(1, ...hourly.map((p) => p.count));
+  const maxBranch = Math.max(1, ...byBranch.map((b) => b.count));
+
+  return (
+    <section data-component="stats-inquiries" className="flex flex-col gap-6 pb-10">
+      <Block name="stats-inquiries-hero" className="shrink-0">
+        <StatsHero
+          title="상담 신청 통계"
+          subtitle="PostHog · 일별/시간대별/지점별/소스별 분석"
+          rightLabel={today.toLocaleDateString("ko-KR", { weekday: "long" })}
+          rightValue={today.toLocaleDateString("ko-KR", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+          })}
+          backHref="/stats"
+          backLabel="통계 overview로"
+          dataComponent="stats-inquiries-hero"
+        />
+      </Block>
+
+      <Block name="stats-inquiries-kpi" className="shrink-0">
+        <div
+          data-component="stats-inquiries-kpi-grid"
+          className="grid grid-cols-2 lg:grid-cols-5 gap-3"
+        >
+          <KpiCard
+            iconEmoji="📝"
+            label="오늘"
+            value={summary.today}
+            unit="건"
+            tone="success"
+            dataComponent="stats-inquiries-kpi-today"
+          />
+          <KpiCard
+            iconEmoji="📅"
+            label="어제"
+            value={summary.yesterday}
+            unit="건"
+            dataComponent="stats-inquiries-kpi-yesterday"
+          />
+          <KpiCard
+            iconEmoji="📊"
+            label="7일 합계"
+            value={summary.sevenDayTotal}
+            unit="건"
+            meta={`평균 ${summary.sevenDayAvg.toFixed(1)}건/일`}
+            dataComponent="stats-inquiries-kpi-week"
+          />
+          <KpiCard
+            iconEmoji="🔀"
+            label="전환율"
+            value={summary.conversionRate.toFixed(1)}
+            unit="%"
+            dataComponent="stats-inquiries-kpi-conversion"
+          />
+          <KpiCard
+            iconEmoji="⏱"
+            label="최근 신청"
+            value={formatRelativeKo(summary.lastSubmissionAt)}
+            dataComponent="stats-inquiries-kpi-last"
+            valueSize="sm"
+          />
+        </div>
+      </Block>
+
+      <Block name="stats-inquiries-daily">
+        <div
+          data-component="stats-inquiries-daily-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-4">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">일별 상담 신청 (최근 30일)</h3>
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+            <span className="ml-auto text-[0.7rem] text-v3-text-muted">
+              총 {summary.thirtyDayTotal}건
+            </span>
+          </header>
+          {summary.thirtyDayTotal === 0 ? (
+            <p className="text-center py-10 text-[0.85rem] text-v3-text-muted">
+              최근 30일간 상담 신청이 없어요.
+            </p>
+          ) : (
+            <>
+              <div className="flex items-end gap-1.5 h-[160px]">
+                {last30.map((p, i) => {
+                  const pct = (p.count / maxDaily) * 100;
+                  const isToday = i === 29;
+                  return (
+                    <div
+                      key={i}
+                      className={`flex-1 rounded-t-md ${
+                        isToday ? "bg-v3-primary" : "bg-blue-300/70"
+                      }`}
+                      style={{ height: `${Math.max(pct, 2)}%` }}
+                      title={`${p.date.toLocaleDateString("ko-KR")}: ${p.count}건`}
+                    />
+                  );
+                })}
+              </div>
+              <div className="mt-2 flex justify-between text-[0.65rem] text-v3-text-muted">
+                <span>{last30[0].date.toLocaleDateString("ko-KR", { month: "2-digit", day: "2-digit" })}</span>
+                <span>{last30[14].date.toLocaleDateString("ko-KR", { month: "2-digit", day: "2-digit" })}</span>
+                <span className="text-v3-primary font-semibold">오늘 ({summary.today})</span>
+              </div>
+            </>
+          )}
+        </div>
+      </Block>
+
+      <Block name="stats-inquiries-breakdown" className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Hourly today */}
+        <div
+          data-component="stats-inquiries-hourly-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">오늘 시간대별</h3>
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+          </header>
+          {hourly.every((p) => p.count === 0) ? (
+            <p className="text-center py-6 text-[0.85rem] text-v3-text-muted">
+              오늘은 아직 상담 신청이 없어요.
+            </p>
+          ) : (
+            <>
+              <div className="flex items-end gap-[3px] h-[110px]">
+                {hourly.map((p) => {
+                  const pct = (p.count / maxHourly) * 100;
+                  const currentHour = new Date().getHours();
+                  const isCurrent = p.hour === currentHour;
+                  return (
+                    <div
+                      key={p.hour}
+                      className={`flex-1 rounded-t-sm ${
+                        isCurrent
+                          ? "bg-v3-primary"
+                          : p.count > 0
+                            ? "bg-blue-300/70"
+                            : "bg-v3-dim-white"
+                      }`}
+                      style={{ height: `${Math.max(pct, 3)}%` }}
+                      title={`${p.hour}시: ${p.count}건`}
+                    />
+                  );
+                })}
+              </div>
+              <div className="mt-1.5 flex justify-between text-[0.65rem] text-v3-text-muted">
+                <span>00시</span>
+                <span>06시</span>
+                <span>12시</span>
+                <span>18시</span>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* By branch */}
+        <div
+          data-component="stats-inquiries-branch-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">지점별 분포 (7일)</h3>
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+          </header>
+          {byBranch.length === 0 ? (
+            <p className="text-center py-6 text-[0.85rem] text-v3-text-muted">
+              지점별 데이터가 아직 없어요.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {byBranch.slice(0, 6).map((b) => (
+                <div key={b.branchSlug} className="flex items-center gap-3">
+                  <span className="w-[120px] truncate text-[0.78rem] font-medium">
+                    {b.branchSlug}
+                  </span>
+                  <div className="flex-1 h-5 rounded-md bg-v3-dim-white overflow-hidden">
+                    <div
+                      className="h-full bg-gradient-to-r from-v3-primary to-blue-700"
+                      style={{ width: `${(b.count / maxBranch) * 100}%` }}
+                    />
+                  </div>
+                  <span className="w-10 text-right text-[0.78rem] font-semibold tabular-nums">
+                    {b.count}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </Block>
+
+      <Block name="stats-inquiries-recent">
+        <div
+          data-component="stats-inquiries-recent-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">최근 상담 신청</h3>
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+            <span className="ml-auto text-[0.65rem] font-mono text-v3-text-muted">
+              PII 마스킹 적용
+            </span>
+          </header>
+          {recent.length === 0 ? (
+            <p className="text-center py-8 text-[0.85rem] text-v3-text-muted">
+              최근 7일간 상담 신청이 없어요.
+            </p>
+          ) : (
+            <table className="w-full text-[0.82rem]">
+              <thead>
+                <tr className="bg-v3-dim-white border-b border-v3-border">
+                  <th className="text-left font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">신청 ID</th>
+                  <th className="text-left font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">지점</th>
+                  <th className="text-left font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">경로</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">시간</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">디바이스</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recent.map((r, i) => (
+                  <tr
+                    key={`${r.distinctId}-${i}`}
+                    data-component="stats-inquiries-recent-row"
+                    className="border-b border-v3-border last:border-0 hover:bg-v3-dim-white"
+                  >
+                    <td className="px-3 py-3 font-mono text-[0.72rem] text-v3-text-muted">
+                      #{r.distinctId}
+                    </td>
+                    <td className="px-3 py-3">{r.branchSlug ?? "—"}</td>
+                    <td className="px-3 py-3 truncate max-w-[260px]">
+                      {r.pathname ?? "—"}
+                      {r.source ? ` · ${r.source}` : ""}
+                    </td>
+                    <td className="px-3 py-3 text-right text-v3-text-muted text-[0.75rem]">
+                      {new Date(r.timestamp).toLocaleTimeString("ko-KR", {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
+                    </td>
+                    <td className="px-3 py-3 text-right text-[0.75rem]">
+                      {r.deviceType === "Mobile"
+                        ? "📱 Mobile"
+                        : r.deviceType === "Desktop"
+                          ? "💻 Desktop"
+                          : r.deviceType ?? "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </Block>
+    </section>
+  );
+}

--- a/frontend/src/app/(protected)/stats/inquiries/page.tsx
+++ b/frontend/src/app/(protected)/stats/inquiries/page.tsx
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation";
 import { Block } from "@/components/app/v3/Block";
 import { getCurrentUser } from "@/lib/auth/cookies";
 import { ROLES } from "@/lib/constants/roles";
@@ -19,6 +20,13 @@ export default async function InquiriesDetailPage() {
   const user = await getCurrentUser();
   const isOwner = user?.role === ROLES.owner;
   const branchSlug = isOwner ? null : user?.branchSlug ?? null;
+
+  // Fail-closed: a non-owner without a usable branchSlug would otherwise
+  // run PostHog queries with an empty branch filter and see cross-branch
+  // inquiries. Block before any fetch.
+  if (!isOwner && !branchSlug) {
+    redirect("/dashboard");
+  }
 
   const [summary, daily, hourly, recent] = await Promise.all([
     getInquiriesSummary(branchSlug),

--- a/frontend/src/app/(protected)/stats/inquiries/page.tsx
+++ b/frontend/src/app/(protected)/stats/inquiries/page.tsx
@@ -1,4 +1,6 @@
 import { Block } from "@/components/app/v3/Block";
+import { getCurrentUser } from "@/lib/auth/cookies";
+import { ROLES } from "@/lib/constants/roles";
 import {
   getInquiriesSummary,
   getInquiriesDailyTrend,
@@ -14,13 +16,17 @@ export const metadata = { title: "상담 신청 · 통계" };
 export const revalidate = 60;
 
 export default async function InquiriesDetailPage() {
-  const [summary, daily, hourly, byBranch, recent] = await Promise.all([
-    getInquiriesSummary(),
-    getInquiriesDailyTrend(30),
-    getInquiriesHourlyToday(),
-    getInquiriesByBranch(7),
-    getRecentInquiries(10),
+  const user = await getCurrentUser();
+  const isOwner = user?.role === ROLES.owner;
+  const branchSlug = isOwner ? null : user?.branchSlug ?? null;
+
+  const [summary, daily, hourly, recent] = await Promise.all([
+    getInquiriesSummary(branchSlug),
+    getInquiriesDailyTrend(30, branchSlug),
+    getInquiriesHourlyToday(branchSlug),
+    getRecentInquiries(10, branchSlug),
   ]);
+  const byBranch = isOwner ? await getInquiriesByBranch(7) : [];
 
   // Build last-30-day bar data
   const dailyMap = new Map(daily.map((p) => [p.day, p.count]));
@@ -40,16 +46,20 @@ export default async function InquiriesDetailPage() {
     <section data-component="stats-inquiries" className="flex flex-col gap-6 pb-10">
       <Block name="stats-inquiries-hero" className="shrink-0">
         <StatsHero
-          title="상담 신청 통계"
-          subtitle="PostHog · 일별/시간대별/지점별/소스별 분석"
+          title={isOwner ? "상담 신청 통계" : `${user?.branchName ?? "내 지점"} 상담 신청 통계`}
+          subtitle={
+            isOwner
+              ? "PostHog · 일별/시간대별/지점별/소스별 분석"
+              : "PostHog · 일별/시간대별/소스별 분석"
+          }
           rightLabel={today.toLocaleDateString("ko-KR", { weekday: "long" })}
           rightValue={today.toLocaleDateString("ko-KR", {
             year: "numeric",
             month: "2-digit",
             day: "2-digit",
           })}
-          backHref="/stats"
-          backLabel="통계 overview로"
+          backHref={isOwner ? "/stats" : undefined}
+          backLabel={isOwner ? "통계 overview로" : undefined}
           dataComponent="stats-inquiries-hero"
         />
       </Block>
@@ -145,7 +155,10 @@ export default async function InquiriesDetailPage() {
         </div>
       </Block>
 
-      <Block name="stats-inquiries-breakdown" className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <Block
+        name="stats-inquiries-breakdown"
+        className={isOwner ? "grid grid-cols-1 lg:grid-cols-2 gap-4" : "grid grid-cols-1 gap-4"}
+      >
         {/* Hourly today */}
         <div
           data-component="stats-inquiries-hourly-card"
@@ -194,42 +207,44 @@ export default async function InquiriesDetailPage() {
           )}
         </div>
 
-        {/* By branch */}
-        <div
-          data-component="stats-inquiries-branch-card"
-          className="bg-white rounded-[28px] shadow-v3 p-6"
-        >
-          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
-            <h3 className="text-[0.95rem] font-bold text-v3-text">지점별 분포 (7일)</h3>
-            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
-              PostHog
-            </span>
-          </header>
-          {byBranch.length === 0 ? (
-            <p className="text-center py-6 text-[0.85rem] text-v3-text-muted">
-              지점별 데이터가 아직 없어요.
-            </p>
-          ) : (
-            <div className="space-y-2">
-              {byBranch.slice(0, 6).map((b) => (
-                <div key={b.branchSlug} className="flex items-center gap-3">
-                  <span className="w-[120px] truncate text-[0.78rem] font-medium">
-                    {b.branchSlug}
-                  </span>
-                  <div className="flex-1 h-5 rounded-md bg-v3-dim-white overflow-hidden">
-                    <div
-                      className="h-full bg-gradient-to-r from-v3-primary to-blue-700"
-                      style={{ width: `${(b.count / maxBranch) * 100}%` }}
-                    />
+        {/* By branch — owner only */}
+        {isOwner && (
+          <div
+            data-component="stats-inquiries-branch-card"
+            className="bg-white rounded-[28px] shadow-v3 p-6"
+          >
+            <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
+              <h3 className="text-[0.95rem] font-bold text-v3-text">지점별 분포 (7일)</h3>
+              <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+                PostHog
+              </span>
+            </header>
+            {byBranch.length === 0 ? (
+              <p className="text-center py-6 text-[0.85rem] text-v3-text-muted">
+                지점별 데이터가 아직 없어요.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {byBranch.slice(0, 6).map((b) => (
+                  <div key={b.branchSlug} className="flex items-center gap-3">
+                    <span className="w-[120px] truncate text-[0.78rem] font-medium">
+                      {b.branchSlug}
+                    </span>
+                    <div className="flex-1 h-5 rounded-md bg-v3-dim-white overflow-hidden">
+                      <div
+                        className="h-full bg-gradient-to-r from-v3-primary to-blue-700"
+                        style={{ width: `${(b.count / maxBranch) * 100}%` }}
+                      />
+                    </div>
+                    <span className="w-10 text-right text-[0.78rem] font-semibold tabular-nums">
+                      {b.count}
+                    </span>
                   </div>
-                  <span className="w-10 text-right text-[0.78rem] font-semibold tabular-nums">
-                    {b.count}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </Block>
 
       <Block name="stats-inquiries-recent">

--- a/frontend/src/app/(protected)/stats/page.tsx
+++ b/frontend/src/app/(protected)/stats/page.tsx
@@ -1,4 +1,7 @@
+import { redirect } from "next/navigation";
 import { Block } from "@/components/app/v3/Block";
+import { getCurrentUser } from "@/lib/auth/cookies";
+import { ROLES } from "@/lib/constants/roles";
 import {
   getSummary as getSentrySummary,
   formatSentryRelativeTime,
@@ -43,6 +46,11 @@ function formatDelta(today: number, yesterday: number): { label: string; tone: "
 }
 
 export default async function StatsPage() {
+  const user = await getCurrentUser();
+  if (user?.role !== ROLES.owner) {
+    redirect("/stats/inquiries");
+  }
+
   const [sentry, inquiries, inquiriesTrend, funnel, traffic, topPages, devices] =
     await Promise.all([
       getSentrySummary(),
@@ -207,7 +215,7 @@ export default async function StatsPage() {
                 <strong>
                   −{funnel.steps[funnel.biggestDropStep - 1].dropFromPrevPct.toFixed(0)}%
                 </strong>{" "}
-                감소 · 가장 큰 누수
+                감소 · 가장 큰 이탈
               </div>
             ) : funnel.totalEntries === 0 ? (
               <div className="text-[0.78rem] text-v3-text-muted">
@@ -215,7 +223,7 @@ export default async function StatsPage() {
               </div>
             ) : (
               <div className="rounded-md border-l-[3px] border-green-500 bg-green-50 px-3 py-2 text-[0.78rem] text-green-700">
-                ✓ 전환율 {formatPct(funnel.conversionRate, 1)} · 단계별 누수 안정적
+                ✓ 전환율 {formatPct(funnel.conversionRate, 1)} · 단계별 이탈 안정적
               </div>
             )}
           </PanelCard>

--- a/frontend/src/app/(protected)/stats/page.tsx
+++ b/frontend/src/app/(protected)/stats/page.tsx
@@ -1,0 +1,298 @@
+import { Block } from "@/components/app/v3/Block";
+import {
+  getSummary as getSentrySummary,
+  formatSentryRelativeTime,
+} from "@/lib/observability/sentry";
+import {
+  getInquiriesSummary,
+  getInquiriesDailyTrend,
+  getFunnelSummary,
+  getTrafficSummary,
+  getTopPages,
+  getDeviceBreakdown,
+  formatRelativeKo,
+} from "@/lib/observability/posthog";
+import { StatsHero } from "./_components/StatsHero";
+import { PanelCard } from "./_components/PanelCard";
+import { Sparkline } from "./_components/Sparkline";
+import { MiniBars } from "./_components/MiniBars";
+import { FunnelBars } from "./_components/FunnelBars";
+
+export const metadata = {
+  title: "통계 · 아가잼잼 Staff",
+};
+
+// Revalidate the entire page every 60 seconds (matches our 1-minute cache spec)
+export const revalidate = 60;
+
+function formatPct(n: number, digits = 1): string {
+  if (!Number.isFinite(n)) return "—";
+  return `${n.toFixed(digits)}%`;
+}
+
+function formatDelta(today: number, yesterday: number): { label: string; tone: "up" | "down" | "flat" } {
+  if (yesterday === 0 && today === 0) return { label: "변동 없음", tone: "flat" };
+  if (yesterday === 0) return { label: "신규 발생", tone: "up" };
+  const diff = ((today - yesterday) / yesterday) * 100;
+  if (Math.abs(diff) < 0.5) return { label: "전일 동일", tone: "flat" };
+  const sign = diff > 0 ? "↑" : "↓";
+  return {
+    label: `${sign} ${Math.abs(diff).toFixed(0)}% vs 어제`,
+    tone: diff > 0 ? "up" : "down",
+  };
+}
+
+export default async function StatsPage() {
+  const [sentry, inquiries, inquiriesTrend, funnel, traffic, topPages, devices] =
+    await Promise.all([
+      getSentrySummary(),
+      getInquiriesSummary(),
+      getInquiriesDailyTrend(7),
+      getFunnelSummary(7),
+      getTrafficSummary(),
+      getTopPages(1, 4),
+      getDeviceBreakdown(1),
+    ]);
+
+  // Build 7-day labels + values for the inquiry mini-bars
+  const today = new Date();
+  const last7DayLabels: string[] = [];
+  const last7DayValues: number[] = [];
+  const trendMap = new Map(inquiriesTrend.map((p) => [p.day, p.count]));
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    const key = d.toISOString().slice(0, 10);
+    last7DayValues.push(trendMap.get(key) ?? 0);
+    last7DayLabels.push(
+      i === 0 ? "오늘" : `${d.getMonth() + 1}/${d.getDate()}`
+    );
+  }
+
+  const inquiryDelta = formatDelta(inquiries.today, inquiries.yesterday);
+
+  // Device split for traffic panel
+  const mobile = devices.find((d) => /mobile/i.test(d.deviceType))?.pct ?? 0;
+  const desktop = devices.find((d) => /desktop/i.test(d.deviceType))?.pct ?? 0;
+
+  return (
+    <section
+      data-component="stats"
+      className="flex flex-col gap-6 pb-10"
+    >
+      <Block name="stats-hero" className="shrink-0">
+        <StatsHero
+          title="오늘 통계"
+          subtitle="4개 패널 한눈에 — 오류, 상담, 페이지 이동, 트래픽"
+          rightLabel={today.toLocaleDateString("ko-KR", { weekday: "long" })}
+          rightValue={today.toLocaleDateString("ko-KR", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+          })}
+          ariaLabel="통계 개요"
+        />
+      </Block>
+
+      <Block name="stats-grid" className="flex-1 min-h-0">
+        <div
+          data-component="stats-grid-inner"
+          className="grid grid-cols-1 lg:grid-cols-2 gap-4"
+        >
+          {/* Panel 1: 오류 통계 */}
+          <PanelCard
+            title="오류 통계"
+            iconEmoji="⚠"
+            source="Sentry"
+            detailHref="/stats/errors"
+            dataComponent="stats-panel-errors"
+          >
+            <div className="flex items-baseline gap-3">
+              <span
+                data-component="stats-panel-errors-count"
+                className="text-[2.4rem] font-bold leading-none tabular-nums text-red-600"
+              >
+                {sentry.openCount}
+              </span>
+              <span className="text-[0.85rem] text-v3-text-muted">미해결 이슈</span>
+              <span
+                className={`ml-auto text-[0.7rem] font-semibold rounded-full px-2.5 py-1 ${
+                  sentry.newIn24h > 0
+                    ? "bg-red-100 text-red-700"
+                    : "bg-green-100 text-green-700"
+                }`}
+              >
+                {sentry.newIn24h > 0 ? `↑ ${sentry.newIn24h} (24h)` : "신규 없음"}
+              </span>
+            </div>
+            <Sparkline values={sentry.sparkline7d} color="hsl(0 84% 55%)" />
+            {sentry.topIssue ? (
+              <div className="rounded-2xl bg-v3-dim-white p-3.5">
+                <div className="text-[0.62rem] font-bold uppercase tracking-wider text-v3-text-muted mb-1.5">
+                  Top issue
+                </div>
+                <div className="text-[0.82rem] font-semibold text-v3-text truncate">
+                  {sentry.topIssue.title}
+                </div>
+                <div className="text-[0.65rem] font-mono text-v3-text-muted truncate">
+                  {sentry.topIssue.culprit ?? sentry.topIssue.filename ?? "—"}
+                  {" · "}
+                  {sentry.topIssue.count} events · {formatSentryRelativeTime(sentry.topIssue.lastSeen)}
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-2xl bg-v3-dim-white p-3.5 text-[0.78rem] text-v3-text-muted">
+                미해결 이슈가 없어요 🎉
+              </div>
+            )}
+          </PanelCard>
+
+          {/* Panel 2: 상담 신청 */}
+          <PanelCard
+            title="상담 신청"
+            iconEmoji="📝"
+            source="PostHog"
+            detailHref="/stats/inquiries"
+            dataComponent="stats-panel-inquiries"
+          >
+            <div className="flex items-baseline gap-3">
+              <span
+                data-component="stats-panel-inquiries-count"
+                className="text-[2.4rem] font-bold leading-none tabular-nums text-v3-primary"
+              >
+                {inquiries.today}
+              </span>
+              <span className="text-[0.85rem] text-v3-text-muted">건 (오늘)</span>
+              <span
+                className={`ml-auto text-[0.7rem] font-semibold rounded-full px-2.5 py-1 ${
+                  inquiryDelta.tone === "up"
+                    ? "bg-green-100 text-green-700"
+                    : inquiryDelta.tone === "down"
+                      ? "bg-red-100 text-red-700"
+                      : "bg-v3-dim-white text-v3-text-muted"
+                }`}
+              >
+                {inquiryDelta.label}
+              </span>
+            </div>
+            <MiniBars values={last7DayValues} labels={last7DayLabels} />
+            <div className="text-[0.78rem] text-v3-text-muted">
+              7일 평균{" "}
+              <strong className="text-v3-text tabular-nums">
+                {inquiries.sevenDayAvg.toFixed(1)}
+              </strong>
+              건 · 최근 신청{" "}
+              <strong className="text-v3-text">
+                {formatRelativeKo(inquiries.lastSubmissionAt)}
+              </strong>
+            </div>
+          </PanelCard>
+
+          {/* Panel 3: 페이지 이동 통계 (funnel) */}
+          <PanelCard
+            title="페이지 이동 통계"
+            iconEmoji="🔀"
+            source="PostHog"
+            detailHref="/stats/funnel"
+            dataComponent="stats-panel-funnel"
+          >
+            <FunnelBars
+              steps={funnel.steps}
+              biggestDropStep={funnel.biggestDropStep}
+              variant="compact"
+            />
+            {funnel.biggestDropStep && funnel.steps[funnel.biggestDropStep - 1] ? (
+              <div className="rounded-md border-l-[3px] border-red-500 bg-red-50 px-3 py-2 text-[0.78rem] text-red-700">
+                ⚠ Step {funnel.biggestDropStep}에서{" "}
+                <strong>
+                  −{funnel.steps[funnel.biggestDropStep - 1].dropFromPrevPct.toFixed(0)}%
+                </strong>{" "}
+                drop · 가장 큰 누수
+              </div>
+            ) : funnel.totalEntries === 0 ? (
+              <div className="text-[0.78rem] text-v3-text-muted">
+                펀널 진입 이벤트가 아직 없어요.
+              </div>
+            ) : (
+              <div className="rounded-md border-l-[3px] border-green-500 bg-green-50 px-3 py-2 text-[0.78rem] text-green-700">
+                ✓ 전환율 {formatPct(funnel.conversionRate, 1)} · 단계별 누수 안정적
+              </div>
+            )}
+          </PanelCard>
+
+          {/* Panel 4: 사이트 트래픽 */}
+          <PanelCard
+            title="사이트 트래픽"
+            iconEmoji="🌐"
+            source="PostHog"
+            detailHref="/stats/traffic"
+            dataComponent="stats-panel-traffic"
+          >
+            <div className="grid grid-cols-3 gap-3">
+              <div data-component="stats-panel-traffic-pv">
+                <div className="text-[0.65rem] font-medium text-v3-text-muted">페이지뷰</div>
+                <div className="text-[1.55rem] font-bold tabular-nums leading-none mt-1">
+                  {traffic.today.pv.toLocaleString("ko-KR")}
+                </div>
+              </div>
+              <div data-component="stats-panel-traffic-unique">
+                <div className="text-[0.65rem] font-medium text-v3-text-muted">방문자</div>
+                <div className="text-[1.55rem] font-bold tabular-nums leading-none mt-1">
+                  {traffic.today.unique.toLocaleString("ko-KR")}
+                </div>
+              </div>
+              <div data-component="stats-panel-traffic-session">
+                <div className="text-[0.65rem] font-medium text-v3-text-muted">평균 세션</div>
+                <div className="text-[1.55rem] font-bold tabular-nums leading-none mt-1">
+                  {traffic.today.pv === 0
+                    ? "—"
+                    : `${Math.floor(traffic.avgSessionSeconds / 60)}:${String(Math.round(traffic.avgSessionSeconds % 60)).padStart(2, "0")}`}
+                </div>
+              </div>
+            </div>
+            <div>
+              <div className="text-[0.62rem] font-bold uppercase tracking-wider text-v3-text-muted mb-1.5">
+                Top pages
+              </div>
+              <div data-component="stats-panel-traffic-top-pages">
+                {topPages.length === 0 ? (
+                  <div className="py-2 text-[0.75rem] text-v3-text-muted">데이터 없음</div>
+                ) : (
+                  topPages.map((p) => (
+                    <div
+                      key={p.path}
+                      className="flex justify-between items-center py-1.5 border-b border-v3-border last:border-0 text-[0.78rem]"
+                    >
+                      <span className="font-mono text-v3-text truncate mr-2">{p.path}</span>
+                      <span className="font-semibold tabular-nums shrink-0">{p.pv}</span>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+            <div>
+              <div className="flex h-2 rounded-full overflow-hidden bg-v3-dim-white">
+                <div
+                  className="bg-v3-primary"
+                  style={{ width: `${mobile}%` }}
+                />
+                <div
+                  className="bg-blue-400"
+                  style={{ width: `${desktop}%` }}
+                />
+              </div>
+              <div className="mt-1.5 flex justify-between text-[0.7rem] text-v3-text-muted">
+                <span>
+                  <strong className="text-v3-text">Mobile</strong> {mobile.toFixed(0)}%
+                </span>
+                <span>
+                  <strong className="text-v3-text">Desktop</strong> {desktop.toFixed(0)}%
+                </span>
+              </div>
+            </div>
+          </PanelCard>
+        </div>
+      </Block>
+    </section>
+  );
+}

--- a/frontend/src/app/(protected)/stats/page.tsx
+++ b/frontend/src/app/(protected)/stats/page.tsx
@@ -122,14 +122,14 @@ export default async function StatsPage() {
                     : "bg-green-100 text-green-700"
                 }`}
               >
-                {sentry.newIn24h > 0 ? `↑ ${sentry.newIn24h} (24h)` : "신규 없음"}
+                {sentry.newIn24h > 0 ? `↑ ${sentry.newIn24h}건 (24시간)` : "신규 없음"}
               </span>
             </div>
             <Sparkline values={sentry.sparkline7d} color="hsl(0 84% 55%)" />
             {sentry.topIssue ? (
               <div className="rounded-2xl bg-v3-dim-white p-3.5">
                 <div className="text-[0.62rem] font-bold uppercase tracking-wider text-v3-text-muted mb-1.5">
-                  Top issue
+                  주요 오류
                 </div>
                 <div className="text-[0.82rem] font-semibold text-v3-text truncate">
                   {sentry.topIssue.title}
@@ -137,7 +137,7 @@ export default async function StatsPage() {
                 <div className="text-[0.65rem] font-mono text-v3-text-muted truncate">
                   {sentry.topIssue.culprit ?? sentry.topIssue.filename ?? "—"}
                   {" · "}
-                  {sentry.topIssue.count} events · {formatSentryRelativeTime(sentry.topIssue.lastSeen)}
+                  {sentry.topIssue.count}건 · {formatSentryRelativeTime(sentry.topIssue.lastSeen)}
                 </div>
               </div>
             ) : (
@@ -203,11 +203,11 @@ export default async function StatsPage() {
             />
             {funnel.biggestDropStep && funnel.steps[funnel.biggestDropStep - 1] ? (
               <div className="rounded-md border-l-[3px] border-red-500 bg-red-50 px-3 py-2 text-[0.78rem] text-red-700">
-                ⚠ Step {funnel.biggestDropStep}에서{" "}
+                ⚠ {funnel.biggestDropStep}단계에서{" "}
                 <strong>
                   −{funnel.steps[funnel.biggestDropStep - 1].dropFromPrevPct.toFixed(0)}%
                 </strong>{" "}
-                drop · 가장 큰 누수
+                감소 · 가장 큰 누수
               </div>
             ) : funnel.totalEntries === 0 ? (
               <div className="text-[0.78rem] text-v3-text-muted">
@@ -242,7 +242,7 @@ export default async function StatsPage() {
                 </div>
               </div>
               <div data-component="stats-panel-traffic-session">
-                <div className="text-[0.65rem] font-medium text-v3-text-muted">평균 세션</div>
+                <div className="text-[0.65rem] font-medium text-v3-text-muted">평균 방문 시간</div>
                 <div className="text-[1.55rem] font-bold tabular-nums leading-none mt-1">
                   {traffic.today.pv === 0
                     ? "—"
@@ -252,7 +252,7 @@ export default async function StatsPage() {
             </div>
             <div>
               <div className="text-[0.62rem] font-bold uppercase tracking-wider text-v3-text-muted mb-1.5">
-                Top pages
+                인기 페이지
               </div>
               <div data-component="stats-panel-traffic-top-pages">
                 {topPages.length === 0 ? (

--- a/frontend/src/app/(protected)/stats/traffic/page.tsx
+++ b/frontend/src/app/(protected)/stats/traffic/page.tsx
@@ -1,0 +1,415 @@
+import { Block } from "@/components/app/v3/Block";
+import {
+  getTrafficSummary,
+  getTrafficTrend,
+  getTopPages,
+  getDeviceBreakdown,
+  getBrowserBreakdown,
+  getSourceBreakdown,
+  getRegionBreakdown,
+} from "@/lib/observability/posthog";
+import { StatsHero } from "../_components/StatsHero";
+import { KpiCard } from "../_components/KpiCard";
+
+export const metadata = { title: "사이트 트래픽 · 통계" };
+export const revalidate = 60;
+
+function formatDelta(today: number, yesterday: number) {
+  if (yesterday === 0 && today === 0) return { label: "—", tone: "flat" as const };
+  if (yesterday === 0) return { label: "신규", tone: "up" as const };
+  const diff = ((today - yesterday) / yesterday) * 100;
+  const sign = diff > 0 ? "↑" : "↓";
+  return {
+    label: `${sign} ${Math.abs(diff).toFixed(1)}%`,
+    tone: (diff >= 0 ? "up" : "down") as "up" | "down",
+  };
+}
+
+export default async function TrafficDetailPage() {
+  const [summary, trend, topPages, devices, browsers, sources, regions] =
+    await Promise.all([
+      getTrafficSummary(),
+      getTrafficTrend(7),
+      getTopPages(7, 10),
+      getDeviceBreakdown(7),
+      getBrowserBreakdown(7),
+      getSourceBreakdown(7),
+      getRegionBreakdown(7),
+    ]);
+
+  const pvDelta = formatDelta(summary.today.pv, summary.yesterday.pv);
+  const uniqueDelta = formatDelta(summary.today.unique, summary.yesterday.unique);
+
+  // Build 7-day chart
+  const todayDate = new Date();
+  const trendMap = new Map(trend.map((p) => [p.day, p]));
+  const last7 = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(todayDate);
+    d.setDate(d.getDate() - (6 - i));
+    const key = d.toISOString().slice(0, 10);
+    const found = trendMap.get(key);
+    return { date: d, pv: found?.pv ?? 0, unique: found?.unique ?? 0 };
+  });
+  const maxValue = Math.max(1, ...last7.map((p) => p.pv));
+  const chartW = 1100;
+  const chartH = 200;
+  const padL = 40;
+  const padR = 20;
+  const usableW = chartW - padL - padR;
+  const yFor = (v: number) => chartH - 36 - (v / maxValue) * (chartH - 56);
+  const pvPoints = last7.map((p, i) => {
+    const x = padL + (i / 6) * usableW;
+    return `${x.toFixed(1)},${yFor(p.pv).toFixed(1)}`;
+  });
+  const uniquePoints = last7.map((p, i) => {
+    const x = padL + (i / 6) * usableW;
+    return `${x.toFixed(1)},${yFor(p.unique).toFixed(1)}`;
+  });
+  const pvLine = pvPoints.length ? `M${pvPoints.join(" L")}` : "";
+  const uniqueLine = uniquePoints.length ? `M${uniquePoints.join(" L")}` : "";
+  const pvArea =
+    pvPoints.length > 0
+      ? `M${padL},${chartH - 36} L${pvPoints.join(" L")} L${
+          padL + usableW
+        },${chartH - 36} Z`
+      : "";
+
+  const mobile = devices.find((d) => /mobile/i.test(d.deviceType)) ?? { pct: 0, count: 0 };
+  const desktop = devices.find((d) => /desktop/i.test(d.deviceType)) ?? { pct: 0, count: 0 };
+
+  return (
+    <section data-component="stats-traffic" className="flex flex-col gap-6 pb-10">
+      <Block name="stats-traffic-hero" className="shrink-0">
+        <StatsHero
+          title="사이트 트래픽"
+          subtitle="PostHog · 페이지뷰/방문자/소스/디바이스/지역 상세 분석"
+          rightLabel={todayDate.toLocaleDateString("ko-KR", { weekday: "long" })}
+          rightValue={todayDate.toLocaleDateString("ko-KR", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+          })}
+          backHref="/stats"
+          backLabel="통계 overview로"
+          dataComponent="stats-traffic-hero"
+        />
+      </Block>
+
+      <Block name="stats-traffic-kpi" className="shrink-0">
+        <div
+          data-component="stats-traffic-kpi-grid"
+          className="grid grid-cols-2 lg:grid-cols-5 gap-3"
+        >
+          <KpiCard
+            iconEmoji="🌐"
+            label="PV (오늘)"
+            value={summary.today.pv.toLocaleString("ko-KR")}
+            delta={pvDelta}
+            dataComponent="stats-traffic-kpi-pv"
+          />
+          <KpiCard
+            iconEmoji="👥"
+            label="방문자"
+            value={summary.today.unique.toLocaleString("ko-KR")}
+            delta={uniqueDelta}
+            dataComponent="stats-traffic-kpi-unique"
+          />
+          <KpiCard
+            iconEmoji="⏱"
+            label="평균 세션"
+            value={
+              summary.sevenDayTotal.pv === 0
+                ? "—"
+                : `${Math.floor(summary.avgSessionSeconds / 60)}:${String(Math.round(summary.avgSessionSeconds % 60)).padStart(2, "0")}`
+            }
+            dataComponent="stats-traffic-kpi-session"
+            valueSize="sm"
+          />
+          <KpiCard
+            iconEmoji="↩"
+            label="이탈률"
+            value={summary.bounceRate.toFixed(1)}
+            unit="%"
+            tone={summary.bounceRate > 60 ? "warn" : "default"}
+            dataComponent="stats-traffic-kpi-bounce"
+          />
+          <KpiCard
+            iconEmoji="✨"
+            label="7일 합계"
+            value={summary.sevenDayTotal.pv.toLocaleString("ko-KR")}
+            unit="PV"
+            meta={`${summary.sevenDayTotal.unique} 방문자`}
+            dataComponent="stats-traffic-kpi-week"
+            valueSize="sm"
+          />
+        </div>
+      </Block>
+
+      <Block name="stats-traffic-trend">
+        <div
+          data-component="stats-traffic-trend-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-4">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">PV · 유니크 추이 (7일)</h3>
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+            <div className="ml-auto flex gap-3 text-[0.7rem]">
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-3 h-0.5 bg-v3-primary" />
+                PV
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-3 h-0.5 bg-purple-500" />
+                유니크
+              </span>
+            </div>
+          </header>
+          {summary.sevenDayTotal.pv === 0 ? (
+            <p className="text-center py-10 text-[0.85rem] text-v3-text-muted">
+              지난 7일간 트래픽 데이터가 없어요.
+            </p>
+          ) : (
+            <svg
+              viewBox={`0 0 ${chartW} ${chartH}`}
+              preserveAspectRatio="none"
+              style={{ width: "100%", height: chartH }}
+            >
+              <defs>
+                <linearGradient id="traffic-pv-grad" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="hsl(214 100% 34%)" stopOpacity={0.22} />
+                  <stop offset="100%" stopColor="hsl(214 100% 34%)" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <line x1={padL} y1={chartH - 36} x2={chartW - padR} y2={chartH - 36} stroke="hsl(214 32% 91%)" />
+              <line x1={padL} y1={yFor(maxValue * 0.5)} x2={chartW - padR} y2={yFor(maxValue * 0.5)} stroke="hsl(214 32% 91%)" strokeDasharray="3,3" />
+              <line x1={padL} y1={yFor(maxValue)} x2={chartW - padR} y2={yFor(maxValue)} stroke="hsl(214 32% 91%)" strokeDasharray="3,3" />
+              <text x={8} y={yFor(maxValue) + 4} fontSize={10} fill="hsl(215 16% 47%)">
+                {maxValue.toFixed(0)}
+              </text>
+              <text x={8} y={yFor(maxValue * 0.5) + 4} fontSize={10} fill="hsl(215 16% 47%)">
+                {Math.round(maxValue * 0.5)}
+              </text>
+              {pvArea && <path d={pvArea} fill="url(#traffic-pv-grad)" />}
+              {pvLine && <path d={pvLine} stroke="hsl(214 100% 34%)" strokeWidth={2.5} fill="none" />}
+              {uniqueLine && (
+                <path
+                  d={uniqueLine}
+                  stroke="hsl(265 70% 55%)"
+                  strokeWidth={2}
+                  fill="none"
+                  strokeDasharray="4,3"
+                />
+              )}
+              {last7.map((p, i) => {
+                const x = padL + (i / 6) * usableW;
+                return (
+                  <g key={i}>
+                    <circle cx={x} cy={yFor(p.pv)} r={3} fill="hsl(214 100% 34%)" />
+                    {i === last7.length - 1 && (
+                      <text x={x} y={yFor(p.pv) - 8} fontSize={11} fontWeight={600} fill="hsl(214 100% 34%)" textAnchor="middle">
+                        {p.pv}
+                      </text>
+                    )}
+                    <text
+                      x={x}
+                      y={chartH - 12}
+                      fontSize={10}
+                      fill={i === last7.length - 1 ? "hsl(214 100% 34%)" : "hsl(215 16% 47%)"}
+                      fontWeight={i === last7.length - 1 ? 600 : 400}
+                      textAnchor="middle"
+                    >
+                      {i === last7.length - 1
+                        ? "오늘"
+                        : `${p.date.getMonth() + 1}/${p.date.getDate()}`}
+                    </text>
+                  </g>
+                );
+              })}
+            </svg>
+          )}
+        </div>
+      </Block>
+
+      <Block
+        name="stats-traffic-pages-sources"
+        className="grid grid-cols-1 lg:grid-cols-[1.4fr_1fr] gap-4"
+      >
+        <div
+          data-component="stats-traffic-top-pages-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">Top pages</h3>
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+          </header>
+          {topPages.length === 0 ? (
+            <p className="text-center py-6 text-[0.85rem] text-v3-text-muted">데이터 없음</p>
+          ) : (
+            <table className="w-full text-[0.82rem]">
+              <thead>
+                <tr className="bg-v3-dim-white border-b border-v3-border">
+                  <th className="text-left font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">경로</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">PV</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">유니크</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">비중</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topPages.map((p, i) => {
+                  const share =
+                    summary.sevenDayTotal.pv > 0
+                      ? (p.pv / summary.sevenDayTotal.pv) * 100
+                      : 0;
+                  return (
+                    <tr
+                      key={`${p.path}-${i}`}
+                      data-component="stats-traffic-page-row"
+                      className="border-b border-v3-border last:border-0 hover:bg-v3-dim-white"
+                    >
+                      <td className="px-3 py-3 font-mono text-v3-text">{p.path}</td>
+                      <td className="px-3 py-3 text-right font-semibold tabular-nums">{p.pv}</td>
+                      <td className="px-3 py-3 text-right tabular-nums">{p.unique}</td>
+                      <td className="px-3 py-3 text-right text-v3-text-muted tabular-nums">
+                        {share.toFixed(1)}%
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        <div
+          data-component="stats-traffic-sources-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">유입 소스</h3>
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+          </header>
+          {sources.length === 0 ? (
+            <p className="text-center py-6 text-[0.85rem] text-v3-text-muted">데이터 없음</p>
+          ) : (
+            <div className="space-y-2.5">
+              {sources.slice(0, 6).map((s) => (
+                <div key={s.source} className="flex items-center gap-3">
+                  <span className="w-[110px] truncate text-[0.78rem] font-medium">{s.source}</span>
+                  <div className="flex-1 h-5 rounded-md bg-v3-dim-white overflow-hidden">
+                    <div
+                      className="h-full bg-gradient-to-r from-v3-primary to-blue-700"
+                      style={{ width: `${s.pct}%` }}
+                    />
+                  </div>
+                  <span className="w-16 text-right text-[0.78rem] font-semibold tabular-nums">
+                    {s.count}
+                    <span className="ml-1 text-[0.65rem] font-normal text-v3-text-muted">{s.pct.toFixed(0)}%</span>
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </Block>
+
+      <Block
+        name="stats-traffic-device-region"
+        className="grid grid-cols-1 lg:grid-cols-2 gap-4"
+      >
+        <div
+          data-component="stats-traffic-device-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-4">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">디바이스 · 브라우저</h3>
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+          </header>
+          <div className="space-y-5">
+            <div>
+              <div className="text-[0.62rem] font-bold uppercase tracking-wider text-v3-text-muted mb-2">
+                디바이스
+              </div>
+              <div className="flex h-3 rounded-full overflow-hidden bg-v3-dim-white">
+                <div className="bg-v3-primary" style={{ width: `${mobile.pct}%` }} />
+                <div className="bg-blue-400" style={{ width: `${desktop.pct}%` }} />
+              </div>
+              <div className="mt-1.5 flex justify-between text-[0.72rem]">
+                <span>
+                  <strong>📱 Mobile</strong> {mobile.pct.toFixed(0)}% · {mobile.count}
+                </span>
+                <span>
+                  <strong>💻 Desktop</strong> {desktop.pct.toFixed(0)}% · {desktop.count}
+                </span>
+              </div>
+            </div>
+            <div>
+              <div className="text-[0.62rem] font-bold uppercase tracking-wider text-v3-text-muted mb-2">
+                브라우저
+              </div>
+              {browsers.length === 0 ? (
+                <p className="text-[0.78rem] text-v3-text-muted">데이터 없음</p>
+              ) : (
+                <div>
+                  {browsers.slice(0, 6).map((b) => (
+                    <div
+                      key={b.browser}
+                      className="flex justify-between items-center py-1.5 border-b border-v3-border last:border-0 text-[0.78rem]"
+                    >
+                      <span className="text-v3-text">{b.browser}</span>
+                      <span className="font-semibold tabular-nums">
+                        {b.pct.toFixed(1)}% · {b.count}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div
+          data-component="stats-traffic-region-card"
+          className="bg-white rounded-[28px] shadow-v3 p-6"
+        >
+          <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
+            <h3 className="text-[0.95rem] font-bold text-v3-text">지역</h3>
+            <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
+              PostHog
+            </span>
+          </header>
+          {regions.length === 0 ? (
+            <p className="text-center py-6 text-[0.85rem] text-v3-text-muted">
+              지역 데이터가 없어요.
+            </p>
+          ) : (
+            <div className="space-y-2.5">
+              {regions.slice(0, 8).map((r) => (
+                <div key={r.region} className="flex items-center gap-3">
+                  <span className="w-[110px] truncate text-[0.78rem] font-medium">{r.region}</span>
+                  <div className="flex-1 h-5 rounded-md bg-v3-dim-white overflow-hidden">
+                    <div
+                      className="h-full bg-gradient-to-r from-v3-primary to-blue-700"
+                      style={{ width: `${r.pct}%` }}
+                    />
+                  </div>
+                  <span className="w-16 text-right text-[0.78rem] font-semibold tabular-nums">
+                    {r.count}
+                    <span className="ml-1 text-[0.65rem] font-normal text-v3-text-muted">{r.pct.toFixed(0)}%</span>
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </Block>
+    </section>
+  );
+}

--- a/frontend/src/app/(protected)/stats/traffic/page.tsx
+++ b/frontend/src/app/(protected)/stats/traffic/page.tsx
@@ -1,4 +1,7 @@
+import { redirect } from "next/navigation";
 import { Block } from "@/components/app/v3/Block";
+import { getCurrentUser } from "@/lib/auth/cookies";
+import { ROLES } from "@/lib/constants/roles";
 import {
   getTrafficSummary,
   getTrafficTrend,
@@ -26,6 +29,11 @@ function formatDelta(today: number, yesterday: number) {
 }
 
 export default async function TrafficDetailPage() {
+  const user = await getCurrentUser();
+  if (user?.role !== ROLES.owner) {
+    redirect("/stats/inquiries");
+  }
+
   const [summary, trend, topPages, devices, browsers, sources, regions] =
     await Promise.all([
       getTrafficSummary(),
@@ -393,7 +401,7 @@ export default async function TrafficDetailPage() {
             <div className="space-y-2.5">
               {regions.slice(0, 8).map((r) => (
                 <div key={r.region} className="flex items-center gap-3">
-                  <span className="w-[110px] truncate text-[0.78rem] font-medium">{r.region}</span>
+                  <span className="w-[180px] truncate text-[0.78rem] font-medium">{r.region}</span>
                   <div className="flex-1 h-5 rounded-md bg-v3-dim-white overflow-hidden">
                     <div
                       className="h-full bg-gradient-to-r from-v3-primary to-blue-700"

--- a/frontend/src/app/(protected)/stats/traffic/page.tsx
+++ b/frontend/src/app/(protected)/stats/traffic/page.tsx
@@ -102,7 +102,7 @@ export default async function TrafficDetailPage() {
         >
           <KpiCard
             iconEmoji="🌐"
-            label="PV (오늘)"
+            label="조회수 (오늘)"
             value={summary.today.pv.toLocaleString("ko-KR")}
             delta={pvDelta}
             dataComponent="stats-traffic-kpi-pv"
@@ -116,7 +116,7 @@ export default async function TrafficDetailPage() {
           />
           <KpiCard
             iconEmoji="⏱"
-            label="평균 세션"
+            label="평균 방문 시간"
             value={
               summary.sevenDayTotal.pv === 0
                 ? "—"
@@ -137,8 +137,8 @@ export default async function TrafficDetailPage() {
             iconEmoji="✨"
             label="7일 합계"
             value={summary.sevenDayTotal.pv.toLocaleString("ko-KR")}
-            unit="PV"
-            meta={`${summary.sevenDayTotal.unique} 방문자`}
+            unit="조회"
+            meta={`방문자 ${summary.sevenDayTotal.unique}명`}
             dataComponent="stats-traffic-kpi-week"
             valueSize="sm"
           />
@@ -151,18 +151,18 @@ export default async function TrafficDetailPage() {
           className="bg-white rounded-[28px] shadow-v3 p-6"
         >
           <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-4">
-            <h3 className="text-[0.95rem] font-bold text-v3-text">PV · 유니크 추이 (7일)</h3>
+            <h3 className="text-[0.95rem] font-bold text-v3-text">조회수 · 방문자 추이 (7일)</h3>
             <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
               PostHog
             </span>
             <div className="ml-auto flex gap-3 text-[0.7rem]">
               <span className="flex items-center gap-1.5">
                 <span className="inline-block w-3 h-0.5 bg-v3-primary" />
-                PV
+                조회수
               </span>
               <span className="flex items-center gap-1.5">
                 <span className="inline-block w-3 h-0.5 bg-purple-500" />
-                유니크
+                방문자
               </span>
             </div>
           </header>
@@ -241,7 +241,7 @@ export default async function TrafficDetailPage() {
           className="bg-white rounded-[28px] shadow-v3 p-6"
         >
           <header className="flex items-center gap-2.5 pb-3.5 border-b border-v3-border mb-3">
-            <h3 className="text-[0.95rem] font-bold text-v3-text">Top pages</h3>
+            <h3 className="text-[0.95rem] font-bold text-v3-text">인기 페이지</h3>
             <span className="text-[0.6rem] font-bold uppercase tracking-wider rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">
               PostHog
             </span>
@@ -253,8 +253,8 @@ export default async function TrafficDetailPage() {
               <thead>
                 <tr className="bg-v3-dim-white border-b border-v3-border">
                   <th className="text-left font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">경로</th>
-                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">PV</th>
-                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">유니크</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">조회수</th>
+                  <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">방문자</th>
                   <th className="text-right font-semibold uppercase tracking-wider text-[0.65rem] text-v3-text-muted px-3 py-2.5">비중</th>
                 </tr>
               </thead>

--- a/frontend/src/components/app/v3/V3Sidebar.tsx
+++ b/frontend/src/components/app/v3/V3Sidebar.tsx
@@ -129,7 +129,7 @@ export const V3Sidebar = () => {
               { label: "홈페이지 관리", href: "/website-admin", icon: Globe },
               ...rest,
             ]
-          : section.items,
+          : [{ ...statsItem, href: "/stats/inquiries" }, ...rest],
       };
     }),
     [isOwner]

--- a/frontend/src/components/app/v3/V3Sidebar.tsx
+++ b/frontend/src/components/app/v3/V3Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   Calculator,
   Headset,
   MessageCircle,
+  BarChart3,
 } from "lucide-react";
 import { useInitialUser } from "@/providers/UserProvider";
 import { isLayoutExcluded } from "@/lib/constants/v3-layout";
@@ -75,6 +76,7 @@ const BASE_NAV_SECTIONS: NavSection[] = [
   {
     title: "시스템 관리",
     items: [
+      { label: "통계", href: "/stats", icon: BarChart3 },
       { label: "설정", href: "/settings", icon: Settings },
     ],
   },
@@ -117,13 +119,15 @@ export const V3Sidebar = () => {
         return section;
       }
 
+      const [statsItem, ...rest] = section.items;
       return {
         ...section,
         items: isOwner
           ? [
+              statsItem,
               { label: "관리자", href: "/system-admin", icon: UserKey },
               { label: "홈페이지 관리", href: "/website-admin", icon: Globe },
-              ...section.items,
+              ...rest,
             ]
           : section.items,
       };

--- a/frontend/src/hooks/useGetAuthUser.ts
+++ b/frontend/src/hooks/useGetAuthUser.ts
@@ -13,6 +13,7 @@ export interface AuthUser {
     profileImage?: string;
     role?: string;
     branchName?: string | null;
+    branchSlug?: string | null;
 }
 
 interface UseGetAuthUserOptions {

--- a/frontend/src/lib/auth/cookies.ts
+++ b/frontend/src/lib/auth/cookies.ts
@@ -17,6 +17,7 @@ interface TokenPayload {
 
 type CurrentUserResponse = AuthUser & {
   branchName?: string | null;
+  branchSlug?: string | null;
   organizationName?: string | null;
 };
 
@@ -78,6 +79,7 @@ export const getCurrentUser = cache(async () => {
     return {
       ...user,
       branchName: user.branchName ?? user.organizationName ?? null,
+      branchSlug: user.branchSlug ?? null,
     };
   } catch (error: unknown) {
     if (error instanceof Error) {

--- a/frontend/src/lib/observability/posthog.ts
+++ b/frontend/src/lib/observability/posthog.ts
@@ -10,6 +10,10 @@ import type {
   InquiryByBranchRow,
   InquiryDailyPoint,
   InquiryHourlyPoint,
+  PageDetailRow,
+  PageEntryExitRow,
+  PageNavSummary,
+  PageTransitionRow,
   RecentInquiry,
   RegionShareRow,
   SourceShareRow,
@@ -470,6 +474,197 @@ export async function getRegionBreakdown(days = 7): Promise<RegionShareRow[]> {
     count: safeNumber(count),
     pct: total > 0 ? (safeNumber(count) / total) * 100 : 0,
   }));
+}
+
+// ============================================================
+// PAGE NAVIGATION (per-page traffic + transitions)
+// ============================================================
+
+/** Per-page details: PV, unique, entries, exits, bounce % */
+export async function getPagesDetail(days = 7, limit = 30): Promise<PageDetailRow[]> {
+  // Single CTE-style query: per session, classify each pathname as entry/exit/bounce
+  const rows = await hogQL<[string, number, number, number, number, number]>(`
+    SELECT
+      pages.path,
+      pages.pv,
+      pages.unique,
+      entries.cnt,
+      exits.cnt,
+      bounces.cnt
+    FROM
+      (SELECT properties.$pathname AS path, count() AS pv, uniq(distinct_id) AS unique
+       FROM events
+       WHERE event = '$pageview'
+         AND timestamp >= now() - INTERVAL ${days} DAY
+         AND properties.$pathname IS NOT NULL
+       GROUP BY path) AS pages
+      LEFT JOIN
+      (SELECT first_path AS path, count() AS cnt FROM (
+        SELECT argMin(properties.$pathname, timestamp) AS first_path
+        FROM events
+        WHERE event = '$pageview'
+          AND timestamp >= now() - INTERVAL ${days} DAY
+          AND properties.$session_id IS NOT NULL
+          AND properties.$pathname IS NOT NULL
+        GROUP BY properties.$session_id
+      ) GROUP BY first_path) AS entries ON entries.path = pages.path
+      LEFT JOIN
+      (SELECT last_path AS path, count() AS cnt FROM (
+        SELECT argMax(properties.$pathname, timestamp) AS last_path
+        FROM events
+        WHERE event = '$pageview'
+          AND timestamp >= now() - INTERVAL ${days} DAY
+          AND properties.$session_id IS NOT NULL
+          AND properties.$pathname IS NOT NULL
+        GROUP BY properties.$session_id
+      ) GROUP BY last_path) AS exits ON exits.path = pages.path
+      LEFT JOIN
+      (SELECT first_path AS path, count() AS cnt FROM (
+        SELECT argMin(properties.$pathname, timestamp) AS first_path, count() AS pv_in_session
+        FROM events
+        WHERE event = '$pageview'
+          AND timestamp >= now() - INTERVAL ${days} DAY
+          AND properties.$session_id IS NOT NULL
+          AND properties.$pathname IS NOT NULL
+        GROUP BY properties.$session_id
+        HAVING pv_in_session = 1
+      ) GROUP BY first_path) AS bounces ON bounces.path = pages.path
+    ORDER BY pages.pv DESC
+    LIMIT ${limit}
+  `);
+  return rows.map(([path, pv, unique, entries, exits, bounces]) => {
+    const entryCount = safeNumber(entries);
+    return {
+      path: safeString(path) ?? "(unknown)",
+      pv: safeNumber(pv),
+      unique: safeNumber(unique),
+      entries: entryCount,
+      exits: safeNumber(exits),
+      bouncePct: entryCount > 0 ? (safeNumber(bounces) / entryCount) * 100 : 0,
+    };
+  });
+}
+
+/** Top pages where sessions begin */
+export async function getEntryPages(days = 7, limit = 8): Promise<PageEntryExitRow[]> {
+  const rows = await hogQL<[string, number]>(`
+    SELECT first_path AS path, count() AS c
+    FROM (
+      SELECT argMin(properties.$pathname, timestamp) AS first_path
+      FROM events
+      WHERE event = '$pageview'
+        AND timestamp >= now() - INTERVAL ${days} DAY
+        AND properties.$session_id IS NOT NULL
+        AND properties.$pathname IS NOT NULL
+      GROUP BY properties.$session_id
+    )
+    WHERE first_path IS NOT NULL
+    GROUP BY path
+    ORDER BY c DESC
+    LIMIT ${limit}
+  `);
+  const total = rows.reduce((s, [, c]) => s + safeNumber(c), 0);
+  return rows.map(([path, count]) => ({
+    path: safeString(path) ?? "(unknown)",
+    count: safeNumber(count),
+    pct: total > 0 ? (safeNumber(count) / total) * 100 : 0,
+  }));
+}
+
+/** Top pages where sessions end (last PV in session) */
+export async function getExitPages(days = 7, limit = 8): Promise<PageEntryExitRow[]> {
+  const rows = await hogQL<[string, number]>(`
+    SELECT last_path AS path, count() AS c
+    FROM (
+      SELECT argMax(properties.$pathname, timestamp) AS last_path
+      FROM events
+      WHERE event = '$pageview'
+        AND timestamp >= now() - INTERVAL ${days} DAY
+        AND properties.$session_id IS NOT NULL
+        AND properties.$pathname IS NOT NULL
+      GROUP BY properties.$session_id
+    )
+    WHERE last_path IS NOT NULL
+    GROUP BY path
+    ORDER BY c DESC
+    LIMIT ${limit}
+  `);
+  const total = rows.reduce((s, [, c]) => s + safeNumber(c), 0);
+  return rows.map(([path, count]) => ({
+    path: safeString(path) ?? "(unknown)",
+    count: safeNumber(count),
+    pct: total > 0 ? (safeNumber(count) / total) * 100 : 0,
+  }));
+}
+
+/** Top page transitions: count of times users went from A → B in the same session */
+export async function getPageTransitions(days = 7, limit = 15): Promise<PageTransitionRow[]> {
+  const rows = await hogQL<[string, string, number]>(`
+    SELECT
+      pair.1 AS from_path,
+      pair.2 AS to_path,
+      count() AS c
+    FROM (
+      SELECT arrayJoin(arrayMap(i -> tuple(paths[i], paths[i+1]), range(1, length(paths)))) AS pair
+      FROM (
+        SELECT arrayMap(x -> x.2, arraySort(x -> x.1, groupArray(tuple(timestamp, properties.$pathname)))) AS paths
+        FROM events
+        WHERE event = '$pageview'
+          AND timestamp >= now() - INTERVAL ${days} DAY
+          AND properties.$session_id IS NOT NULL
+          AND properties.$pathname IS NOT NULL
+        GROUP BY properties.$session_id
+        HAVING length(paths) >= 2
+      )
+    )
+    WHERE pair.1 != pair.2
+    GROUP BY from_path, to_path
+    ORDER BY c DESC
+    LIMIT ${limit}
+  `);
+  const total = rows.reduce((s, [, , c]) => s + safeNumber(c), 0);
+  return rows.map(([from, to, count]) => ({
+    fromPath: safeString(from) ?? "(unknown)",
+    toPath: safeString(to) ?? "(unknown)",
+    count: safeNumber(count),
+    pct: total > 0 ? (safeNumber(count) / total) * 100 : 0,
+  }));
+}
+
+/** Site-wide page navigation summary (top-of-page KPIs) */
+export async function getPageNavSummary(days = 7): Promise<PageNavSummary> {
+  const rows = await hogQL<[number, number]>(`
+    SELECT
+      uniq(properties.$pathname) AS active_pages,
+      count() AS total_pv
+    FROM events
+    WHERE event = '$pageview'
+      AND timestamp >= now() - INTERVAL ${days} DAY
+      AND properties.$pathname IS NOT NULL
+  `);
+  const bounceRows = await hogQL<[number, number]>(`
+    SELECT
+      countIf(pv_count = 1) AS bounces,
+      count() AS total
+    FROM (
+      SELECT properties.$session_id AS sid, count() AS pv_count
+      FROM events
+      WHERE event = '$pageview'
+        AND timestamp >= now() - INTERVAL ${days} DAY
+        AND properties.$session_id IS NOT NULL
+      GROUP BY sid
+    )
+  `);
+  const activePages = safeNumber(rows[0]?.[0]);
+  const totalPv = safeNumber(rows[0]?.[1]);
+  const bounces = safeNumber(bounceRows[0]?.[0]);
+  const totalSessions = safeNumber(bounceRows[0]?.[1]);
+  return {
+    activePages,
+    totalPv,
+    avgPvPerPage: activePages > 0 ? totalPv / activePages : 0,
+    avgBouncePct: totalSessions > 0 ? (bounces / totalSessions) * 100 : 0,
+  };
 }
 
 // Helper: format Korean relative time. Guards against epoch-zero / "no data"

--- a/frontend/src/lib/observability/posthog.ts
+++ b/frontend/src/lib/observability/posthog.ts
@@ -1,0 +1,492 @@
+import type {
+  BrowserShareRow,
+  DeviceShareRow,
+  FunnelByDevice,
+  FunnelBySource,
+  FunnelStep,
+  FunnelSummary,
+  FunnelTrendPoint,
+  InquiriesSummary,
+  InquiryByBranchRow,
+  InquiryDailyPoint,
+  InquiryHourlyPoint,
+  RecentInquiry,
+  RegionShareRow,
+  SourceShareRow,
+  TopPageRow,
+  TrafficSummary,
+  TrafficTrendPoint,
+} from "./types";
+
+const POSTHOG_HOST = process.env.POSTHOG_HOST ?? "https://us.posthog.com";
+const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY ?? "";
+const POSTHOG_PROJECT_ID = process.env.POSTHOG_PROJECT_ID ?? "";
+
+const REVALIDATE_SECONDS = 60;
+
+const FUNNEL_STEPS: Array<{ event: string; label: string }> = [
+  { event: "pricing_viewed", label: "가격 페이지 진입" },
+  { event: "pricing_quote_loaded", label: "견적 로딩 완료" },
+  { event: "consultation_modal_opened", label: "상담 모달 오픈" },
+  { event: "consultation_form_started", label: "폼 입력 시작" },
+  { event: "consultation_submitted", label: "상담 제출 완료" },
+];
+
+interface HogQLResponse {
+  results: unknown[][];
+  columns?: string[];
+  hasMore?: boolean;
+  error?: string;
+}
+
+async function hogQL<Row extends unknown[]>(
+  query: string,
+  revalidate = REVALIDATE_SECONDS
+): Promise<Row[]> {
+  if (!POSTHOG_API_KEY || !POSTHOG_PROJECT_ID) {
+    console.warn("[posthog] missing POSTHOG_API_KEY or POSTHOG_PROJECT_ID");
+    return [];
+  }
+  try {
+    const res = await fetch(
+      `${POSTHOG_HOST}/api/projects/${POSTHOG_PROJECT_ID}/query/`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${POSTHOG_API_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ query: { kind: "HogQLQuery", query } }),
+        next: { revalidate },
+      }
+    );
+    if (!res.ok) {
+      console.warn(`[posthog] ${res.status} - ${query.slice(0, 80)}`);
+      return [];
+    }
+    const data = (await res.json()) as HogQLResponse;
+    if (data.error) {
+      console.warn("[posthog] query error", data.error);
+      return [];
+    }
+    return (data.results ?? []) as Row[];
+  } catch (err) {
+    console.warn("[posthog] fetch failed", err);
+    return [];
+  }
+}
+
+function safeNumber(v: unknown): number {
+  return typeof v === "number" ? v : Number(v ?? 0) || 0;
+}
+
+function safeString(v: unknown): string | null {
+  if (v == null) return null;
+  const s = String(v);
+  return s === "null" || s === "" ? null : s;
+}
+
+// ============================================================
+// INQUIRIES
+// ============================================================
+
+export async function getInquiriesSummary(): Promise<InquiriesSummary> {
+  const rows = await hogQL<[number, number, number, number, string | null]>(`
+    SELECT
+      countIf(toDate(timestamp) = today()) AS today,
+      countIf(toDate(timestamp) = today() - 1) AS yesterday,
+      countIf(timestamp >= now() - INTERVAL 7 DAY) AS seven_day,
+      countIf(timestamp >= now() - INTERVAL 30 DAY) AS thirty_day,
+      max(timestamp) AS last_at
+    FROM events
+    WHERE event = 'consultation_submitted'
+      AND timestamp >= now() - INTERVAL 30 DAY
+  `);
+
+  const submittedSeven = await hogQL<[number]>(`
+    SELECT count() FROM events
+    WHERE event = 'consultation_submitted'
+      AND timestamp >= now() - INTERVAL 7 DAY
+  `);
+  const viewedSeven = await hogQL<[number]>(`
+    SELECT count() FROM events
+    WHERE event = 'pricing_viewed'
+      AND timestamp >= now() - INTERVAL 7 DAY
+  `);
+  const subs = safeNumber(submittedSeven[0]?.[0]);
+  const views = safeNumber(viewedSeven[0]?.[0]);
+  const conv = views > 0 ? (subs / views) * 100 : 0;
+
+  const r = rows[0];
+  return {
+    today: safeNumber(r?.[0]),
+    yesterday: safeNumber(r?.[1]),
+    sevenDayTotal: safeNumber(r?.[2]),
+    sevenDayAvg: safeNumber(r?.[2]) / 7,
+    thirtyDayTotal: safeNumber(r?.[3]),
+    lastSubmissionAt: safeString(r?.[4]),
+    conversionRate: conv,
+  };
+}
+
+export async function getInquiriesDailyTrend(days = 30): Promise<InquiryDailyPoint[]> {
+  const rows = await hogQL<[string, number]>(`
+    SELECT toDate(timestamp) AS day, count() AS c
+    FROM events
+    WHERE event = 'consultation_submitted'
+      AND timestamp >= now() - INTERVAL ${days} DAY
+    GROUP BY day ORDER BY day ASC
+  `);
+  return rows.map(([day, count]) => ({ day: safeString(day) ?? "", count: safeNumber(count) }));
+}
+
+export async function getInquiriesHourlyToday(): Promise<InquiryHourlyPoint[]> {
+  const rows = await hogQL<[number, number]>(`
+    SELECT toHour(timestamp) AS hour, count() AS c
+    FROM events
+    WHERE event = 'consultation_submitted'
+      AND toDate(timestamp) = today()
+    GROUP BY hour ORDER BY hour ASC
+  `);
+  const map = new Map<number, number>();
+  for (const [h, c] of rows) map.set(safeNumber(h), safeNumber(c));
+  return Array.from({ length: 24 }, (_, hour) => ({ hour, count: map.get(hour) ?? 0 }));
+}
+
+export async function getInquiriesByBranch(days = 1): Promise<InquiryByBranchRow[]> {
+  const rows = await hogQL<[string, number]>(`
+    SELECT properties.branch_slug AS branch, count() AS c
+    FROM events
+    WHERE event = 'consultation_submitted'
+      AND timestamp >= now() - INTERVAL ${days} DAY
+      AND properties.branch_slug IS NOT NULL
+    GROUP BY branch ORDER BY c DESC
+  `);
+  return rows.map(([branch, count]) => ({
+    branchSlug: safeString(branch) ?? "unknown",
+    count: safeNumber(count),
+  }));
+}
+
+export async function getRecentInquiries(limit = 10): Promise<RecentInquiry[]> {
+  const rows = await hogQL<[string, string | null, string | null, string | null, string | null, string]>(`
+    SELECT
+      distinct_id,
+      properties.branch_slug AS branch,
+      properties.source AS source,
+      properties.pathname AS pathname,
+      properties.$device_type AS device,
+      timestamp
+    FROM events
+    WHERE event = 'consultation_submitted'
+      AND timestamp >= now() - INTERVAL 7 DAY
+    ORDER BY timestamp DESC
+    LIMIT ${limit}
+  `);
+  return rows.map(([distinctId, branch, source, pathname, device, timestamp]) => ({
+    distinctId: String(distinctId).slice(-8),
+    branchSlug: safeString(branch),
+    source: safeString(source),
+    pathname: safeString(pathname),
+    deviceType: safeString(device),
+    timestamp: String(timestamp),
+  }));
+}
+
+// ============================================================
+// FUNNEL (pricing → consultation)
+// ============================================================
+
+async function countEventsInRange(event: string, days: number): Promise<number> {
+  const rows = await hogQL<[number]>(`
+    SELECT count() FROM events
+    WHERE event = '${event}'
+      AND timestamp >= now() - INTERVAL ${days} DAY
+  `);
+  return safeNumber(rows[0]?.[0]);
+}
+
+export async function getFunnelSummary(days = 7): Promise<FunnelSummary> {
+  const counts = await Promise.all(
+    FUNNEL_STEPS.map((s) => countEventsInRange(s.event, days))
+  );
+
+  const steps: FunnelStep[] = FUNNEL_STEPS.map((s, i) => {
+    const count = counts[i];
+    const pct = counts[0] > 0 ? (count / counts[0]) * 100 : 0;
+    const dropFromPrev =
+      i === 0 ? 0 : counts[i - 1] > 0 ? (1 - count / counts[i - 1]) * 100 : 0;
+    return {
+      step: i + 1,
+      event: s.event,
+      label: s.label,
+      count,
+      pct,
+      dropFromPrevPct: dropFromPrev,
+    };
+  });
+
+  // Biggest drop excluding step 1 (no prev)
+  let biggestDropStep: number | null = null;
+  let biggestDropValue = 0;
+  for (let i = 1; i < steps.length; i++) {
+    if (steps[i].dropFromPrevPct > biggestDropValue) {
+      biggestDropValue = steps[i].dropFromPrevPct;
+      biggestDropStep = steps[i].step;
+    }
+  }
+
+  return {
+    steps,
+    conversionRate: steps[steps.length - 1]?.pct ?? 0,
+    biggestDropStep,
+    completedConversions: steps[steps.length - 1]?.count ?? 0,
+    totalEntries: counts[0],
+  };
+}
+
+export async function getFunnelTrend(days = 30): Promise<FunnelTrendPoint[]> {
+  const rows = await hogQL<[string, number, number]>(`
+    SELECT
+      toDate(timestamp) AS day,
+      countIf(event = 'pricing_viewed') AS entries,
+      countIf(event = 'consultation_submitted') AS completions
+    FROM events
+    WHERE event IN ('pricing_viewed', 'consultation_submitted')
+      AND timestamp >= now() - INTERVAL ${days} DAY
+    GROUP BY day ORDER BY day ASC
+  `);
+  return rows.map(([day, entries, completions]) => {
+    const e = safeNumber(entries);
+    const c = safeNumber(completions);
+    return {
+      day: safeString(day) ?? "",
+      conversionRate: e > 0 ? (c / e) * 100 : 0,
+    };
+  });
+}
+
+export async function getFunnelByDevice(days = 7): Promise<FunnelByDevice[]> {
+  const rows = await hogQL<[string, number, number]>(`
+    SELECT
+      properties.$device_type AS device,
+      countIf(event = 'pricing_viewed') AS entries,
+      countIf(event = 'consultation_submitted') AS completions
+    FROM events
+    WHERE event IN ('pricing_viewed', 'consultation_submitted')
+      AND timestamp >= now() - INTERVAL ${days} DAY
+      AND properties.$device_type IS NOT NULL
+    GROUP BY device ORDER BY entries DESC
+  `);
+  return rows.map(([device, entries, completions]) => {
+    const e = safeNumber(entries);
+    const c = safeNumber(completions);
+    return {
+      device: safeString(device) ?? "unknown",
+      entries: e,
+      completions: c,
+      conversionRate: e > 0 ? (c / e) * 100 : 0,
+    };
+  });
+}
+
+export async function getFunnelBySource(days = 7): Promise<FunnelBySource[]> {
+  const rows = await hogQL<[string, number, number, number, number, number]>(`
+    SELECT
+      coalesce(properties.$initial_referring_domain, 'direct') AS source,
+      countIf(event = 'pricing_viewed') AS entries,
+      countIf(event = 'pricing_quote_loaded') AS loaded,
+      countIf(event = 'consultation_modal_opened') AS modal,
+      countIf(event = 'consultation_form_started') AS started,
+      countIf(event = 'consultation_submitted') AS submitted
+    FROM events
+    WHERE event IN ('pricing_viewed','pricing_quote_loaded','consultation_modal_opened','consultation_form_started','consultation_submitted')
+      AND timestamp >= now() - INTERVAL ${days} DAY
+    GROUP BY source ORDER BY entries DESC LIMIT 10
+  `);
+  return rows.map(([source, entries, loaded, modal, started, submitted]) => {
+    const e = safeNumber(entries);
+    const s = safeNumber(submitted);
+    return {
+      source: safeString(source) ?? "direct",
+      entries: e,
+      loaded: safeNumber(loaded),
+      modalOpened: safeNumber(modal),
+      started: safeNumber(started),
+      submitted: s,
+      conversionRate: e > 0 ? (s / e) * 100 : 0,
+    };
+  });
+}
+
+// ============================================================
+// TRAFFIC
+// ============================================================
+
+export async function getTrafficSummary(): Promise<TrafficSummary> {
+  const rows = await hogQL<[number, number, number, number, number, number]>(`
+    SELECT
+      countIf(toDate(timestamp) = today()) AS pv_today,
+      uniqIf(distinct_id, toDate(timestamp) = today()) AS u_today,
+      countIf(toDate(timestamp) = today() - 1) AS pv_yest,
+      uniqIf(distinct_id, toDate(timestamp) = today() - 1) AS u_yest,
+      countIf(timestamp >= now() - INTERVAL 7 DAY) AS pv_7d,
+      uniqIf(distinct_id, timestamp >= now() - INTERVAL 7 DAY) AS u_7d
+    FROM events
+    WHERE event = '$pageview'
+      AND timestamp >= now() - INTERVAL 7 DAY
+  `);
+  const r = rows[0];
+
+  // Bounce rate: sessions with only 1 pageview
+  const bounceRows = await hogQL<[number, number]>(`
+    SELECT
+      countIf(pv_count = 1) AS bounces,
+      count() AS total
+    FROM (
+      SELECT properties.$session_id AS sid, count() AS pv_count
+      FROM events
+      WHERE event = '$pageview'
+        AND timestamp >= now() - INTERVAL 7 DAY
+        AND properties.$session_id IS NOT NULL
+      GROUP BY sid
+    )
+  `);
+  const bounces = safeNumber(bounceRows[0]?.[0]);
+  const totalSessions = safeNumber(bounceRows[0]?.[1]);
+  const bounceRate = totalSessions > 0 ? (bounces / totalSessions) * 100 : 0;
+
+  // Avg session: rough estimate via session duration
+  const sessionRows = await hogQL<[number]>(`
+    SELECT avg(duration_s) FROM (
+      SELECT properties.$session_id AS sid,
+        dateDiff('second', min(timestamp), max(timestamp)) AS duration_s
+      FROM events
+      WHERE timestamp >= now() - INTERVAL 7 DAY
+        AND properties.$session_id IS NOT NULL
+      GROUP BY sid
+      HAVING count() >= 2
+    )
+  `);
+  const avgSession = safeNumber(sessionRows[0]?.[0]);
+
+  return {
+    today: { pv: safeNumber(r?.[0]), unique: safeNumber(r?.[1]) },
+    yesterday: { pv: safeNumber(r?.[2]), unique: safeNumber(r?.[3]) },
+    sevenDayTotal: { pv: safeNumber(r?.[4]), unique: safeNumber(r?.[5]) },
+    avgSessionSeconds: avgSession,
+    bounceRate,
+  };
+}
+
+export async function getTrafficTrend(days = 7): Promise<TrafficTrendPoint[]> {
+  const rows = await hogQL<[string, number, number]>(`
+    SELECT toDate(timestamp) AS day, count() AS pv, uniq(distinct_id) AS u
+    FROM events
+    WHERE event = '$pageview' AND timestamp >= now() - INTERVAL ${days} DAY
+    GROUP BY day ORDER BY day ASC
+  `);
+  return rows.map(([day, pv, unique]) => ({
+    day: safeString(day) ?? "",
+    pv: safeNumber(pv),
+    unique: safeNumber(unique),
+  }));
+}
+
+export async function getTopPages(days = 1, limit = 10): Promise<TopPageRow[]> {
+  const rows = await hogQL<[string, number, number]>(`
+    SELECT properties.$pathname AS path, count() AS pv, uniq(distinct_id) AS u
+    FROM events
+    WHERE event = '$pageview' AND timestamp >= now() - INTERVAL ${days} DAY
+      AND properties.$pathname IS NOT NULL
+    GROUP BY path ORDER BY pv DESC LIMIT ${limit}
+  `);
+  return rows.map(([path, pv, unique]) => ({
+    path: safeString(path) ?? "(unknown)",
+    pv: safeNumber(pv),
+    unique: safeNumber(unique),
+    avgTimeSeconds: 0,
+  }));
+}
+
+export async function getDeviceBreakdown(days = 7): Promise<DeviceShareRow[]> {
+  const rows = await hogQL<[string, number]>(`
+    SELECT properties.$device_type AS device, count() AS c
+    FROM events
+    WHERE event = '$pageview' AND timestamp >= now() - INTERVAL ${days} DAY
+      AND properties.$device_type IS NOT NULL
+    GROUP BY device ORDER BY c DESC
+  `);
+  const total = rows.reduce((s, [, c]) => s + safeNumber(c), 0);
+  return rows.map(([device, count]) => ({
+    deviceType: safeString(device) ?? "unknown",
+    count: safeNumber(count),
+    pct: total > 0 ? (safeNumber(count) / total) * 100 : 0,
+  }));
+}
+
+export async function getBrowserBreakdown(days = 7): Promise<BrowserShareRow[]> {
+  const rows = await hogQL<[string, number]>(`
+    SELECT
+      concat(coalesce(properties.$browser, 'Other'), ' / ', coalesce(properties.$device_type, 'Unknown')) AS browser,
+      count() AS c
+    FROM events
+    WHERE event = '$pageview' AND timestamp >= now() - INTERVAL ${days} DAY
+    GROUP BY browser ORDER BY c DESC LIMIT 6
+  `);
+  const total = rows.reduce((s, [, c]) => s + safeNumber(c), 0);
+  return rows.map(([browser, count]) => ({
+    browser: safeString(browser) ?? "Other",
+    count: safeNumber(count),
+    pct: total > 0 ? (safeNumber(count) / total) * 100 : 0,
+  }));
+}
+
+export async function getSourceBreakdown(days = 7): Promise<SourceShareRow[]> {
+  const rows = await hogQL<[string, number]>(`
+    SELECT coalesce(properties.$initial_referring_domain, 'direct') AS source, count() AS c
+    FROM events
+    WHERE event = '$pageview' AND timestamp >= now() - INTERVAL ${days} DAY
+    GROUP BY source ORDER BY c DESC LIMIT 8
+  `);
+  const total = rows.reduce((s, [, c]) => s + safeNumber(c), 0);
+  return rows.map(([source, count]) => ({
+    source: safeString(source) ?? "direct",
+    count: safeNumber(count),
+    pct: total > 0 ? (safeNumber(count) / total) * 100 : 0,
+  }));
+}
+
+export async function getRegionBreakdown(days = 7): Promise<RegionShareRow[]> {
+  const rows = await hogQL<[string, number]>(`
+    SELECT coalesce(properties.$geoip_subdivision_1_name, 'Unknown') AS region, count() AS c
+    FROM events
+    WHERE event = '$pageview' AND timestamp >= now() - INTERVAL ${days} DAY
+    GROUP BY region ORDER BY c DESC LIMIT 8
+  `);
+  const total = rows.reduce((s, [, c]) => s + safeNumber(c), 0);
+  return rows.map(([region, count]) => ({
+    region: safeString(region) ?? "Unknown",
+    count: safeNumber(count),
+    pct: total > 0 ? (safeNumber(count) / total) * 100 : 0,
+  }));
+}
+
+// Helper: format Korean relative time. Guards against epoch-zero / "no data"
+// sentinel timestamps that some PostHog queries return when there are no rows.
+export function formatRelativeKo(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const ts = new Date(iso).getTime();
+  if (!Number.isFinite(ts) || ts <= 0) return "—";
+  const diff = Date.now() - ts;
+  // Anything more than a year old is treated as "no recent data" for the
+  // observability dashboard. The widgets all use < 30-day windows.
+  if (diff > 365 * 24 * 60 * 60 * 1000) return "—";
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "방금 전";
+  if (minutes < 60) return `${minutes}분 전`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}시간 전`;
+  const days = Math.floor(hours / 24);
+  return `${days}일 전`;
+}

--- a/frontend/src/lib/observability/posthog.ts
+++ b/frontend/src/lib/observability/posthog.ts
@@ -90,11 +90,27 @@ function safeString(v: unknown): string | null {
   return s === "null" || s === "" ? null : s;
 }
 
+// HogQL queries are sent as raw text, so any value injected into a WHERE
+// clause has to be allowlisted. Branch slugs are kebab-case ASCII
+// identifiers (e.g. "incheon-junggu"); anything else is dropped.
+function sanitizeBranchSlug(slug: string | null | undefined): string | null {
+  if (!slug) return null;
+  return /^[a-zA-Z0-9_-]+$/.test(slug) ? slug : null;
+}
+
+function branchFilter(slug: string | null | undefined): string {
+  const s = sanitizeBranchSlug(slug);
+  return s ? `AND properties.branch_slug = '${s}'` : "";
+}
+
 // ============================================================
 // INQUIRIES
 // ============================================================
 
-export async function getInquiriesSummary(): Promise<InquiriesSummary> {
+export async function getInquiriesSummary(
+  branchSlug?: string | null
+): Promise<InquiriesSummary> {
+  const bf = branchFilter(branchSlug);
   const rows = await hogQL<[number, number, number, number, string | null]>(`
     SELECT
       countIf(toDate(timestamp) = today()) AS today,
@@ -105,13 +121,17 @@ export async function getInquiriesSummary(): Promise<InquiriesSummary> {
     FROM events
     WHERE event = 'consultation_submitted'
       AND timestamp >= now() - INTERVAL 30 DAY
+      ${bf}
   `);
 
   const submittedSeven = await hogQL<[number]>(`
     SELECT count() FROM events
     WHERE event = 'consultation_submitted'
       AND timestamp >= now() - INTERVAL 7 DAY
+      ${bf}
   `);
+  // pricing_viewed events don't carry branch_slug — the conversion rate is
+  // site-wide regardless of the user's branch filter.
   const viewedSeven = await hogQL<[number]>(`
     SELECT count() FROM events
     WHERE event = 'pricing_viewed'
@@ -133,23 +153,30 @@ export async function getInquiriesSummary(): Promise<InquiriesSummary> {
   };
 }
 
-export async function getInquiriesDailyTrend(days = 30): Promise<InquiryDailyPoint[]> {
+export async function getInquiriesDailyTrend(
+  days = 30,
+  branchSlug?: string | null
+): Promise<InquiryDailyPoint[]> {
   const rows = await hogQL<[string, number]>(`
     SELECT toDate(timestamp) AS day, count() AS c
     FROM events
     WHERE event = 'consultation_submitted'
       AND timestamp >= now() - INTERVAL ${days} DAY
+      ${branchFilter(branchSlug)}
     GROUP BY day ORDER BY day ASC
   `);
   return rows.map(([day, count]) => ({ day: safeString(day) ?? "", count: safeNumber(count) }));
 }
 
-export async function getInquiriesHourlyToday(): Promise<InquiryHourlyPoint[]> {
+export async function getInquiriesHourlyToday(
+  branchSlug?: string | null
+): Promise<InquiryHourlyPoint[]> {
   const rows = await hogQL<[number, number]>(`
     SELECT toHour(timestamp) AS hour, count() AS c
     FROM events
     WHERE event = 'consultation_submitted'
       AND toDate(timestamp) = today()
+      ${branchFilter(branchSlug)}
     GROUP BY hour ORDER BY hour ASC
   `);
   const map = new Map<number, number>();
@@ -172,7 +199,10 @@ export async function getInquiriesByBranch(days = 1): Promise<InquiryByBranchRow
   }));
 }
 
-export async function getRecentInquiries(limit = 10): Promise<RecentInquiry[]> {
+export async function getRecentInquiries(
+  limit = 10,
+  branchSlug?: string | null
+): Promise<RecentInquiry[]> {
   const rows = await hogQL<[string, string | null, string | null, string | null, string | null, string]>(`
     SELECT
       distinct_id,
@@ -184,6 +214,7 @@ export async function getRecentInquiries(limit = 10): Promise<RecentInquiry[]> {
     FROM events
     WHERE event = 'consultation_submitted'
       AND timestamp >= now() - INTERVAL 7 DAY
+      ${branchFilter(branchSlug)}
     ORDER BY timestamp DESC
     LIMIT ${limit}
   `);
@@ -461,16 +492,138 @@ export async function getSourceBreakdown(days = 7): Promise<SourceShareRow[]> {
   }));
 }
 
+// MaxMind GeoIP returns English names. Translate the common Korean
+// subdivisions + cities/districts for readability. Falls back to raw
+// English when the name isn't in the map.
+const KOR_PROVINCE_MAP: Record<string, string> = {
+  Seoul: "서울특별시",
+  Busan: "부산광역시",
+  Daegu: "대구광역시",
+  Incheon: "인천광역시",
+  Gwangju: "광주광역시",
+  Daejeon: "대전광역시",
+  Ulsan: "울산광역시",
+  Sejong: "세종특별자치시",
+  "Gyeonggi-do": "경기도",
+  Gyeonggi: "경기도",
+  "Gangwon-do": "강원특별자치도",
+  Gangwon: "강원특별자치도",
+  "Chungcheongbuk-do": "충청북도",
+  "North Chungcheong": "충청북도",
+  "Chungcheongnam-do": "충청남도",
+  "South Chungcheong": "충청남도",
+  "Jeollabuk-do": "전북특별자치도",
+  "North Jeolla": "전북특별자치도",
+  "Jeollanam-do": "전라남도",
+  "South Jeolla": "전라남도",
+  "Gyeongsangbuk-do": "경상북도",
+  "North Gyeongsang": "경상북도",
+  "Gyeongsangnam-do": "경상남도",
+  "South Gyeongsang": "경상남도",
+  "Jeju-do": "제주특별자치도",
+  Jeju: "제주특별자치도",
+};
+
+const KOR_CITY_MAP: Record<string, string> = {
+  // Seoul 25 districts
+  "Gangnam-gu": "강남구", Gangnam: "강남구",
+  "Gangdong-gu": "강동구", Gangdong: "강동구",
+  "Gangbuk-gu": "강북구", Gangbuk: "강북구",
+  "Gangseo-gu": "강서구", Gangseo: "강서구",
+  "Geumcheon-gu": "금천구", Geumcheon: "금천구",
+  "Guro-gu": "구로구", Guro: "구로구",
+  "Gwanak-gu": "관악구", Gwanak: "관악구",
+  "Gwangjin-gu": "광진구", Gwangjin: "광진구",
+  "Mapo-gu": "마포구", Mapo: "마포구",
+  "Nowon-gu": "노원구", Nowon: "노원구",
+  "Dobong-gu": "도봉구", Dobong: "도봉구",
+  "Dongdaemun-gu": "동대문구", Dongdaemun: "동대문구",
+  "Dongjak-gu": "동작구", Dongjak: "동작구",
+  "Eunpyeong-gu": "은평구", Eunpyeong: "은평구",
+  "Jongno-gu": "종로구", Jongno: "종로구",
+  "Jungnang-gu": "중랑구", Jungnang: "중랑구",
+  "Seocho-gu": "서초구", Seocho: "서초구",
+  "Seodaemun-gu": "서대문구", Seodaemun: "서대문구",
+  "Seongbuk-gu": "성북구", Seongbuk: "성북구",
+  "Seongdong-gu": "성동구", Seongdong: "성동구",
+  "Songpa-gu": "송파구", Songpa: "송파구",
+  "Yangcheon-gu": "양천구", Yangcheon: "양천구",
+  "Yeongdeungpo-gu": "영등포구", Yeongdeungpo: "영등포구",
+  "Yongsan-gu": "용산구", Yongsan: "용산구",
+  // Incheon districts
+  "Bupyeong-gu": "부평구", Bupyeong: "부평구",
+  "Namdong-gu": "남동구", Namdong: "남동구",
+  "Yeonsu-gu": "연수구", Yeonsu: "연수구",
+  "Michuhol-gu": "미추홀구", Michuhol: "미추홀구",
+  "Gyeyang-gu": "계양구", Gyeyang: "계양구",
+  "Ganghwa-gun": "강화군", Ganghwa: "강화군",
+  "Ongjin-gun": "옹진군", Ongjin: "옹진군",
+  // Directional gus (shared across metros — Seoul/Busan/Daegu/Incheon/Daejeon/Gwangju)
+  "Jung-gu": "중구",
+  "Dong-gu": "동구",
+  "Seo-gu": "서구",
+  "Nam-gu": "남구",
+  "Buk-gu": "북구",
+  // Gyeonggi-do cities
+  "Goyang-si": "고양시", Goyang: "고양시",
+  "Suwon-si": "수원시", Suwon: "수원시",
+  "Seongnam-si": "성남시", Seongnam: "성남시",
+  "Yongin-si": "용인시", Yongin: "용인시",
+  "Bucheon-si": "부천시", Bucheon: "부천시",
+  "Ansan-si": "안산시", Ansan: "안산시",
+  "Anyang-si": "안양시", Anyang: "안양시",
+  "Namyangju-si": "남양주시", Namyangju: "남양주시",
+  "Hwaseong-si": "화성시", Hwaseong: "화성시",
+  "Pyeongtaek-si": "평택시", Pyeongtaek: "평택시",
+  "Uijeongbu-si": "의정부시", Uijeongbu: "의정부시",
+  "Siheung-si": "시흥시", Siheung: "시흥시",
+  "Paju-si": "파주시", Paju: "파주시",
+  "Gimpo-si": "김포시", Gimpo: "김포시",
+  "Gwangmyeong-si": "광명시", Gwangmyeong: "광명시",
+  "Gunpo-si": "군포시", Gunpo: "군포시",
+  "Osan-si": "오산시", Osan: "오산시",
+  "Icheon-si": "이천시", Icheon: "이천시",
+  "Yangju-si": "양주시", Yangju: "양주시",
+  "Hanam-si": "하남시", Hanam: "하남시",
+  "Anseong-si": "안성시", Anseong: "안성시",
+  "Pocheon-si": "포천시", Pocheon: "포천시",
+  "Yeoju-si": "여주시", Yeoju: "여주시",
+  "Yangpyeong-gun": "양평군", Yangpyeong: "양평군",
+  "Gapyeong-gun": "가평군", Gapyeong: "가평군",
+  "Yeoncheon-gun": "연천군", Yeoncheon: "연천군",
+  // Busan / Daegu / Daejeon / Jeju standouts
+  "Haeundae-gu": "해운대구", Haeundae: "해운대구",
+  "Saha-gu": "사하구", Saha: "사하구",
+  "Suseong-gu": "수성구", Suseong: "수성구",
+  "Yuseong-gu": "유성구", Yuseong: "유성구",
+  "Jeju-si": "제주시",
+  "Seogwipo-si": "서귀포시", Seogwipo: "서귀포시",
+};
+
+function translateKorRegion(province: string | null, city: string | null): string {
+  const p = province?.trim() || null;
+  const c = city?.trim() || null;
+  const pK = p ? KOR_PROVINCE_MAP[p] ?? p : null;
+  const cK = c ? KOR_CITY_MAP[c] ?? c : null;
+  if (pK && cK) return `${pK} / ${cK}`;
+  if (pK) return pK;
+  if (cK) return cK;
+  return "Unknown";
+}
+
 export async function getRegionBreakdown(days = 7): Promise<RegionShareRow[]> {
-  const rows = await hogQL<[string, number]>(`
-    SELECT coalesce(properties.$geoip_subdivision_1_name, 'Unknown') AS region, count() AS c
+  const rows = await hogQL<[string | null, string | null, number]>(`
+    SELECT
+      properties.$geoip_subdivision_1_name AS province,
+      properties.$geoip_city_name AS city,
+      count() AS c
     FROM events
     WHERE event = '$pageview' AND timestamp >= now() - INTERVAL ${days} DAY
-    GROUP BY region ORDER BY c DESC LIMIT 8
+    GROUP BY province, city ORDER BY c DESC LIMIT 10
   `);
-  const total = rows.reduce((s, [, c]) => s + safeNumber(c), 0);
-  return rows.map(([region, count]) => ({
-    region: safeString(region) ?? "Unknown",
+  const total = rows.reduce((s, [, , c]) => s + safeNumber(c), 0);
+  return rows.map(([province, city, count]) => ({
+    region: translateKorRegion(safeString(province), safeString(city)),
     count: safeNumber(count),
     pct: total > 0 ? (safeNumber(count) / total) * 100 : 0,
   }));

--- a/frontend/src/lib/observability/sentry.ts
+++ b/frontend/src/lib/observability/sentry.ts
@@ -1,0 +1,171 @@
+import type { SentryIssue, SentryLevel, SentrySummary } from "./types";
+
+const SENTRY_BASE = "https://sentry.io/api/0";
+const SENTRY_ORG = process.env.SENTRY_ORG ?? "";
+const SENTRY_PROJECT_ID = "4511387543011328";
+const SENTRY_TOKEN = process.env.SENTRY_AUTH_TOKEN ?? "";
+
+const REVALIDATE_SECONDS = 60;
+
+interface RawIssue {
+  id: string;
+  title: string;
+  level: SentryLevel;
+  count: string | number;
+  userCount: number;
+  lastSeen: string;
+  firstSeen: string;
+  permalink: string;
+  culprit?: string | null;
+  metadata?: { filename?: string; function?: string };
+  stats?: { "24h"?: Array<[number, number]>; "30d"?: Array<[number, number]> };
+}
+
+async function sentryGet<T>(path: string, revalidate = REVALIDATE_SECONDS): Promise<T | null> {
+  if (!SENTRY_TOKEN || !SENTRY_ORG) {
+    console.warn("[sentry] missing SENTRY_AUTH_TOKEN or SENTRY_ORG");
+    return null;
+  }
+  const url = path.startsWith("http") ? path : `${SENTRY_BASE}${path}`;
+  try {
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${SENTRY_TOKEN}` },
+      next: { revalidate },
+    });
+    if (!res.ok) {
+      console.warn(`[sentry] ${res.status} ${path}`);
+      return null;
+    }
+    return (await res.json()) as T;
+  } catch (err) {
+    console.warn("[sentry] fetch failed", path, err);
+    return null;
+  }
+}
+
+function normalizeIssue(raw: RawIssue): SentryIssue {
+  return {
+    id: raw.id,
+    title: raw.title,
+    level: raw.level,
+    count: Number(raw.count ?? 0),
+    userCount: raw.userCount ?? 0,
+    lastSeen: raw.lastSeen,
+    firstSeen: raw.firstSeen,
+    permalink: raw.permalink,
+    culprit: raw.culprit ?? null,
+    filename: raw.metadata?.filename ?? null,
+    function: raw.metadata?.function ?? null,
+  };
+}
+
+export async function getOpenIssues(
+  options: { limit?: number; statsPeriod?: "24h" | "7d" | "30d"; query?: string } = {}
+): Promise<SentryIssue[]> {
+  const { limit = 25, statsPeriod = "24h", query = "is:unresolved" } = options;
+  const params = new URLSearchParams({
+    project: SENTRY_PROJECT_ID,
+    query,
+    limit: String(limit),
+    sort: "freq",
+    statsPeriod,
+  });
+  const path = `/organizations/${SENTRY_ORG}/issues/?${params.toString()}`;
+  const data = await sentryGet<RawIssue[]>(path);
+  if (!Array.isArray(data)) return [];
+  return data.map(normalizeIssue);
+}
+
+export async function getIssuesWithStats(): Promise<{ issues: SentryIssue[]; raw: RawIssue[] }> {
+  const params = new URLSearchParams({
+    project: SENTRY_PROJECT_ID,
+    query: "is:unresolved",
+    limit: "100",
+    sort: "freq",
+    statsPeriod: "7d",
+  });
+  const path = `/organizations/${SENTRY_ORG}/issues/?${params.toString()}`;
+  const data = await sentryGet<RawIssue[]>(path);
+  if (!Array.isArray(data)) return { issues: [], raw: [] };
+  return { issues: data.map(normalizeIssue), raw: data };
+}
+
+export async function getSummary(): Promise<SentrySummary> {
+  const { issues, raw } = await getIssuesWithStats();
+
+  const oneDay = 24 * 60 * 60 * 1000;
+  const now = Date.now();
+
+  const newIn24h = issues.filter(
+    (i) => now - new Date(i.firstSeen).getTime() < oneDay
+  ).length;
+
+  const severity = {
+    critical: issues.filter((i) => i.level === "fatal").length,
+    error: issues.filter((i) => i.level === "error").length,
+    warning: issues.filter((i) => i.level === "warning").length,
+    info: issues.filter((i) => i.level === "info").length,
+  };
+
+  const topIssue = issues[0] ?? null;
+  const totalEvents7d = issues.reduce((sum, i) => sum + i.count, 0);
+  const affectedUsers = issues.reduce((sum, i) => sum + i.userCount, 0);
+  const lastErrorAt = issues.reduce<string | null>((latest, i) => {
+    if (!latest) return i.lastSeen;
+    return new Date(i.lastSeen).getTime() > new Date(latest).getTime() ? i.lastSeen : latest;
+  }, null);
+
+  // Daily event counts from 30d stats (aggregate across issues)
+  const dailyMap = new Map<string, number>();
+  for (const r of raw) {
+    const series = r.stats?.["30d"] ?? r.stats?.["24h"] ?? [];
+    for (const [ts, count] of series) {
+      const dayKey = new Date(ts * 1000).toISOString().slice(0, 10);
+      dailyMap.set(dayKey, (dailyMap.get(dayKey) ?? 0) + count);
+    }
+  }
+  const sortedDays = Array.from(dailyMap.keys()).sort();
+  const last7Days = sortedDays.slice(-7);
+  const sparkline7d = last7Days.map((d) => dailyMap.get(d) ?? 0);
+  while (sparkline7d.length < 7) sparkline7d.unshift(0);
+
+  return {
+    openCount: issues.length,
+    newIn24h,
+    severity,
+    topIssue,
+    totalEvents7d,
+    affectedUsers,
+    lastErrorAt,
+    sparkline7d,
+  };
+}
+
+export async function get24hEventTrend(): Promise<Array<{ timestamp: string; count: number }>> {
+  // Aggregate 24h stats from all open issues
+  const { raw } = await getIssuesWithStats();
+  const map = new Map<number, number>();
+  for (const r of raw) {
+    const series = r.stats?.["24h"] ?? [];
+    for (const [ts, count] of series) {
+      map.set(ts, (map.get(ts) ?? 0) + count);
+    }
+  }
+  const sorted = Array.from(map.entries()).sort(([a], [b]) => a - b);
+  return sorted.map(([ts, count]) => ({
+    timestamp: new Date(ts * 1000).toISOString(),
+    count,
+  }));
+}
+
+export function formatSentryRelativeTime(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "방금 전";
+  if (minutes < 60) return `${minutes}분 전`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}시간 전`;
+  const days = Math.floor(hours / 24);
+  return `${days}일 전`;
+}

--- a/frontend/src/lib/observability/types.ts
+++ b/frontend/src/lib/observability/types.ts
@@ -1,0 +1,149 @@
+export type SentryLevel = "fatal" | "error" | "warning" | "info";
+
+export interface SentryIssue {
+  id: string;
+  title: string;
+  level: SentryLevel;
+  count: number;
+  userCount: number;
+  lastSeen: string;
+  firstSeen: string;
+  permalink: string;
+  culprit: string | null;
+  filename: string | null;
+  function: string | null;
+}
+
+export interface SentrySummary {
+  openCount: number;
+  newIn24h: number;
+  severity: {
+    critical: number;
+    error: number;
+    warning: number;
+    info: number;
+  };
+  topIssue: SentryIssue | null;
+  totalEvents7d: number;
+  affectedUsers: number;
+  lastErrorAt: string | null;
+  sparkline7d: number[];
+}
+
+export interface InquiriesSummary {
+  today: number;
+  yesterday: number;
+  sevenDayTotal: number;
+  sevenDayAvg: number;
+  thirtyDayTotal: number;
+  lastSubmissionAt: string | null;
+  conversionRate: number;
+}
+
+export interface InquiryDailyPoint {
+  day: string;
+  count: number;
+}
+
+export interface InquiryHourlyPoint {
+  hour: number;
+  count: number;
+}
+
+export interface InquiryByBranchRow {
+  branchSlug: string;
+  count: number;
+}
+
+export interface RecentInquiry {
+  distinctId: string;
+  branchSlug: string | null;
+  source: string | null;
+  pathname: string | null;
+  deviceType: string | null;
+  timestamp: string;
+}
+
+export interface FunnelStep {
+  step: number;
+  event: string;
+  label: string;
+  count: number;
+  pct: number;
+  dropFromPrevPct: number;
+}
+
+export interface FunnelSummary {
+  steps: FunnelStep[];
+  conversionRate: number;
+  biggestDropStep: number | null;
+  completedConversions: number;
+  totalEntries: number;
+}
+
+export interface FunnelTrendPoint {
+  day: string;
+  conversionRate: number;
+}
+
+export interface FunnelByDevice {
+  device: string;
+  entries: number;
+  completions: number;
+  conversionRate: number;
+}
+
+export interface FunnelBySource {
+  source: string;
+  entries: number;
+  loaded: number;
+  modalOpened: number;
+  started: number;
+  submitted: number;
+  conversionRate: number;
+}
+
+export interface TrafficSummary {
+  today: { pv: number; unique: number };
+  yesterday: { pv: number; unique: number };
+  sevenDayTotal: { pv: number; unique: number };
+  avgSessionSeconds: number;
+  bounceRate: number;
+}
+
+export interface TrafficTrendPoint {
+  day: string;
+  pv: number;
+  unique: number;
+}
+
+export interface TopPageRow {
+  path: string;
+  pv: number;
+  unique: number;
+  avgTimeSeconds: number;
+}
+
+export interface DeviceShareRow {
+  deviceType: string;
+  count: number;
+  pct: number;
+}
+
+export interface BrowserShareRow {
+  browser: string;
+  count: number;
+  pct: number;
+}
+
+export interface SourceShareRow {
+  source: string;
+  count: number;
+  pct: number;
+}
+
+export interface RegionShareRow {
+  region: string;
+  count: number;
+  pct: number;
+}

--- a/frontend/src/lib/observability/types.ts
+++ b/frontend/src/lib/observability/types.ts
@@ -147,3 +147,35 @@ export interface RegionShareRow {
   count: number;
   pct: number;
 }
+
+// ============================================================
+// PAGE NAVIGATION (used by /stats/funnel "페이지 이동 통계")
+// ============================================================
+export interface PageDetailRow {
+  path: string;
+  pv: number;
+  unique: number;
+  entries: number;
+  exits: number;
+  bouncePct: number;
+}
+
+export interface PageEntryExitRow {
+  path: string;
+  count: number;
+  pct: number;
+}
+
+export interface PageTransitionRow {
+  fromPath: string;
+  toPath: string;
+  count: number;
+  pct: number;
+}
+
+export interface PageNavSummary {
+  activePages: number;
+  totalPv: number;
+  avgPvPerPage: number;
+  avgBouncePct: number;
+}


### PR DESCRIPTION
## Summary
- `/stats` 오버뷰 + `errors`/`funnel`/`traffic` 상세 페이지를 **owner 전용**으로 제한하고, non-owner staff는 `/stats/inquiries`로 자동 redirect
- `/stats/inquiries`는 non-owner인 경우 **자기 브랜치의 상담 신청만** 보여주고 지점별 분포 카드는 숨김
- 백엔드 `/auth/me`가 `branchSlug` (branch.slug 컬럼) 노출 → frontend에서 PostHog `branch_slug` filter에 사용
- UI polish: 누수 → **이탈**, 트래픽 지역을 **도/시 디테일**로 (예: `경기도 / 고양시`)

## Changes
**Backend**
- `auth.controller.ts`: `getCurrentUser` 응답에 `branchSlug` 포함

**Auth/Types**
- `useGetAuthUser.ts`, `lib/auth/cookies.ts`: AuthUser 타입에 `branchSlug?: string \| null` 추가, RSC `getCurrentUser`가 전달

**PostHog fetchers**
- `lib/observability/posthog.ts`: `getInquiriesSummary/DailyTrend/HourlyToday/RecentInquiries`에 옵셔널 `branchSlug` 인자 추가
- SQL injection 방어: `sanitizeBranchSlug` (`^[a-zA-Z0-9_-]+$` allowlist) + `branchFilter` 헬퍼
- `pricing_viewed`에 branch_slug가 없어 전환율은 의도적으로 site-wide 유지 (주석으로 명시)
- `getRegionBreakdown`: `$geoip_subdivision_1_name + $geoip_city_name` 조합, 17개 도 + 80여 시·구 한글 매핑

**Pages**
- `/stats/page.tsx`, `/stats/errors/page.tsx`, `/stats/funnel/page.tsx`, `/stats/traffic/page.tsx`: 페이지 시작점에 owner 가드 (`role !== owner` ⇒ `redirect("/stats/inquiries")`)
- `/stats/inquiries/page.tsx`: owner/non-owner 분기 — hero title에 branchName prefix, subtitle/grid/back-link 조정, 지점별 분포 카드 숨김

**Sidebar**
- `V3Sidebar.tsx`: non-owner의 "통계" 메뉴 href를 `/stats/inquiries`로 직접

**UI polish (포함)**
- `_components/FunnelBars.tsx`, `stats/page.tsx`: 배지 `누수` → `이탈`, "단계별 누수 안정적" → "단계별 이탈 안정적"
- `stats/traffic/page.tsx`: region label width 110 → 180px (긴 한글 이름 수용)

## Test plan
- [x] **Owner (송진호 / 인천점)**: `/stats` overview + 4개 detail 페이지 모두 정상 접근, 지점별 분포 카드 표시
- [x] **백엔드 `/auth/me`**: `branchSlug: "incheon"` 응답 정상 (curl)
- [x] **타입체크**: stats/observability 영역 0 에러
- [ ] **Non-owner staff 계정**: `/stats` 직접 접근 시 `/stats/inquiries`로 redirect 검증 (다른 계정 필요)
- [ ] **Non-owner inquiries**: branchSlug 필터 적용된 데이터만 표시 + 지점별 카드 숨김 검증
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)