### PR TITLE
test(backend): retry known socket-hang-up flake in eformsign integration spec

### DIFF
--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -7,6 +7,13 @@ import { TenantGuard } from "infrastructure/tenant";
 import { EformsignController } from "interface/controllers/eformsign.controller";
 import request from "supertest";
 
+// Known transport-level flake (~1/8 full-suite runs under parallel-worker
+// load, observed locally 2026-06-06 and once in CI): a supertest request
+// intermittently dies with "socket hang up" on the early-400 validation
+// paths. Retry masks only the transport race — a deterministic failure
+// still fails on the retry.
+jest.retryTimes(1, { logErrorsBeforeRetry: true });
+
 describe("EformsignController (Integration)", () => {
     let app: INestApplication;
     let eformsignService: jest.Mocked<Pick<


### PR DESCRIPTION
## Summary

Closes audit follow-up #14 (flaky backend test hunt). Reproduced by brute force — 8 consecutive full-suite runs; run 6 failed with the exact CI signature:

```
FAIL test/integration/eformsign.controller.integration.spec.ts
  ● rejects non-numeric signature execution time before service execution
    socket hang up
```

Diagnosis: load-dependent supertest transport race on the early-400 validation paths (failing run 9.3s vs usual 4.7s — machine was under parallel-suite stress; 1-byte body rules out the body-streaming RST variant). Not test logic, not production code.

Fix: file-scoped `jest.retryTimes(1, { logErrorsBeforeRetry: true })` with the diagnosis documented inline. A deterministic regression still fails on the retry; only the transport race is absorbed, and the pre-retry error stays in the log for observability.

## Test plan

- [x] Suite green (5/5), type-check clean, lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)