### PR TITLE
ci(e2e): generate Prisma client before seeding

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "db:seed": "ts-node prisma/seed.ts",
-    "db:seed:e2e": "ts-node test/e2e-env/seed-e2e.ts",
+    "db:seed:e2e": "prisma generate && ts-node test/e2e-env/seed-e2e.ts",
     "db:migrate": "prisma migrate dev",
     "db:migrate:deploy": "prisma migrate deploy"
   },


### PR DESCRIPTION
## Summary

The first `workflow_dispatch` run of the real-backend e2e stack (post-#238) failed at the **seed step**: `test/e2e-env/seed-e2e.ts(1,10): error TS2305: Module '"@prisma/client"' has no exported member 'PrismaClient'`. pnpm v10 blocks Prisma's postinstall `generate`, and the e2e job path — unlike the backend `type-check` script, which runs `prisma generate &&` for exactly this reason — never generated the client.

`db:seed:e2e` now runs `prisma generate` first. The seed step precedes backend start, so the boot step is covered too. Playwright never executed in the failed run, so this is the next gate to the actual suite-vs-real-stack results.

## Test plan

- [x] Backend type-check/lint/jest unaffected (script-only change)
- [ ] Post-merge: re-dispatch the e2e run → expect the seed + boot to pass and Playwright to produce its first clean-runner verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)