### PR TITLE
fix(security): helmet, trust proxy + req.ip, PII log masking (P2 quick wins)

### DIFF
--- a/backend/application/services/aligo.service.ts
+++ b/backend/application/services/aligo.service.ts
@@ -6,6 +6,7 @@ import {
 import { SendAligoSmsDto, SendAligoSmsResult } from "application/dto/aligo/send-sms.dto";
 import { ClientEntity } from "domain/entities/client.entity";
 import { PhoneNumber } from "domain/value-objects/phone-number.vo";
+import { maskPhone } from "application/utils/mask";
 
 interface ContractSignedInfo {
     contractType: string;
@@ -35,7 +36,7 @@ export class AligoService {
             return await this.sendSmsUsecase.execute(dto);
         } catch (error) {
             this.logger.error(
-                `[Aligo] Failed to send sms to ${dto.receiver}`,
+                `[Aligo] Failed to send sms to ${maskPhone(dto.receiver)}`,
                 error instanceof Error ? error.stack : String(error),
             );
             throw error;
@@ -45,7 +46,7 @@ export class AligoService {
     async sendClientCreatedAlimtalk(client: ClientEntity): Promise<void> {
         const phone = PhoneNumber.create(client.phone);
         if (!phone) {
-            this.logger.warn(`[Aligo] Invalid or missing phone for client ${client.id}: ${client.phone}`);
+            this.logger.warn(`[Aligo] Invalid or missing phone for client ${client.id}: ${maskPhone(client.phone)}`);
             return;
         }
 
@@ -66,7 +67,7 @@ export class AligoService {
     ): Promise<void> {
         const phone = PhoneNumber.create(client.phone);
         if (!phone) {
-            this.logger.warn(`[Aligo] Invalid or missing phone for client ${client.id}: ${client.phone}`);
+            this.logger.warn(`[Aligo] Invalid or missing phone for client ${client.id}: ${maskPhone(client.phone)}`);
             return;
         }
 
@@ -89,7 +90,7 @@ export class AligoService {
     ): Promise<void> {
         const phone = PhoneNumber.create(client.phone);
         if (!phone) {
-            this.logger.warn(`[Aligo] Invalid or missing phone for client ${client.id}: ${client.phone}`);
+            this.logger.warn(`[Aligo] Invalid or missing phone for client ${client.id}: ${maskPhone(client.phone)}`);
             return;
         }
 
@@ -109,7 +110,7 @@ export class AligoService {
     ): Promise<void> {
         const phone = PhoneNumber.create(client.phone);
         if (!phone) {
-            this.logger.warn(`[Aligo] Invalid or missing phone for client ${client.id}: ${client.phone}`);
+            this.logger.warn(`[Aligo] Invalid or missing phone for client ${client.id}: ${maskPhone(client.phone)}`);
             return;
         }
 
@@ -129,7 +130,7 @@ export class AligoService {
     ): Promise<void> {
         const phone = PhoneNumber.create(client.phone);
         if (!phone) {
-            this.logger.warn(`[Aligo] Invalid or missing phone for client ${client.id}: ${client.phone}`);
+            this.logger.warn(`[Aligo] Invalid or missing phone for client ${client.id}: ${maskPhone(client.phone)}`);
             return;
         }
 
@@ -154,7 +155,7 @@ export class AligoService {
     ): Promise<void> {
         const phone = PhoneNumber.create(client.phone);
         if (!phone) {
-            this.logger.warn(`[Aligo] Invalid or missing phone for client ${client.id}: ${client.phone}`);
+            this.logger.warn(`[Aligo] Invalid or missing phone for client ${client.id}: ${maskPhone(client.phone)}`);
             return;
         }
 
@@ -180,7 +181,7 @@ export class AligoService {
     ): Promise<void> {
         const phone = PhoneNumber.create(client.phone);
         if (!phone) {
-            this.logger.warn(`[Aligo] Invalid or missing phone for client ${client.id}: ${client.phone}`);
+            this.logger.warn(`[Aligo] Invalid or missing phone for client ${client.id}: ${maskPhone(client.phone)}`);
             return;
         }
 

--- a/backend/application/services/alimtalk-retry-scheduler.service.ts
+++ b/backend/application/services/alimtalk-retry-scheduler.service.ts
@@ -5,6 +5,7 @@ import { ALIGO_API_PORT, IAligoApiPort } from "domain/ports/aligo-api.port";
 import { ALIGO_TEMPLATES } from "application/dto/aligo";
 import { AligoTemplateKey } from "application/dto/aligo/alimtalk-template.dto";
 import { AligoService } from "application/services/aligo.service";
+import { maskPhone } from "application/utils/mask";
 import { AlimtalkLogEntity } from "domain/entities/alimtalk-log.entity";
 import { SchedulerExecutionGuard } from "./scheduler-execution.guard";
 import {
@@ -74,7 +75,7 @@ export class AlimtalkRetrySchedulerService {
 
                     log.markSent(response.info?.mid?.toString());
                     await this.logRepository.update(log);
-                    this.logger.log(`[Retry] Successfully resent ${log.templateKey} to ${log.receiver}`);
+                    this.logger.log(`[Retry] Successfully resent ${log.templateKey} to ${maskPhone(log.receiver)}`);
                 } catch (error) {
                     log.markFailed(error instanceof Error ? error.message : String(error));
                     await this.logRepository.update(log);
@@ -116,7 +117,7 @@ export class AlimtalkRetrySchedulerService {
 
             log.markSent(result.response.msg_id ? String(result.response.msg_id) : undefined);
             await this.logRepository.update(log);
-            this.logger.log(`[Retry] Successfully resent SMS ${log.templateKey} to ${log.receiver}`);
+            this.logger.log(`[Retry] Successfully resent SMS ${log.templateKey} to ${maskPhone(log.receiver)}`);
         } catch (error) {
             this.markSmsRetryFailed(log, error instanceof Error ? error.message : String(error));
             await this.logRepository.update(log);

--- a/backend/application/services/auth.service.ts
+++ b/backend/application/services/auth.service.ts
@@ -7,6 +7,7 @@ import { EMAIL_PORT, EmailPort } from "../../domain/ports/email.port";
 import { AUTH_TOKEN_REPOSITORY, IAuthTokenRepository } from "../../domain/repositories/auth-token.repository.interface";
 import { AuthTokenEntity } from "../../domain/entities/auth-token.entity";
 import { getAuthTokenExpiresIn } from "./auth-token-policy";
+import { maskEmail } from "application/utils/mask";
 import { isVisibleStaffBranchSlug } from "domain/constants/branch-routing.constants";
 
 export interface KakaoData {
@@ -1214,7 +1215,7 @@ export class AuthService {
         if (existingUser) {
             // Check if user has Kakao account only (no password) - link the accounts
             if (existingUser.kakaoId && !existingUser.passwordHash) {
-                this.logger.log(`Linking email/password to existing Kakao account: ${email}`);
+                this.logger.log(`Linking email/password to existing Kakao account: ${maskEmail(email)}`);
 
                 const passwordHash = await this.hashPassword(password);
                 await this.prisma.user.update({
@@ -1243,7 +1244,7 @@ export class AuthService {
             // User already has email account (with or without Kakao)
             // Don't reveal that the email exists - return generic success
             // But still send an email to notify the user
-            this.logger.log(`Registration attempt for existing email: ${email}`);
+            this.logger.log(`Registration attempt for existing email: ${maskEmail(email)}`);
             return {
                 success: true,
                 message: '인증 이메일이 발송되었습니다. 이메일을 확인해주세요.',
@@ -1316,7 +1317,7 @@ export class AuthService {
 
         // Send email
         await this.emailService.sendVerificationEmail(email, user?.name || null, verificationUrl);
-        this.logger.log(`Verification email sent to ${email}`);
+        this.logger.log(`Verification email sent to ${maskEmail(email)}`);
     }
 
     /**
@@ -1438,10 +1439,10 @@ export class AuthService {
 
         try {
             await this.emailService.sendPasswordResetEmail(user.email!, user.name, resetUrl);
-            this.logger.log(`Password reset email sent to ${email}`);
+            this.logger.log(`Password reset email sent to ${maskEmail(email)}`);
         } catch (error) {
             this.logger.error(
-                `Failed to send password reset email to ${email}`,
+                `Failed to send password reset email to ${maskEmail(email)}`,
                 error instanceof Error ? error.stack : String(error),
             );
         }
@@ -1545,7 +1546,7 @@ export class AuthService {
             await this.sendVerificationEmail(user.id, user.email!);
         } catch (error) {
             this.logger.error(
-                `Failed to resend verification email to ${email}`,
+                `Failed to resend verification email to ${maskEmail(email)}`,
                 error instanceof Error ? error.stack : String(error),
             );
         }

--- a/backend/application/services/client-greeting-sms-automation.service.ts
+++ b/backend/application/services/client-greeting-sms-automation.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from "@nestjs/common";
 import { AligoService } from "application/services/aligo.service";
 import { MessageSenderApprovalService } from "application/services/message-sender-approval.service";
 import { SystemTemplateService } from "application/services/system-template.service";
+import { maskPhone } from "application/utils/mask";
 import { SystemTemplateKey, SYSTEM_TEMPLATE_REGISTRY } from "domain/constants/system-template-registry";
 import { ClientEntity } from "domain/entities/client.entity";
 import { PhoneNumber } from "domain/value-objects/phone-number.vo";
@@ -25,7 +26,7 @@ export class ClientGreetingSmsAutomationService {
     async sendClientGreetingSms(branchId: string, client: ClientEntity): Promise<void> {
         const phone = PhoneNumber.create(client.phone);
         if (!phone) {
-            this.logger.warn(`[SMS Automation] Invalid or missing phone for client ${client.id}: ${client.phone}`);
+            this.logger.warn(`[SMS Automation] Invalid or missing phone for client ${client.id}: ${maskPhone(client.phone)}`);
             return;
         }
 

--- a/backend/application/usecases/aligo/send-alimtalk.usecase.ts
+++ b/backend/application/usecases/aligo/send-alimtalk.usecase.ts
@@ -1,6 +1,7 @@
 import { Injectable, Inject, Logger } from "@nestjs/common";
 import { ALIGO_API_PORT, IAligoApiPort, AligoAlimtalkResponse } from "domain/ports/aligo-api.port";
 import { SendAligoAlimtalkDto, AligoMessageBuilder, ALIGO_TEMPLATES } from "application/dto/aligo";
+import { maskPhone } from "application/utils/mask";
 import { ALIMTALK_LOG_REPOSITORY, IAlimtalkLogRepository } from "domain/repositories/alimtalk-log.repository.interface";
 import { AlimtalkLogEntity } from "domain/entities/alimtalk-log.entity";
 
@@ -37,7 +38,7 @@ export class SendAligoAlimtalkUsecase {
         });
         const savedLog = await this.logRepository.save(log);
 
-        this.logger.debug(`[Aligo] Sending ${dto.templateKey} to ${dto.receiver}`);
+        this.logger.debug(`[Aligo] Sending ${dto.templateKey} to ${maskPhone(dto.receiver)}`);
 
         try {
             const response = await this.aligoApi.sendAlimtalk({

--- a/backend/application/utils/mask.ts
+++ b/backend/application/utils/mask.ts
@@ -1,0 +1,41 @@
+export function maskPhone(value: string | null | undefined): string | null | undefined {
+    if (value == null) {
+        return value;
+    }
+
+    const hyphenatedMatch = value.match(/^(\d{2,3})-(\d{3,4})-(\d{4})$/);
+    if (hyphenatedMatch) {
+        const prefix = hyphenatedMatch[1] ?? "";
+        const middle = hyphenatedMatch[2] ?? "";
+        const suffix = hyphenatedMatch[3] ?? "";
+        return `${prefix}-${"*".repeat(middle.length)}-${suffix}`;
+    }
+
+    const digits = value.replace(/\D/g, "");
+    if (digits.length < 10) {
+        return value;
+    }
+
+    const prefix = digits.slice(0, 3);
+    const suffix = digits.slice(-4);
+    const middleLength = digits.length - prefix.length - suffix.length;
+
+    if (middleLength <= 0) {
+        return value;
+    }
+
+    return `${prefix}${"*".repeat(middleLength)}${suffix}`;
+}
+
+export function maskEmail(value: string | null | undefined): string | null | undefined {
+    if (value == null) {
+        return value;
+    }
+
+    const atIndex = value.indexOf("@");
+    if (atIndex <= 0 || atIndex === value.length - 1) {
+        return value;
+    }
+
+    return `${value[0]}***${value.slice(atIndex)}`;
+}

--- a/backend/infrastructure/adapters/resend-email.adapter.ts
+++ b/backend/infrastructure/adapters/resend-email.adapter.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Resend } from 'resend';
+import { maskEmail } from 'application/utils/mask';
 import { EmailPort, EmailOptions } from '../../domain/ports/email.port';
 
 // Published Resend template IDs
@@ -27,7 +28,7 @@ export class ResendEmailAdapter implements EmailPort {
 
     async send(options: EmailOptions): Promise<string> {
         if (!this.resend) {
-            this.logger.warn(`Email not sent (no API key): to=${options.to}, subject=${options.subject}`);
+            this.logger.warn(`Email not sent (no API key): to=${maskEmail(options.to)}, subject=${options.subject}`);
             return 'disabled';
         }
 
@@ -45,10 +46,10 @@ export class ResendEmailAdapter implements EmailPort {
                 throw new Error(response.error.message);
             }
 
-            this.logger.log(`Email sent successfully to ${options.to}, ID: ${response.data?.id}`);
+            this.logger.log(`Email sent successfully to ${maskEmail(options.to)}, ID: ${response.data?.id}`);
             return response.data?.id || '';
         } catch (error) {
-            this.logger.error(`Failed to send email to ${options.to}:`, error);
+            this.logger.error(`Failed to send email to ${maskEmail(options.to)}:`, error);
             throw error;
         }
     }
@@ -91,7 +92,7 @@ export class ResendEmailAdapter implements EmailPort {
         variables: Record<string, string | number>;
     }): Promise<string> {
         if (!this.resend) {
-            this.logger.warn(`Email not sent (no API key): to=${options.to}, template=${options.templateId}`);
+            this.logger.warn(`Email not sent (no API key): to=${maskEmail(options.to)}, template=${options.templateId}`);
             return 'disabled';
         }
 
@@ -110,10 +111,10 @@ export class ResendEmailAdapter implements EmailPort {
                 throw new Error(response.error.message);
             }
 
-            this.logger.log(`Template email sent to ${options.to}, ID: ${response.data?.id}`);
+            this.logger.log(`Template email sent to ${maskEmail(options.to)}, ID: ${response.data?.id}`);
             return response.data?.id || '';
         } catch (error) {
-            this.logger.error(`Failed to send template email to ${options.to}:`, error);
+            this.logger.error(`Failed to send template email to ${maskEmail(options.to)}:`, error);
             throw error;
         }
     }

--- a/backend/infrastructure/api/aligo-api.client.ts
+++ b/backend/infrastructure/api/aligo-api.client.ts
@@ -13,6 +13,7 @@ import {
     AligoSmsResponse,
     IAligoSmsApiPort,
 } from "domain/ports/aligo-sms-api.port";
+import { maskPhone } from "application/utils/mask";
 
 @Injectable()
 export class AligoApiClient implements IAligoApiPort, IAligoSmsApiPort {
@@ -75,7 +76,7 @@ export class AligoApiClient implements IAligoApiPort, IAligoSmsApiPort {
             }
         }
 
-        this.logger.debug(`[Aligo] Sending alimtalk: ${params.tplCode} to ${params.receiver}`);
+        this.logger.debug(`[Aligo] Sending alimtalk: ${params.tplCode} to ${maskPhone(params.receiver)}`);
 
         const response = await fetch(url, {
             method: "POST",
@@ -129,7 +130,7 @@ export class AligoApiClient implements IAligoApiPort, IAligoSmsApiPort {
             formData.append("testmode_yn", params.testModeYn);
         }
 
-        this.logger.debug(`[Aligo] Sending sms to ${params.receiver}`);
+        this.logger.debug(`[Aligo] Sending sms to ${maskPhone(params.receiver)}`);
 
         const response = await fetch(url, {
             method: "POST",

--- a/backend/infrastructure/auth/rate-limit.guard.ts
+++ b/backend/infrastructure/auth/rate-limit.guard.ts
@@ -87,16 +87,9 @@ export class RateLimitGuard implements CanActivate {
 
     /**
      * Get client IP address from request
-     * Handles proxied requests (X-Forwarded-For)
+     * req.ip is trustworthy once Express trust proxy is configured.
      */
     private getClientIp(request: Request): string {
-        const forwardedFor = request.headers['x-forwarded-for'];
-        if (forwardedFor) {
-            const ips = Array.isArray(forwardedFor)
-                ? forwardedFor[0]
-                : forwardedFor.split(',')[0];
-            return ips?.trim() || 'unknown';
-        }
         return request.ip || request.socket?.remoteAddress || 'unknown';
     }
 

--- a/backend/main.ts
+++ b/backend/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from "@nestjs/core";
 import { ValidationPipe } from "@nestjs/common";
+import helmet from "helmet";
 import { AppModule } from "./app.module";
 import cookieParser from "cookie-parser";
 import { PrismaExceptionFilter } from "./infrastructure/filters/prisma-exception.filter";
@@ -20,6 +21,9 @@ process.on('unhandledRejection', (reason, promise) => {
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule);
+    app.use(helmet());
+    const expressApp = app.getHttpAdapter().getInstance();
+    expressApp.set("trust proxy", 1);
     app.use(cookieParser());
     app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
     app.useGlobalFilters(new PrismaExceptionFilter());

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,6 +46,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "cookie-parser": "^1.4.7",
+    "helmet": "^8.2.0",
     "nanoid": "^5.1.6",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
@@ -82,7 +83,7 @@
     "supertest": "^7.1.4",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.1",
-    "typescript-eslint": "^8.57.0",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.3",
+    "typescript-eslint": "^8.57.0"
   }
 }

--- a/backend/test/application/utils/mask.spec.ts
+++ b/backend/test/application/utils/mask.spec.ts
@@ -1,0 +1,32 @@
+import { maskEmail, maskPhone } from "application/utils/mask";
+
+describe("mask utils", () => {
+    describe("maskPhone", () => {
+        it("should mask a hyphenated mobile number", () => {
+            expect(maskPhone("010-1234-5678")).toBe("010-****-5678");
+        });
+
+        it("should mask a digits-only mobile number", () => {
+            expect(maskPhone("01012345678")).toBe("010****5678");
+        });
+
+        it("should pass through null and short strings unchanged", () => {
+            expect(maskPhone(null)).toBeNull();
+            expect(maskPhone(undefined)).toBeUndefined();
+            expect(maskPhone("010-12")).toBe("010-12");
+        });
+    });
+
+    describe("maskEmail", () => {
+        it("should mask the local part of an email", () => {
+            expect(maskEmail("user@host.com")).toBe("u***@host.com");
+        });
+
+        it("should pass through malformed or empty values unchanged", () => {
+            expect(maskEmail("not-an-email")).toBe("not-an-email");
+            expect(maskEmail("")).toBe("");
+            expect(maskEmail(null)).toBeNull();
+            expect(maskEmail(undefined)).toBeUndefined();
+        });
+    });
+});

--- a/backend/test/infrastructure/auth/rate-limit.guard.spec.ts
+++ b/backend/test/infrastructure/auth/rate-limit.guard.spec.ts
@@ -1,0 +1,88 @@
+import { HttpStatus } from "@nestjs/common";
+import { ExecutionContext } from "@nestjs/common/interfaces";
+import { Request } from "express";
+import { RateLimitGuard } from "infrastructure/auth/rate-limit.guard";
+
+type MockRequest = {
+    headers: Record<string, string | string[] | undefined>;
+    body: { email?: string };
+    socket: { remoteAddress?: string } | undefined;
+    ip?: string;
+    query?: { email?: string | string[] };
+};
+
+const createExecutionContext = (request: MockRequest): ExecutionContext =>
+    ({
+        switchToHttp: () => ({
+            getRequest: () => request as Request,
+            getResponse: () => undefined,
+            getNext: () => undefined,
+        }),
+    }) as ExecutionContext;
+
+describe("RateLimitGuard", () => {
+    let guard: RateLimitGuard;
+
+    beforeEach(() => {
+        guard = new RateLimitGuard();
+    });
+
+    afterEach(() => {
+        guard.onModuleDestroy();
+    });
+
+    it("should ignore a forged x-forwarded-for header when deriving the rate-limit key", async () => {
+        const email = "user@example.com";
+
+        for (let attempt = 0; attempt < 5; attempt += 1) {
+            const request: MockRequest = {
+                ip: "198.51.100.10",
+                headers: {
+                    "x-forwarded-for": `203.0.113.${attempt + 1}`,
+                },
+                body: { email },
+                socket: undefined,
+            };
+
+            await expect(
+                guard.canActivate(createExecutionContext(request)),
+            ).resolves.toBe(true);
+        }
+
+        const spoofedRequest: MockRequest = {
+            ip: "198.51.100.10",
+            headers: {
+                "x-forwarded-for": "203.0.113.250",
+            },
+            body: { email },
+            socket: undefined,
+        };
+
+        await expect(guard.canActivate(createExecutionContext(spoofedRequest))).rejects.toMatchObject({
+            response: expect.objectContaining({
+                statusCode: HttpStatus.TOO_MANY_REQUESTS,
+                error: "Too Many Requests",
+            }),
+        });
+    });
+
+    it("should fall back to socket.remoteAddress when req.ip is unavailable", async () => {
+        const request: MockRequest = {
+            headers: {},
+            body: {},
+            socket: {
+                remoteAddress: "::1",
+            },
+        };
+
+        await expect(
+            guard.canActivate(createExecutionContext(request)),
+        ).resolves.toBe(true);
+
+        const attempts = (guard as unknown as {
+            attempts: Map<string, unknown>;
+        }).attempts;
+
+        expect(attempts.has("::1")).toBe(true);
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       cookie-parser:
         specifier: ^1.4.7
         version: 1.4.7
+      helmet:
+        specifier: ^8.2.0
+        version: 8.2.0
       nanoid:
         specifier: ^5.1.6
         version: 5.1.6
@@ -4658,6 +4661,10 @@ packages:
 
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  helmet@8.2.0:
+    resolution: {integrity: sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==}
+    engines: {node: '>=18.0.0'}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -12002,6 +12009,8 @@ snapshots:
       hast-util-parse-selector: 4.0.0
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
+
+  helmet@8.2.0: {}
 
   hermes-estree@0.25.1: {}
 


### PR DESCRIPTION
## Summary
Three independent security fixes from the SaaS-readiness audit (plan Phase 2 tasks 2.1, 2.4-A, 2.6):
- **helmet** on the NestJS app (no security response headers previously); full defaults kept — no Swagger/HTML surface needed a CSP exception
- **Express `trust proxy` (Railway single hop) + `req.ip`** in the rate-limit guard — a client-supplied `X-Forwarded-For` can no longer spoof the limiter key (new spoofing spec included)
- **`maskPhone`/`maskEmail` util** applied across every PII-emitting log site found (aligo service/client, alimtalk retry scheduler, greeting-SMS automation, auth service, resend-email adapter) — Korean PIPA exposure

## Out of scope (separate plan tasks)
Durable rate-limit store + per-tenant paid-send caps (needs a table → after migrations baseline), webhook hardening, bucket privatization.

## Validation
- type-check ✓ · lint 0 errors ✓ · jest **964/964** (956 passed + 8 skipped; was 957 total — +7 new specs for masking & limiter spoofing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)