### PR TITLE
perf(mobile): tame dashboard refetch burst; rebrand SW cache names

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -9,7 +9,7 @@
 
 // Cache version - increment to force update
 const CACHE_VERSION = 'v4';
-const CACHE_NAME = `imirae-back-office-${CACHE_VERSION}`;
+const CACHE_NAME = `babyjamjam-staff-${CACHE_VERSION}`;
 
 // Assets to precache during install
 const PRECACHE_ASSETS = [
@@ -59,7 +59,8 @@ self.addEventListener('activate', (event) => {
         caches.keys().then((cacheNames) => {
             return Promise.all(
                 cacheNames
-                    .filter((name) => name.startsWith('imirae-back-office-') && name !== CACHE_NAME)
+                    // Old imirae-prefixed caches are still evicted post-rebrand.
+                    .filter((name) => (name.startsWith('babyjamjam-staff-') || name.startsWith('imirae-back-office-')) && name !== CACHE_NAME)
                     .map((name) => caches.delete(name))
             );
         }).then(() => {

--- a/mobile/public/sw.js
+++ b/mobile/public/sw.js
@@ -9,7 +9,7 @@
 
 // Cache version - increment to force update
 const CACHE_VERSION = 'v4';
-const CACHE_NAME = `imirae-back-office-${CACHE_VERSION}`;
+const CACHE_NAME = `babyjamjam-admin-${CACHE_VERSION}`;
 
 // Assets to precache during install
 const PRECACHE_ASSETS = [
@@ -59,7 +59,8 @@ self.addEventListener('activate', (event) => {
         caches.keys().then((cacheNames) => {
             return Promise.all(
                 cacheNames
-                    .filter((name) => name.startsWith('imirae-back-office-') && name !== CACHE_NAME)
+                    // Old imirae-prefixed caches are still evicted post-rebrand.
+                    .filter((name) => (name.startsWith('babyjamjam-admin-') || name.startsWith('imirae-back-office-')) && name !== CACHE_NAME)
                     .map((name) => caches.delete(name))
             );
         }).then(() => {

--- a/mobile/src/app/dashboard/page.tsx
+++ b/mobile/src/app/dashboard/page.tsx
@@ -227,13 +227,14 @@ function mergeDashboardRows(rows: DashboardStatusRow[]): ListRow[] {
 }
 
 export default function DashboardPage() {
+  // 60s staleTime: dashboard revisits within the window reuse the cache
+  // instead of re-firing analytics + clients (and the eformsign sync burst
+  // their invalidations cascade into) on every mount.
   const { data: analytics, isLoading: analyticsLoading } = useDashboardAnalytics({
-    refetchOnMount: "always",
-    staleTime: 0,
+    staleTime: 60_000,
   });
   const { data: clientsData, isLoading: clientsLoading } = useClients(1, 50, undefined, {
-    refetchOnMount: "always",
-    staleTime: 0,
+    staleTime: 60_000,
   });
   const user = useInitialUser();
   const [activeFilter, setActiveFilter] = useState<string>(ALL_FILTER);

--- a/mobile/src/hooks/__tests__/useSyncStaleEformsignStatuses.test.tsx
+++ b/mobile/src/hooks/__tests__/useSyncStaleEformsignStatuses.test.tsx
@@ -6,7 +6,10 @@ import { dashboardQueryKeys } from "@/hooks/useDashboardAnalytics";
 import { clientQueryKeys } from "@/hooks/useClients";
 import { eformsignApi, withEformsignReauth } from "@/services/api";
 import type { Client } from "@/lib/client/types";
-import { useSyncStaleEformsignStatuses } from "../useSyncStaleEformsignStatuses";
+import {
+  __resetEformsignSyncGateForTests,
+  useSyncStaleEformsignStatuses,
+} from "../useSyncStaleEformsignStatuses";
 
 jest.mock("@/services/api", () => ({
   eformsignApi: {
@@ -61,6 +64,7 @@ describe("useSyncStaleEformsignStatuses", () => {
   let invalidateSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    __resetEformsignSyncGateForTests();
     queryClient = new QueryClient({
       defaultOptions: {
         queries: {
@@ -129,5 +133,23 @@ describe("useSyncStaleEformsignStatuses", () => {
 
     await waitFor(() => expect(mockedSyncDocumentStatus).toHaveBeenCalledTimes(1));
     expect(mockedSyncDocumentStatus).toHaveBeenCalledWith("doc-2");
+  });
+
+  it("does not re-sync the same document across remounts within the retry interval", async () => {
+    const pendingClients = [client({ eDocId: "doc-1", documentStatus: "requested" })];
+
+    const { unmount } = renderHook(() => useSyncStaleEformsignStatuses(pendingClients), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(mockedSyncDocumentStatus).toHaveBeenCalledTimes(1));
+    unmount();
+
+    renderHook(() => useSyncStaleEformsignStatuses(pendingClients), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await Promise.resolve();
+    expect(mockedSyncDocumentStatus).toHaveBeenCalledTimes(1);
   });
 });

--- a/mobile/src/hooks/useSyncStaleEformsignStatuses.ts
+++ b/mobile/src/hooks/useSyncStaleEformsignStatuses.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { dashboardQueryKeys } from "@/hooks/useDashboardAnalytics";
@@ -9,6 +9,15 @@ import type { Client } from "@/lib/client/types";
 import { eformsignApi, withEformsignReauth } from "@/services/api";
 
 const DEFAULT_MAX_SYNC_COUNT = 10;
+// Module-level gate: a per-instance ref reset on every mount, so each
+// dashboard visit re-fired the full pending-document sync burst. Documents
+// are retried at most once per interval for the lifetime of the tab.
+const SYNC_RETRY_INTERVAL_MS = 5 * 60 * 1000;
+const lastSyncAttemptAtByDocumentId = new Map<string, number>();
+
+export function __resetEformsignSyncGateForTests(): void {
+  lastSyncAttemptAtByDocumentId.clear();
+}
 
 interface UseSyncStaleEformsignStatusesOptions {
   enabled?: boolean;
@@ -34,7 +43,6 @@ export function useSyncStaleEformsignStatuses(
   options: UseSyncStaleEformsignStatusesOptions = {},
 ) {
   const queryClient = useQueryClient();
-  const syncedDocumentIdsRef = useRef(new Set<string>());
   const enabled = options.enabled ?? true;
   const maxSyncCount = options.maxSyncCount ?? DEFAULT_MAX_SYNC_COUNT;
   const documentIds = useMemo(
@@ -45,13 +53,15 @@ export function useSyncStaleEformsignStatuses(
   useEffect(() => {
     if (!enabled || documentIds.length === 0) return;
 
-    const documentIdsToSync = documentIds.filter(
-      (documentId) => !syncedDocumentIdsRef.current.has(documentId),
-    );
+    const now = Date.now();
+    const documentIdsToSync = documentIds.filter((documentId) => {
+      const lastAttemptAt = lastSyncAttemptAtByDocumentId.get(documentId);
+      return lastAttemptAt === undefined || now - lastAttemptAt >= SYNC_RETRY_INTERVAL_MS;
+    });
     if (documentIdsToSync.length === 0) return;
 
     for (const documentId of documentIdsToSync) {
-      syncedDocumentIdsRef.current.add(documentId);
+      lastSyncAttemptAtByDocumentId.set(documentId, now);
     }
 
     let cancelled = false;


### PR DESCRIPTION
## Summary

Trivial-tier batch from the SaaS audit remediation (P4.5 + P4.9-safe + P4.6 audit):

- **P4.5 dashboard refetch**: both dashboard queries drop `refetchOnMount: "always"` + `staleTime: 0` for a 60s `staleTime`. The eformsign stale-status sync gate moves from a per-mount `useRef` (which reset on every visit — re-firing up to 10 vendor sync calls + 2 cache invalidations per dashboard mount) to a module-level 5-minute TTL map. Cross-remount regression test added.
- **P4.9 (safe part)**: service-worker cache names rebranded — frontend `imirae-back-office-*` → `babyjamjam-staff-*`, mobile → `babyjamjam-admin-*`. The activate-phase cleanup evicts both old and new prefixes so existing clients converge after the rename. (Remaining `imirae` references — marketing URLs in greeting templates, mock emails, AI prompt copy — are user-facing content and stay decision-gated.)
- **P4.6 audited as no-change**: every cookie-set site already shares `httpOnly` / `secure` / `sameSite: "lax"`. The single `sameSite: "none"` site (`api/auth/token`) carries an explicit comment requiring it for OAuth flows — left untouched.

## Test plan

- [x] New test: same document not re-synced across remounts within the TTL
- [x] Mobile: type-check clean, lint 0 errors, **465 tests green**, production build exit 0
- [x] Frontend: sw.js is static; CI build gate covers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)