### PR TITLE
refactor(workspace): share reconciled alimtalk types (P5.4b)

### DIFF
--- a/frontend/src/features/alimtalk-triggers/types.ts
+++ b/frontend/src/features/alimtalk-triggers/types.ts
@@ -1,124 +1,17 @@
-import type { AlimtalkProvider } from "@/services/api";
+import type {
+  AlimtalkTriggerEventType,
+  AlimtalkTriggerOffsetType,
+  AlimtalkTriggerRecipientType,
+  AlimtalkTriggerTemplateCatalogItem,
+  AlimtalkTriggerTemplateKey,
+  AlimtalkTriggerTemplateVariable,
+} from "@babyjamjam/shared/types/alimtalk";
 
-export type TriggerEventType =
-    | "CLIENT_CREATED"
-    | "SERVICE_START"
-    | "SERVICE_END"
-    | "EMPLOYEE_ASSIGNED";
+export * from "@babyjamjam/shared/types/alimtalk";
 
-export type TriggerOffsetType = "IMMEDIATE" | "SAME_DAY" | "BEFORE_DAYS" | "AFTER_DAYS";
-
-export type TriggerRecipientType = "CLIENT" | "PRIMARY_EMPLOYEE" | "SECONDARY_EMPLOYEE";
-
-export type TriggerTemplateKey =
-    | "CLIENT_WELCOME"
-    | "SERVICE_START_REMINDER"
-    | "SERVICE_INFO"
-    | "SERVICE_END_REMINDER"
-    | "EMPLOYEE_ASSIGNED";
-
-export interface AlimtalkTriggerRule {
-    id: string;
-    branchId: string | null;
-    name: string;
-    isActive: boolean;
-    eventType: TriggerEventType;
-    offsetType: TriggerOffsetType;
-    offsetDays: number;
-    recipientType: TriggerRecipientType;
-    templateKey: TriggerTemplateKey;
-    createdAt: string;
-    updatedAt: string;
-}
-
-export interface TriggerTemplateVariable {
-    key: string;
-    label: string;
-}
-
-export interface TriggerTemplateCatalogItem {
-    key: TriggerTemplateKey;
-    name: string;
-    description: string;
-    allowedEventTypes: TriggerEventType[];
-    allowedRecipientTypes: TriggerRecipientType[];
-    requiredVariables: TriggerTemplateVariable[];
-    providers: Partial<Record<Exclude<AlimtalkProvider, "none">, { templateKey: string }>>;
-}
-
-export interface UpcomingAlimtalkJobPayload {
-    clientId?: number | null;
-    clientName?: string | null;
-    employeeId?: number | null;
-    employeeName?: string | null;
-    memberId: string;
-    recipientName: string;
-    recipientPhone: string;
-    templateVariables: Record<string, string>;
-    buttonUrl?: string | null;
-}
-
-export interface UpcomingAlimtalkJob {
-    id: string;
-    ruleId: string;
-    ruleName: string;
-    eventType: TriggerEventType | null;
-    offsetType: TriggerOffsetType | null;
-    offsetDays: number;
-    recipientType: TriggerRecipientType;
-    recipientPhone: string | null;
-    templateKey: TriggerTemplateKey;
-    status: "pending" | "sent" | "failed" | "canceled";
-    scheduledFor: string;
-    sentAt: string | null;
-    canceledAt: string | null;
-    cancelReason: string | null;
-    clientId: number | null;
-    employeeScheduleId: number | null;
-    payload: UpcomingAlimtalkJobPayload;
-    createdAt: string;
-    updatedAt: string;
-}
-
-export type AlimtalkHistoryStatus = "pending" | "sent" | "failed";
-
-export interface AlimtalkHistoryRecord {
-    id: number;
-    provider: string;
-    templateKey: string;
-    triggerJobId: string | null;
-    receiver: string;
-    clientId: number | null;
-    messageBody: string;
-    variables: Record<string, string>;
-    status: AlimtalkHistoryStatus;
-    aligoMid: string | null;
-    errorMessage: string | null;
-    attempts: number;
-    lastAttemptAt: string | null;
-    nextRetryAt: string | null;
-    createdAt: string;
-    updatedAt: string;
-    ruleId: string | null;
-    ruleName: string | null;
-    eventType: TriggerEventType | null;
-    offsetType: TriggerOffsetType | null;
-    offsetDays: number;
-    scheduledFor: string | null;
-    recipientType: TriggerRecipientType | null;
-    recipientName: string | null;
-    clientName: string | null;
-    employeeName: string | null;
-}
-
-export interface CreateAlimtalkTriggerRuleDto {
-    name: string;
-    isActive?: boolean;
-    eventType: TriggerEventType;
-    offsetType: TriggerOffsetType;
-    offsetDays?: number;
-    recipientType: TriggerRecipientType;
-    templateKey: TriggerTemplateKey;
-}
-
-export type UpdateAlimtalkTriggerRuleDto = Partial<CreateAlimtalkTriggerRuleDto>;
+export type TriggerEventType = AlimtalkTriggerEventType;
+export type TriggerOffsetType = AlimtalkTriggerOffsetType;
+export type TriggerRecipientType = AlimtalkTriggerRecipientType;
+export type TriggerTemplateKey = AlimtalkTriggerTemplateKey;
+export type TriggerTemplateVariable = AlimtalkTriggerTemplateVariable;
+export type TriggerTemplateCatalogItem = AlimtalkTriggerTemplateCatalogItem;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,8 @@
 import axios from "axios";
+import type {
+    AlimtalkProvider,
+    AlimtalkProviderResponse,
+} from "@babyjamjam/shared/types/alimtalk";
 import { api } from "@/lib/api/client";
 import { ContractDataDto } from '@/backend/application/dto/contract.dto';
 import {
@@ -249,13 +253,7 @@ export const eformsignApi = {
     },
 }
 
-export type AlimtalkProvider = 'aligo' | 'channeltalk' | 'none';
-
-export interface AlimtalkProviderResponse {
-    provider: AlimtalkProvider;
-    enabled: boolean;
-    updatedAt?: string;
-}
+export type { AlimtalkProvider, AlimtalkProviderResponse };
 
 export interface NotificationPreferencesResponse {
     emailNotificationsEnabled: boolean;

--- a/mobile/src/features/alimtalk-triggers/types.ts
+++ b/mobile/src/features/alimtalk-triggers/types.ts
@@ -1,59 +1,17 @@
-import type { AlimtalkProvider } from "@/services/api";
+import type {
+  AlimtalkTriggerEventType,
+  AlimtalkTriggerOffsetType,
+  AlimtalkTriggerRecipientType,
+  AlimtalkTriggerTemplateCatalogItem,
+  AlimtalkTriggerTemplateKey,
+  AlimtalkTriggerTemplateVariable,
+} from "@babyjamjam/shared/types/alimtalk";
 
-export type TriggerEventType =
-    | "CLIENT_CREATED"
-    | "SERVICE_START"
-    | "SERVICE_END"
-    | "EMPLOYEE_ASSIGNED";
+export * from "@babyjamjam/shared/types/alimtalk";
 
-export type TriggerOffsetType = "IMMEDIATE" | "SAME_DAY" | "BEFORE_DAYS" | "AFTER_DAYS";
-
-export type TriggerRecipientType = "CLIENT" | "PRIMARY_EMPLOYEE" | "SECONDARY_EMPLOYEE";
-
-export type TriggerTemplateKey =
-    | "CLIENT_WELCOME"
-    | "SERVICE_START_REMINDER"
-    | "SERVICE_INFO"
-    | "SERVICE_END_REMINDER"
-    | "EMPLOYEE_ASSIGNED";
-
-export interface AlimtalkTriggerRule {
-    id: string;
-    branchId: string | null;
-    name: string;
-    isActive: boolean;
-    eventType: TriggerEventType;
-    offsetType: TriggerOffsetType;
-    offsetDays: number;
-    recipientType: TriggerRecipientType;
-    templateKey: TriggerTemplateKey;
-    createdAt: string;
-    updatedAt: string;
-}
-
-export interface TriggerTemplateVariable {
-    key: string;
-    label: string;
-}
-
-export interface TriggerTemplateCatalogItem {
-    key: TriggerTemplateKey;
-    name: string;
-    description: string;
-    allowedEventTypes: TriggerEventType[];
-    allowedRecipientTypes: TriggerRecipientType[];
-    requiredVariables: TriggerTemplateVariable[];
-    providers: Partial<Record<Exclude<AlimtalkProvider, "none">, { templateKey: string }>>;
-}
-
-export interface CreateAlimtalkTriggerRuleDto {
-    name: string;
-    isActive?: boolean;
-    eventType: TriggerEventType;
-    offsetType: TriggerOffsetType;
-    offsetDays?: number;
-    recipientType: TriggerRecipientType;
-    templateKey: TriggerTemplateKey;
-}
-
-export type UpdateAlimtalkTriggerRuleDto = Partial<CreateAlimtalkTriggerRuleDto>;
+export type TriggerEventType = AlimtalkTriggerEventType;
+export type TriggerOffsetType = AlimtalkTriggerOffsetType;
+export type TriggerRecipientType = AlimtalkTriggerRecipientType;
+export type TriggerTemplateKey = AlimtalkTriggerTemplateKey;
+export type TriggerTemplateVariable = AlimtalkTriggerTemplateVariable;
+export type TriggerTemplateCatalogItem = AlimtalkTriggerTemplateCatalogItem;

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -1,3 +1,7 @@
+import type {
+    AlimtalkProvider,
+    AlimtalkProviderResponse,
+} from "@babyjamjam/shared/types/alimtalk";
 import { api } from "@/lib/api/client";
 import { PUBLIC_BACKEND_BASE_URL } from "@/lib/env";
 import {
@@ -311,15 +315,9 @@ export async function withEformsignReauth<T>(fn: () => Promise<T>): Promise<T> {
     }
 }
 
-export type AlimtalkProvider = 'aligo' | 'channeltalk' | 'none';
-
 export type MessageSenderApprovalStatus = "not_requested" | "pending" | "approved";
 
-export interface AlimtalkProviderResponse {
-    provider: AlimtalkProvider;
-    enabled: boolean;
-    updatedAt?: string;
-}
+export type { AlimtalkProvider, AlimtalkProviderResponse };
 
 export interface MessageSenderApprovalResponse {
     senderPhone: string | null;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,6 +8,7 @@
     "types": "src/index.ts",
     "exports": {
         ".": "./src/index.ts",
+        "./types/alimtalk": "./src/types/alimtalk.ts",
         "./types/eformsign": "./src/types/eformsign.ts",
         "./utils": "./src/utils/index.ts",
         "./eslint-plugin": "./eslint-plugin/index.mjs"

--- a/packages/shared/src/types/alimtalk.ts
+++ b/packages/shared/src/types/alimtalk.ts
@@ -1,0 +1,227 @@
+// Shared alimtalk contracts used by both frontend and mobile.
+//
+// The source of truth for these shapes is the backend contract surface:
+// - backend/interface/dto/alimtalk-trigger.dto.ts
+// - backend/interface/dto/alimtalk-template.dto.ts
+// - backend/interface/dto/system-setting.dto.ts
+// - backend/domain/constants/alimtalk-trigger-catalog.ts
+// - backend/domain/entities/alimtalk-trigger-rule.entity.ts
+// - backend/domain/entities/system-setting.entity.ts
+// - backend/application/services/alimtalk-trigger.service.ts
+// - backend/application/services/alimtalk-template.service.ts
+// - backend/domain/ports/aligo-api.port.ts
+//
+// Controllers return Date-backed entities/views directly for trigger rules,
+// upcoming jobs, and history logs. Those dates serialize to ISO strings on
+// the wire, so the shared client-facing response types below use string.
+
+export type AlimtalkTriggerEventType =
+  | "CLIENT_CREATED"
+  | "SERVICE_START"
+  | "SERVICE_END"
+  | "EMPLOYEE_ASSIGNED";
+
+export type AlimtalkTriggerOffsetType =
+  | "IMMEDIATE"
+  | "SAME_DAY"
+  | "BEFORE_DAYS"
+  | "AFTER_DAYS";
+
+export type AlimtalkTriggerRecipientType =
+  | "CLIENT"
+  | "PRIMARY_EMPLOYEE"
+  | "SECONDARY_EMPLOYEE";
+
+export type AlimtalkTriggerTemplateKey =
+  | "CLIENT_WELCOME"
+  | "SERVICE_START_REMINDER"
+  | "SERVICE_INFO"
+  | "SERVICE_END_REMINDER"
+  | "EMPLOYEE_ASSIGNED";
+
+export type SupportedTriggerProvider = "aligo" | "channeltalk";
+export type AlimtalkProvider = SupportedTriggerProvider | "none";
+
+export interface AlimtalkTriggerTemplateVariable {
+  key: string;
+  label: string;
+}
+
+export interface AlimtalkTriggerTemplateProviderConfig {
+  templateKey: string;
+}
+
+export interface AlimtalkTriggerTemplateCatalogItem {
+  key: AlimtalkTriggerTemplateKey;
+  name: string;
+  description: string;
+  allowedEventTypes: AlimtalkTriggerEventType[];
+  allowedRecipientTypes: AlimtalkTriggerRecipientType[];
+  requiredVariables: AlimtalkTriggerTemplateVariable[];
+  providers: Partial<
+    Record<SupportedTriggerProvider, AlimtalkTriggerTemplateProviderConfig>
+  >;
+}
+
+export interface AlimtalkTriggerRule {
+  id: string;
+  branchId: string | null;
+  name: string;
+  isActive: boolean;
+  eventType: AlimtalkTriggerEventType;
+  offsetType: AlimtalkTriggerOffsetType;
+  offsetDays: number;
+  recipientType: AlimtalkTriggerRecipientType;
+  templateKey: AlimtalkTriggerTemplateKey;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateAlimtalkTriggerRuleDto {
+  name: string;
+  isActive?: boolean;
+  eventType: AlimtalkTriggerEventType;
+  offsetType: AlimtalkTriggerOffsetType;
+  offsetDays?: number;
+  recipientType: AlimtalkTriggerRecipientType;
+  templateKey: AlimtalkTriggerTemplateKey;
+}
+
+export type UpdateAlimtalkTriggerRuleDto = Partial<CreateAlimtalkTriggerRuleDto>;
+
+export type AlimtalkTriggerJobStatus =
+  | "pending"
+  | "sent"
+  | "failed"
+  | "canceled";
+
+export interface UpcomingAlimtalkJobPayload {
+  clientId?: number | null;
+  clientName?: string | null;
+  employeeId?: number | null;
+  employeeName?: string | null;
+  memberId: string;
+  recipientName: string;
+  recipientPhone: string;
+  templateVariables: Record<string, string>;
+  buttonUrl?: string | null;
+}
+
+export interface UpcomingAlimtalkJob {
+  id: string;
+  ruleId: string;
+  ruleName: string;
+  eventType: AlimtalkTriggerEventType | null;
+  offsetType: AlimtalkTriggerOffsetType | null;
+  offsetDays: number;
+  recipientType: AlimtalkTriggerRecipientType;
+  recipientPhone: string | null;
+  templateKey: AlimtalkTriggerTemplateKey;
+  status: AlimtalkTriggerJobStatus;
+  scheduledFor: string;
+  sentAt: string | null;
+  canceledAt: string | null;
+  cancelReason: string | null;
+  clientId: number | null;
+  employeeScheduleId: number | null;
+  payload: UpcomingAlimtalkJobPayload;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type AlimtalkHistoryStatus = "pending" | "sent" | "failed";
+
+export interface AlimtalkHistoryRecord {
+  id: number;
+  provider: string;
+  templateKey: string;
+  triggerJobId: string | null;
+  receiver: string;
+  clientId: number | null;
+  messageBody: string;
+  variables: Record<string, string>;
+  status: AlimtalkHistoryStatus;
+  aligoMid: string | null;
+  errorMessage: string | null;
+  attempts: number;
+  lastAttemptAt: string | null;
+  nextRetryAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  ruleId: string | null;
+  ruleName: string | null;
+  eventType: AlimtalkTriggerEventType | null;
+  offsetType: AlimtalkTriggerOffsetType | null;
+  offsetDays: number;
+  scheduledFor: string | null;
+  recipientType: AlimtalkTriggerRecipientType | null;
+  recipientName: string | null;
+  clientName: string | null;
+  employeeName: string | null;
+}
+
+export interface AlimtalkProviderResponse {
+  provider: AlimtalkProvider;
+  enabled: boolean;
+  updatedAt?: string;
+}
+
+export type AlimtalkTemplateType = "BA" | "EX" | "AD" | "MI";
+export type AlimtalkTemplateEmphasisType = "NONE" | "TEXT" | "IMAGE";
+export type AlimtalkTemplateButtonLinkType =
+  | "WL"
+  | "AL"
+  | "BK"
+  | "MD"
+  | "DS"
+  | "AC";
+
+export interface AlimtalkTemplateButton {
+  name: string;
+  linkType: AlimtalkTemplateButtonLinkType;
+  linkM?: string;
+  linkP?: string;
+  linkI?: string;
+  linkA?: string;
+}
+
+export interface CreateAlimtalkTemplateButtonDto
+  extends AlimtalkTemplateButton {}
+
+export interface CreateAlimtalkTemplateDto {
+  name: string;
+  tplType: AlimtalkTemplateType;
+  tplEmType: AlimtalkTemplateEmphasisType;
+  title?: string;
+  subtitle?: string;
+  content: string;
+  extra?: string;
+  advert?: string;
+  buttons: CreateAlimtalkTemplateButtonDto[];
+}
+
+export interface AlimtalkTemplateListItem {
+  templateCode: string;
+  name: string;
+  content: string;
+  title?: string;
+  subtitle?: string;
+  extra?: string;
+  advert?: string;
+  templateType: AlimtalkTemplateType;
+  emphasisType: AlimtalkTemplateEmphasisType;
+  inspectionStatus?: string;
+  isApproved: boolean;
+  category?: string;
+  buttons: AlimtalkTemplateButton[];
+  createdAt?: string;
+  updatedAt?: string;
+  senderKey?: string;
+}
+
+// The create-template endpoint currently returns the raw Aligo payload.
+export interface AligoTemplateCreateResponse {
+  code: number;
+  message: string;
+  info?: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary

P5.4b — alimtalk type group reconciled against backend truth into `@babyjamjam/shared/types/alimtalk` (same pattern as the merged eformsign slice):

| Drift | Resolution |
|---|---|
| Duplicated trigger enums/catalog shapes per app | Canonical shared types sourced from `alimtalk-trigger-catalog.ts` |
| Rule input vs persisted rule conflated | Distinct `Create/UpdateAlimtalkTriggerRuleDto` vs `AlimtalkTriggerRule`, matching backend service normalization |
| No shared jobs/history contracts | `UpcomingAlimtalkJob`/`AlimtalkHistoryRecord` shared; Date-backed backend views modeled as ISO strings client-side |
| Provider unions flattened | Settings `none` vs trigger-template `aligo\|channeltalk` split preserved |
| Template list vs raw Aligo create response mixed | Both modeled explicitly |

App-local files become thin shims keeping existing alias names — consumer churn stayed near zero.

## Test plan

- [x] Both type-checks exit 0; **630 + 245 tests green**; lint counts unchanged (`0/206`, `0/146`)
- [x] Both production builds exit 0 (outside-sandbox verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)