### PR TITLE
feat(mobile): add error boundaries with shared Korean fallback

### DIFF
--- a/mobile/src/app/clients/error.tsx
+++ b/mobile/src/app/clients/error.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { ErrorFallback } from "@/components/app/ui/error-fallback";
+
+interface ClientsErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function ClientsError({ reset }: ClientsErrorProps) {
+  return (
+    <ErrorFallback
+      description="잠시 후 다시 시도해주세요."
+      onReset={reset}
+      title="고객 목록을 불러오는 중 문제가 발생했어요."
+    />
+  );
+}

--- a/mobile/src/app/dashboard/error.tsx
+++ b/mobile/src/app/dashboard/error.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { ErrorFallback } from "@/components/app/ui/error-fallback";
+
+interface DashboardErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function DashboardError({ reset }: DashboardErrorProps) {
+  return (
+    <ErrorFallback
+      description="잠시 후 다시 시도해주세요."
+      onReset={reset}
+      title="대시보드를 불러오는 중 문제가 발생했어요."
+    />
+  );
+}

--- a/mobile/src/app/error.tsx
+++ b/mobile/src/app/error.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { ErrorFallback } from "@/components/app/ui/error-fallback";
+
+interface AppErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+const IS_DEVELOPMENT = process.env.NODE_ENV !== "production";
+
+export default function AppError({ error, reset }: AppErrorProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <ErrorFallback
+      debugDigest={IS_DEVELOPMENT ? error.digest : undefined}
+      debugMessage={IS_DEVELOPMENT ? error.message : undefined}
+      description="잠시 후 다시 시도해주세요."
+      onReset={reset}
+      title="페이지를 불러오는 중 문제가 발생했어요."
+    />
+  );
+}

--- a/mobile/src/app/global-error.tsx
+++ b/mobile/src/app/global-error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { ErrorFallback } from "@/components/app/ui/error-fallback";
+
+interface GlobalErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function GlobalError({ reset }: GlobalErrorProps) {
+  return (
+    <html lang="ko">
+      <body className="min-h-screen bg-[radial-gradient(circle_at_top,_hsla(214,100%,34%,0.08),_transparent_55%),linear-gradient(180deg,_hsl(210,100%,99%),_#ffffff)]">
+        <ErrorFallback
+          className="min-h-screen px-6 py-10"
+          description="잠시 후 다시 시도해주세요."
+          onReset={reset}
+          title="앱을 불러오는 중 문제가 발생했어요."
+        />
+      </body>
+    </html>
+  );
+}

--- a/mobile/src/components/app/ui/error-fallback.test.tsx
+++ b/mobile/src/components/app/ui/error-fallback.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { ErrorFallback } from "./error-fallback";
+
+describe("ErrorFallback", () => {
+  it("renders Korean copy and retries when the button is clicked", () => {
+    const handleReset = jest.fn();
+
+    render(
+      <ErrorFallback
+        description="잠시 후 다시 시도해주세요."
+        onReset={handleReset}
+        title="페이지를 불러오는 중 문제가 발생했어요."
+      />,
+    );
+
+    expect(
+      screen.getByText("페이지를 불러오는 중 문제가 발생했어요."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("잠시 후 다시 시도해주세요.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+
+    expect(handleReset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/components/app/ui/error-fallback.tsx
+++ b/mobile/src/components/app/ui/error-fallback.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export interface ErrorFallbackProps {
+  title: string;
+  description: string;
+  onReset: () => void;
+  resetLabel?: string;
+  debugMessage?: string;
+  debugDigest?: string;
+  className?: string;
+}
+
+export function ErrorFallback({
+  title,
+  description,
+  onReset,
+  resetLabel = "다시 시도",
+  debugMessage,
+  debugDigest,
+  className,
+}: ErrorFallbackProps) {
+  return (
+    <div
+      data-component="mobile_error_fallback_container"
+      className={cn(
+        "flex min-h-[60vh] items-center justify-center px-5 py-10",
+        className,
+      )}
+    >
+      <section
+        aria-live="assertive"
+        data-component="mobile_error_fallback_card"
+        className="w-full max-w-md rounded-[28px] bg-white px-6 py-8 text-center shadow-v3 ring-1 ring-[hsla(214,30%,20%,0.08)]"
+        role="alert"
+      >
+        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-[hsl(355,40%,94%)]">
+          <AlertTriangle className="h-6 w-6 text-[hsl(355,36%,45%)]" />
+        </div>
+        <h1 className="mt-4 text-lg font-bold text-v3-dark">{title}</h1>
+        <p className="mt-2 text-sm leading-6 text-v3-text-muted">
+          {description}
+        </p>
+
+        {debugMessage || debugDigest ? (
+          <div
+            data-component="mobile_error_fallback_debug"
+            className="mt-5 rounded-2xl border border-border bg-muted/40 p-4 text-left"
+          >
+            <p className="text-xs font-semibold text-foreground">
+              개발용 오류 정보
+            </p>
+            {debugMessage ? (
+              <p className="mt-2 break-words font-mono text-xs leading-5 text-muted-foreground">
+                {debugMessage}
+              </p>
+            ) : null}
+            {debugDigest ? (
+              <p className="mt-2 font-mono text-xs leading-5 text-muted-foreground">
+                digest: {debugDigest}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+
+        <Button
+          className="mt-6 w-full"
+          data-component="mobile_error_fallback_retry"
+          onClick={onReset}
+          type="button"
+          variant="v3"
+        >
+          {resetLabel}
+        </Button>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

P4.2 of the SaaS audit remediation: the mobile app previously had **no error boundaries** — any render/data error white-screened the route.

- `global-error.tsx` (root fallback rendering its own `<html><body>` per the App Router contract)
- app-level `error.tsx`: Korean copy, reset button, `console.error` in `useEffect`, error message/digest shown only when `NODE_ENV !== "production"`
- per-segment boundaries for `dashboard` and `clients` (`documents` segment does not exist — intentionally skipped)
- one shared presentational `ErrorFallback` card (`components/app/ui`) reusing the existing `Button` `variant="v3"` and design tokens; thin wrappers supply segment copy only

## Test plan

- [x] New `error-fallback.test.tsx`: renders Korean copy, fires reset callback
- [x] Mobile type-check clean, lint 0 errors (206 pre-existing warnings), 462 tests green, production build exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)