### PR TITLE
fix(security): stop forwarding client identity in file-storage proxy

### DIFF
--- a/mobile/src/app/api/file-storage/__tests__/route.test.ts
+++ b/mobile/src/app/api/file-storage/__tests__/route.test.ts
@@ -43,10 +43,13 @@ function createGetRequest(path: string): NextRequest {
   });
 }
 
-function createUploadRequest(): NextRequest {
+function createUploadRequest(extraFields: Record<string, string | File> = {}): NextRequest {
   const formData = new FormData();
   formData.append("file", new File(["contents"], "document.txt", { type: "text/plain" }));
   formData.append("name", "Document");
+  for (const [key, value] of Object.entries(extraFields)) {
+    formData.append(key, value);
+  }
 
   return new NextRequest("http://localhost/api/file-storage/files", {
     method: "POST",
@@ -94,6 +97,32 @@ describe("file-storage API routes", () => {
 
     expect(response.status).toBe(202);
     await expect(response.json()).resolves.toEqual({ queued: true });
+  });
+
+  it("never forwards client-supplied identity fields on upload", async () => {
+    mockPost.mockResolvedValue({ status: 201, data: { id: "doc-1" } });
+
+    const response = await uploadFile(
+      createUploadRequest({ orgId: "another-tenant", uploadedBy: "attacker" }),
+    );
+
+    expect(response.status).toBe(201);
+    const forwardedFormData = mockPost.mock.calls[0][1] as FormData;
+    expect(forwardedFormData.has("orgId")).toBe(false);
+    expect(forwardedFormData.has("uploadedBy")).toBe(false);
+    expect(forwardedFormData.get("name")).toBe("Document");
+  });
+
+  it("rejects non-string upload metadata before proxying", async () => {
+    const response = await uploadFile(
+      createUploadRequest({
+        categoryId: new File(["x"], "sneaky.txt", { type: "text/plain" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid upload metadata" });
+    expect(mockPost).not.toHaveBeenCalled();
   });
 
   it("rejects unsafe file detail IDs before proxying", async () => {

--- a/mobile/src/app/api/file-storage/files/route.ts
+++ b/mobile/src/app/api/file-storage/files/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
 import { serverAPIClient } from "@/lib/api/server";
 import {
     backendJsonResponse,
@@ -7,6 +9,17 @@ import {
     getAuthToken,
     unauthorizedResponse,
 } from "@/lib/api/route-utils";
+
+// Identity fields (orgId/uploadedBy) are deliberately NOT part of this
+// whitelist: the backend derives branch + uploader from the JWT
+// (@CurrentTenant), so client-supplied identity is spoofable noise and is
+// never forwarded. Only validated metadata crosses the proxy.
+const uploadMetadataSchema = z.object({
+    name: z.string().trim().min(1).max(255).optional(),
+    description: z.string().max(2000).optional(),
+    categoryId: z.string().trim().min(1).max(100).optional(),
+    tags: z.string().max(2000).optional(),
+});
 
 export async function GET(request: NextRequest) {
     try {
@@ -54,19 +67,24 @@ export async function POST(request: NextRequest) {
         const blob = new Blob([buffer], { type: file.type });
         backendFormData.append("file", blob, file.name);
 
-        const name = formData.get("name");
-        const description = formData.get("description");
-        const categoryId = formData.get("categoryId");
-        const tags = formData.get("tags");
-        const orgId = formData.get("orgId");
-        const uploadedBy = formData.get("uploadedBy");
+        const metadataResult = uploadMetadataSchema.safeParse({
+            name: formData.get("name") ?? undefined,
+            description: formData.get("description") ?? undefined,
+            categoryId: formData.get("categoryId") ?? undefined,
+            tags: formData.get("tags") ?? undefined,
+        });
+        if (!metadataResult.success) {
+            return NextResponse.json(
+                { error: "Invalid upload metadata" },
+                { status: 400 }
+            );
+        }
 
-        if (name) backendFormData.append("name", name as string);
-        if (description) backendFormData.append("description", description as string);
-        if (categoryId) backendFormData.append("categoryId", categoryId as string);
-        if (tags) backendFormData.append("tags", tags as string);
-        if (orgId) backendFormData.append("orgId", orgId as string);
-        if (uploadedBy) backendFormData.append("uploadedBy", uploadedBy as string);
+        const { name, description, categoryId, tags } = metadataResult.data;
+        if (name) backendFormData.append("name", name);
+        if (description) backendFormData.append("description", description);
+        if (categoryId) backendFormData.append("categoryId", categoryId);
+        if (tags) backendFormData.append("tags", tags);
 
         const response = await serverAPIClient.post("/documents/upload", backendFormData, {
             timeout: 120000,


### PR DESCRIPTION
## Summary

P4.3 of the SaaS audit remediation. The mobile file-storage upload proxy forwarded client-supplied `orgId`/`uploadedBy` form fields to the backend.

Verified backend behavior first: `POST /documents/upload` derives branch + uploader exclusively from the JWT via `@CurrentTenant` (`document.controller.ts:117,128`), and the whitelist `ValidationPipe` strips both forwarded fields (`orgId` isn't in `UploadDocumentDto`; `uploadedBy` casing doesn't match) — so the fields were **spoofable dead surface**, not an active cross-tenant hole. This PR removes the misleading surface and adds validation:

- the proxy never forwards identity fields (whitelist-only forwarding)
- remaining metadata (`name`/`description`/`categoryId`/`tags`) is zod-validated — non-string (e.g. File-typed) or oversized values → 400 before any backend call

Observation (left as is): `UploadDocumentDto` still declares legacy optional `branchid`/`uploadedby` fields the handler ignores — backend cleanup candidate for the P5/P6 passes.

## Test plan

- [x] New test: forged `orgId`/`uploadedBy` never appear in the backend form data (201 path)
- [x] New test: File-typed `categoryId` → 400, no proxy call
- [x] Mobile type-check clean, lint 0 errors, **466 tests green**
- [x] Build: local worktree hits the known Turbopack cross-worktree-symlink panic (environment, not code) — the required CI build check on this PR is the authoritative gate, same as PR #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)