### PR TITLE
fix(mobile): accept null sessionId and drop proxy-only caps in chat schemas

### DIFF
--- a/mobile/src/app/api/ai/chat/__tests__/route.test.ts
+++ b/mobile/src/app/api/ai/chat/__tests__/route.test.ts
@@ -175,6 +175,58 @@ describe("AI chat API routes", () => {
     expect(forwarded).toEqual({ message: "hello", sessionId: "s1" });
   });
 
+  it("accepts a null sessionId for new chat sessions", async () => {
+    // Regression (PR #236 review): useChatStream sends sessionId: null until
+    // the backend assigns one; the proxy must not 400 first-time chats.
+    setAuthCookie("auth-token");
+    mockFetch.mockResolvedValue(
+      new Response("event: message\ndata: {}\n\n", {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    );
+
+    const response = await streamChat(
+      createRequest(
+        "/api/ai/chat/stream",
+        JSON.stringify({ message: "hello", sessionId: null }),
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const forwarded = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(forwarded).toEqual({ message: "hello", sessionId: null });
+  });
+
+  it("persists null-session and long assistant replies without a proxy cap", async () => {
+    // Regression (PR #236 review): long generated answers must not be
+    // silently dropped from history by a proxy-only length cap.
+    setAuthCookie("auth-token");
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const longReply = "가".repeat(20_000);
+    const response = await persistChat(
+      createRequest(
+        "/api/ai/chat/persist",
+        JSON.stringify({
+          userMessage: "질문",
+          assistantContent: longReply,
+          sessionId: null,
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const forwarded = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(forwarded.assistantContent).toHaveLength(20_000);
+    expect(forwarded.sessionId).toBeNull();
+  });
+
   it("maps stream transport failures to a structured SSE error", async () => {
     setAuthCookie("auth-token");
     mockFetch.mockRejectedValue(new Error("backend unavailable"));

--- a/mobile/src/app/api/ai/chat/feedback/route.ts
+++ b/mobile/src/app/api/ai/chat/feedback/route.ts
@@ -15,7 +15,7 @@ const chatFeedbackSchema = z
         type: z.enum(["positive", "negative"]),
         messageId: z.string().optional(),
         messageIndex: z.number().int().min(0).optional(),
-        comment: z.string().max(10_000).optional(),
+        comment: z.string().optional(),
     })
     .passthrough();
 

--- a/mobile/src/app/api/ai/chat/persist/route.ts
+++ b/mobile/src/app/api/ai/chat/persist/route.ts
@@ -7,13 +7,15 @@ import { parseBody, upstreamJsonErrorResponse } from "@/lib/api/route-utils";
 const BACKEND_URL = BACKEND_BASE_URL;
 
 // Mirrors backend ChatPersistDto: `userMessage` and `assistantContent` are
-// required (@IsNotEmpty @IsString); `sessionId` is optional. Other fields pass
-// through to the backend pipe.
+// required (@IsNotEmpty @IsString); `sessionId` is optional and may be null
+// for new sessions (class-validator @IsOptional allows null). No length caps:
+// the backend DTO has none, and long generated replies are a normal outcome —
+// a proxy-only cap would silently drop turns from history.
 const chatPersistSchema = z
     .object({
-        userMessage: z.string().min(1).max(10_000),
-        assistantContent: z.string().min(1).max(10_000),
-        sessionId: z.string().optional(),
+        userMessage: z.string().min(1),
+        assistantContent: z.string().min(1),
+        sessionId: z.string().nullable().optional(),
     })
     .passthrough();
 

--- a/mobile/src/app/api/ai/chat/stream/route.ts
+++ b/mobile/src/app/api/ai/chat/stream/route.ts
@@ -7,11 +7,13 @@ import { parseBody, upstreamSseErrorResponse } from "@/lib/api/route-utils";
 const BACKEND_URL = BACKEND_BASE_URL;
 
 // Mirrors backend ChatStreamDto: `message` is required (@IsNotEmpty @IsString),
-// `sessionId` optional string. Other fields pass through to the backend pipe.
+// `sessionId` optional. useChatStream sends sessionId: null for NEW sessions
+// and class-validator's @IsOptional treats null as absent, so the proxy must
+// accept null too. No message cap: the backend DTO has none.
 const chatStreamSchema = z
     .object({
-        message: z.string().min(1).max(10_000),
-        sessionId: z.string().optional(),
+        message: z.string().min(1),
+        sessionId: z.string().nullable().optional(),
     })
     .passthrough();
 


### PR DESCRIPTION
## Summary

Hotfix for two valid findings from the Codex review on PR #236 — the first is a live regression:

- **P1**: `useChatStream` initializes `sessionId: null` for new sessions (`useChatStream.ts:109,342-344`) and the backend's `@IsOptional` accepts null — but the proxy schema rejected it, so **every first-time chat request 400'd**. `sessionId` is now `.nullable().optional()` in stream + persist.
- **P2**: the proxy-only 10k caps (`message`, `userMessage`, `assistantContent`, feedback `comment`) are removed — the backend DTOs carry no caps, and a long generated reply would render in the UI while the persist call silently failed, dropping the turn from history. Caps were drift, exactly what the schema philosophy says to avoid.

## Test plan

- [x] New regression tests: `sessionId: null` stream → 200 + forwarded verbatim; 20,000-char `assistantContent` persists uncapped with null session
- [x] Chat suite 22/22; full mobile **567/567 green**, type-check clean, lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)