### PR TITLE
fix(mobile): use server logout action on branch selector

### DIFF
--- a/mobile/src/app/select-branch/page.tsx
+++ b/mobile/src/app/select-branch/page.tsx
@@ -7,6 +7,7 @@ import { Building2, Check } from "lucide-react";
 import { useInitialUser } from "@/providers/UserProvider";
 import { useLocale } from "@/providers/LocaleProvider";
 import { t } from "@/lib/i18n/translations";
+import { logout } from "@/app/logout/actions";
 import { getUserBranches, setCurrentBranch } from "./actions";
 import "@/components/app/mobile-redesign/redesign.css";
 
@@ -84,10 +85,11 @@ export default function SelectBranchPage() {
     fetchBranches();
   }, [confirmSelectBranch]);
 
-  const handleLogout = () => {
-    document.cookie = "auth_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
-    document.cookie = "refresh_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
-    document.cookie = "selected_branch_id=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+  const handleLogout = async () => {
+    // auth_token/refresh_token are httpOnly — document.cookie cannot clear
+    // them, and the middleware bounces authenticated users straight back
+    // from /login. The server action clears them properly.
+    await logout();
     router.replace("/login");
   };
 


### PR DESCRIPTION
## Summary

Addresses the Codex review finding on PR #220 (verified real): the branch-selector logout cleared cookies via `document.cookie`, but `auth_token`/`refresh_token` are httpOnly — the writes were silent no-ops, and the middleware redirects authenticated users straight back from `/login`, so logout looped into the app. Now calls the existing `logout()` server action (clears httpOnly cookies + notifies the backend) before `router.replace("/login")`.

## Test plan

- [x] Mobile type-check clean, lint 0 errors (after clearing a local playwright-report artifact), 565 tests green
- [x] Build via required CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)