### PR TITLE
chore(workspace): scaffold inert @babyjamjam/shared package

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -6,6 +6,7 @@ on:
     branches: [ main, dev, preview, "feature/**", "fix/**", "ci/**" ]
     paths:
       - 'frontend/**'
+      - 'packages/shared/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -6,6 +6,7 @@ on:
     branches: [ main, dev, preview, "feature/**", "fix/**" ]
     paths:
       - 'mobile/**'
+      - 'packages/shared/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -12,6 +12,8 @@ const localStaticGenerationMaxConcurrency =
     readPositiveInt(process.env.NEXT_STATIC_GENERATION_MAX_CONCURRENCY) ?? (process.env.CI ? undefined : 1);
 
 const nextConfig: NextConfig = {
+    // Workspace package ships TS source; Next transpiles it in-app.
+    transpilePackages: ["@babyjamjam/shared"],
     turbopack: {
         root: path.resolve(__dirname, ".."),
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "magi": "node ./bin/magi"
   },
   "dependencies": {
+    "@babyjamjam/shared": "workspace:*",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/mobile/next.config.ts
+++ b/mobile/next.config.ts
@@ -6,6 +6,8 @@ const nextConfig: NextConfig = {
     env: {
         NEXT_PUBLIC_APP_VERSION: packageJson.version,
     },
+    // Workspace package ships TS source; Next transpiles it in-app.
+    transpilePackages: ["@babyjamjam/shared"],
     turbopack: {
         root: path.resolve(__dirname, ".."),
     },

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -17,6 +17,7 @@
     "test:screenshots": "playwright test tests/screenshots"
   },
   "dependencies": {
+    "@babyjamjam/shared": "workspace:*",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "@babyjamjam/shared",
+    "version": "0.1.0",
+    "private": true,
+    "description": "Shared types, utils, and API plumbing for the babyjamjam frontend and mobile apps",
+    "type": "module",
+    "main": "src/index.ts",
+    "types": "src/index.ts",
+    "exports": {
+        ".": "./src/index.ts"
+    },
+    "scripts": {
+        "type-check": "tsc --noEmit"
+    },
+    "devDependencies": {
+        "typescript": "^5"
+    }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,4 @@
+// Intentionally empty: P5 slices 5.2-5.5 move shared code (eslint plugin,
+// lib/utils, drifted types, API plumbing) here incrementally. Each slice is
+// its own PR with the frontend/mobile test+lint baselines held.
+export {};

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM"],
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "strict": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+        "esModuleInterop": true,
+        "isolatedModules": true
+    },
+    "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
 
   frontend:
     dependencies:
+      '@babyjamjam/shared':
+        specifier: workspace:*
+        version: link:../packages/shared
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -363,6 +366,9 @@ importers:
 
   mobile:
     dependencies:
+      '@babyjamjam/shared':
+        specifier: workspace:*
+        version: link:../packages/shared
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -535,6 +541,12 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.2.1
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
+  packages/shared:
+    devDependencies:
       typescript:
         specifier: ^5
         version: 5.9.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - frontend
   - mobile
   - backend
+  - packages/*


### PR DESCRIPTION
## Summary

P5.1 of the SaaS audit remediation — the inert scaffold slice:

- `packages/*` added to `pnpm-workspace.yaml`; `@babyjamjam/shared` created with empty exports (`export {}`)
- `workspace:*` dep in both apps; `transpilePackages: ["@babyjamjam/shared"]` in both Next configs (package ships TS source)
- `packages/shared/**` added to both CI push-path filters — the follow-up promised in the PR #221 review thread
- Lockfile picks up the workspace link (+12 lines)

Nothing imports the package yet. Slices 5.2–5.5 (eslint plugin → lib/utils → drifted types per group → API plumbing) each land as their own PR with the frontend 245 / mobile-suite baselines held.

## Test plan

- [x] Mobile: type-check, lint 0 errors, full jest green, production build exit 0
- [x] Frontend: type-check, lint 0 errors, 245/245, production build exit 0
- [x] `pnpm install` idempotent (workspace link only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)