### PR TITLE
test(mobile): auth-rejection coverage for the high-risk proxy surface

### DIFF
--- a/mobile/src/app/api/__tests__/alimtalk-routes.test.ts
+++ b/mobile/src/app/api/__tests__/alimtalk-routes.test.ts
@@ -46,6 +46,28 @@ describe("Alimtalk API routes", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  describe("auth rejection", () => {
+    const noAuth = { headers: { cookie: "" } };
+
+    it("rejects alimtalk logs GET without an auth cookie before proxying", async () => {
+      const response = await listAlimtalkLogs(createRequest("/api/alimtalk-logs", noAuth));
+      expect(response.status).toBe(401);
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects upcoming jobs GET without an auth cookie before proxying", async () => {
+      const response = await listUpcomingJobs(createRequest("/api/alimtalk-trigger-jobs/upcoming", noAuth));
+      expect(response.status).toBe(401);
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects trigger templates GET without an auth cookie before proxying", async () => {
+      const response = await listTriggerTemplates(createRequest("/api/alimtalk-trigger-templates", noAuth));
+      expect(response.status).toBe(401);
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+  });
+
   it("preserves backend error status and sanitizes payload when listing Alimtalk logs", async () => {
     mockGet.mockRejectedValue({
       response: {

--- a/mobile/src/app/api/access-token/__tests__/route.test.ts
+++ b/mobile/src/app/api/access-token/__tests__/route.test.ts
@@ -40,6 +40,20 @@ describe("POST /api/access-token", () => {
         consoleErrorSpy.mockRestore();
     });
 
+    it("rejects requests without an auth cookie before proxying", async () => {
+        const request = new NextRequest("http://localhost/api/access-token", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ executionTime: 1780000000000 }),
+        });
+
+        const response = await POST(request);
+
+        expect(response.status).toBe(401);
+        await expect(response.json()).resolves.toEqual({ error: "Unauthorized - please log in first" });
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
     it("rejects bodies missing executionTime before proxying", async () => {
         const response = await POST(createRequest(JSON.stringify({ memberEmail: "member@example.com" })));
 

--- a/mobile/src/app/api/admin/feedback/__tests__/route.test.ts
+++ b/mobile/src/app/api/admin/feedback/__tests__/route.test.ts
@@ -46,6 +46,25 @@ describe("admin feedback API authorization", () => {
     mockFetch.mockReset();
   });
 
+  describe("auth rejection", () => {
+    it("rejects feedback detail GET without an auth cookie before proxying", async () => {
+      setAuthCookie();
+      const response = await getFeedbackDetail(
+        createRequest("/api/admin/feedback/fb-1"),
+        { params: Promise.resolve({ id: "fb-1" }) },
+      );
+      expect(response.status).toBe(401);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects feedback stats GET without an auth cookie before proxying", async () => {
+      setAuthCookie();
+      const response = await getFeedbackStats();
+      expect(response.status).toBe(401);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
   it("proxies backend authorization denials when listing feedback", async () => {
     setAuthCookie("user-token");
     mockFetch.mockResolvedValue({ ok: false, status: 403 });

--- a/mobile/src/app/api/ai/chat/__tests__/route.test.ts
+++ b/mobile/src/app/api/ai/chat/__tests__/route.test.ts
@@ -64,6 +64,60 @@ describe("AI chat API routes", () => {
     mockFetch.mockReset();
   });
 
+  describe("auth rejection", () => {
+    it("rejects stream POST without an auth cookie before proxying", async () => {
+      setAuthCookie();
+      const response = await streamChat(createRequest("/api/ai/chat/stream", JSON.stringify({ message: "hi" })));
+      expect(response.status).toBe(401);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects persist POST without an auth cookie before proxying", async () => {
+      setAuthCookie();
+      const response = await persistChat(
+        createRequest("/api/ai/chat/persist", JSON.stringify({ userMessage: "hi", assistantContent: "yo" })),
+      );
+      expect(response.status).toBe(401);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects feedback POST without an auth cookie before proxying", async () => {
+      setAuthCookie();
+      const response = await submitFeedback(
+        createRequest("/api/ai/chat/feedback", JSON.stringify({ sessionId: "s1", type: "positive" })),
+      );
+      expect(response.status).toBe(401);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects history GET without an auth cookie before proxying", async () => {
+      setAuthCookie();
+      const response = await getChatHistory(createGetRequest("/api/ai/chat/history"));
+      expect(response.status).toBe(401);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects session GET without an auth cookie before proxying", async () => {
+      setAuthCookie();
+      const response = await getChatSession(
+        createGetRequest("/api/ai/chat/sessions/session-1"),
+        createSessionParams("session-1"),
+      );
+      expect(response.status).toBe(401);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects session DELETE without an auth cookie before proxying", async () => {
+      setAuthCookie();
+      const response = await deleteChatSession(
+        createGetRequest("/api/ai/chat/sessions/session-1"),
+        createSessionParams("session-1"),
+      );
+      expect(response.status).toBe(401);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
   it("rejects malformed persist JSON before proxying", async () => {
     setAuthCookie("auth-token");
 

--- a/mobile/src/app/api/alimtalk-templates/__tests__/route.test.ts
+++ b/mobile/src/app/api/alimtalk-templates/__tests__/route.test.ts
@@ -51,6 +51,24 @@ describe("alimtalk-template API routes", () => {
     buttons: [],
   };
 
+  describe("auth rejection", () => {
+    const noAuth = { headers: { cookie: "" } };
+
+    it("rejects template GET without an auth cookie before proxying", async () => {
+      const response = await listTemplates(createRequest("/api/alimtalk-templates", noAuth));
+      expect(response.status).toBe(401);
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects template POST without an auth cookie before proxying", async () => {
+      const response = await createTemplate(
+        createRequest("/api/alimtalk-templates", { method: "POST", headers: { cookie: "" } }),
+      );
+      expect(response.status).toBe(401);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+  });
+
   it("forwards the validated payload to the backend when creating templates", async () => {
     mockPost.mockResolvedValue({
       status: 202,

--- a/mobile/src/app/api/alimtalk-trigger-rules/__tests__/route.test.ts
+++ b/mobile/src/app/api/alimtalk-trigger-rules/__tests__/route.test.ts
@@ -51,6 +51,35 @@ describe("Alimtalk trigger rule API routes", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  describe("auth rejection", () => {
+    const noAuth = { headers: { cookie: "" } };
+    const ctx = { params: Promise.resolve({ triggerId: "rule_123" }) };
+
+    it("rejects rule GET without an auth cookie before proxying", async () => {
+      const response = await getRule(createRequest("/api/alimtalk-trigger-rules/rule_123", noAuth), ctx);
+      expect(response.status).toBe(401);
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects rule PATCH without an auth cookie before proxying", async () => {
+      const response = await updateRule(
+        createRequest("/api/alimtalk-trigger-rules/rule_123", { method: "PATCH", headers: { cookie: "" } }),
+        ctx,
+      );
+      expect(response.status).toBe(401);
+      expect(mockPatch).not.toHaveBeenCalled();
+    });
+
+    it("rejects rule DELETE without an auth cookie before proxying", async () => {
+      const response = await deleteRule(
+        createRequest("/api/alimtalk-trigger-rules/rule_123", { method: "DELETE", headers: { cookie: "" } }),
+        ctx,
+      );
+      expect(response.status).toBe(401);
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+  });
+
   it("preserves backend error status and sanitizes payload when listing rules", async () => {
     mockGet.mockRejectedValue({
       response: {

--- a/mobile/src/app/api/area-templates/__tests__/route.test.ts
+++ b/mobile/src/app/api/area-templates/__tests__/route.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+import { GET as listAreaTemplates } from "../route";
+
+jest.mock("@/lib/api/server", () => ({
+  serverAPIClient: {
+    get: jest.fn(),
+  },
+}));
+
+const mockGet = serverAPIClient.get as jest.Mock;
+
+function createRequest(
+  path: string,
+  init: { headers?: Record<string, string> } = {},
+): NextRequest {
+  return new NextRequest(`http://localhost${path}`, {
+    headers: {
+      cookie: "auth_token=auth-token",
+      ...init.headers,
+    },
+  });
+}
+
+describe("area-templates API routes", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  describe("auth rejection", () => {
+    it("rejects area templates GET without an auth cookie before proxying", async () => {
+      const response = await listAreaTemplates(createRequest("/api/area-templates", { headers: { cookie: "" } }));
+      expect(response.status).toBe(401);
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/mobile/src/app/api/bank-account-infos/__tests__/route.test.ts
+++ b/mobile/src/app/api/bank-account-infos/__tests__/route.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+import { GET as listBankAccountInfos } from "../route";
+
+jest.mock("@/lib/api/server", () => ({
+  serverAPIClient: {
+    get: jest.fn(),
+  },
+}));
+
+const mockGet = serverAPIClient.get as jest.Mock;
+
+describe("bank-account-infos API routes", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  describe("auth rejection", () => {
+    it("rejects bank account info listing without auth_token", async () => {
+      const request = new NextRequest("http://localhost/api/bank-account-infos");
+      const response = await listBankAccountInfos(request);
+      expect(response.status).toBe(401);
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/mobile/src/app/api/clients/__tests__/route.test.ts
+++ b/mobile/src/app/api/clients/__tests__/route.test.ts
@@ -5,10 +5,11 @@ import { NextRequest } from "next/server";
 
 import { serverAPIClient } from "@/lib/api/server";
 import { GET as getClients, POST as createClient } from "../route";
-import { GET as getClient, PATCH as updateClient } from "../[id]/route";
+import { GET as getClient, PATCH as updateClient, DELETE as deleteClient } from "../[id]/route";
 import { PATCH as terminateClient } from "../[id]/terminate/route";
 import { PATCH as requestReplacement } from "../[id]/request-replacement/route";
 import { PATCH as completeReplacement } from "../[id]/complete-replacement/route";
+import { GET as checkClientPhone } from "../check-phone/route";
 
 jest.mock("@/lib/api/server", () => ({
   serverAPIClient: {
@@ -22,6 +23,7 @@ jest.mock("@/lib/api/server", () => ({
 const mockGet = serverAPIClient.get as jest.Mock;
 const mockPatch = serverAPIClient.patch as jest.Mock;
 const mockPost = serverAPIClient.post as jest.Mock;
+const mockDelete = serverAPIClient.delete as jest.Mock;
 
 function createRequest(path: string, init: { method?: string; body?: BodyInit; headers?: Record<string, string> } = {}): NextRequest {
   return new NextRequest(`http://localhost${path}`, {
@@ -312,5 +314,74 @@ describe("client API routes", () => {
       {},
       expect.any(Object),
     );
+  });
+});
+
+describe("client API routes auth rejection", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPatch.mockReset();
+    mockDelete.mockReset();
+    mockPost.mockReset();
+  });
+
+  function noAuthRequest(path: string, method = "GET"): NextRequest {
+    return new NextRequest(`http://localhost${path}`, { method });
+  }
+
+  it("rejects client detail GET without auth_token", async () => {
+    const response = await getClient(noAuthRequest("/api/clients/12"), {
+      params: Promise.resolve({ id: "12" }),
+    });
+    expect(response.status).toBe(401);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("rejects client update without auth_token", async () => {
+    const response = await updateClient(noAuthRequest("/api/clients/12", "PATCH"), {
+      params: Promise.resolve({ id: "12" }),
+    });
+    expect(response.status).toBe(401);
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects client delete without auth_token", async () => {
+    const response = await deleteClient(noAuthRequest("/api/clients/12", "DELETE"), {
+      params: Promise.resolve({ id: "12" }),
+    });
+    expect(response.status).toBe(401);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("rejects terminate without auth_token", async () => {
+    const response = await terminateClient(noAuthRequest("/api/clients/12/terminate", "PATCH"), {
+      params: Promise.resolve({ id: "12" }),
+    });
+    expect(response.status).toBe(401);
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects request-replacement without auth_token", async () => {
+    const response = await requestReplacement(
+      noAuthRequest("/api/clients/12/request-replacement", "PATCH"),
+      { params: Promise.resolve({ id: "12" }) },
+    );
+    expect(response.status).toBe(401);
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects complete-replacement without auth_token", async () => {
+    const response = await completeReplacement(
+      noAuthRequest("/api/clients/12/complete-replacement", "PATCH"),
+      { params: Promise.resolve({ id: "12" }) },
+    );
+    expect(response.status).toBe(401);
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects check-phone without auth_token", async () => {
+    const response = await checkClientPhone(noAuthRequest("/api/clients/check-phone?phone=01000000000"));
+    expect(response.status).toBe(401);
+    expect(mockGet).not.toHaveBeenCalled();
   });
 });

--- a/mobile/src/app/api/consultation-inquiries/__tests__/route.test.ts
+++ b/mobile/src/app/api/consultation-inquiries/__tests__/route.test.ts
@@ -80,4 +80,17 @@ describe("consultation inquiry API routes", () => {
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({ error: "Failed to mark consultation inquiry as read" });
   });
+
+  describe("auth rejection", () => {
+    it("rejects mark-read without auth_token", async () => {
+      const request = new NextRequest("http://localhost/api/consultation-inquiries/inquiry_123/read", {
+        method: "PATCH",
+      });
+      const response = await markInquiryRead(request, {
+        params: Promise.resolve({ id: "inquiry_123" }),
+      });
+      expect(response.status).toBe(401);
+      expect(mockPatch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/mobile/src/app/api/eformsign-docs/__tests__/command-routes.test.ts
+++ b/mobile/src/app/api/eformsign-docs/__tests__/command-routes.test.ts
@@ -7,13 +7,16 @@ import { serverAPIClient } from "@/lib/api/server";
 import { POST as createEformsignDoc } from "../route";
 import { POST as dispatchHeadless } from "../dispatch-headless/route";
 import { POST as finalizeHeadless } from "../finalize-headless/route";
+import { GET as getClientNames } from "../client-names/route";
 
 jest.mock("@/lib/api/server", () => ({
   serverAPIClient: {
+    get: jest.fn(),
     post: jest.fn(),
   },
 }));
 
+const mockGet = serverAPIClient.get as jest.Mock;
 const mockPost = serverAPIClient.post as jest.Mock;
 
 function createRequest(path: string, body: BodyInit): NextRequest {
@@ -166,5 +169,35 @@ describe("eformsign-docs command API routes", () => {
 
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toEqual({ error: "already finalized" });
+  });
+
+  describe("auth rejection", () => {
+    function noAuthRequest(path: string, method = "POST"): NextRequest {
+      return new NextRequest(`http://localhost${path}`, { method });
+    }
+
+    it("rejects create without auth_token", async () => {
+      const response = await createEformsignDoc(noAuthRequest("/api/eformsign-docs"));
+      expect(response.status).toBe(401);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("rejects dispatch without auth_token", async () => {
+      const response = await dispatchHeadless(noAuthRequest("/api/eformsign-docs/dispatch-headless"));
+      expect(response.status).toBe(401);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("rejects finalize without auth_token", async () => {
+      const response = await finalizeHeadless(noAuthRequest("/api/eformsign-docs/finalize-headless"));
+      expect(response.status).toBe(401);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("rejects client-names without auth_token", async () => {
+      const response = await getClientNames(noAuthRequest("/api/eformsign-docs/client-names", "GET"));
+      expect(response.status).toBe(401);
+      expect(mockGet).not.toHaveBeenCalled();
+    });
   });
 });

--- a/mobile/src/app/api/employees/__tests__/route.test.ts
+++ b/mobile/src/app/api/employees/__tests__/route.test.ts
@@ -10,6 +10,7 @@ import {
   PATCH as updateEmployee,
   POST as createEmployee,
 } from "../route";
+import { GET as checkEmployeePhone } from "../check-phone/route";
 
 jest.mock("@/lib/api/server", () => ({
   serverAPIClient: {
@@ -213,5 +214,14 @@ describe("employee API routes", () => {
 
     expect(response.status).toBe(204);
     await expect(response.text()).resolves.toBe("");
+  });
+
+  describe("auth rejection", () => {
+    it("rejects check-phone without auth_token", async () => {
+      const request = new NextRequest("http://localhost/api/employees/check-phone?phone=01000000000");
+      const response = await checkEmployeePhone(request);
+      expect(response.status).toBe(401);
+      expect(mockGet).not.toHaveBeenCalled();
+    });
   });
 });

--- a/mobile/src/app/api/file-storage/__tests__/route.test.ts
+++ b/mobile/src/app/api/file-storage/__tests__/route.test.ts
@@ -214,4 +214,55 @@ describe("file-storage API routes", () => {
     await expect(response.json()).resolves.toEqual({ error: "Invalid file id" });
     expect(mockGet).not.toHaveBeenCalled();
   });
+
+  describe("auth rejection", () => {
+    function noAuthRequest(path: string, method = "GET"): NextRequest {
+      return new NextRequest(`http://localhost${path}`, { method });
+    }
+
+    it("rejects file listing without auth_token", async () => {
+      const response = await listFiles(noAuthRequest("/api/file-storage/files"));
+      expect(response.status).toBe(401);
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects file upload without auth_token", async () => {
+      const response = await uploadFile(noAuthRequest("/api/file-storage/files", "POST"));
+      expect(response.status).toBe(401);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("rejects file detail GET without auth_token", async () => {
+      const response = await getFile(noAuthRequest("/api/file-storage/files/file_123"), {
+        params: Promise.resolve({ fileId: "file_123" }),
+      });
+      expect(response.status).toBe(401);
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects file update without auth_token", async () => {
+      const response = await updateFile(noAuthRequest("/api/file-storage/files/file_123", "PUT"), {
+        params: Promise.resolve({ fileId: "file_123" }),
+      });
+      expect(response.status).toBe(401);
+      expect(mockPut).not.toHaveBeenCalled();
+    });
+
+    it("rejects file delete without auth_token", async () => {
+      const response = await deleteFile(noAuthRequest("/api/file-storage/files/file_123", "DELETE"), {
+        params: Promise.resolve({ fileId: "file_123" }),
+      });
+      expect(response.status).toBe(401);
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    it("rejects file download without auth_token", async () => {
+      const response = await downloadFile(
+        noAuthRequest("/api/file-storage/files/file_123/download"),
+        { params: Promise.resolve({ fileId: "file_123" }) },
+      );
+      expect(response.status).toBe(401);
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/mobile/src/app/api/message-deliveries/__tests__/sms-route.test.ts
+++ b/mobile/src/app/api/message-deliveries/__tests__/sms-route.test.ts
@@ -42,6 +42,20 @@ describe("SMS delivery API route", () => {
     message: "hello",
   };
 
+  it("rejects an SMS request without an auth cookie before proxying", async () => {
+    const request = new NextRequest("http://localhost/api/message-deliveries/sms", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validSmsPayload),
+    });
+
+    const response = await sendSms(request);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
   it("rejects malformed JSON before proxying", async () => {
     const response = await sendSms(createRequest("{bad-json"));
 

--- a/mobile/src/app/api/message-templates/__tests__/route.test.ts
+++ b/mobile/src/app/api/message-templates/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import { serverAPIClient } from "@/lib/api/server";
 import { GET as listMessageTemplates, POST as createMessageTemplate } from "../route";
 import {
   DELETE as deleteMessageTemplate,
+  GET as getMessageTemplate,
   PATCH as updateMessageTemplate,
 } from "../[id]/route";
 
@@ -48,6 +49,43 @@ describe("message-template API routes", () => {
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+  });
+
+  function noCookieRequest(path: string, method = "GET"): NextRequest {
+    return new NextRequest(`http://localhost${path}`, { method });
+  }
+
+  const idParams = { params: Promise.resolve({ id: "24" }) };
+
+  it("requires auth before listing message templates", async () => {
+    const response = await listMessageTemplates(noCookieRequest("/api/message-templates"));
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before creating message templates", async () => {
+    const response = await createMessageTemplate(noCookieRequest("/api/message-templates", "POST"));
+    expect(response.status).toBe(401);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before fetching a single message template", async () => {
+    const response = await getMessageTemplate(noCookieRequest("/api/message-templates/24"), idParams);
+    expect(response.status).toBe(401);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before updating a message template", async () => {
+    const response = await updateMessageTemplate(noCookieRequest("/api/message-templates/24", "PATCH"), idParams);
+    expect(response.status).toBe(401);
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before deleting a message template", async () => {
+    const response = await deleteMessageTemplate(noCookieRequest("/api/message-templates/24", "DELETE"), idParams);
+    expect(response.status).toBe(401);
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 
   it("preserves backend status and payload when listing message templates", async () => {

--- a/mobile/src/app/api/notifications/__tests__/route.test.ts
+++ b/mobile/src/app/api/notifications/__tests__/route.test.ts
@@ -8,6 +8,9 @@ import { GET as getNotifications } from "../route";
 import { POST as subscribeNotifications } from "../subscribe/route";
 import { POST as unsubscribeNotifications } from "../unsubscribe/route";
 import { GET as getVapidKey } from "../vapid-key/route";
+import { PATCH as markAllRead } from "../read-all/route";
+import { GET as getUnreadCount } from "../unread/count/route";
+import { POST as testBroadcast } from "../test-broadcast/route";
 
 jest.mock("@/lib/api/server", () => ({
   serverAPIClient: {
@@ -24,6 +27,7 @@ jest.mock("@/lib/e2e", () => ({
 
 const mockGet = serverAPIClient.get as jest.Mock;
 const mockPost = serverAPIClient.post as jest.Mock;
+const mockPatch = serverAPIClient.patch as jest.Mock;
 
 interface TestRequestInit {
   method?: string;
@@ -46,6 +50,51 @@ describe("notification API routes", () => {
   beforeEach(() => {
     mockGet.mockReset();
     mockPost.mockReset();
+    mockPatch.mockReset();
+  });
+
+  function noCookieRequest(path: string, method = "GET"): NextRequest {
+    return new NextRequest(`http://localhost${path}`, { method });
+  }
+
+  it("requires auth before listing notifications", async () => {
+    const response = await getNotifications(noCookieRequest("/api/notifications"));
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before marking all notifications read", async () => {
+    const response = await markAllRead(noCookieRequest("/api/notifications/read-all", "PATCH"));
+    expect(response.status).toBe(401);
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before subscribing to notifications", async () => {
+    const response = await subscribeNotifications(noCookieRequest("/api/notifications/subscribe", "POST"));
+    expect(response.status).toBe(401);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before unsubscribing from notifications", async () => {
+    const response = await unsubscribeNotifications(noCookieRequest("/api/notifications/unsubscribe", "POST"));
+    expect(response.status).toBe(401);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before fetching the unread count", async () => {
+    const response = await getUnreadCount(noCookieRequest("/api/notifications/unread/count"));
+    expect(response.status).toBe(401);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before sending a test broadcast", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue(new Response("{}"));
+    const response = await testBroadcast(noCookieRequest("/api/notifications/test-broadcast", "POST"));
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
   });
 
   it("preserves backend status and payload when listing notifications", async () => {

--- a/mobile/src/app/api/refresh-access-token/__tests__/route.test.ts
+++ b/mobile/src/app/api/refresh-access-token/__tests__/route.test.ts
@@ -38,6 +38,20 @@ describe("POST /api/refresh-access-token", () => {
         consoleErrorSpy.mockRestore();
     });
 
+    it("rejects requests without an auth cookie before proxying", async () => {
+        const request = new NextRequest("http://localhost/api/refresh-access-token", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ executionTime: 1780000000000 }),
+        });
+
+        const response = await POST(request);
+
+        expect(response.status).toBe(401);
+        await expect(response.json()).resolves.toEqual({ error: "Authentication required. Please log in." });
+        expect(mockServerPost).not.toHaveBeenCalled();
+    });
+
     it("rejects bodies missing executionTime before proxying", async () => {
         const response = await POST(createRequest(JSON.stringify({})));
 

--- a/mobile/src/app/api/settings/__tests__/route.test.ts
+++ b/mobile/src/app/api/settings/__tests__/route.test.ts
@@ -8,7 +8,10 @@ import {
   GET as getAlimtalkProvider,
   PUT as updateAlimtalkProvider,
 } from "../alimtalk-provider/route";
-import { POST as requestMessageSenderApproval } from "../message-sender-approval/route";
+import {
+  GET as getMessageSenderApproval,
+  POST as requestMessageSenderApproval,
+} from "../message-sender-approval/route";
 
 jest.mock("@/lib/api/server", () => ({
   serverAPIClient: {
@@ -45,6 +48,35 @@ describe("settings API routes", () => {
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+  });
+
+  function noCookieRequest(path: string, method = "GET"): NextRequest {
+    return new NextRequest(`http://localhost${path}`, { method });
+  }
+
+  it("requires auth before fetching the Alimtalk provider", async () => {
+    const response = await getAlimtalkProvider(noCookieRequest("/api/settings/alimtalk-provider"));
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before updating the Alimtalk provider", async () => {
+    const response = await updateAlimtalkProvider(noCookieRequest("/api/settings/alimtalk-provider", "PUT"));
+    expect(response.status).toBe(401);
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before fetching message sender approval status", async () => {
+    const response = await getMessageSenderApproval(noCookieRequest("/api/settings/message-sender-approval"));
+    expect(response.status).toBe(401);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before requesting message sender approval", async () => {
+    const response = await requestMessageSenderApproval(noCookieRequest("/api/settings/message-sender-approval", "POST"));
+    expect(response.status).toBe(401);
+    expect(mockPost).not.toHaveBeenCalled();
   });
 
   it("preserves backend error status and sanitizes payload for Alimtalk provider settings", async () => {

--- a/mobile/src/app/api/system-templates/__tests__/nested-routes.test.ts
+++ b/mobile/src/app/api/system-templates/__tests__/nested-routes.test.ts
@@ -8,6 +8,7 @@ import { serverAPIClient } from "@/lib/api/server";
 import { POST as rollbackTemplate } from "../[key]/rollback/[version]/route";
 import { POST as validateTemplate } from "../[key]/validate/route";
 import { GET as getTemplateVersions } from "../[key]/versions/route";
+import { GET as getTemplateVersion } from "../[key]/versions/[version]/route";
 
 jest.mock("@/lib/api/server", () => ({
     serverAPIClient: {
@@ -48,6 +49,19 @@ describe("system-template nested API routes", () => {
         const response = await getTemplateVersions(
             createRequest("/api/system-templates/GREETING/versions"),
             { params: Promise.resolve({ key: "GREETING" }) },
+        );
+
+        expect(response.status).toBe(401);
+        await expect(response.json()).resolves.toEqual({
+            error: "Authentication required. Please log in.",
+        });
+        expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("requires auth before fetching a specific system-template version", async () => {
+        const response = await getTemplateVersion(
+            createRequest("/api/system-templates/GREETING/versions/2"),
+            { params: Promise.resolve({ key: "GREETING", version: "2" }) },
         );
 
         expect(response.status).toBe(401);

--- a/mobile/src/app/api/system-templates/__tests__/root-routes.test.ts
+++ b/mobile/src/app/api/system-templates/__tests__/root-routes.test.ts
@@ -41,6 +41,31 @@ describe("system-template root API routes", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  function noCookieRequest(path: string, method = "GET"): NextRequest {
+    return new NextRequest(`http://localhost${path}`, { method });
+  }
+
+  const keyParams = { params: Promise.resolve({ key: "INTRO" }) };
+
+  it("requires auth before listing system templates", async () => {
+    const response = await listSystemTemplates(noCookieRequest("/api/system-templates"));
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before fetching a system template", async () => {
+    const response = await getSystemTemplate(noCookieRequest("/api/system-templates/INTRO"), keyParams);
+    expect(response.status).toBe(401);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before updating a system template", async () => {
+    const response = await updateSystemTemplate(noCookieRequest("/api/system-templates/INTRO", "PUT"), keyParams);
+    expect(response.status).toBe(401);
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
   it("preserves backend status and payload when listing system templates", async () => {
     mockGet.mockResolvedValue({
       status: 403,

--- a/mobile/src/app/api/voucher-price-infos/__tests__/route.test.ts
+++ b/mobile/src/app/api/voucher-price-infos/__tests__/route.test.ts
@@ -42,6 +42,30 @@ describe("voucher price info API routes", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  function noCookieRequest(path: string, method = "GET"): NextRequest {
+    return new NextRequest(`http://localhost${path}`, { method });
+  }
+
+  it("requires auth before fetching voucher price infos by type", async () => {
+    const response = await getVoucherPriceInfosByType(noCookieRequest("/api/voucher-price-infos/type"));
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before fetching voucher price years", async () => {
+    const response = await getVoucherPriceYears(noCookieRequest("/api/voucher-price-infos/years"));
+    expect(response.status).toBe(401);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("requires auth before bulk updating voucher prices", async () => {
+    const response = await bulkUpdateVoucherPrices(noCookieRequest("/api/voucher-price-infos/bulk-update", "POST"));
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
   it("preserves backend status and payload when fetching voucher price infos by type", async () => {
     mockGet.mockResolvedValue({
       status: 409,

--- a/mobile/src/app/api/voucher-price-infos/parse-image/__tests__/route.test.ts
+++ b/mobile/src/app/api/voucher-price-infos/parse-image/__tests__/route.test.ts
@@ -40,6 +40,18 @@ describe("POST /api/voucher-price-infos/parse-image", () => {
         consoleErrorSpy.mockRestore();
     });
 
+    it("requires auth before parsing a voucher image", async () => {
+        const request = new NextRequest("http://localhost/api/voucher-price-infos/parse-image", {
+            method: "POST",
+        });
+
+        const response = await POST(request);
+
+        expect(response.status).toBe(401);
+        await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
     it("forwards multipart uploads without overriding the form-data boundary", async () => {
         mockPost.mockResolvedValue({
             status: 200,


### PR DESCRIPTION
## Summary

P6.2 of the SaaS audit remediation. A scout pass found only **5 of ~60** auth-checked API routes had a test pinning the 401/unauthenticated path. This adds **63 cases across 22 test files** covering the high-risk surface (ai/chat, admin, alimtalk family, clients/[id] family, bank-account-infos, file-storage, eformsign-docs, paid SMS path, message-templates, notifications, settings, system-templates, voucher-price-infos, eformsign token routes).

Every case asserts: cookie-less request → 401 **and** no proxy/`fetch` call. Both auth mechanisms in the codebase handled (`next/headers` cookies mock vs `request.cookies` via `getAuthToken`). Notable details preserved exactly: per-handler 401 message variants; `access-token`/`refresh-token` check `auth_token` before eformsign cookies; `test-broadcast`'s prod-env gate sits before auth (test env reaches the 401 path).

**Result of the sweep:** no unprotected handler found — every route in scope gates on auth before any backend call.

No production code touched — test files only.

## Test plan

- [x] Full mobile suite: **93 suites, 630 tests green** (+63), type-check clean, lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)