### PR TITLE
ci(e2e): stand up real-backend stack for mobile Playwright job

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -60,15 +60,37 @@ jobs:
           NEXT_PUBLIC_API_BASE_URL: https://ci-build.invalid
         run: pnpm --filter babyjamjam-admin run build
 
-  # Manual-only until Phase 6 stands up the real backend stack in CI
-  # (Postgres container + migrate deploy + seed + NestJS boot). The suites
-  # are backend-coupled and time out without it — verified 2026-06-06.
+  # Manual-only for now even though the real backend stack is wired here.
+  # Keep this dispatch-only until the existing suite is proven stable enough
+  # to promote from exploratory coverage to a blocking check.
   e2e:
-    name: playwright e2e (manual until real-backend CI lands)
+    name: playwright e2e (dispatch-only real backend)
     if: github.event_name == 'workflow_dispatch'
     needs: verify
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    env:
+      BASE_URL: http://localhost:3000
+      CI: true
+      DATABASE_URL: postgresql://postgres@localhost:5432/postgres
+      DEVELOPMENT_API_BASE_URL: http://localhost:3001
+      DEVELOPMENT_FRONTEND_URL: http://localhost:3000
+      DIRECT_URL: postgresql://postgres@localhost:5432/postgres
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      NODE_ENV: development
+      STORAGE_BOOTSTRAP_DISABLED: '1'
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
 
     steps:
       - uses: actions/checkout@v4
@@ -88,14 +110,35 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Apply database migrations
+        run: pnpm --filter babyjamjam-staff-backend run db:migrate:deploy
+
+      - name: Seed e2e fixtures
+        run: pnpm --filter babyjamjam-staff-backend run db:seed:e2e
+
+      - name: Start backend
+        run: |
+          pnpm --filter babyjamjam-staff-backend run start > /tmp/bjj-backend.log 2>&1 &
+          echo $! > /tmp/bjj-backend.pid
+
+      - name: Wait for backend
+        run: |
+          for attempt in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:3001/ >/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "Backend failed to become ready"
+          cat /tmp/bjj-backend.log
+          exit 1
+
       - name: Install Playwright browsers
         run: pnpm --filter babyjamjam-admin exec playwright install --with-deps chromium
 
       - name: Playwright tests
         run: pnpm --filter babyjamjam-admin run test:e2e
-        env:
-          CI: true
-          JWT_SECRET: ${{ secrets.JWT_SECRET }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
@@ -103,4 +146,12 @@ jobs:
         with:
           name: mobile-playwright-report
           path: mobile/playwright-report/
+          retention-days: 30
+
+      - name: Upload backend log
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mobile-backend-log
+          path: /tmp/bjj-backend.log
           retention-days: 30

--- a/backend/infrastructure/adapters/__tests__/supabase-storage.adapter.spec.ts
+++ b/backend/infrastructure/adapters/__tests__/supabase-storage.adapter.spec.ts
@@ -63,6 +63,22 @@ describe("SupabaseStorageAdapter", () => {
         jest.clearAllMocks();
     });
 
+    it("should skip bucket bootstrap when storage bootstrap is disabled", async () => {
+        const { client } = createSupabaseMock();
+        jest.mocked(createClient).mockReturnValue(client as never);
+
+        const adapter = new SupabaseStorageAdapter(
+            createConfigService({ STORAGE_BOOTSTRAP_DISABLED: "1" }),
+        );
+        const ensureBucketExistsSpy = jest.spyOn(adapter, "ensureBucketExists");
+
+        await adapter.onModuleInit();
+
+        expect(ensureBucketExistsSpy).not.toHaveBeenCalled();
+        expect(client.storage.getBucket).not.toHaveBeenCalled();
+        expect(client.storage.createBucket).not.toHaveBeenCalled();
+    });
+
     it("should create a private bucket when the documents bucket is missing", async () => {
         const { client } = createSupabaseMock();
         client.storage.getBucket.mockResolvedValue({

--- a/backend/infrastructure/adapters/supabase-storage.adapter.ts
+++ b/backend/infrastructure/adapters/supabase-storage.adapter.ts
@@ -18,9 +18,12 @@ export class SupabaseStorageAdapter implements FileStoragePort, OnModuleInit {
   private readonly bucketName = 'documents';
   private readonly logger = new Logger(SupabaseStorageAdapter.name);
   private readonly signedUrlTtlSeconds: number;
+  private readonly storageBootstrapDisabled: boolean;
 
   constructor(private readonly configService: ConfigService) {
     this.signedUrlTtlSeconds = this.parseSignedUrlTtlSeconds();
+    this.storageBootstrapDisabled =
+      this.configService.get<string>('STORAGE_BOOTSTRAP_DISABLED') === '1';
 
     const supabaseUrl = this.configService.get<string>('SUPABASE_URL');
     const supabaseServiceKey = this.configService.get<string>(
@@ -39,6 +42,13 @@ export class SupabaseStorageAdapter implements FileStoragePort, OnModuleInit {
 
   async onModuleInit(): Promise<void> {
     if (!this.supabase) {
+      return;
+    }
+
+    if (this.storageBootstrapDisabled) {
+      this.logger.warn(
+        'STORAGE_BOOTSTRAP_DISABLED=1. Skipping Supabase bucket bootstrap.',
+      );
       return;
     }
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "db:seed": "ts-node prisma/seed.ts",
+    "db:seed:e2e": "ts-node test/e2e-env/seed-e2e.ts",
     "db:migrate": "prisma migrate dev",
     "db:migrate:deploy": "prisma migrate deploy"
   },

--- a/backend/test/e2e-env/seed-e2e.ts
+++ b/backend/test/e2e-env/seed-e2e.ts
@@ -1,0 +1,422 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const BRANCH_ID = "33dbe950-1574-4951-b7b4-92d97ab29512";
+const USER_ID = "ac5f25d7-f8cc-4c68-82a5-db6dc2968c5f";
+const USER_BRANCH_ID = "d3f5b0a3-7892-4715-96de-3db0d0f87f3a";
+const AREA_ID = "namdong";
+const CLIENT_ID = 1;
+
+const now = new Date("2026-06-06T00:00:00.000Z");
+
+const areaTemplates = [
+    {
+        id: "area-template-1",
+        areaId: AREA_ID,
+        templateId: "tpl-create-test",
+        templateName: "남동구 계약서",
+    },
+    {
+        id: "area-template-existing",
+        areaId: AREA_ID,
+        templateId: "tpl-existing-test",
+        templateName: "남동구 계약서",
+    },
+    {
+        id: "area-template-finalize",
+        areaId: AREA_ID,
+        templateId: "tpl-test",
+        templateName: "남동구 계약서",
+    },
+] as const;
+
+const eformsignDocs = [
+    {
+        documentId: "doc-create-test",
+        createdDate: new Date("2026-05-01T09:00:00.000Z"),
+        updatedDate: new Date("2026-05-01T09:00:00.000Z"),
+        statusType: "060",
+        statusDetail: "대기",
+        stepType: "05",
+        stepIndex: "2",
+        stepName: "이용자 서명",
+        stepRecipientType: "02",
+        stepRecipientName: "홍테스트",
+        stepRecipientSms: "01012345678",
+        expiredDate: new Date("2026-06-30T09:00:00.000Z"),
+        clientId: CLIENT_ID,
+    },
+    {
+        documentId: "doc-finalize-test",
+        createdDate: new Date("2026-06-01T09:00:00.000Z"),
+        updatedDate: new Date("2026-06-02T09:00:00.000Z"),
+        statusType: "060",
+        statusDetail: "검토 필요",
+        stepType: "05",
+        stepIndex: "3",
+        stepName: "이용자 서명",
+        stepRecipientType: "01",
+        stepRecipientName: "홍테스트",
+        stepRecipientSms: "01012345678",
+        expiredDate: new Date("2026-06-30T09:00:00.000Z"),
+        clientId: CLIENT_ID,
+    },
+    {
+        documentId: "doc-delete-target",
+        createdDate: new Date("2026-06-03T09:00:00.000Z"),
+        updatedDate: new Date("2026-06-03T09:00:00.000Z"),
+        statusType: "002",
+        statusDetail: "대기",
+        stepType: "01",
+        stepIndex: "1",
+        stepName: "발송 대기",
+        stepRecipientType: "02",
+        stepRecipientName: "홍테스트",
+        stepRecipientSms: "01012345678",
+        expiredDate: new Date("2026-07-03T09:00:00.000Z"),
+        clientId: CLIENT_ID,
+    },
+    {
+        documentId: "doc-keep-1",
+        createdDate: new Date("2026-06-02T09:00:00.000Z"),
+        updatedDate: new Date("2026-06-02T09:00:00.000Z"),
+        statusType: "002",
+        statusDetail: "대기",
+        stepType: "01",
+        stepIndex: "1",
+        stepName: "발송 대기",
+        stepRecipientType: "02",
+        stepRecipientName: "홍테스트",
+        stepRecipientSms: "01012345678",
+        expiredDate: new Date("2026-07-02T09:00:00.000Z"),
+        clientId: CLIENT_ID,
+    },
+] as const;
+
+const systemTemplates = [
+    {
+        id: "tpl-price",
+        templateKey: "PRICE_INFO",
+        content: "비용 안내 메시지: {{name}}",
+    },
+    {
+        id: "tpl-greeting",
+        templateKey: "GREETING",
+        content: "안녕하세요!",
+    },
+    {
+        id: "tpl-thanks",
+        templateKey: "THANKS",
+        content: "감사합니다 {{name}}님",
+    },
+    {
+        id: "tpl-survey",
+        templateKey: "SURVEY",
+        content: "설문 부탁드립니다 {{name}}님",
+    },
+    {
+        id: "tpl-service",
+        templateKey: "SERVICE_INFO",
+        content: "서비스 안내드립니다 {{name}}님",
+    },
+    {
+        id: "tpl-reminder",
+        templateKey: "REMINDER",
+        content: "리마인더입니다 {{name}}님",
+    },
+    {
+        id: "tpl-info",
+        templateKey: "INFO",
+        content: "안내드립니다",
+    },
+] as const;
+
+async function upsertSystemTemplateVersion(
+    templateId: string,
+    content: string,
+): Promise<void> {
+    const existing = await prisma.system_template_version.findFirst({
+        where: {
+            templateId,
+            versionNumber: 1,
+        },
+        select: { id: true },
+    });
+
+    if (existing) {
+        await prisma.system_template_version.update({
+            where: { id: existing.id },
+            data: {
+                content,
+                createdBy: "e2e-seed",
+            },
+        });
+        return;
+    }
+
+    await prisma.system_template_version.create({
+        data: {
+            templateId,
+            content,
+            versionNumber: 1,
+            createdBy: "e2e-seed",
+        },
+    });
+}
+
+async function main(): Promise<void> {
+    await prisma.user.upsert({
+        where: { id: USER_ID },
+        update: {
+            email: "owner-e2e@babyjamjam.test",
+            name: "E2E Owner",
+            role: "owner",
+        },
+        create: {
+            id: USER_ID,
+            email: "owner-e2e@babyjamjam.test",
+            name: "E2E Owner",
+            role: "owner",
+        },
+    });
+
+    await prisma.branch.upsert({
+        where: { id: BRANCH_ID },
+        update: {
+            name: "인천 E2E점",
+            slug: "e2e-namdong",
+            region: "인천",
+            district: "남동구",
+            branchType: "direct",
+            phone: "1661-2386",
+            address: "인천 남동구 테스트로 123",
+            ownerId: USER_ID,
+            isActive: true,
+            smsSenderPhone: "01012345678",
+            smsSenderApprovalStatus: "approved",
+            smsSenderApprovalRequestedAt: now,
+            smsSenderApprovalRequestedBy: USER_ID,
+            smsSenderApprovalApprovedAt: now,
+            smsSenderApprovalApprovedBy: USER_ID,
+        },
+        create: {
+            id: BRANCH_ID,
+            name: "인천 E2E점",
+            slug: "e2e-namdong",
+            region: "인천",
+            district: "남동구",
+            branchType: "direct",
+            phone: "1661-2386",
+            address: "인천 남동구 테스트로 123",
+            ownerId: USER_ID,
+            isActive: true,
+            smsSenderPhone: "01012345678",
+            smsSenderApprovalStatus: "approved",
+            smsSenderApprovalRequestedAt: now,
+            smsSenderApprovalRequestedBy: USER_ID,
+            smsSenderApprovalApprovedAt: now,
+            smsSenderApprovalApprovedBy: USER_ID,
+        },
+    });
+
+    await prisma.user_branch.upsert({
+        where: { id: USER_BRANCH_ID },
+        update: {
+            userId: USER_ID,
+            branchId: BRANCH_ID,
+            role: "admin",
+        },
+        create: {
+            id: USER_BRANCH_ID,
+            userId: USER_ID,
+            branchId: BRANCH_ID,
+            role: "admin",
+        },
+    });
+
+    await prisma.area.upsert({
+        where: { id: AREA_ID },
+        update: {
+            name: "namdong",
+            koreanName: "남동구",
+            branchId: BRANCH_ID,
+        },
+        create: {
+            id: AREA_ID,
+            name: "namdong",
+            koreanName: "남동구",
+            branchId: BRANCH_ID,
+        },
+    });
+
+    for (const template of areaTemplates) {
+        await prisma.doc_template.upsert({
+            where: { id: template.id },
+            update: {
+                areaId: template.areaId,
+                templateId: template.templateId,
+                templateName: template.templateName,
+            },
+            create: template,
+        });
+    }
+
+    await prisma.client.upsert({
+        where: { id: CLIENT_ID },
+        update: {
+            name: "홍테스트",
+            address: "인천 남동구 테스트로 123",
+            phone: "01012345678",
+            birthday: "900101",
+            type: "A가1형",
+            duration: 10,
+            fullPrice: "1234567",
+            grant: "1000000",
+            actualPrice: "234567",
+            dueDate: new Date("2026-05-30T00:00:00.000Z"),
+            careCenter: false,
+            voucherClient: true,
+            branchId: BRANCH_ID,
+            areaId: AREA_ID,
+            eDocId: null,
+        },
+        create: {
+            id: CLIENT_ID,
+            name: "홍테스트",
+            address: "인천 남동구 테스트로 123",
+            phone: "01012345678",
+            birthday: "900101",
+            type: "A가1형",
+            duration: 10,
+            fullPrice: "1234567",
+            grant: "1000000",
+            actualPrice: "234567",
+            dueDate: new Date("2026-05-30T00:00:00.000Z"),
+            careCenter: false,
+            voucherClient: true,
+            branchId: BRANCH_ID,
+            areaId: AREA_ID,
+            eDocId: null,
+        },
+    });
+
+    await prisma.employee.upsert({
+        where: { id: 1 },
+        update: {
+            name: "테스트직원",
+            workArea: ["남동구"],
+            phone: "01000000000",
+            grade: "A",
+            openToNextWork: true,
+            companyRegisteredDate: new Date("2026-01-01T00:00:00.000Z"),
+            branchId: BRANCH_ID,
+        },
+        create: {
+            id: 1,
+            name: "테스트직원",
+            workArea: ["남동구"],
+            phone: "01000000000",
+            grade: "A",
+            openToNextWork: true,
+            companyRegisteredDate: new Date("2026-01-01T00:00:00.000Z"),
+            branchId: BRANCH_ID,
+        },
+    });
+
+    await prisma.employee.upsert({
+        where: { id: 2 },
+        update: {
+            name: "보조직원",
+            workArea: ["남동구"],
+            phone: "01000000001",
+            grade: "A",
+            openToNextWork: true,
+            companyRegisteredDate: new Date("2026-01-02T00:00:00.000Z"),
+            branchId: BRANCH_ID,
+        },
+        create: {
+            id: 2,
+            name: "보조직원",
+            workArea: ["남동구"],
+            phone: "01000000001",
+            grade: "A",
+            openToNextWork: true,
+            companyRegisteredDate: new Date("2026-01-02T00:00:00.000Z"),
+            branchId: BRANCH_ID,
+        },
+    });
+
+    await prisma.voucher_price_info.upsert({
+        where: { id: 2 },
+        update: {
+            type: "A가1형",
+            duration: BigInt(10),
+            fullPrice: "1234567",
+            grant: "1000000",
+            actualPrice: "234567",
+            year: 2026,
+        },
+        create: {
+            id: 2,
+            type: "A가1형",
+            duration: BigInt(10),
+            fullPrice: "1234567",
+            grant: "1000000",
+            actualPrice: "234567",
+            year: 2026,
+        },
+    });
+
+    for (const doc of eformsignDocs) {
+        await prisma.eformsign_doc.upsert({
+            where: { documentId: doc.documentId },
+            update: {
+                ...doc,
+                branchId: BRANCH_ID,
+                expired: false,
+            },
+            create: {
+                ...doc,
+                branchId: BRANCH_ID,
+                expired: false,
+            },
+        });
+    }
+
+    await prisma.client.update({
+        where: { id: CLIENT_ID },
+        data: {
+            eDocId: "doc-finalize-test",
+        },
+    });
+
+    for (const template of systemTemplates) {
+        const persistedTemplate = await prisma.system_template.upsert({
+            where: { templateKey: template.templateKey },
+            update: {
+                content: template.content,
+            },
+            create: {
+                id: template.id,
+                templateKey: template.templateKey,
+                content: template.content,
+            },
+        });
+
+        await upsertSystemTemplateVersion(persistedTemplate.id, template.content);
+    }
+
+    console.log(
+        `Seeded e2e fixtures for branch ${BRANCH_ID} with ${eformsignDocs.length} documents and ${systemTemplates.length} system templates.`,
+    );
+}
+
+main()
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    })
+    .finally(async () => {
+        await prisma.$disconnect();
+    });


### PR DESCRIPTION
## Summary

P6.3a of the SaaS audit remediation (user decision: **real backend in CI**, never route-mock conversions). The dispatch-only mobile e2e job now provisions the full stack in-job:

`postgres:16` (trust auth — no password-shaped strings, GitGuardian-proven pattern) → `prisma migrate deploy` → **idempotent seed** (`backend/test/e2e-env/seed-e2e.ts`: E2E user `ac5f25d7…`/org `33dbe950…`, client 1 홍테스트, employees 1–2, namdong area + `tpl-*` doc templates, voucher price info, `doc-create-test`/`doc-finalize-test`/`doc-delete-target`, system templates) → NestJS boot on :3001 (vendors unconfigured → existing warn-and-disable paths; **no real SMS/alimtalk/eformsign possible**) → existing Playwright suite → report + backend-log artifacts.

One minimal production change: `STORAGE_BOOTSTRAP_DISABLED=1` env-gates the Supabase bucket bootstrap in `onModuleInit` (the only boot-time vendor network call), with unit coverage. Seed work also surfaced and fixed a real FK-ordering hazard on `client.eDocId`.

**Status honesty:** the job stays `workflow_dispatch`-only. Local proof ran migrate+seed clean against a disposable Postgres; the backend-boot step was blocked locally by an unrelated process squatting :3001, so the first clean-runner dispatch (post-merge) is the authoritative stack proof. Known mock-first suites (`contract-creation`, `staff-finalize`, `contracts-delete`) are expected to need follow-up (P6.3b) before this can flip to blocking.

## Test plan

- [x] Backend: type-check clean, lint 0 errors, **105 suites / 1078 tests green** (incl. new bootstrap-skip test)
- [x] `migrate deploy` + seed proven against a disposable local Postgres
- [ ] Post-merge: `workflow_dispatch` run on a clean runner → harvest pass/fail per suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)