### PR TITLE
refactor(workspace): share lib/utils via @babyjamjam/shared (P5.3)

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,6 +1,1 @@
-import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export * from "@babyjamjam/shared/utils";

--- a/mobile/src/lib/utils.ts
+++ b/mobile/src/lib/utils.ts
@@ -1,6 +1,1 @@
-import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export * from "@babyjamjam/shared/utils";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,10 +8,15 @@
     "types": "src/index.ts",
     "exports": {
         ".": "./src/index.ts",
+        "./utils": "./src/utils/index.ts",
         "./eslint-plugin": "./eslint-plugin/index.mjs"
     },
     "scripts": {
         "type-check": "tsc --noEmit"
+    },
+    "dependencies": {
+        "clsx": "^2.1.1",
+        "tailwind-merge": "^3.4.0"
     },
     "devDependencies": {
         "typescript": "^5"

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+    return twMerge(clsx(inputs));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,6 +546,13 @@ importers:
         version: 5.9.3
 
   packages/shared:
+    dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      tailwind-merge:
+        specifier: ^3.4.0
+        version: 3.5.0
     devDependencies:
       typescript:
         specifier: ^5


### PR DESCRIPTION
## Summary

P5.3 — second real shared slice. `frontend/src/lib/utils.ts` and `mobile/src/lib/utils.ts` were byte-identical (`cmp` + matching sha256). The implementation now lives at `packages/shared/src/utils` (subpath export `@babyjamjam/shared/utils`, consistent with the `./eslint-plugin` pattern); each app keeps a **one-line re-export shim** at the old path so zero consumer files change. `clsx`/`tailwind-merge` move to the shared package at the locked versions.

**Baseline contract held exactly**: mobile lint `0/206`, frontend `0/146` before and after; both type-checks exit 0; **630 + 245 tests green; both production builds exit 0** (verified outside the Codex sandbox, whose install/build failures were environmental).

Next: 5.4 drifted types per group → 5.5 API plumbing.

## Test plan

- [x] Identity proof (`cmp` exit 0, sha256 match) before merge of copies
- [x] Lint-count identity per app; type-checks; both jest suites; both builds
- [x] CI required checks on the merge ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)