### PR TITLE
chore(db): carry live RLS state as a real migration

### DIFF
--- a/backend/prisma/migrations/20260607000000_rls_baseline/migration.sql
+++ b/backend/prisma/migrations/20260607000000_rls_baseline/migration.sql
@@ -1,0 +1,42 @@
+-- RLS baseline: row-level-security state introspected from the live dev DB
+-- (pg_class.relrowsecurity + pg_policies, 2026-06-07). The 0_init baseline
+-- could not capture these objects because `prisma migrate diff` emits only
+-- datamodel DDL — Prisma itself warned the RLS setup must be carried
+-- manually (see PR #223 review). Fresh databases (CI e2e, future envs) now
+-- match the live schema.
+--
+-- Live truth notes:
+--  * voucher_price_info_2025 has RLS DISABLED live — intentionally absent.
+--  * The anon public-read policy on bank_account_info is reproduced
+--    faithfully but flagged as a likely unintended PII exposure (accNum is
+--    anon-readable via Supabase PostgREST). Dropping it is a separate,
+--    decision-gated migration pending operator sign-off.
+--  * The prod DB is separate; the migrations-cutover drift check re-verifies
+--    this state against prod before `migrate resolve`.
+
+-- Plain-Postgres environments (CI e2e service container) lack Supabase's
+-- predefined roles; create an inert stand-in so the policies apply cleanly.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN
+        CREATE ROLE anon NOLOGIN;
+    END IF;
+END
+$$;
+
+ALTER TABLE "bank_account_info" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "voucher_price_info" ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Allow public read access on bankAccountInfo" ON "bank_account_info";
+CREATE POLICY "Allow public read access on bankAccountInfo"
+    ON "bank_account_info"
+    FOR SELECT
+    TO anon
+    USING (true);
+
+DROP POLICY IF EXISTS "Allow public read access on voucherPriceInfo" ON "voucher_price_info";
+CREATE POLICY "Allow public read access on voucherPriceInfo"
+    ON "voucher_price_info"
+    FOR SELECT
+    TO anon
+    USING (true);


### PR DESCRIPTION
## Summary

Closes the Codex review finding on PR #223: the `0_init` baseline (generated via `prisma migrate diff`) silently dropped the live DB's row-level-security objects — fresh databases (including the new e2e CI database) were being built less restrictive than dev/prod.

Introspected live state (dev DB, read-only, 2026-06-07):

| table | RLS | policy |
|---|---|---|
| `bank_account_info` | enabled | `anon` public-read SELECT, `USING (true)` |
| `voucher_price_info` | enabled | `anon` public-read SELECT, `USING (true)` |
| `voucher_price_info_2025` | **disabled** | none — intentionally absent from the migration |

- Idempotent (`DROP POLICY IF EXISTS` + `CREATE`); safe on databases that already carry the objects (post-cutover `migrate deploy` against staging/prod)
- Creates an inert `NOLOGIN` `anon` role when missing, so the plain-Postgres CI service container applies cleanly
- **Proven locally**: `0_init` → this migration on a disposable cluster reproduces the live state exactly (verified via `pg_class.relrowsecurity` + `pg_policies`)
- Drift guard unaffected: RLS objects are invisible to the datamodel diff

## ⚠️ Flagged for operator decision (NOT changed here)

The `anon` public-read policy on **`bank_account_info`** makes account numbers (P7 tier-1 PII) readable through Supabase PostgREST with the public anon key — it looks like a copy-paste of the voucher-price policy. Recommended: drop it (one-line gated migration) after confirming no legitimate anon consumer exists. Awaiting sign-off.

## Test plan

- [x] Local two-migration chain proof on disposable Postgres (state matches live; re-run idempotent)
- [x] Backend CI drift guard + jest run as required checks on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)