### PR TITLE
fix(security): webhook allow-list env split; block cross-tenant path signing

### DIFF
--- a/backend/application/services/document.service.ts
+++ b/backend/application/services/document.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject, NotFoundException } from "@nestjs/common";
+import { Injectable, Inject, NotFoundException, ForbiddenException } from "@nestjs/common";
 import { DocumentEntity } from "domain/entities/document.entity";
 import { IDocumentRepository, DOCUMENT_REPOSITORY } from "domain/repositories/document.repository.interface";
 
@@ -21,6 +21,14 @@ export class DocumentService {
         branchid?: string;
         uploadedby: string;
     }): Promise<DocumentEntity> {
+        const isClaimedOutsideBranch = await this.documentRepository.existsByStoragePathOutsideBranch(
+            branchId,
+            params.storagepath,
+        );
+        if (isClaimedOutsideBranch) {
+            throw new ForbiddenException("storage path unavailable");
+        }
+
         const doc = DocumentEntity.create({
             name: params.name,
             description: params.description,

--- a/backend/domain/repositories/document.repository.interface.ts
+++ b/backend/domain/repositories/document.repository.interface.ts
@@ -12,6 +12,7 @@ export interface IDocumentRepository {
     findByOrgId(branchid: string, orgId: string): Promise<DocumentEntity[]>;
     findByCategoryId(branchid: string, categoryId: string): Promise<DocumentEntity[]>;
     findAll(branchid: string): Promise<DocumentEntity[]>;
+    existsByStoragePathOutsideBranch(branchid: string, storagePath: string): Promise<boolean>;
     create(branchid: string, doc: DocumentEntity): Promise<DocumentEntity>;
     update(branchid: string, doc: DocumentEntity): Promise<DocumentEntity>;
     delete(branchid: string, id: string): Promise<void>;

--- a/backend/env.example
+++ b/backend/env.example
@@ -9,5 +9,9 @@ PRODUCTION_FRONTEND_URL="http://localhost:3000"
 PREVIEW_FRONTEND_URL="http://localhost:3000"
 STORAGE_SIGNED_URL_TTL_SECONDS="300"
 
+EFORMSIGN_COMPANY_ID="replace-me"
+EFORMSIGN_WEBHOOK_ALLOWED_COMPANY_IDS=""
+EFORMSIGN_WEBHOOK_SECRET="replace-me"
+
 # Railway Static Outbound IP registered in the Aligo console for this environment.
 ALIGO_STATIC_OUTBOUND_IP="replace-me"

--- a/backend/infrastructure/auth/webhook.guard.ts
+++ b/backend/infrastructure/auth/webhook.guard.ts
@@ -65,13 +65,10 @@ export class WebhookGuard implements CanActivate {
             throw new ForbiddenException("Unknown company id");
         }
 
-        const allowedCompanyIds = (this.configService.get<string>("EFORMSIGN_COMPANY_ID") ?? "")
-            .split(",")
-            .map((value) => value.trim())
-            .filter(Boolean);
+        const allowedCompanyIds = this.getAllowedCompanyIds();
 
         if (allowedCompanyIds.length === 0) {
-            this.logger.error("EFORMSIGN_COMPANY_ID not configured");
+            this.logger.error("EFORMSIGN_WEBHOOK_ALLOWED_COMPANY_IDS or EFORMSIGN_COMPANY_ID not configured");
             throw new ForbiddenException("Webhook tenant validation not configured");
         }
 
@@ -84,6 +81,19 @@ export class WebhookGuard implements CanActivate {
             );
             throw new ForbiddenException("Unknown company id");
         }
+    }
+
+    private getAllowedCompanyIds(): string[] {
+        const webhookAllowedCompanyIds = this.configService.get<string>("EFORMSIGN_WEBHOOK_ALLOWED_COMPANY_IDS");
+        if (typeof webhookAllowedCompanyIds === "string" && webhookAllowedCompanyIds.trim().length > 0) {
+            return webhookAllowedCompanyIds
+                .split(",")
+                .map((value) => value.trim())
+                .filter(Boolean);
+        }
+
+        const fallbackCompanyId = this.configService.get<string>("EFORMSIGN_COMPANY_ID")?.trim() ?? "";
+        return fallbackCompanyId ? [fallbackCompanyId] : [];
     }
 
     private secureCompare(a: string, b: string): boolean {

--- a/backend/infrastructure/database/repositories/sb.document.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.document.repository.ts
@@ -1,24 +1,8 @@
 import { Injectable } from "@nestjs/common";
-import { IDocumentRepository, DocumentFilter } from "domain/repositories/document.repository.interface";
+import { IDocumentRepository } from "domain/repositories/document.repository.interface";
 import { DocumentEntity } from "domain/entities/document.entity";
 import { PrismaService } from "infrastructure/database/prisma.service";
 import { DocumentMapper } from "infrastructure/database/mapper/document.mapper";
-
-type PrismaDocumentRow = {
-    id: string;
-    name: string;
-    description: string | null;
-    category: string;
-    tags: string[];
-    mime_type: string;
-    file_size: number;
-    storage_path: string;
-    storage_url: string | null;
-    org_id: string | null;
-    uploaded_by: string;
-    created_at: Date;
-    updated_at: Date;
-};
 
 @Injectable()
 export class DocumentRepository implements IDocumentRepository {
@@ -50,6 +34,21 @@ export class DocumentRepository implements IDocumentRepository {
             where: { branchId: branchid },
         });
         return docs.map(DocumentMapper.toDomain);
+    }
+
+    async existsByStoragePathOutsideBranch(branchid: string, storagePath: string): Promise<boolean> {
+        const existingDocument = await this.prismaService.document.findFirst({
+            where: {
+                storagePath,
+                OR: [
+                    { branchId: null },
+                    { branchId: { not: branchid } },
+                ],
+            },
+            select: { id: true },
+        });
+
+        return existingDocument !== null;
     }
 
     async create(branchid: string, doc: DocumentEntity): Promise<DocumentEntity> {

--- a/backend/test/infrastructure/auth/webhook.guard.spec.ts
+++ b/backend/test/infrastructure/auth/webhook.guard.spec.ts
@@ -27,6 +27,7 @@ describe("WebhookGuard", () => {
     const defaultConfig: Record<string, string | undefined> = {
         EFORMSIGN_WEBHOOK_SECRET: "webhook-secret",
         EFORMSIGN_COMPANY_ID: "company-1",
+        EFORMSIGN_WEBHOOK_ALLOWED_COMPANY_IDS: undefined,
     };
 
     const createRequest = (overrides?: Partial<MockRequest>): MockRequest => ({
@@ -39,10 +40,22 @@ describe("WebhookGuard", () => {
         ...overrides,
     });
 
-    it("returns true for a valid bearer token and allowed company id", () => {
+    it("returns true for a valid bearer token and fallback company id", () => {
         const guard = new WebhookGuard(createConfigService());
 
         expect(guard.canActivate(createExecutionContext(createRequest()))).toBe(true);
+    });
+
+    it("returns true for company ids listed in EFORMSIGN_WEBHOOK_ALLOWED_COMPANY_IDS", () => {
+        const guard = new WebhookGuard(createConfigService({
+            EFORMSIGN_WEBHOOK_ALLOWED_COMPANY_IDS: "company-1, company-2",
+        }));
+
+        expect(guard.canActivate(createExecutionContext(createRequest({
+            body: {
+                company_id: "company-2",
+            },
+        })))).toBe(true);
     });
 
     it("throws 401 when the authorization header is missing", () => {
@@ -64,11 +77,30 @@ describe("WebhookGuard", () => {
     });
 
     it("throws 403 when the company id is unknown", () => {
-        const guard = new WebhookGuard(createConfigService());
+        const guard = new WebhookGuard(createConfigService({
+            EFORMSIGN_WEBHOOK_ALLOWED_COMPANY_IDS: "company-1, company-2",
+        }));
 
         expect(() => guard.canActivate(createExecutionContext(createRequest({
             body: {
                 company_id: "unknown-company",
+            },
+        })))).toThrow(ForbiddenException);
+    });
+
+    it("treats fallback EFORMSIGN_COMPANY_ID as one literal value without splitting commas", () => {
+        const guard = new WebhookGuard(createConfigService({
+            EFORMSIGN_COMPANY_ID: "company-1,company-2",
+        }));
+
+        expect(guard.canActivate(createExecutionContext(createRequest({
+            body: {
+                company_id: "company-1,company-2",
+            },
+        })))).toBe(true);
+        expect(() => guard.canActivate(createExecutionContext(createRequest({
+            body: {
+                company_id: "company-1",
             },
         })))).toThrow(ForbiddenException);
     });

--- a/backend/test/integration/document.controller.integration.spec.ts
+++ b/backend/test/integration/document.controller.integration.spec.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, INestApplication, ValidationPipe } from "@nestjs/common";
+import { ExecutionContext, ForbiddenException, INestApplication, ValidationPipe } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { DocumentService } from "application/services/document.service";
 import { DocumentEntity } from "domain/entities/document.entity";
@@ -135,6 +135,26 @@ describe("DocumentController (Integration)", () => {
         );
         expect(documentService.create.mock.calls[0]?.[1]).not.toHaveProperty("storageurl");
         expect(fileStorage.createSignedUrl).toHaveBeenCalledWith("documents/contract.pdf");
+    });
+
+    it("should reject unavailable storage paths before signing a URL", async () => {
+        documentService.create.mockRejectedValue(new ForbiddenException("storage path unavailable"));
+
+        const response = await request(app.getHttpServer())
+            .post("/documents")
+            .send({
+                name: "Contract",
+                categoryId: "contract",
+                tags: ["signed"],
+                mimetype: "application/pdf",
+                filesize: 100,
+                storagepath: "documents/shared.pdf",
+                uploadedby: "user-1",
+            });
+
+        expect(response.status).toBe(403);
+        expect(response.body.message).toBe("storage path unavailable");
+        expect(fileStorage.createSignedUrl).not.toHaveBeenCalled();
     });
 
     it("should use tenant branch as document metadata branch when uploading documents", async () => {

--- a/backend/test/services/document.service.spec.ts
+++ b/backend/test/services/document.service.spec.ts
@@ -1,0 +1,101 @@
+import { ForbiddenException } from "@nestjs/common";
+
+import { DocumentService } from "application/services/document.service";
+import { DocumentEntity } from "domain/entities/document.entity";
+import { IDocumentRepository } from "domain/repositories/document.repository.interface";
+
+type MockDocumentRepository = jest.Mocked<IDocumentRepository>;
+
+function createDocumentEntity(branchId: string, storagePath = "documents/contract.pdf"): DocumentEntity {
+    return DocumentEntity.reconstitute(
+        "doc-1",
+        "Contract",
+        null,
+        "contract",
+        ["signed"],
+        "application/pdf",
+        100,
+        storagePath,
+        null,
+        branchId,
+        "user-1",
+        new Date("2026-01-01T00:00:00.000Z"),
+        new Date("2026-01-01T00:00:00.000Z"),
+    );
+}
+
+function createRepository(): MockDocumentRepository {
+    return {
+        findById: jest.fn(),
+        findByOrgId: jest.fn(),
+        findByCategoryId: jest.fn(),
+        findAll: jest.fn(),
+        existsByStoragePathOutsideBranch: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+    };
+}
+
+describe("DocumentService", () => {
+    let documentRepository: MockDocumentRepository;
+    let service: DocumentService;
+
+    beforeEach(() => {
+        documentRepository = createRepository();
+        service = new DocumentService(documentRepository);
+    });
+
+    it("rejects document creation when another branch already claims the storage path", async () => {
+        documentRepository.existsByStoragePathOutsideBranch.mockResolvedValue(true);
+
+        await expect(service.create("branch-1", {
+            name: "Contract",
+            description: "Branch contract",
+            categoryId: "contract",
+            tags: ["signed"],
+            mimetype: "application/pdf",
+            filesize: 100,
+            storagepath: "documents/shared.pdf",
+            branchid: "branch-1",
+            uploadedby: "user-1",
+        })).rejects.toThrow(new ForbiddenException("storage path unavailable"));
+
+        expect(documentRepository.existsByStoragePathOutsideBranch).toHaveBeenCalledWith(
+            "branch-1",
+            "documents/shared.pdf",
+        );
+        expect(documentRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("preserves same-branch storage path re-creation behavior", async () => {
+        const createdEntity = createDocumentEntity("branch-1");
+        documentRepository.existsByStoragePathOutsideBranch.mockResolvedValue(false);
+        documentRepository.create.mockResolvedValue(createdEntity);
+
+        const result = await service.create("branch-1", {
+            name: "Contract",
+            description: "Branch contract",
+            categoryId: "contract",
+            tags: ["signed"],
+            mimetype: "application/pdf",
+            filesize: 100,
+            storagepath: "documents/contract.pdf",
+            branchid: "branch-1",
+            uploadedby: "user-1",
+        });
+
+        expect(result).toBe(createdEntity);
+        expect(documentRepository.existsByStoragePathOutsideBranch).toHaveBeenCalledWith(
+            "branch-1",
+            "documents/contract.pdf",
+        );
+        expect(documentRepository.create).toHaveBeenCalledWith(
+            "branch-1",
+            expect.objectContaining({
+                storagePath: "documents/contract.pdf",
+                orgId: "branch-1",
+            }),
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Closes the two remaining verified findings from the Codex reviews on PR #228 and PR #227:

**1. Webhook allow-list no longer overloads `EFORMSIGN_COMPANY_ID`** — the guard splits only the new dedicated `EFORMSIGN_WEBHOOK_ALLOWED_COMPANY_IDS`; the fallback to `EFORMSIGN_COMPANY_ID` treats it as a single literal (no comma split). Configuring a multi-tenant allow-list can no longer corrupt the outbound `company.id` used by `EformsignService` (`eformsign.service.ts:168,267`). Tests cover the comma-list var, the single-id fallback, and the comma-containing-fallback-stays-literal case. `env.example` documents the new var.

**2. Cross-tenant signing oracle closed** — `DocumentService.create` now rejects (403, non-leaky `"storage path unavailable"`) when the client-supplied `storagepath` is already claimed by a document in another branch, before persistence and before any signed-URL minting. New repo method `existsByStoragePathOutsideBranch` (boolean existence check, branch-first signature per house style). Same-branch duplicates keep existing behavior; `update` cannot change `storagepath` (not exposed in the DTO — verified). **Residual risk documented:** orphan storage keys with no DB row remain outside a DB-only guard; per-tenant path prefixes are the structural follow-up.

## Test plan

- [x] New guard specs (allow-list var, fallback literal, 403 paths) + document.service spec + integration spec updates
- [x] Backend full suite outside sandbox: **106 suites, 1083 passed / 8 skipped**, type-check clean, lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)