### PR TITLE
feat(mobile): zod-validate all unvalidated mutation API routes

### DIFF
--- a/mobile/src/app/api/ai/chat/__tests__/route.test.ts
+++ b/mobile/src/app/api/ai/chat/__tests__/route.test.ts
@@ -76,6 +76,17 @@ describe("AI chat API routes", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("rejects persist bodies missing required fields before proxying", async () => {
+    setAuthCookie("auth-token");
+
+    const response = await persistChat(
+      createRequest("/api/ai/chat/persist", JSON.stringify({ userMessage: "hi" })),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("preserves successful backend status when persisting chat state", async () => {
     setAuthCookie("auth-token");
     mockFetch.mockResolvedValue(
@@ -86,11 +97,16 @@ describe("AI chat API routes", () => {
     );
 
     const response = await persistChat(
-      createRequest("/api/ai/chat/persist", JSON.stringify({ message: "hello" })),
+      createRequest(
+        "/api/ai/chat/persist",
+        JSON.stringify({ userMessage: "hello", assistantContent: "hi there" }),
+      ),
     );
 
     expect(response.status).toBe(202);
     await expect(response.json()).resolves.toEqual({ queued: true });
+    const forwarded = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(forwarded).toEqual({ userMessage: "hello", assistantContent: "hi there" });
   });
 
   it("maps persist upstream errors without returning raw backend text", async () => {
@@ -103,7 +119,10 @@ describe("AI chat API routes", () => {
     );
 
     const response = await persistChat(
-      createRequest("/api/ai/chat/persist", JSON.stringify({ message: "hello" })),
+      createRequest(
+        "/api/ai/chat/persist",
+        JSON.stringify({ userMessage: "hello", assistantContent: "hi" }),
+      ),
     );
 
     expect(response.status).toBe(500);
@@ -123,6 +142,37 @@ describe("AI chat API routes", () => {
       error: "Request body must be valid JSON",
     });
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects stream bodies missing the required message before proxying", async () => {
+    setAuthCookie("auth-token");
+
+    const response = await streamChat(
+      createRequest("/api/ai/chat/stream", JSON.stringify({ sessionId: "s1" })),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards the validated stream body to the backend", async () => {
+    setAuthCookie("auth-token");
+    mockFetch.mockResolvedValue(
+      new Response("event: message\ndata: {}\n\n", {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    );
+
+    await streamChat(
+      createRequest(
+        "/api/ai/chat/stream",
+        JSON.stringify({ message: "hello", sessionId: "s1" }),
+      ),
+    );
+
+    const forwarded = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(forwarded).toEqual({ message: "hello", sessionId: "s1" });
   });
 
   it("maps stream transport failures to a structured SSE error", async () => {
@@ -297,5 +347,41 @@ describe("AI chat API routes", () => {
       error: "Request body must be valid JSON",
     });
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects feedback with an invalid type before proxying", async () => {
+    setAuthCookie("auth-token");
+
+    const response = await submitFeedback(
+      createRequest(
+        "/api/ai/chat/feedback",
+        JSON.stringify({ sessionId: "s1", type: "meh" }),
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards the validated feedback body to the backend", async () => {
+    setAuthCookie("auth-token");
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ success: true, id: "fb-1" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const response = await submitFeedback(
+      createRequest(
+        "/api/ai/chat/feedback",
+        JSON.stringify({ sessionId: "s1", type: "positive", comment: "great" }),
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true, id: "fb-1" });
+    const forwarded = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(forwarded).toEqual({ sessionId: "s1", type: "positive", comment: "great" });
   });
 });

--- a/mobile/src/app/api/ai/chat/feedback/route.ts
+++ b/mobile/src/app/api/ai/chat/feedback/route.ts
@@ -1,37 +1,47 @@
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { BACKEND_BASE_URL } from "@/lib/api/server";
-import { invalidJsonResponse, readJsonObjectBody } from "@/lib/api/route-utils";
+import { parseBody } from "@/lib/api/route-utils";
 
 const BACKEND_URL = BACKEND_BASE_URL;
 
+// Mirrors backend ChatFeedbackDto: `sessionId` (@IsNotEmpty @IsString) and
+// `type` (@IsIn positive|negative) are required. `messageId`, `messageIndex`
+// (@IsInt @Min(0)) and `comment` are optional. Other fields pass through.
+const chatFeedbackSchema = z
+    .object({
+        sessionId: z.string().min(1),
+        type: z.enum(["positive", "negative"]),
+        messageId: z.string().optional(),
+        messageIndex: z.number().int().min(0).optional(),
+        comment: z.string().max(10_000).optional(),
+    })
+    .passthrough();
+
 export async function POST(req: NextRequest) {
+    const cookieStore = await cookies();
+    const authToken = cookieStore.get("auth_token");
+    if (!authToken) {
+        return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { data, response: invalidBody } = await parseBody(chatFeedbackSchema, req);
+    if (invalidBody) return invalidBody;
+
     try {
-        const cookieStore = await cookies();
-        const authToken = cookieStore.get("auth_token");
-        if (!authToken) {
-            return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
-        }
-
-        const body = await readJsonObjectBody(req);
-
         const response = await fetch(`${BACKEND_URL}/ai/chat/feedback`, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
                 Authorization: `Bearer ${authToken.value}`,
             },
-            body: JSON.stringify(body),
+            body: JSON.stringify(data),
         });
 
-        const data = await response.json();
-        return NextResponse.json(data, { status: response.status });
+        const responseData = await response.json();
+        return NextResponse.json(responseData, { status: response.status });
     } catch (error) {
-        const invalidJson = invalidJsonResponse(error);
-        if (invalidJson) {
-            return invalidJson;
-        }
-
         console.error("Feedback proxy error:", error);
         return NextResponse.json({ success: false, error: "Failed to submit feedback" }, { status: 500 });
     }

--- a/mobile/src/app/api/ai/chat/persist/route.ts
+++ b/mobile/src/app/api/ai/chat/persist/route.ts
@@ -1,9 +1,21 @@
 import { cookies } from "next/headers";
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { BACKEND_BASE_URL } from "@/lib/api/server";
-import { invalidJsonResponse, readJsonObjectBody, upstreamJsonErrorResponse } from "@/lib/api/route-utils";
+import { parseBody, upstreamJsonErrorResponse } from "@/lib/api/route-utils";
 
 const BACKEND_URL = BACKEND_BASE_URL;
+
+// Mirrors backend ChatPersistDto: `userMessage` and `assistantContent` are
+// required (@IsNotEmpty @IsString); `sessionId` is optional. Other fields pass
+// through to the backend pipe.
+const chatPersistSchema = z
+    .object({
+        userMessage: z.string().min(1).max(10_000),
+        assistantContent: z.string().min(1).max(10_000),
+        sessionId: z.string().optional(),
+    })
+    .passthrough();
 
 export async function POST(request: NextRequest) {
     const cookieStore = await cookies();
@@ -16,15 +28,17 @@ export async function POST(request: NextRequest) {
         });
     }
 
+    const { data, response } = await parseBody(chatPersistSchema, request);
+    if (response) return response;
+
     try {
-        const body = await readJsonObjectBody(request);
         const backendResponse = await fetch(`${BACKEND_URL}/ai/chat/persist`, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
                 Authorization: `Bearer ${authToken.value}`,
             },
-            body: JSON.stringify(body),
+            body: JSON.stringify(data),
         });
 
         if (!backendResponse.ok) {
@@ -37,12 +51,7 @@ export async function POST(request: NextRequest) {
             status: backendResponse.status,
             headers: { "Content-Type": "application/json" },
         });
-    } catch (error) {
-        const invalidJson = invalidJsonResponse(error);
-        if (invalidJson) {
-            return invalidJson;
-        }
-
+    } catch {
         return upstreamJsonErrorResponse(502);
     }
 }

--- a/mobile/src/app/api/ai/chat/stream/route.ts
+++ b/mobile/src/app/api/ai/chat/stream/route.ts
@@ -1,9 +1,19 @@
 import { cookies } from "next/headers";
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { BACKEND_BASE_URL } from "@/lib/api/server";
-import { invalidJsonResponse, readJsonObjectBody, upstreamSseErrorResponse } from "@/lib/api/route-utils";
+import { parseBody, upstreamSseErrorResponse } from "@/lib/api/route-utils";
 
 const BACKEND_URL = BACKEND_BASE_URL;
+
+// Mirrors backend ChatStreamDto: `message` is required (@IsNotEmpty @IsString),
+// `sessionId` optional string. Other fields pass through to the backend pipe.
+const chatStreamSchema = z
+    .object({
+        message: z.string().min(1).max(10_000),
+        sessionId: z.string().optional(),
+    })
+    .passthrough();
 
 export async function POST(request: NextRequest) {
     const cookieStore = await cookies();
@@ -16,16 +26,17 @@ export async function POST(request: NextRequest) {
         });
     }
 
-    try {
-        const body = await readJsonObjectBody(request);
+    const { data, response } = await parseBody(chatStreamSchema, request);
+    if (response) return response;
 
+    try {
         const backendResponse = await fetch(`${BACKEND_URL}/ai/chat/stream`, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
                 Authorization: `Bearer ${authToken.value}`,
             },
-            body: JSON.stringify(body),
+            body: JSON.stringify(data),
         });
 
         if (!backendResponse.ok) {
@@ -40,12 +51,7 @@ export async function POST(request: NextRequest) {
                 Connection: "keep-alive",
             },
         });
-    } catch (error) {
-        const invalidJson = invalidJsonResponse(error);
-        if (invalidJson) {
-            return invalidJson;
-        }
-
+    } catch {
         return upstreamSseErrorResponse();
     }
 }

--- a/mobile/src/app/api/alimtalk-templates/__tests__/route.test.ts
+++ b/mobile/src/app/api/alimtalk-templates/__tests__/route.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+import { GET as listTemplates, POST as createTemplate } from "../route";
+
+jest.mock("@/lib/api/server", () => ({
+  serverAPIClient: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+const mockGet = serverAPIClient.get as jest.Mock;
+const mockPost = serverAPIClient.post as jest.Mock;
+
+function createRequest(
+  path: string,
+  init: { method?: string; body?: BodyInit; headers?: Record<string, string> } = {},
+): NextRequest {
+  return new NextRequest(`http://localhost${path}`, {
+    method: init.method,
+    headers: {
+      cookie: "auth_token=auth-token",
+      ...init.headers,
+    },
+    body: init.body,
+  });
+}
+
+describe("alimtalk-template API routes", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPost.mockReset();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  const validTemplatePayload = {
+    name: "신규 환영",
+    tplType: "BA",
+    tplEmType: "NONE",
+    content: "안녕하세요 {{name}}님",
+    buttons: [],
+  };
+
+  it("forwards the validated payload to the backend when creating templates", async () => {
+    mockPost.mockResolvedValue({
+      status: 202,
+      data: { queued: true },
+    });
+
+    const response = await createTemplate(
+      createRequest("/api/alimtalk-templates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(validTemplatePayload),
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({ queued: true });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/alimtalk-templates",
+      validTemplatePayload,
+      expect.anything(),
+    );
+  });
+
+  it("rejects a create body with an invalid tplType before proxying", async () => {
+    const response = await createTemplate(
+      createRequest("/api/alimtalk-templates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...validTemplatePayload, tplType: "ZZ" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("rejects a create body missing required fields before proxying", async () => {
+    const response = await createTemplate(
+      createRequest("/api/alimtalk-templates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "신규 환영" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/app/api/alimtalk-templates/route.ts
+++ b/mobile/src/app/api/alimtalk-templates/route.ts
@@ -1,14 +1,26 @@
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import {
   backendJsonResponse,
   errorResponse,
   getAuthHeaders,
   getAuthToken,
-  invalidJsonResponse,
-  readJsonObjectBody,
+  parseBody,
   unauthorizedResponse,
 } from "@/lib/api/route-utils";
+
+// Mirrors backend CreateAlimtalkTemplateDto: name, tplType, tplEmType,
+// content and buttons are required; optional fields flow through passthrough.
+const createAlimtalkTemplateSchema = z
+  .object({
+    name: z.string().min(1).max(30),
+    tplType: z.enum(["BA", "EX", "AD", "MI"]),
+    tplEmType: z.enum(["NONE", "TEXT", "IMAGE"]),
+    content: z.string().min(1).max(1000),
+    buttons: z.array(z.unknown()).max(5),
+  })
+  .passthrough();
 
 export async function GET(request: NextRequest) {
   const token = getAuthToken(request);
@@ -34,18 +46,20 @@ export async function POST(request: NextRequest) {
       return unauthorizedResponse("Unauthorized");
     }
 
-    const body = await readJsonObjectBody(request);
-    const response = await serverAPIClient.post("/alimtalk-templates", body, {
+    const { data, response: invalidBody } = await parseBody(
+      createAlimtalkTemplateSchema,
+      request,
+    );
+    if (invalidBody) {
+      return invalidBody;
+    }
+
+    const response = await serverAPIClient.post("/alimtalk-templates", data, {
       headers: getAuthHeaders(token),
     });
 
     return backendJsonResponse(response);
   } catch (error) {
-    const invalidJson = invalidJsonResponse(error);
-    if (invalidJson) {
-      return invalidJson;
-    }
-
     return errorResponse(error, "create alimtalk template");
   }
 }

--- a/mobile/src/app/api/alimtalk-trigger-rules/__tests__/route.test.ts
+++ b/mobile/src/app/api/alimtalk-trigger-rules/__tests__/route.test.ts
@@ -65,7 +65,15 @@ describe("Alimtalk trigger rule API routes", () => {
     await expect(response.json()).resolves.toEqual({ error: "Failed to fetch alimtalk trigger rules" });
   });
 
-  it("preserves backend status and payload when creating rules", async () => {
+  const validRulePayload = {
+    name: "Reminder",
+    eventType: "SERVICE_START",
+    offsetType: "BEFORE_DAYS",
+    recipientType: "CLIENT",
+    templateKey: "SERVICE_START_REMINDER",
+  };
+
+  it("forwards the validated payload to the backend when creating rules", async () => {
     mockPost.mockResolvedValue({
       status: 202,
       data: { queued: true },
@@ -75,12 +83,30 @@ describe("Alimtalk trigger rule API routes", () => {
       createRequest("/api/alimtalk-trigger-rules", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: "Reminder" }),
+        body: JSON.stringify({ ...validRulePayload, offsetDays: 3 }),
       }),
     );
 
     expect(response.status).toBe(202);
     await expect(response.json()).resolves.toEqual({ queued: true });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/alimtalk-trigger-rules",
+      { ...validRulePayload, offsetDays: 3 },
+      expect.anything(),
+    );
+  });
+
+  it("rejects a create body missing required fields before proxying", async () => {
+    const response = await createRule(
+      createRequest("/api/alimtalk-trigger-rules", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Reminder" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPost).not.toHaveBeenCalled();
   });
 
   it("rejects malformed create JSON before proxying", async () => {

--- a/mobile/src/app/api/alimtalk-trigger-rules/route.ts
+++ b/mobile/src/app/api/alimtalk-trigger-rules/route.ts
@@ -1,14 +1,41 @@
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import {
   backendJsonResponse,
   errorResponse,
   getAuthHeaders,
   getAuthToken,
-  invalidJsonResponse,
-  readJsonObjectBody,
+  parseBody,
   unauthorizedResponse,
 } from "@/lib/api/route-utils";
+
+// Mirrors backend CreateAlimtalkTriggerRuleDto: name, eventType, offsetType,
+// recipientType and templateKey are required enums; optional fields passthrough.
+const createTriggerRuleSchema = z
+  .object({
+    name: z.string().min(1),
+    eventType: z.enum([
+      "CLIENT_CREATED",
+      "SERVICE_START",
+      "SERVICE_END",
+      "EMPLOYEE_ASSIGNED",
+    ]),
+    offsetType: z.enum(["IMMEDIATE", "SAME_DAY", "BEFORE_DAYS", "AFTER_DAYS"]),
+    recipientType: z.enum([
+      "CLIENT",
+      "PRIMARY_EMPLOYEE",
+      "SECONDARY_EMPLOYEE",
+    ]),
+    templateKey: z.enum([
+      "CLIENT_WELCOME",
+      "SERVICE_START_REMINDER",
+      "SERVICE_INFO",
+      "SERVICE_END_REMINDER",
+      "EMPLOYEE_ASSIGNED",
+    ]),
+  })
+  .passthrough();
 
 export async function GET(request: NextRequest) {
   try {
@@ -33,17 +60,19 @@ export async function POST(request: NextRequest) {
       return unauthorizedResponse("Unauthorized");
     }
 
-    const body = await readJsonObjectBody(request);
-    const response = await serverAPIClient.post("/alimtalk-trigger-rules", body, {
+    const { data, response: invalidBody } = await parseBody(
+      createTriggerRuleSchema,
+      request,
+    );
+    if (invalidBody) {
+      return invalidBody;
+    }
+
+    const response = await serverAPIClient.post("/alimtalk-trigger-rules", data, {
       headers: getAuthHeaders(token),
     });
     return backendJsonResponse(response);
   } catch (error) {
-    const invalidJson = invalidJsonResponse(error);
-    if (invalidJson) {
-      return invalidJson;
-    }
-
     return errorResponse(error, "create alimtalk trigger rule");
   }
 }

--- a/mobile/src/app/api/auth/__tests__/error-sanitization.test.ts
+++ b/mobile/src/app/api/auth/__tests__/error-sanitization.test.ts
@@ -41,7 +41,19 @@ function createRequest(path: string): NextRequest {
       "Content-Type": "application/json",
       cookie: "auth_token=auth-token",
     },
-    body: JSON.stringify({ email: "user@example.com", password: "password", token: "token" }),
+    // Superset body satisfying every auth route's zod schema (P4.4) so each
+    // handler reaches the mocked upstream instead of 400ing at validation.
+    body: JSON.stringify({
+      email: "user@example.com",
+      password: "password",
+      newPassword: "password",
+      token: "token",
+      name: "테스트",
+      phone: "01012345678",
+      birthDate: "1990-01-01",
+      branchId: "branch-1",
+      role: "manager",
+    }),
   });
 }
 

--- a/mobile/src/app/api/auth/forgot-password/__tests__/route.test.ts
+++ b/mobile/src/app/api/auth/forgot-password/__tests__/route.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+
+import { POST } from "../route";
+
+jest.mock("@/lib/api/server", () => ({
+    serverAPIClient: {
+        post: jest.fn(),
+    },
+}));
+
+const mockPost = serverAPIClient.post as jest.Mock;
+
+function createRequest(body: BodyInit): NextRequest {
+    return new NextRequest("http://localhost/api/auth/forgot-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+    });
+}
+
+describe("POST /api/auth/forgot-password", () => {
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        mockPost.mockReset();
+        consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    it("rejects a body with an invalid email without proxying", async () => {
+        const response = await POST(createRequest(JSON.stringify({ email: "not-an-email" })));
+
+        expect(response.status).toBe(400);
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("forwards a valid body to the backend", async () => {
+        mockPost.mockResolvedValue({ status: 200, data: { success: true } });
+
+        const response = await POST(createRequest(JSON.stringify({ email: "user@example.com" })));
+
+        expect(response.status).toBe(200);
+        expect(mockPost).toHaveBeenCalledWith("/auth/forgot-password", { email: "user@example.com" });
+    });
+});

--- a/mobile/src/app/api/auth/forgot-password/route.ts
+++ b/mobile/src/app/api/auth/forgot-password/route.ts
@@ -1,14 +1,23 @@
 import { NextResponse, NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import { AxiosError } from "axios";
-import { getUpstreamErrorStatus, logUpstreamError, sanitizeUpstreamClientError } from "@/lib/api/route-utils";
+import { getUpstreamErrorStatus, logUpstreamError, parseBody, sanitizeUpstreamClientError } from "@/lib/api/route-utils";
+
+const forgotPasswordSchema = z
+    .object({
+        email: z.string().email(),
+    })
+    .passthrough();
 
 export async function POST(request: NextRequest) {
-    try {
-        const body = await request.json();
-        const { data, status } = await serverAPIClient.post("/auth/forgot-password", body);
+    const { data, response } = await parseBody(forgotPasswordSchema, request);
+    if (response) return response;
 
-        return NextResponse.json(data, { status });
+    try {
+        const { data: responseData, status } = await serverAPIClient.post("/auth/forgot-password", data);
+
+        return NextResponse.json(responseData, { status });
     } catch (error) {
         logUpstreamError("Auth Forgot Password", error);
 

--- a/mobile/src/app/api/auth/link-password/__tests__/route.test.ts
+++ b/mobile/src/app/api/auth/link-password/__tests__/route.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+
+import { POST } from "../route";
+
+jest.mock("@/lib/api/server", () => ({
+    serverAPIClient: {
+        post: jest.fn(),
+    },
+}));
+
+const mockPost = serverAPIClient.post as jest.Mock;
+
+function createRequest(body: BodyInit): NextRequest {
+    return new NextRequest("http://localhost/api/auth/link-password", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            cookie: "auth_token=auth-token",
+        },
+        body,
+    });
+}
+
+describe("POST /api/auth/link-password", () => {
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        mockPost.mockReset();
+        consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    it("rejects a body with a too-short password without proxying", async () => {
+        const response = await POST(createRequest(JSON.stringify({ password: "short" })));
+
+        expect(response.status).toBe(400);
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("forwards a valid body to the backend with the auth header", async () => {
+        mockPost.mockResolvedValue({ status: 200, data: { success: true } });
+
+        const response = await POST(createRequest(JSON.stringify({ password: "password123" })));
+
+        expect(response.status).toBe(200);
+        expect(mockPost).toHaveBeenCalledWith(
+            "/auth/link-password",
+            { password: "password123" },
+            { headers: { Authorization: "Bearer auth-token" } },
+        );
+    });
+});

--- a/mobile/src/app/api/auth/link-password/route.ts
+++ b/mobile/src/app/api/auth/link-password/route.ts
@@ -1,26 +1,35 @@
 import { NextResponse, NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
-import { getAuthToken, getUpstreamErrorStatus, logUpstreamError, sanitizeUpstreamClientError } from "@/lib/api/route-utils";
+import { getAuthToken, getUpstreamErrorStatus, logUpstreamError, parseBody, sanitizeUpstreamClientError } from "@/lib/api/route-utils";
 import { AxiosError } from "axios";
 
-export async function POST(request: NextRequest) {
-    try {
-        const token = getAuthToken(request);
-        if (!token) {
-            return NextResponse.json(
-                { error: "Unauthorized" },
-                { status: 401 }
-            );
-        }
+const linkPasswordSchema = z
+    .object({
+        password: z.string().min(8),
+    })
+    .passthrough();
 
-        const body = await request.json();
-        const { data, status } = await serverAPIClient.post("/auth/link-password", body, {
+export async function POST(request: NextRequest) {
+    const token = getAuthToken(request);
+    if (!token) {
+        return NextResponse.json(
+            { error: "Unauthorized" },
+            { status: 401 }
+        );
+    }
+
+    const { data, response } = await parseBody(linkPasswordSchema, request);
+    if (response) return response;
+
+    try {
+        const { data: responseData, status } = await serverAPIClient.post("/auth/link-password", data, {
             headers: {
                 Authorization: `Bearer ${token}`,
             },
         });
 
-        return NextResponse.json(data, { status });
+        return NextResponse.json(responseData, { status });
     } catch (error) {
         logUpstreamError("Auth Link Password", error);
 

--- a/mobile/src/app/api/auth/register/__tests__/route.test.ts
+++ b/mobile/src/app/api/auth/register/__tests__/route.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+
+import { POST } from "../route";
+
+jest.mock("@/lib/api/server", () => ({
+    serverAPIClient: {
+        post: jest.fn(),
+    },
+}));
+
+const mockPost = serverAPIClient.post as jest.Mock;
+
+function createRequest(body: BodyInit): NextRequest {
+    return new NextRequest("http://localhost/api/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+    });
+}
+
+const validBody = {
+    email: "user@example.com",
+    password: "password123",
+    name: "Hong Gildong",
+    phone: "010-1234-5678",
+    birthDate: "1990-01-01",
+    branchId: "11111111-1111-4111-8111-111111111111",
+    role: "user",
+};
+
+describe("POST /api/auth/register", () => {
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        mockPost.mockReset();
+        consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    it("rejects a body missing required fields without proxying", async () => {
+        const response = await POST(createRequest(JSON.stringify({ email: "user@example.com" })));
+
+        expect(response.status).toBe(400);
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("rejects malformed JSON without proxying", async () => {
+        const response = await POST(createRequest("{bad-json"));
+
+        expect(response.status).toBe(400);
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("forwards a valid body to the backend", async () => {
+        mockPost.mockResolvedValue({ status: 201, data: { success: true } });
+
+        const response = await POST(createRequest(JSON.stringify(validBody)));
+
+        expect(response.status).toBe(201);
+        expect(mockPost).toHaveBeenCalledWith("/auth/register", validBody);
+    });
+});

--- a/mobile/src/app/api/auth/register/route.ts
+++ b/mobile/src/app/api/auth/register/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse, NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import { AxiosError } from "axios";
-import { getUpstreamErrorStatus, logUpstreamError, sanitizeUpstreamClientError } from "@/lib/api/route-utils";
+import { getUpstreamErrorStatus, logUpstreamError, parseBody, sanitizeUpstreamClientError } from "@/lib/api/route-utils";
 
 interface APIErrorResponse {
     statusCode: number;
@@ -11,12 +12,26 @@ interface APIErrorResponse {
     hasKakaoAccount?: boolean;
 }
 
-export async function POST(request: NextRequest) {
-    try {
-        const body = await request.json();
-        const { data, status } = await serverAPIClient.post("/auth/register", body);
+const registerSchema = z
+    .object({
+        email: z.string().email(),
+        password: z.string().min(8),
+        name: z.string().min(1),
+        phone: z.string().min(1),
+        birthDate: z.string().min(1),
+        branchId: z.string().min(1),
+        role: z.string().min(1),
+    })
+    .passthrough();
 
-        return NextResponse.json(data, { status });
+export async function POST(request: NextRequest) {
+    const { data, response } = await parseBody(registerSchema, request);
+    if (response) return response;
+
+    try {
+        const { data: responseData, status } = await serverAPIClient.post("/auth/register", data);
+
+        return NextResponse.json(responseData, { status });
     } catch (error) {
         logUpstreamError("Auth Register", error);
 

--- a/mobile/src/app/api/auth/resend-verification/__tests__/route.test.ts
+++ b/mobile/src/app/api/auth/resend-verification/__tests__/route.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+
+import { POST } from "../route";
+
+jest.mock("@/lib/api/server", () => ({
+    serverAPIClient: {
+        post: jest.fn(),
+    },
+}));
+
+const mockPost = serverAPIClient.post as jest.Mock;
+
+function createRequest(body: BodyInit): NextRequest {
+    return new NextRequest("http://localhost/api/auth/resend-verification", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+    });
+}
+
+describe("POST /api/auth/resend-verification", () => {
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        mockPost.mockReset();
+        consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    it("rejects a body with an invalid email without proxying", async () => {
+        const response = await POST(createRequest(JSON.stringify({ email: "not-an-email" })));
+
+        expect(response.status).toBe(400);
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("forwards a valid body to the backend", async () => {
+        mockPost.mockResolvedValue({ status: 200, data: { success: true } });
+
+        const response = await POST(createRequest(JSON.stringify({ email: "user@example.com" })));
+
+        expect(response.status).toBe(200);
+        expect(mockPost).toHaveBeenCalledWith("/auth/resend-verification", { email: "user@example.com" });
+    });
+});

--- a/mobile/src/app/api/auth/resend-verification/route.ts
+++ b/mobile/src/app/api/auth/resend-verification/route.ts
@@ -1,14 +1,23 @@
 import { NextResponse, NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import { AxiosError } from "axios";
-import { getUpstreamErrorStatus, logUpstreamError, sanitizeUpstreamClientError } from "@/lib/api/route-utils";
+import { getUpstreamErrorStatus, logUpstreamError, parseBody, sanitizeUpstreamClientError } from "@/lib/api/route-utils";
+
+const resendVerificationSchema = z
+    .object({
+        email: z.string().email(),
+    })
+    .passthrough();
 
 export async function POST(request: NextRequest) {
-    try {
-        const body = await request.json();
-        const { data, status } = await serverAPIClient.post("/auth/resend-verification", body);
+    const { data, response } = await parseBody(resendVerificationSchema, request);
+    if (response) return response;
 
-        return NextResponse.json(data, { status });
+    try {
+        const { data: responseData, status } = await serverAPIClient.post("/auth/resend-verification", data);
+
+        return NextResponse.json(responseData, { status });
     } catch (error) {
         logUpstreamError("Auth Resend Verification", error);
 

--- a/mobile/src/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/mobile/src/app/api/auth/reset-password/__tests__/route.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+
+import { POST } from "../route";
+
+jest.mock("@/lib/api/server", () => ({
+    serverAPIClient: {
+        post: jest.fn(),
+    },
+}));
+
+const mockPost = serverAPIClient.post as jest.Mock;
+
+function createRequest(body: BodyInit): NextRequest {
+    return new NextRequest("http://localhost/api/auth/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+    });
+}
+
+describe("POST /api/auth/reset-password", () => {
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        mockPost.mockReset();
+        consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    it("rejects a body with a too-short newPassword without proxying", async () => {
+        const response = await POST(
+            createRequest(JSON.stringify({ token: "reset-token", newPassword: "short" })),
+        );
+
+        expect(response.status).toBe(400);
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("forwards a valid body to the backend", async () => {
+        mockPost.mockResolvedValue({ status: 200, data: { success: true } });
+
+        const validBody = { token: "reset-token", newPassword: "password123" };
+        const response = await POST(createRequest(JSON.stringify(validBody)));
+
+        expect(response.status).toBe(200);
+        expect(mockPost).toHaveBeenCalledWith("/auth/reset-password", validBody);
+    });
+});

--- a/mobile/src/app/api/auth/reset-password/route.ts
+++ b/mobile/src/app/api/auth/reset-password/route.ts
@@ -1,14 +1,24 @@
 import { NextResponse, NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import { AxiosError } from "axios";
-import { getUpstreamErrorStatus, logUpstreamError, sanitizeUpstreamClientError } from "@/lib/api/route-utils";
+import { getUpstreamErrorStatus, logUpstreamError, parseBody, sanitizeUpstreamClientError } from "@/lib/api/route-utils";
+
+const resetPasswordSchema = z
+    .object({
+        token: z.string().min(1).max(10_000),
+        newPassword: z.string().min(8),
+    })
+    .passthrough();
 
 export async function POST(request: NextRequest) {
-    try {
-        const body = await request.json();
-        const { data, status } = await serverAPIClient.post("/auth/reset-password", body);
+    const { data, response } = await parseBody(resetPasswordSchema, request);
+    if (response) return response;
 
-        return NextResponse.json(data, { status });
+    try {
+        const { data: responseData, status } = await serverAPIClient.post("/auth/reset-password", data);
+
+        return NextResponse.json(responseData, { status });
     } catch (error) {
         logUpstreamError("Auth Reset Password", error);
 

--- a/mobile/src/app/api/auth/verify-email/__tests__/route.test.ts
+++ b/mobile/src/app/api/auth/verify-email/__tests__/route.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+
+import { POST } from "../route";
+
+jest.mock("@/lib/api/server", () => ({
+    serverAPIClient: {
+        post: jest.fn(),
+    },
+}));
+
+const mockPost = serverAPIClient.post as jest.Mock;
+
+function createRequest(body: BodyInit): NextRequest {
+    return new NextRequest("http://localhost/api/auth/verify-email", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+    });
+}
+
+describe("POST /api/auth/verify-email", () => {
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        mockPost.mockReset();
+        consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    it("rejects a body with a non-string token without proxying", async () => {
+        const response = await POST(createRequest(JSON.stringify({ token: 123 })));
+
+        expect(response.status).toBe(400);
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("forwards a valid body to the backend", async () => {
+        mockPost.mockResolvedValue({ status: 200, data: { success: true } });
+
+        const response = await POST(createRequest(JSON.stringify({ token: "verify-token" })));
+
+        expect(response.status).toBe(200);
+        expect(mockPost).toHaveBeenCalledWith("/auth/verify-email", { token: "verify-token" });
+    });
+});

--- a/mobile/src/app/api/auth/verify-email/route.ts
+++ b/mobile/src/app/api/auth/verify-email/route.ts
@@ -1,14 +1,23 @@
 import { NextResponse, NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import { AxiosError } from "axios";
-import { getUpstreamErrorStatus, logUpstreamError, sanitizeUpstreamClientError } from "@/lib/api/route-utils";
+import { getUpstreamErrorStatus, logUpstreamError, parseBody, sanitizeUpstreamClientError } from "@/lib/api/route-utils";
+
+const verifyEmailSchema = z
+    .object({
+        token: z.string().min(1).max(10_000),
+    })
+    .passthrough();
 
 export async function POST(request: NextRequest) {
-    try {
-        const body = await request.json();
-        const { data, status } = await serverAPIClient.post("/auth/verify-email", body);
+    const { data, response } = await parseBody(verifyEmailSchema, request);
+    if (response) return response;
 
-        return NextResponse.json(data, { status });
+    try {
+        const { data: responseData, status } = await serverAPIClient.post("/auth/verify-email", data);
+
+        return NextResponse.json(responseData, { status });
     } catch (error) {
         logUpstreamError("Auth Verify Email", error);
 

--- a/mobile/src/app/api/clients/__tests__/route.test.ts
+++ b/mobile/src/app/api/clients/__tests__/route.test.ts
@@ -68,6 +68,44 @@ describe("client API routes", () => {
     expect(mockPost).not.toHaveBeenCalled();
   });
 
+  it("rejects create bodies missing required fields before proxying", async () => {
+    const response = await createClient(
+      createRequest("/api/clients", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        // missing the required booleans careCenter/voucherClient/breastPump
+        body: JSON.stringify({ name: "Baby Kim" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("forwards the validated create body to the backend", async () => {
+    mockPost.mockResolvedValue({ status: 201, data: { id: 7 } });
+
+    const payload = {
+      name: "Baby Kim",
+      careCenter: false,
+      voucherClient: true,
+      breastPump: false,
+      primaryEmployeeId: 12,
+    };
+
+    const response = await createClient(
+      createRequest("/api/clients", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({ id: 7 });
+    expect(mockPost).toHaveBeenCalledWith("/clients", payload, expect.any(Object));
+  });
+
   it("rejects invalid client detail IDs before proxying", async () => {
     const response = await getClient(
       createRequest("/api/clients/not-a-number"),

--- a/mobile/src/app/api/clients/route.ts
+++ b/mobile/src/app/api/clients/route.ts
@@ -1,15 +1,28 @@
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import {
     backendJsonResponse,
     errorResponse,
     getAuthHeaders,
     getAuthToken,
-    invalidJsonResponse,
-    readJsonObjectBody,
+    parseBody,
     unauthorizedResponse,
     withNoStore,
 } from "@/lib/api/route-utils";
+
+// Mirrors backend CreateClientDto: `name` (@IsString) plus the three booleans
+// `careCenter`, `voucherClient`, `breastPump` (@IsBoolean, no @IsOptional) are
+// required. Every other field is @IsOptional, so it passes through to the
+// backend's authoritative ValidationPipe.
+const createClientSchema = z
+    .object({
+        name: z.string().max(10_000),
+        careCenter: z.boolean(),
+        voucherClient: z.boolean(),
+        breastPump: z.boolean(),
+    })
+    .passthrough();
 
 // GET /api/clients - Get all clients (with optional pagination)
 export async function GET(request: NextRequest) {
@@ -43,21 +56,20 @@ export async function GET(request: NextRequest) {
 
 // POST /api/clients - Create a new client
 export async function POST(request: NextRequest) {
-    try {
-        const token = getAuthToken(request);
-        if (!token) {
-            return unauthorizedResponse("Unauthorized");
-        }
+    const token = getAuthToken(request);
+    if (!token) {
+        return unauthorizedResponse("Unauthorized");
+    }
 
-        const body = await readJsonObjectBody(request);
-        const response = await serverAPIClient.post("/clients", body, {
+    const { data, response } = await parseBody(createClientSchema, request);
+    if (response) return response;
+
+    try {
+        const backendResponse = await serverAPIClient.post("/clients", data, {
             headers: getAuthHeaders(token),
         });
-        return backendJsonResponse(response);
+        return backendJsonResponse(backendResponse);
     } catch (error) {
-        const invalidJson = invalidJsonResponse(error);
-        if (invalidJson) return invalidJson;
-
         return errorResponse(error, "create client");
     }
 }

--- a/mobile/src/app/api/document-categories/__tests__/route.test.ts
+++ b/mobile/src/app/api/document-categories/__tests__/route.test.ts
@@ -54,22 +54,39 @@ describe("document category API route", () => {
     await expect(response.json()).resolves.toEqual({ error: "Failed to fetch document categories" });
   });
 
-  it("preserves backend status and payload when creating categories", async () => {
+  it("preserves backend status and forwards the validated body when creating categories", async () => {
     mockPost.mockResolvedValue({
       status: 202,
       data: { queued: true },
     });
 
+    const payload = { value: "contracts", label: "Contracts", color: "#ff0000" };
+
     const response = await createCategory(
       createRequest("/api/document-categories", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: "Docs" }),
+        body: JSON.stringify(payload),
       }),
     );
 
     expect(response.status).toBe(202);
     await expect(response.json()).resolves.toEqual({ queued: true });
+    expect(mockPost).toHaveBeenCalledWith("/document-categories", payload, expect.any(Object));
+  });
+
+  it("rejects create bodies missing required fields before proxying", async () => {
+    const response = await createCategory(
+      createRequest("/api/document-categories", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        // missing the required label/color strings
+        body: JSON.stringify({ value: "contracts" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPost).not.toHaveBeenCalled();
   });
 
   it("rejects malformed create JSON before proxying", async () => {

--- a/mobile/src/app/api/document-categories/route.ts
+++ b/mobile/src/app/api/document-categories/route.ts
@@ -1,14 +1,25 @@
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import {
     backendJsonResponse,
     errorResponse,
     getAuthHeaders,
     getAuthToken,
-    invalidJsonResponse,
-    readJsonObjectBody,
+    parseBody,
     unauthorizedResponse,
 } from "@/lib/api/route-utils";
+
+// Mirrors backend CreateDocumentCategoryDto: `value`, `label`, `color` are all
+// required strings (@IsString, no @IsOptional). Other fields pass through to the
+// backend's authoritative ValidationPipe.
+const createDocumentCategorySchema = z
+    .object({
+        value: z.string().max(10_000),
+        label: z.string().max(10_000),
+        color: z.string().max(10_000),
+    })
+    .passthrough();
 
 export async function GET(request: NextRequest) {
     try {
@@ -27,23 +38,20 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-    try {
-        const token = getAuthToken(request);
-        if (!token) {
-            return unauthorizedResponse("Unauthorized");
-        }
+    const token = getAuthToken(request);
+    if (!token) {
+        return unauthorizedResponse("Unauthorized");
+    }
 
-        const body = await readJsonObjectBody(request);
-        const response = await serverAPIClient.post("/document-categories", body, {
+    const { data, response } = await parseBody(createDocumentCategorySchema, request);
+    if (response) return response;
+
+    try {
+        const backendResponse = await serverAPIClient.post("/document-categories", data, {
             headers: getAuthHeaders(token),
         });
-        return backendJsonResponse(response);
+        return backendJsonResponse(backendResponse);
     } catch (error) {
-        const invalidJson = invalidJsonResponse(error);
-        if (invalidJson) {
-            return invalidJson;
-        }
-
         return errorResponse(error, "create document category");
     }
 }

--- a/mobile/src/app/api/eformsign-docs/__tests__/command-routes.test.ts
+++ b/mobile/src/app/api/eformsign-docs/__tests__/command-routes.test.ts
@@ -32,18 +32,114 @@ describe("eformsign-docs command API routes", () => {
     mockPost.mockReset();
   });
 
-  it("preserves backend status and payload when creating eformsign doc records", async () => {
+  const validCreateBody = {
+    documentId: "doc-1",
+    clientId: 7,
+    statusType: "on_progress",
+    statusDetail: "step_1",
+    stepType: "sign",
+    stepIndex: "0",
+    stepName: "고객 서명",
+    stepRecipientType: "outsider",
+    stepRecipientName: "홍길동",
+    stepRecipientSms: "01000000000",
+    expiredDate: "2026-12-31T00:00:00.000Z",
+  };
+
+  it("rejects create payloads missing required fields before proxying", async () => {
+    const response = await createEformsignDoc(
+      createRequest("/api/eformsign-docs", JSON.stringify({ documentId: "doc-1" })),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("rejects create payloads with wrong field types before proxying", async () => {
+    const response = await createEformsignDoc(
+      createRequest(
+        "/api/eformsign-docs",
+        JSON.stringify({ ...validCreateBody, clientId: "not-a-number" }),
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("forwards validated create payload and preserves backend status", async () => {
     mockPost.mockResolvedValue({
       status: 202,
       data: { queued: true },
     });
 
     const response = await createEformsignDoc(
-      createRequest("/api/eformsign-docs", JSON.stringify({ documentId: "doc-1" })),
+      createRequest("/api/eformsign-docs", JSON.stringify(validCreateBody)),
     );
 
     expect(response.status).toBe(202);
     await expect(response.json()).resolves.toEqual({ queued: true });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/eformsign-docs",
+      validCreateBody,
+      { headers: { Authorization: "Bearer auth-token" } },
+    );
+  });
+
+  it("rejects dispatch payloads missing contractData before proxying", async () => {
+    const response = await dispatchHeadless(
+      createRequest("/api/eformsign-docs/dispatch-headless", JSON.stringify({ clientId: 7 })),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("forwards validated dispatch payload to the backend", async () => {
+    mockPost.mockResolvedValue({ status: 200, data: { ok: true } });
+
+    const dispatchBody = {
+      contractData: { customerName: "홍길동" },
+      clientId: 7,
+      progressId: "p-1",
+    };
+
+    const response = await dispatchHeadless(
+      createRequest("/api/eformsign-docs/dispatch-headless", JSON.stringify(dispatchBody)),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockPost).toHaveBeenCalledWith(
+      "/eformsign-docs/dispatch-headless",
+      dispatchBody,
+      expect.objectContaining({ headers: { Authorization: "Bearer auth-token" } }),
+    );
+  });
+
+  it("rejects finalize payloads missing documentId before proxying", async () => {
+    const response = await finalizeHeadless(
+      createRequest("/api/eformsign-docs/finalize-headless", JSON.stringify({ progressId: "p-1" })),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("forwards validated finalize payload to the backend", async () => {
+    mockPost.mockResolvedValue({ status: 200, data: { ok: true } });
+
+    const finalizeBody = { documentId: "doc-1", prefillEndDate: "2026-12-31" };
+
+    const response = await finalizeHeadless(
+      createRequest("/api/eformsign-docs/finalize-headless", JSON.stringify(finalizeBody)),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockPost).toHaveBeenCalledWith(
+      "/eformsign-docs/finalize-headless",
+      finalizeBody,
+      expect.objectContaining({ headers: { Authorization: "Bearer auth-token" } }),
+    );
   });
 
   it("rejects malformed dispatch JSON before proxying", async () => {

--- a/mobile/src/app/api/eformsign-docs/dispatch-headless/route.ts
+++ b/mobile/src/app/api/eformsign-docs/dispatch-headless/route.ts
@@ -1,14 +1,26 @@
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import {
     backendJsonResponse,
     errorResponse,
     getAuthHeaders,
     getAuthToken,
-    invalidJsonResponse,
-    readJsonObjectBody,
+    parseBody,
     unauthorizedResponse,
 } from "@/lib/api/route-utils";
+
+// Mirrors backend DispatchHeadlessRequestDto: contractData is @IsObject()
+// required (ContractDataDto is itself an interface, not nested-validated, so the
+// proxy only pins object-ness); clientId/progressId are optional. Passthrough
+// keeps the contractData shape and any extra fields intact for the backend.
+const dispatchHeadlessSchema = z
+    .object({
+        contractData: z.object({}).passthrough(),
+        clientId: z.number().optional(),
+        progressId: z.string().optional(),
+    })
+    .passthrough();
 
 export async function POST(request: NextRequest) {
     try {
@@ -17,9 +29,10 @@ export async function POST(request: NextRequest) {
             return unauthorizedResponse("Unauthorized");
         }
 
-        const body = await readJsonObjectBody(request);
+        const { data, response: invalid } = await parseBody(dispatchHeadlessSchema, request);
+        if (invalid) return invalid;
 
-        const response = await serverAPIClient.post("/eformsign-docs/dispatch-headless", body, {
+        const response = await serverAPIClient.post("/eformsign-docs/dispatch-headless", data, {
             headers: getAuthHeaders(token),
             // Headless dispatch can approach 90s when eformsign is slow to fire the SDK
             // success callback; keep the proxy above that ceiling.
@@ -28,9 +41,6 @@ export async function POST(request: NextRequest) {
 
         return backendJsonResponse(response);
     } catch (error) {
-        const invalidJson = invalidJsonResponse(error);
-        if (invalidJson) return invalidJson;
-
         return errorResponse(error, "headless eformsign dispatch");
     }
 }

--- a/mobile/src/app/api/eformsign-docs/finalize-headless/route.ts
+++ b/mobile/src/app/api/eformsign-docs/finalize-headless/route.ts
@@ -1,14 +1,28 @@
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import {
     backendJsonResponse,
     errorResponse,
     getAuthHeaders,
     getAuthToken,
-    invalidJsonResponse,
-    readJsonObjectBody,
+    parseBody,
     unauthorizedResponse,
 } from "@/lib/api/route-utils";
+
+// Mirrors backend FinalizeHeadlessRequestDto: documentId is @IsString()
+// @IsNotEmpty() required; prefillEndDate (YYYY-MM-DD) and progressId are
+// optional. Passthrough preserves any forward-compatible fields.
+const finalizeHeadlessSchema = z
+    .object({
+        documentId: z.string().min(1),
+        prefillEndDate: z
+            .string()
+            .regex(/^\d{4}-\d{2}-\d{2}$/, "prefillEndDate must match YYYY-MM-DD")
+            .optional(),
+        progressId: z.string().optional(),
+    })
+    .passthrough();
 
 export async function POST(request: NextRequest) {
     try {
@@ -17,18 +31,16 @@ export async function POST(request: NextRequest) {
             return unauthorizedResponse("Unauthorized");
         }
 
-        const body = await readJsonObjectBody(request);
+        const { data, response: invalid } = await parseBody(finalizeHeadlessSchema, request);
+        if (invalid) return invalid;
 
-        const response = await serverAPIClient.post("/eformsign-docs/finalize-headless", body, {
+        const response = await serverAPIClient.post("/eformsign-docs/finalize-headless", data, {
             headers: getAuthHeaders(token),
             timeout: 60_000,
         });
 
         return backendJsonResponse(response);
     } catch (error) {
-        const invalidJson = invalidJsonResponse(error);
-        if (invalidJson) return invalidJson;
-
         return errorResponse(error, "headless eformsign finalize");
     }
 }

--- a/mobile/src/app/api/eformsign-docs/route.ts
+++ b/mobile/src/app/api/eformsign-docs/route.ts
@@ -1,14 +1,35 @@
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import {
     backendJsonResponse,
     errorResponse,
     getAuthHeaders,
     getAuthToken,
-    invalidJsonResponse,
-    readJsonObjectBody,
+    parseBody,
     unauthorizedResponse,
 } from "@/lib/api/route-utils";
+
+// Mirrors backend CreateEformsignDocLocalDto: documentId/clientId and the
+// status/step strings are all @IsString()/@IsNumber() required; expiredDate is
+// @IsDateString(); linkToClient is the only optional field. Passthrough keeps
+// any forward-compatible fields flowing to the backend ValidationPipe.
+const createEformsignDocSchema = z
+    .object({
+        documentId: z.string(),
+        clientId: z.number(),
+        statusType: z.string(),
+        statusDetail: z.string(),
+        stepType: z.string(),
+        stepIndex: z.string(),
+        stepName: z.string(),
+        stepRecipientType: z.string(),
+        stepRecipientName: z.string(),
+        stepRecipientSms: z.string(),
+        expiredDate: z.string(),
+        linkToClient: z.boolean().optional(),
+    })
+    .passthrough();
 
 export async function POST(request: NextRequest) {
     try {
@@ -17,17 +38,15 @@ export async function POST(request: NextRequest) {
             return unauthorizedResponse("Unauthorized");
         }
 
-        const body = await readJsonObjectBody(request);
+        const { data, response: invalid } = await parseBody(createEformsignDocSchema, request);
+        if (invalid) return invalid;
 
-        const response = await serverAPIClient.post("/eformsign-docs", body, {
+        const response = await serverAPIClient.post("/eformsign-docs", data, {
             headers: getAuthHeaders(token),
         });
 
         return backendJsonResponse(response);
     } catch (error) {
-        const invalidJson = invalidJsonResponse(error);
-        if (invalidJson) return invalidJson;
-
         return errorResponse(error, "create eformsign doc record");
     }
 }

--- a/mobile/src/app/api/message-deliveries/__tests__/sms-route.test.ts
+++ b/mobile/src/app/api/message-deliveries/__tests__/sms-route.test.ts
@@ -37,6 +37,11 @@ describe("SMS delivery API route", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  const validSmsPayload = {
+    receiver: "010-1234-5678",
+    message: "hello",
+  };
+
   it("rejects malformed JSON before proxying", async () => {
     const response = await sendSms(createRequest("{bad-json"));
 
@@ -47,16 +52,28 @@ describe("SMS delivery API route", () => {
     expect(mockPost).not.toHaveBeenCalled();
   });
 
-  it("preserves backend status and payload", async () => {
+  it("rejects an SMS body missing the required receiver before proxying", async () => {
+    const response = await sendSms(createRequest(JSON.stringify({ message: "hello" })));
+
+    expect(response.status).toBe(400);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("forwards the validated payload to the backend", async () => {
     mockPost.mockResolvedValue({
       status: 202,
       data: { queued: true },
     });
 
-    const response = await sendSms(createRequest(JSON.stringify({ message: "hello" })));
+    const response = await sendSms(createRequest(JSON.stringify(validSmsPayload)));
 
     expect(response.status).toBe(202);
     await expect(response.json()).resolves.toEqual({ queued: true });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/message-deliveries/sms",
+      validSmsPayload,
+      expect.anything(),
+    );
   });
 
   it("does not return or log raw upstream SMS error payloads", async () => {
@@ -73,7 +90,7 @@ describe("SMS delivery API route", () => {
       name: "AxiosError",
     });
 
-    const response = await sendSms(createRequest(JSON.stringify({ message: "hello" })));
+    const response = await sendSms(createRequest(JSON.stringify(validSmsPayload)));
 
     expect(response.status).toBe(502);
     await expect(response.json()).resolves.toEqual({

--- a/mobile/src/app/api/message-deliveries/sms/route.ts
+++ b/mobile/src/app/api/message-deliveries/sms/route.ts
@@ -1,14 +1,28 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import {
   getAuthHeaders,
   getAuthToken,
   getUpstreamErrorStatus,
-  invalidJsonResponse,
   logUpstreamError,
-  readJsonObjectBody,
+  parseBody,
   sanitizeUpstreamClientError,
 } from "@/lib/api/route-utils";
+
+// Mirrors backend SendSmsMessageDto. This is a PAID send path, so the two
+// fields the backend marks @IsNotEmpty — receiver and message — are required
+// here; the receiver pattern and message length cap match the DTO. Optional
+// fields (title, msgType, triggerType, scheduledDate/Time, etc.) passthrough.
+const sendSmsSchema = z
+  .object({
+    receiver: z
+      .string()
+      .min(1)
+      .regex(/^[0-9,\-\s]+$/, "수신자 연락처 형식이 올바르지 않습니다."),
+    message: z.string().min(1).max(2000),
+  })
+  .passthrough();
 
 export async function POST(request: NextRequest) {
   try {
@@ -17,17 +31,16 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const body = await readJsonObjectBody(request);
-    const response = await serverAPIClient.post("/message-deliveries/sms", body, {
+    const { data, response: invalidBody } = await parseBody(sendSmsSchema, request);
+    if (invalidBody) {
+      return invalidBody;
+    }
+
+    const response = await serverAPIClient.post("/message-deliveries/sms", data, {
       headers: getAuthHeaders(token),
     });
     return NextResponse.json(response.data, { status: response.status });
   } catch (error) {
-    const invalidJson = invalidJsonResponse(error);
-    if (invalidJson) {
-      return invalidJson;
-    }
-
     if (error && typeof error === "object" && "response" in error) {
       const axiosErr = error as { response?: { status?: number; data?: unknown } };
       if (axiosErr.response) {

--- a/mobile/src/app/api/message-templates/[id]/route.ts
+++ b/mobile/src/app/api/message-templates/[id]/route.ts
@@ -1,14 +1,32 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import {
     backendJsonResponse,
     errorResponse,
     getAuthHeaders,
     getAuthToken,
-    invalidJsonResponse,
-    readJsonObjectBody,
+    parseBody,
     unauthorizedResponse,
 } from "@/lib/api/route-utils";
+
+function isValidTemplateId(id: string): boolean {
+    return /^[A-Za-z0-9_-]+$/.test(id);
+}
+
+function invalidTemplateIdResponse(): NextResponse {
+    return NextResponse.json({ error: "Invalid message template id" }, { status: 400 });
+}
+
+// Mirrors backend UpdateMessageTemplateDto: every field is optional, so this is
+// a passthrough object that only type-checks the known fields when present.
+const updateMessageTemplateSchema = z
+    .object({
+        name: z.string().max(10_000).optional(),
+        content: z.string().max(10_000).optional(),
+        variables: z.array(z.unknown()).optional(),
+    })
+    .passthrough();
 
 export async function GET(
     request: NextRequest,
@@ -41,17 +59,23 @@ export async function PATCH(
         }
 
         const { id } = await params;
-        const body = await readJsonObjectBody(request);
-        const response = await serverAPIClient.patch(`/message-templates/${id}`, body, {
+        if (!isValidTemplateId(id)) {
+            return invalidTemplateIdResponse();
+        }
+
+        const { data, response: invalidBody } = await parseBody(
+            updateMessageTemplateSchema,
+            request,
+        );
+        if (invalidBody) {
+            return invalidBody;
+        }
+
+        const response = await serverAPIClient.patch(`/message-templates/${id}`, data, {
             headers: getAuthHeaders(token),
         });
         return backendJsonResponse(response);
     } catch (error) {
-        const invalidJson = invalidJsonResponse(error);
-        if (invalidJson) {
-            return invalidJson;
-        }
-
         return errorResponse(error, "update message template");
     }
 }

--- a/mobile/src/app/api/message-templates/__tests__/route.test.ts
+++ b/mobile/src/app/api/message-templates/__tests__/route.test.ts
@@ -62,7 +62,13 @@ describe("message-template API routes", () => {
     await expect(response.json()).resolves.toEqual({ error: "message template conflict" });
   });
 
-  it("preserves backend status and payload when creating message templates", async () => {
+  const validTemplatePayload = {
+    name: "Reminder",
+    content: "안녕하세요 {{name}}",
+    variables: [],
+  };
+
+  it("forwards the validated payload to the backend when creating message templates", async () => {
     mockPost.mockResolvedValue({
       status: 202,
       data: { queued: true },
@@ -72,12 +78,30 @@ describe("message-template API routes", () => {
       createRequest("/api/message-templates", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title: "Reminder" }),
+        body: JSON.stringify(validTemplatePayload),
       }),
     );
 
     expect(response.status).toBe(202);
     await expect(response.json()).resolves.toEqual({ queued: true });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/message-templates",
+      validTemplatePayload,
+      expect.anything(),
+    );
+  });
+
+  it("rejects a create body missing required fields before proxying", async () => {
+    const response = await createMessageTemplate(
+      createRequest("/api/message-templates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "Reminder" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPost).not.toHaveBeenCalled();
   });
 
   it("rejects malformed create JSON before proxying", async () => {
@@ -109,6 +133,60 @@ describe("message-template API routes", () => {
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
       error: "Request body must be valid JSON",
+    });
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+
+  it("forwards the validated payload to the backend when updating", async () => {
+    mockPatch.mockResolvedValue({
+      status: 200,
+      data: { id: "24" },
+    });
+
+    const response = await updateMessageTemplate(
+      createRequest("/api/message-templates/24", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Updated" }),
+      }),
+      { params: Promise.resolve({ id: "24" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockPatch).toHaveBeenCalledWith(
+      "/message-templates/24",
+      { name: "Updated" },
+      expect.anything(),
+    );
+  });
+
+  it("rejects an update body with a wrong-typed field before proxying", async () => {
+    const response = await updateMessageTemplate(
+      createRequest("/api/message-templates/24", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: 42 }),
+      }),
+      { params: Promise.resolve({ id: "24" }) },
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsafe message template IDs before proxying", async () => {
+    const response = await updateMessageTemplate(
+      createRequest("/api/message-templates/bad%2Fid", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Updated" }),
+      }),
+      { params: Promise.resolve({ id: "bad/id" }) },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid message template id",
     });
     expect(mockPatch).not.toHaveBeenCalled();
   });

--- a/mobile/src/app/api/message-templates/route.ts
+++ b/mobile/src/app/api/message-templates/route.ts
@@ -1,14 +1,24 @@
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import {
     backendJsonResponse,
     errorResponse,
     getAuthHeaders,
     getAuthToken,
-    invalidJsonResponse,
-    readJsonObjectBody,
+    parseBody,
     unauthorizedResponse,
 } from "@/lib/api/route-utils";
+
+// Mirrors backend CreateMessageTemplateDto: name, content and variables (array)
+// are all required; optional/forward-compatible fields flow through passthrough.
+const createMessageTemplateSchema = z
+    .object({
+        name: z.string().max(10_000),
+        content: z.string().max(10_000),
+        variables: z.array(z.unknown()),
+    })
+    .passthrough();
 
 export async function GET(request: NextRequest) {
     try {
@@ -33,17 +43,19 @@ export async function POST(request: NextRequest) {
             return unauthorizedResponse("Unauthorized");
         }
 
-        const body = await readJsonObjectBody(request);
-        const response = await serverAPIClient.post("/message-templates", body, {
+        const { data, response: invalidBody } = await parseBody(
+            createMessageTemplateSchema,
+            request,
+        );
+        if (invalidBody) {
+            return invalidBody;
+        }
+
+        const response = await serverAPIClient.post("/message-templates", data, {
             headers: getAuthHeaders(token),
         });
         return backendJsonResponse(response);
     } catch (error) {
-        const invalidJson = invalidJsonResponse(error);
-        if (invalidJson) {
-            return invalidJson;
-        }
-
         return errorResponse(error, "create message template");
     }
 }

--- a/mobile/src/app/api/notifications/__tests__/route.test.ts
+++ b/mobile/src/app/api/notifications/__tests__/route.test.ts
@@ -6,6 +6,7 @@ import { NextRequest } from "next/server";
 import { serverAPIClient } from "@/lib/api/server";
 import { GET as getNotifications } from "../route";
 import { POST as subscribeNotifications } from "../subscribe/route";
+import { POST as unsubscribeNotifications } from "../unsubscribe/route";
 import { GET as getVapidKey } from "../vapid-key/route";
 
 jest.mock("@/lib/api/server", () => ({
@@ -77,6 +78,79 @@ describe("notification API routes", () => {
       error: "Request body must be valid JSON",
     });
     expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("rejects subscribe payloads missing required push keys before proxying", async () => {
+    const response = await subscribeNotifications(
+      createRequest("/api/notifications/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ endpoint: "https://push.example/abc" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("forwards validated subscribe payload to the backend", async () => {
+    mockPost.mockResolvedValue({ status: 201, data: { success: true } });
+
+    const subscribeBody = {
+      endpoint: "https://push.example/abc",
+      p256dh: "p256dh-key",
+      auth: "auth-key",
+      userAgent: "jest",
+    };
+
+    const response = await subscribeNotifications(
+      createRequest("/api/notifications/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(subscribeBody),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockPost).toHaveBeenCalledWith(
+      "/notifications/subscribe",
+      subscribeBody,
+      { headers: { Authorization: "Bearer auth-token" } },
+    );
+  });
+
+  it("rejects unsubscribe payloads missing endpoint before proxying", async () => {
+    const response = await unsubscribeNotifications(
+      createRequest("/api/notifications/unsubscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("forwards validated unsubscribe payload to the backend", async () => {
+    mockPost.mockResolvedValue({ status: 200, data: { success: true } });
+
+    const unsubscribeBody = { endpoint: "https://push.example/abc" };
+
+    const response = await unsubscribeNotifications(
+      createRequest("/api/notifications/unsubscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(unsubscribeBody),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockPost).toHaveBeenCalledWith(
+      "/notifications/unsubscribe",
+      unsubscribeBody,
+      { headers: { Authorization: "Bearer auth-token" } },
+    );
   });
 
   it("preserves backend status and payload when fetching the VAPID key", async () => {

--- a/mobile/src/app/api/notifications/subscribe/route.ts
+++ b/mobile/src/app/api/notifications/subscribe/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import { z } from "zod";
 
 import { serverAPIClient } from "@/lib/api/server";
 import {
@@ -6,10 +7,21 @@ import {
     errorResponse,
     getAuthHeaders,
     getAuthToken,
-    invalidJsonResponse,
-    readJsonObjectBody,
+    parseBody,
     unauthorizedResponse,
 } from "@/lib/api/route-utils";
+
+// Mirrors backend SubscribePushDto: endpoint/p256dh/auth are @IsString()
+// @IsNotEmpty() required; userAgent is optional. Passthrough preserves any
+// forward-compatible fields.
+const subscribePushSchema = z
+    .object({
+        endpoint: z.string().min(1),
+        p256dh: z.string().min(1),
+        auth: z.string().min(1),
+        userAgent: z.string().optional(),
+    })
+    .passthrough();
 
 export async function POST(request: NextRequest) {
     try {
@@ -18,15 +30,14 @@ export async function POST(request: NextRequest) {
             return unauthorizedResponse("Unauthorized");
         }
 
-        const body = await readJsonObjectBody(request);
-        const response = await serverAPIClient.post("/notifications/subscribe", body, {
+        const { data, response: invalid } = await parseBody(subscribePushSchema, request);
+        if (invalid) return invalid;
+
+        const response = await serverAPIClient.post("/notifications/subscribe", data, {
             headers: getAuthHeaders(token),
         });
         return backendJsonResponse(response);
     } catch (error) {
-        const invalidJson = invalidJsonResponse(error);
-        if (invalidJson) return invalidJson;
-
         return errorResponse(error, "subscribe to notifications");
     }
 }

--- a/mobile/src/app/api/notifications/unsubscribe/route.ts
+++ b/mobile/src/app/api/notifications/unsubscribe/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import { z } from "zod";
 
 import { serverAPIClient } from "@/lib/api/server";
 import {
@@ -6,10 +7,17 @@ import {
     errorResponse,
     getAuthHeaders,
     getAuthToken,
-    invalidJsonResponse,
-    readJsonObjectBody,
+    parseBody,
     unauthorizedResponse,
 } from "@/lib/api/route-utils";
+
+// Mirrors backend UnsubscribePushDto: endpoint is the only field, @IsString()
+// @IsNotEmpty() required. Passthrough preserves any forward-compatible fields.
+const unsubscribePushSchema = z
+    .object({
+        endpoint: z.string().min(1),
+    })
+    .passthrough();
 
 export async function POST(request: NextRequest) {
     try {
@@ -18,15 +26,14 @@ export async function POST(request: NextRequest) {
             return unauthorizedResponse("Unauthorized");
         }
 
-        const body = await readJsonObjectBody(request);
-        const response = await serverAPIClient.post("/notifications/unsubscribe", body, {
+        const { data, response: invalid } = await parseBody(unsubscribePushSchema, request);
+        if (invalid) return invalid;
+
+        const response = await serverAPIClient.post("/notifications/unsubscribe", data, {
             headers: getAuthHeaders(token),
         });
         return backendJsonResponse(response);
     } catch (error) {
-        const invalidJson = invalidJsonResponse(error);
-        if (invalidJson) return invalidJson;
-
         return errorResponse(error, "unsubscribe from notifications");
     }
 }

--- a/mobile/src/app/api/settings/__tests__/route.test.ts
+++ b/mobile/src/app/api/settings/__tests__/route.test.ts
@@ -63,7 +63,7 @@ describe("settings API routes", () => {
     await expect(response.json()).resolves.toEqual({ error: "Failed to fetch alimtalk provider" });
   });
 
-  it("preserves backend status and payload when updating Alimtalk provider settings", async () => {
+  it("forwards validated Alimtalk provider and preserves backend status", async () => {
     mockPut.mockResolvedValue({
       status: 202,
       data: { queued: true },
@@ -73,12 +73,30 @@ describe("settings API routes", () => {
       createRequest("/api/settings/alimtalk-provider", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ provider: "kakao" }),
+        body: JSON.stringify({ provider: "aligo" }),
       }),
     );
 
     expect(response.status).toBe(202);
     await expect(response.json()).resolves.toEqual({ queued: true });
+    expect(mockPut).toHaveBeenCalledWith(
+      "/settings/alimtalk-provider",
+      { provider: "aligo" },
+      { headers: { Authorization: "Bearer auth-token" } },
+    );
+  });
+
+  it("rejects Alimtalk provider values outside the allowed enum before proxying", async () => {
+    const response = await updateAlimtalkProvider(
+      createRequest("/api/settings/alimtalk-provider", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: "kakao" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPut).not.toHaveBeenCalled();
   });
 
   it("rejects malformed Alimtalk provider JSON before proxying", async () => {
@@ -111,5 +129,40 @@ describe("settings API routes", () => {
       error: "Request body must be valid JSON",
     });
     expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("rejects message sender approval requests missing senderPhone before proxying", async () => {
+    const response = await requestMessageSenderApproval(
+      createRequest("/api/settings/message-sender-approval", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("forwards validated message sender approval request to the backend", async () => {
+    mockPost.mockResolvedValue({ status: 200, data: { approvalStatus: "pending" } });
+
+    const approvalBody = { senderPhone: "01012345678" };
+
+    const response = await requestMessageSenderApproval(
+      createRequest("/api/settings/message-sender-approval", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(approvalBody),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ approvalStatus: "pending" });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/settings/message-sender-approval/request",
+      approvalBody,
+      { headers: { Authorization: "Bearer auth-token" } },
+    );
   });
 });

--- a/mobile/src/app/api/settings/alimtalk-provider/route.ts
+++ b/mobile/src/app/api/settings/alimtalk-provider/route.ts
@@ -1,14 +1,24 @@
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import {
     backendJsonResponse,
     errorResponse,
     getAuthHeaders,
     getAuthToken,
-    invalidJsonResponse,
-    readJsonObjectBody,
+    parseBody,
     unauthorizedResponse,
 } from "@/lib/api/route-utils";
+
+// Mirrors backend UpdateAlimtalkProviderDto: provider is @IsString()
+// @IsNotEmpty() @IsIn(ALIMTALK_PROVIDERS) required. The provider enum mirrors
+// backend ALIMTALK_PROVIDERS = ["channeltalk", "aligo", "none"]. Passthrough
+// preserves any forward-compatible fields.
+const updateAlimtalkProviderSchema = z
+    .object({
+        provider: z.enum(["channeltalk", "aligo", "none"]),
+    })
+    .passthrough();
 
 export async function GET(request: NextRequest) {
     try {
@@ -33,17 +43,16 @@ export async function PUT(request: NextRequest) {
             return unauthorizedResponse("Unauthorized");
         }
 
-        const body = await readJsonObjectBody(request);
-        const response = await serverAPIClient.put("/settings/alimtalk-provider", body, {
+        const { data, response: invalid } = await parseBody(updateAlimtalkProviderSchema, request);
+        if (invalid) {
+            return invalid;
+        }
+
+        const response = await serverAPIClient.put("/settings/alimtalk-provider", data, {
             headers: getAuthHeaders(token),
         });
         return backendJsonResponse(response);
     } catch (error) {
-        const invalidJson = invalidJsonResponse(error);
-        if (invalidJson) {
-            return invalidJson;
-        }
-
         return errorResponse(error, "update alimtalk provider");
     }
 }

--- a/mobile/src/app/api/settings/message-sender-approval/route.ts
+++ b/mobile/src/app/api/settings/message-sender-approval/route.ts
@@ -1,14 +1,23 @@
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { serverAPIClient } from "@/lib/api/server";
 import {
   backendJsonResponse,
   errorResponse,
   getAuthHeaders,
   getAuthToken,
-  invalidJsonResponse,
-  readJsonObjectBody,
+  parseBody,
   unauthorizedResponse,
 } from "@/lib/api/route-utils";
+
+// Mirrors backend RequestMessageSenderApprovalDto: senderPhone is @IsString()
+// @IsNotEmpty() @MaxLength(20) required. Passthrough preserves any
+// forward-compatible fields.
+const requestMessageSenderApprovalSchema = z
+  .object({
+    senderPhone: z.string().min(1).max(20),
+  })
+  .passthrough();
 
 export async function GET(request: NextRequest) {
   const token = getAuthToken(request);
@@ -33,11 +42,18 @@ export async function POST(request: NextRequest) {
     return unauthorizedResponse("Unauthorized");
   }
 
+  const { data, response: invalid } = await parseBody(
+    requestMessageSenderApprovalSchema,
+    request,
+  );
+  if (invalid) {
+    return invalid;
+  }
+
   try {
-    const body = await readJsonObjectBody(request);
     const response = await serverAPIClient.post(
       "/settings/message-sender-approval/request",
-      body,
+      data,
       {
         headers: getAuthHeaders(token),
       },
@@ -45,11 +61,6 @@ export async function POST(request: NextRequest) {
 
     return backendJsonResponse(response);
   } catch (error) {
-    const invalidJson = invalidJsonResponse(error);
-    if (invalidJson) {
-      return invalidJson;
-    }
-
     return errorResponse(error, "message sender approval request");
   }
 }

--- a/mobile/src/lib/api/route-utils.ts
+++ b/mobile/src/lib/api/route-utils.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { AxiosError } from "axios";
+import { z } from "zod";
 
 import { serverAPIClient } from "@/lib/api/server";
 import { getServerRuntimeConfig } from "@/lib/env";
@@ -52,6 +53,53 @@ export function invalidJsonResponse(error: unknown): NextResponse | null {
     }
 
     return null;
+}
+
+export type ParsedBody<T> =
+    | { data: T; response: null }
+    | { data: null; response: NextResponse };
+
+/**
+ * Read + zod-validate a JSON request body for mutation routes.
+ *
+ * Proxy routes sit in front of the backend's authoritative ValidationPipe,
+ * so schemas here pin the ESSENTIAL contract (required fields and types —
+ * use .passthrough() for forward-compatible optional fields) rather than
+ * duplicating full backend DTOs. Returns a ready 400 NextResponse on
+ * malformed JSON or schema violation.
+ */
+export async function parseBody<T>(
+    schema: z.ZodType<T>,
+    request: NextRequest,
+): Promise<ParsedBody<T>> {
+    let body: Record<string, unknown>;
+    try {
+        body = await readJsonObjectBody(request);
+    } catch (error) {
+        const invalidJson = invalidJsonResponse(error);
+        return {
+            data: null,
+            response:
+                invalidJson ??
+                NextResponse.json({ error: "Request body must be valid JSON" }, { status: 400 }),
+        };
+    }
+
+    const result = schema.safeParse(body);
+    if (!result.success) {
+        const issues = result.error.issues
+            .slice(0, 5)
+            .map((issue) => `${issue.path.join(".") || "body"}: ${issue.message}`);
+        return {
+            data: null,
+            response: NextResponse.json(
+                { error: "Invalid request body", issues },
+                { status: 400 },
+            ),
+        };
+    }
+
+    return { data: result.data, response: null };
 }
 
 /**


### PR DESCRIPTION
## Summary

P4.4 of the SaaS audit remediation, built by a 4-agent workflow + adversarial completeness audit.

- **Shared `parseBody(schema, request)`** in `route-utils.ts` — reads JSON + zod-validates in one step; malformed JSON and schema violations both return a ready 400 (with up to 5 readable issues)
- **23 previously-unvalidated mutation routes converted** (ai/chat ×3, clients POST, document-categories, auth ×6, alimtalk-templates, alimtalk-trigger-rules, message-templates ×2 incl. the missing `[id]` format guard, message-deliveries/sms, eformsign-docs ×3, notifications ×2, settings ×2)
- The six auth routes also stop 500ing on malformed JSON (previously unhandled `request.json()` throws)
- The paid-SMS path mirrors the backend DTO exactly: `receiver` regex `^[0-9,\-\s]+$`, `message` max 2000
- **Schema philosophy** (anti-drift): pin only fields the backend DTO marks required, `.passthrough()` everything else — the backend `ValidationPipe` stays the authority; the proxy rejects garbage early without duplicating contracts

**Audit results** (read-only agent over the combined diff): 0 missing routes from the target list, 0 out-of-scope edits, 0 behavior-preservation red flags (auth checks, headers, timeouts, SSE/error handling intact). The audit also inventoried ~15 *additional* body-forwarding routes with partial/manual validation (auth/login, auth/token, employees, clients/[id] PATCH family, generate-*, `proxyPostRequest` internals) — queued as a follow-up round, not silently skipped.

## Test plan

- [x] Per-route tests: invalid body → 400 with no proxy call; valid body → forwarded payload asserted (+44 tests)
- [x] Shared auth error-sanitization fixture updated to a schema-valid superset body (upstream-passthrough paths still exercised)
- [x] Full mobile: **510/510 green**, type-check clean, lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)