### PR TITLE
refactor(workspace): share reconciled message types (P5.4c)

### DIFF
--- a/frontend/src/app/(protected)/messages/page.tsx
+++ b/frontend/src/app/(protected)/messages/page.tsx
@@ -1751,7 +1751,7 @@ export default function MessagesPage() {
   const [templatePreviewOverride, setTemplatePreviewOverride] = useState<string | null>(null);
 
   const { data: userTemplatesData, isLoading: isLoadingUserTemplates } = useMessageTemplates(1, 100);
-  const userTemplates = useMemo(() => userTemplatesData?.data ?? [], [userTemplatesData]);
+  const userTemplates = useMemo(() => userTemplatesData ?? [], [userTemplatesData]);
 
   const userTemplateItems = useMemo<TemplateListItem[]>(() => {
     return userTemplates.map((template) => ({

--- a/frontend/src/app/(protected)/messages/templates/page.tsx
+++ b/frontend/src/app/(protected)/messages/templates/page.tsx
@@ -128,7 +128,7 @@ export default function TemplatesPage() {
   const [selectedValue, setSelectedValue] = useState<string | null>(null);
 
   const { data: branchTemplatesData, isLoading: isLoadingBranchTemplates } = useMessageTemplates(1, 100);
-  const branchTemplates = useMemo(() => branchTemplatesData?.data ?? [], [branchTemplatesData]);
+  const branchTemplates = useMemo(() => branchTemplatesData ?? [], [branchTemplatesData]);
 
   const branchItems = useMemo<TemplateListItem[]>(
     () =>

--- a/frontend/src/features/message-templates/types.ts
+++ b/frontend/src/features/message-templates/types.ts
@@ -1,35 +1,19 @@
-export interface TemplateVariable {
-    key: string;
-    label: string;
-    type: string;
-    required: boolean;
-}
+import type {
+    CreateMessageTemplateRequest,
+    MessageTemplate,
+    MessageTemplateListResponse,
+    MessageTemplateVariable,
+    UpdateMessageTemplateRequest,
+} from "@babyjamjam/shared/types/message";
 
-export interface MessageTemplate {
-    id: string;
-    name: string;
-    content: string;
-    variables: TemplateVariable[];
-    createdAt: string;
-    updatedAt: string;
-}
+export type TemplateVariable = MessageTemplateVariable;
 
-export interface PaginatedTemplates {
-    data: MessageTemplate[];
-    total: number;
-    page: number;
-    limit: number;
-    totalPages: number;
-}
+export type {
+    MessageTemplate,
+};
 
-export interface CreateTemplateDto {
-    name: string;
-    content: string;
-    variables: TemplateVariable[];
-}
-
-export interface UpdateTemplateDto {
-    name: string;
-    content: string;
-    variables: TemplateVariable[];
-}
+// Legacy alias kept locally so feature imports stay stable while the real
+// backend contract remains an array response.
+export type PaginatedTemplates = MessageTemplateListResponse;
+export type CreateTemplateDto = CreateMessageTemplateRequest;
+export type UpdateTemplateDto = UpdateMessageTemplateRequest;

--- a/frontend/src/lib/api/system-admin.ts
+++ b/frontend/src/lib/api/system-admin.ts
@@ -1,48 +1,19 @@
+import type {
+  MessageSenderApprovalResponse,
+  SystemAdminBranchRequest,
+  SystemAdminBranchMessageSenderApproval,
+  SystemAdminBranchUser,
+  MessageSenderApprovalStatus,
+} from "@babyjamjam/shared/types/message";
 import { api } from "@/lib/api/client";
 
-export type MessageSenderApprovalStatus = "not_requested" | "pending" | "approved";
-
-export interface SystemAdminBranchUser {
-  id: string;
-  name: string | null;
-  email: string | null;
-  phone: string | null;
-  role: string | null;
-}
-
-export interface SystemAdminBranchMessageSenderApproval {
-  senderPhone: string | null;
-  approvalStatus: MessageSenderApprovalStatus;
-  requestedAt: string | null;
-  approvedAt: string | null;
-  requestedBy: SystemAdminBranchUser | null;
-}
-
-export interface SystemAdminBranchRequest {
-  id: string;
-  name: string;
-  slug: string;
-  region: string | null;
-  district: string | null;
-  address: string | null;
-  phone: string | null;
-  email: string | null;
-  isActive: boolean;
-  createdAt: string | null;
-  updatedAt: string | null;
-  owner: SystemAdminBranchUser;
-  messageSenderApproval: SystemAdminBranchMessageSenderApproval;
-}
-
-export interface MessageSenderApprovalResponse {
-  senderPhone: string | null;
-  senderPhoneFormatted: string | null;
-  approvalStatus: MessageSenderApprovalStatus;
-  isApproved: boolean;
-  canRequest: boolean;
-  requestedAt: string | null;
-  approvedAt: string | null;
-}
+export type {
+  MessageSenderApprovalResponse,
+  MessageSenderApprovalStatus,
+  SystemAdminBranchMessageSenderApproval,
+  SystemAdminBranchRequest,
+  SystemAdminBranchUser,
+};
 
 export async function getSystemAdminBranchRequests(): Promise<SystemAdminBranchRequest[]> {
   const { data } = await api.get("/system-admin/branch-requests");

--- a/frontend/src/lib/template/types.ts
+++ b/frontend/src/lib/template/types.ts
@@ -1,35 +1,16 @@
-export type VariableType = "text" | "phone" | "select" | "date" | "number" | "textarea";
+import type {
+    CreateMessageTemplateRequest,
+    MessageTemplate,
+    MessageTemplateVariable,
+    MessageTemplateVariableType,
+    UpdateMessageTemplateRequest,
+} from "@babyjamjam/shared/types/message";
 
-export interface TemplateVariable {
-    key: string;
-    type: VariableType;
-    label: string;
-    placeholder?: string;
-    required: boolean;
-    optionType?: "custom" | "dataSource";
-    options?: string[];
-    dataSource?: string;
-    min?: number;
-    max?: number;
-}
+export type VariableType = MessageTemplateVariableType;
+export type TemplateVariable = MessageTemplateVariable;
 
-export interface MessageTemplate {
-    id: string;
-    name: string;
-    content: string;
-    variables: TemplateVariable[];
-    createdAt: string;
-    updatedAt: string;
-}
-
-export interface CreateMessageTemplateRequest {
-    name: string;
-    content: string;
-    variables: TemplateVariable[];
-}
-
-export interface UpdateMessageTemplateRequest {
-    name?: string;
-    content?: string;
-    variables?: TemplateVariable[];
-}
+export type {
+    CreateMessageTemplateRequest,
+    MessageTemplate,
+    UpdateMessageTemplateRequest,
+};

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -16,6 +16,12 @@ import {
     HeadlessDispatchResponse,
     HeadlessFinalizeResponse,
 } from '@babyjamjam/shared/types/eformsign';
+import type {
+    MessageDeliverySmsType,
+    MessageDeliveryTriggerType,
+    SendMessageDeliverySmsRequest,
+    SendMessageDeliverySmsResponse,
+} from "@babyjamjam/shared/types/message";
 
 const DEFAULT_EFORMSIGN_LIMIT = 100;
 const DEFAULT_EFORMSIGN_SKIP = 0;
@@ -260,39 +266,12 @@ export interface NotificationPreferencesResponse {
     updatedAt?: string;
 }
 
-export type MessageDeliverySmsType = "AUTO" | "SMS" | "LMS";
-export type MessageDeliveryTriggerType = "immediate" | "scheduled";
-
-export interface SendMessageDeliverySmsRequest {
-    receiver: string;
-    message: string;
-    recipientName?: string;
-    title?: string;
-    msgType?: MessageDeliverySmsType;
-    triggerType?: MessageDeliveryTriggerType;
-    scheduledDate?: string;
-    scheduledTime?: string;
-    testMode?: boolean;
-}
-
-export interface SendMessageDeliverySmsResponse {
-    provider: "aligo";
-    triggerType: Exclude<MessageDeliveryTriggerType, undefined>;
-    request: {
-        receiver: string;
-        msgType: "SMS" | "LMS";
-        scheduledAt?: string;
-        testMode: boolean;
-    };
-    result: {
-        resultCode: number;
-        message: string;
-        msgId?: number;
-        successCount?: number;
-        errorCount?: number;
-        msgType?: string;
-    };
-}
+export type {
+    MessageDeliverySmsType,
+    MessageDeliveryTriggerType,
+    SendMessageDeliverySmsRequest,
+    SendMessageDeliverySmsResponse,
+};
 
 export interface RibbonConfig {
     enabled: boolean;

--- a/mobile/src/app/messages/new/page.tsx
+++ b/mobile/src/app/messages/new/page.tsx
@@ -46,17 +46,11 @@ import { formatKoreanPhoneNumber, normalizeKoreanPhoneDigits } from "@/lib/phone
 import { parsePositiveIntQueryParam } from "@/lib/query-params";
 import { extractVariables, renderTemplate } from "@/lib/template-utils";
 import { cn } from "@/lib/utils";
+import type { SendMessageDeliverySmsResponse } from "@babyjamjam/shared/types/message";
 
 import styles from "./page.module.css";
 
-interface SendResponse {
-  result?: {
-    resultCode?: number;
-    message?: string;
-    errorCount?: number;
-  };
-  message?: string;
-}
+type SendResponse = SendMessageDeliverySmsResponse;
 
 interface RecipientChip {
   id: string;

--- a/mobile/src/app/messages/page.tsx
+++ b/mobile/src/app/messages/page.tsx
@@ -233,7 +233,7 @@ export default function MessagesPage() {
   const [activeDetailTab, setActiveDetailTab] = useState<MessageDetailTab>("content");
 
   const { data: userTemplatesData } = useMessageTemplates(1, 100);
-  const userTemplates = Array.isArray(userTemplatesData?.data) ? userTemplatesData.data : [];
+  const userTemplates = Array.isArray(userTemplatesData) ? userTemplatesData : [];
 
   const { data: upcomingJobsData } = useQuery<UpcomingAlimtalkJob[]>({
     queryKey: ["alimtalk", "upcoming", 100],

--- a/mobile/src/features/message-templates/types.ts
+++ b/mobile/src/features/message-templates/types.ts
@@ -1,35 +1,19 @@
-export interface TemplateVariable {
-    key: string;
-    label: string;
-    type: string;
-    required: boolean;
-}
+import type {
+    CreateMessageTemplateRequest,
+    MessageTemplate,
+    MessageTemplateListResponse,
+    MessageTemplateVariable,
+    UpdateMessageTemplateRequest,
+} from "@babyjamjam/shared/types/message";
 
-export interface MessageTemplate {
-    id: string;
-    name: string;
-    content: string;
-    variables: TemplateVariable[];
-    createdAt: string;
-    updatedAt: string;
-}
+export type TemplateVariable = MessageTemplateVariable;
 
-export interface PaginatedTemplates {
-    data: MessageTemplate[];
-    total: number;
-    page: number;
-    limit: number;
-    totalPages: number;
-}
+export type {
+    MessageTemplate,
+};
 
-export interface CreateTemplateDto {
-    name: string;
-    content: string;
-    variables: TemplateVariable[];
-}
-
-export interface UpdateTemplateDto {
-    name: string;
-    content: string;
-    variables: TemplateVariable[];
-}
+// Legacy alias kept locally so feature imports stay stable while the real
+// backend contract remains an array response.
+export type PaginatedTemplates = MessageTemplateListResponse;
+export type CreateTemplateDto = CreateMessageTemplateRequest;
+export type UpdateTemplateDto = UpdateMessageTemplateRequest;

--- a/mobile/src/lib/template/types.ts
+++ b/mobile/src/lib/template/types.ts
@@ -1,35 +1,16 @@
-export type VariableType = "text" | "phone" | "select" | "date" | "number" | "textarea";
+import type {
+    CreateMessageTemplateRequest,
+    MessageTemplate,
+    MessageTemplateVariable,
+    MessageTemplateVariableType,
+    UpdateMessageTemplateRequest,
+} from "@babyjamjam/shared/types/message";
 
-export interface TemplateVariable {
-    key: string;
-    type: VariableType;
-    label: string;
-    placeholder?: string;
-    required: boolean;
-    optionType?: "custom" | "dataSource";
-    options?: string[];
-    dataSource?: string;
-    min?: number;
-    max?: number;
-}
+export type VariableType = MessageTemplateVariableType;
+export type TemplateVariable = MessageTemplateVariable;
 
-export interface MessageTemplate {
-    id: string;
-    name: string;
-    content: string;
-    variables: TemplateVariable[];
-    createdAt: string;
-    updatedAt: string;
-}
-
-export interface CreateMessageTemplateRequest {
-    name: string;
-    content: string;
-    variables: TemplateVariable[];
-}
-
-export interface UpdateMessageTemplateRequest {
-    name?: string;
-    content?: string;
-    variables?: TemplateVariable[];
-}
+export type {
+    CreateMessageTemplateRequest,
+    MessageTemplate,
+    UpdateMessageTemplateRequest,
+};

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -15,6 +15,10 @@ import {
     FinalizeHeadlessResponse,
     HeadlessDispatchResponse,
 } from "@babyjamjam/shared/types/eformsign";
+import type {
+    MessageSenderApprovalResponse,
+    MessageSenderApprovalStatus,
+} from "@babyjamjam/shared/types/message";
 import { safeStorageSetItem } from "@/lib/safe-storage";
 import { isAxiosError } from "axios";
 
@@ -387,19 +391,11 @@ export async function withEformsignReauth<T>(fn: () => Promise<T>): Promise<T> {
     }
 }
 
-export type MessageSenderApprovalStatus = "not_requested" | "pending" | "approved";
-
 export type { AlimtalkProvider, AlimtalkProviderResponse };
-
-export interface MessageSenderApprovalResponse {
-    senderPhone: string | null;
-    senderPhoneFormatted: string | null;
-    approvalStatus: MessageSenderApprovalStatus;
-    isApproved: boolean;
-    canRequest: boolean;
-    requestedAt: string | null;
-    approvedAt: string | null;
-}
+export type {
+    MessageSenderApprovalResponse,
+    MessageSenderApprovalStatus,
+};
 
 export const settingsApi = {
     getAlimtalkProvider: async (): Promise<AlimtalkProviderResponse> => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,6 +10,7 @@
         ".": "./src/index.ts",
         "./types/alimtalk": "./src/types/alimtalk.ts",
         "./types/eformsign": "./src/types/eformsign.ts",
+        "./types/message": "./src/types/message.ts",
         "./utils": "./src/utils/index.ts",
         "./eslint-plugin": "./eslint-plugin/index.mjs"
     },

--- a/packages/shared/src/types/message.ts
+++ b/packages/shared/src/types/message.ts
@@ -1,0 +1,192 @@
+// Shared message contracts used by both frontend and mobile.
+//
+// The source of truth for these shapes is the backend contract surface:
+// - backend/interface/dto/message.dto.ts
+// - backend/interface/dto/message-template.dto.ts
+// - backend/interface/dto/message-delivery.dto.ts
+// - backend/interface/dto/message-sender-approval.dto.ts
+// - backend/interface/dto/system-admin.dto.ts
+// - backend/domain/entities/message.entity.ts
+// - backend/domain/entities/message-template.entity.ts
+// - backend/interface/controllers/message-delivery.controller.ts
+// - backend/interface/controllers/system-setting.controller.ts
+// - backend/application/services/system-admin.service.ts
+//
+// Message and message-template controllers currently return Date-backed
+// entities directly. Those dates serialize to ISO strings on the wire, so the
+// client-facing response types below use string while Raw* variants retain Date
+// for backend-reference parity.
+
+export type MessageTemplateVariableType =
+  | "text"
+  | "phone"
+  | "select"
+  | "date"
+  | "number"
+  | "textarea";
+
+export type MessageTemplateVariableOptionType = "custom" | "dataSource";
+
+export interface MessageTemplateVariable {
+  key: string;
+  type: MessageTemplateVariableType;
+  label: string;
+  placeholder?: string;
+  required: boolean;
+  optionType?: MessageTemplateVariableOptionType;
+  options?: string[];
+  dataSource?: string;
+  min?: number;
+  max?: number;
+}
+
+export interface RawMessageRecord {
+  id: number;
+  title: string;
+  text: string;
+  createdAt: Date;
+  editedAt: Date | null;
+}
+
+export interface MessageRecord {
+  id: number;
+  title: string;
+  text: string;
+  createdAt: string;
+  editedAt: string | null;
+}
+
+export interface CreateMessageRequest {
+  title: string;
+  text: string;
+}
+
+export interface UpdateMessageRequest {
+  title: string;
+  text: string;
+}
+
+export interface RawMessageTemplate {
+  id: string;
+  name: string;
+  content: string;
+  variables: MessageTemplateVariable[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface MessageTemplate {
+  id: string;
+  name: string;
+  content: string;
+  variables: MessageTemplateVariable[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type MessageTemplateListResponse = MessageTemplate[];
+
+export interface CreateMessageTemplateRequest {
+  name: string;
+  content: string;
+  variables: MessageTemplateVariable[];
+}
+
+export interface UpdateMessageTemplateRequest {
+  name?: string;
+  content?: string;
+  variables?: MessageTemplateVariable[];
+}
+
+export type MessageDeliverySmsType = "AUTO" | "SMS" | "LMS";
+export type MessageDeliveryTriggerType = "immediate" | "scheduled";
+export type MessageDeliveryResolvedSmsType = "SMS" | "LMS";
+export type MessageDeliveryProviderSmsType = "SMS" | "LMS" | "MMS";
+
+export interface SendMessageDeliverySmsRequest {
+  receiver: string;
+  message: string;
+  title?: string;
+  recipientName?: string;
+  clientId?: number;
+  msgType?: MessageDeliverySmsType;
+  triggerType?: MessageDeliveryTriggerType;
+  scheduledDate?: string;
+  scheduledTime?: string;
+  testMode?: boolean;
+}
+
+export interface SendMessageDeliverySmsResponse {
+  provider: "aligo";
+  triggerType: MessageDeliveryTriggerType;
+  request: {
+    senderPhone?: string;
+    receiver: string;
+    msgType: MessageDeliveryResolvedSmsType;
+    scheduledAt?: string;
+    testMode: boolean;
+  };
+  result: {
+    resultCode: number;
+    message: string;
+    msgId?: number;
+    successCount?: number;
+    errorCount?: number;
+    msgType?: MessageDeliveryProviderSmsType;
+  };
+}
+
+export const MESSAGE_SENDER_APPROVAL_STATUSES = [
+  "not_requested",
+  "pending",
+  "approved",
+] as const;
+
+export type MessageSenderApprovalStatus =
+  (typeof MESSAGE_SENDER_APPROVAL_STATUSES)[number];
+
+export interface RequestMessageSenderApproval {
+  senderPhone: string;
+}
+
+export interface MessageSenderApprovalResponse {
+  senderPhone: string | null;
+  senderPhoneFormatted: string | null;
+  approvalStatus: MessageSenderApprovalStatus;
+  isApproved: boolean;
+  canRequest: boolean;
+  requestedAt: string | null;
+  approvedAt: string | null;
+}
+
+export interface SystemAdminBranchUser {
+  id: string;
+  name: string | null;
+  email: string | null;
+  phone: string | null;
+  role: string | null;
+}
+
+export interface SystemAdminBranchMessageSenderApproval {
+  senderPhone: string | null;
+  approvalStatus: MessageSenderApprovalStatus;
+  requestedAt: string | null;
+  approvedAt: string | null;
+  requestedBy: SystemAdminBranchUser | null;
+}
+
+export interface SystemAdminBranchRequest {
+  id: string;
+  name: string;
+  slug: string;
+  region: string | null;
+  district: string | null;
+  address: string | null;
+  phone: string | null;
+  email: string | null;
+  isActive: boolean;
+  createdAt: string | null;
+  updatedAt: string | null;
+  owner: SystemAdminBranchUser;
+  messageSenderApproval: SystemAdminBranchMessageSenderApproval;
+}


### PR DESCRIPTION
## Summary

P5.4c — message type group reconciled into `@babyjamjam/shared/types/message`:

| Drift | Resolution |
|---|---|
| Both apps stripped `TemplateVariable` to 4 fields | Backend fields restored: `placeholder`, `optionType`, `options`, `dataSource`, `min`, `max` |
| Apps modeled `GET /message-templates` as paginated | Corrected to the actual array contract |
| Frontend SMS response dropped `request.senderPhone`; mobile used a page-local partial | Shared `SendMessageDeliverySmsRequest/Response` with the full backend shape |
| Duplicated sender-approval/system-admin view types | Shared, alias names preserved via shims |
| `/messages` records | Shared raw/app-facing + create/update contracts; UI-derived view models stay local |

## Test plan

- [x] Both type-checks exit 0; **632 + 245 tests green**; lint counts unchanged
- [x] Both production builds exit 0 (outside-sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)