### PR TITLE
refactor(workspace): share reconciled system-template types (P5.4d)

### DIFF
--- a/frontend/src/app/(protected)/messages/page.tsx
+++ b/frontend/src/app/(protected)/messages/page.tsx
@@ -5,6 +5,7 @@ import { t } from "@/lib/i18n/translations";
 import { useLocale } from "@/providers/LocaleProvider";
 import { useMessageTemplates } from "@/features/message-templates/hooks/use-message-templates";
 import { useSystemTemplate } from "@/features/system-templates/hooks";
+import type { SystemTemplateKey } from "@/features/system-templates/types";
 import {
   useAlimtalkHistory,
   useUpcomingAlimtalkJobs,
@@ -364,9 +365,9 @@ const TEMPLATE_DETAIL_TABS = [
   { key: "preview", label: "미리보기" },
 ];
 
-const BUILTIN_TEMPLATE_SYSTEM_KEYS: Record<BuiltinTemplateType, string> = {
+const BUILTIN_TEMPLATE_SYSTEM_KEYS: Record<BuiltinTemplateType, SystemTemplateKey> = {
   greeting: "GREETING",
-  "service-info": "service_info",
+  "service-info": "SERVICE_INFO",
   "price-info": "PRICE_INFO",
   reminder: "REMINDER",
   thanks: "THANKS",

--- a/frontend/src/components/app/messages/forms/service-info-message-form.tsx
+++ b/frontend/src/components/app/messages/forms/service-info-message-form.tsx
@@ -16,7 +16,7 @@ export const ServiceInfoMessageForm = ({ onPreviewMessageChange }: ServiceInfoMe
   const locale = useLocale();
   const [name, setName] = useState("");
   const [messageOverride, setMessageOverride] = useState<string | null>(null);
-  const { data: systemTemplate } = useSystemTemplate("service_info");
+  const { data: systemTemplate } = useSystemTemplate("SERVICE_INFO");
 
   const handleCopy = () => {
     navigator.clipboard.writeText(generatedMessage);

--- a/frontend/src/features/system-templates/hooks/use-update-system-template.ts
+++ b/frontend/src/features/system-templates/hooks/use-update-system-template.ts
@@ -3,7 +3,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { systemTemplateService } from '@/services/system-template.service';
 import { systemTemplateKeys } from './useSystemTemplates';
-import type { CustomVariable, SystemTemplate } from '../types';
+import type { CustomVariable, UpdateSystemTemplateResponse } from '../types';
 
 export interface ApiErrorResponse {
   message: string;
@@ -19,7 +19,7 @@ interface UpdateParams {
 export function useUpdateSystemTemplate() {
   const queryClient = useQueryClient();
   
-  return useMutation<SystemTemplate, ApiErrorResponse, UpdateParams>({
+  return useMutation<UpdateSystemTemplateResponse, ApiErrorResponse, UpdateParams>({
     mutationFn: ({ key, content, customVariables }) =>
       systemTemplateService.update(key, content, customVariables).then(r => r.data),
     onSuccess: (_, { key }) => {

--- a/frontend/src/features/system-templates/types.ts
+++ b/frontend/src/features/system-templates/types.ts
@@ -1,41 +1,35 @@
-export interface TemplateVariable {
-    key: string;
-    label: string;
-    type: 'string' | 'number' | 'currency';
-    required: boolean;
-    description?: string;
-}
+export { SYSTEM_TEMPLATE_KEYS } from '@babyjamjam/shared/types/system-template';
 
-export interface CustomVariable {
-    key: string;
-    label: string;
-    required: boolean;
-}
+export type {
+    CustomVariable,
+    PreviewSystemTemplateRequest,
+    PreviewSystemTemplateResponse,
+    RawSystemTemplate,
+    RawSystemTemplateRecord,
+    RawSystemTemplateVersionRecord,
+    ResetSystemTemplateResponse,
+    RollbackSystemTemplateResponse,
+    SystemTemplate,
+    SystemTemplateContract,
+    SystemTemplateKey,
+    SystemTemplateListResponse,
+    SystemTemplateRecord,
+    SystemTemplateVersionDetail,
+    SystemTemplateVersionDetailResponse,
+    SystemTemplateVersionListResponse,
+    SystemTemplateVersionRecord,
+    SystemTemplateVersionSummary,
+    SystemTemplateValidationResult,
+    TemplateVariable,
+    TemplateVariableType,
+    UpdateSystemTemplateRequest,
+    UpdateSystemTemplateResponse,
+    ValidateSystemTemplateRequest,
+    ValidateSystemTemplateResponse,
+} from '@babyjamjam/shared/types/system-template';
 
-export interface SystemTemplate {
-    id: string;
-    templateKey: string;
-    name: string;
-    description: string;
-    content: string;
-    requiredVariables: TemplateVariable[];
-    customVariables: CustomVariable[];
-    updatedAt: string;
-}
-
-export interface VersionHistoryItem {
-    versionNumber: number;
-    createdAt: string;
-    createdBy: string | null;
-}
-
-export interface VersionDetail extends VersionHistoryItem {
-    content: string;
-}
-
-export interface ValidationResult {
-    valid: boolean;
-    missingVariables: string[];
-    unknownVariables: string[];
-    syntaxErrors: string[];
-}
+export type {
+    SystemTemplateVersionDetail as VersionDetail,
+    SystemTemplateVersionSummary as VersionHistoryItem,
+    SystemTemplateValidationResult as ValidationResult,
+} from '@babyjamjam/shared/types/system-template';

--- a/frontend/src/services/system-template.service.ts
+++ b/frontend/src/services/system-template.service.ts
@@ -2,10 +2,14 @@ import { api } from '@/lib/api/client';
 
 import type {
     CustomVariable,
+    PreviewSystemTemplateRequest,
+    PreviewSystemTemplateResponse,
     SystemTemplate,
-    ValidationResult,
-    VersionDetail,
-    VersionHistoryItem,
+    SystemTemplateVersionDetail,
+    SystemTemplateVersionSummary,
+    SystemTemplateValidationResult,
+    UpdateSystemTemplateRequest,
+    UpdateSystemTemplateResponse,
 } from '../features/system-templates/types';
 
 export const systemTemplateService = {
@@ -13,23 +17,30 @@ export const systemTemplateService = {
 
     getByKey: (key: string) => api.get<SystemTemplate>(`/system-templates/${key}`),
 
-    update: (key: string, content: string, customVariables?: CustomVariable[]) =>
-        api.put<SystemTemplate>(`/system-templates/${key}`, { content, customVariables }),
+    update: (key: string, content: string, customVariables?: CustomVariable[]) => {
+        const payload: UpdateSystemTemplateRequest = customVariables
+            ? { content, customVariables }
+            : { content };
+        return api.put<UpdateSystemTemplateResponse>(`/system-templates/${key}`, payload);
+    },
 
     validate: (key: string, content: string) =>
-        api.post<ValidationResult>(`/system-templates/${key}/validate`, { content }),
+        api.post<SystemTemplateValidationResult>(`/system-templates/${key}/validate`, { content }),
 
-    preview: (key: string, data: Record<string, unknown>, content?: string) =>
-        api.post<string>(`/system-templates/${key}/preview`, { content, data }),
+    preview: (key: string, data: Record<string, unknown>, content?: string) => {
+        const payload: PreviewSystemTemplateRequest =
+            content === undefined ? { data } : { content, data };
+        return api.post<PreviewSystemTemplateResponse>(`/system-templates/${key}/preview`, payload);
+    },
 
     getVersions: (key: string) =>
-        api.get<VersionHistoryItem[]>(`/system-templates/${key}/versions`),
+        api.get<SystemTemplateVersionSummary[]>(`/system-templates/${key}/versions`),
 
     getVersionContent: (key: string, versionNumber: number) =>
-        api.get<VersionDetail>(`/system-templates/${key}/versions/${versionNumber}`),
+        api.get<SystemTemplateVersionDetail>(`/system-templates/${key}/versions/${versionNumber}`),
 
     rollback: (key: string, versionNumber: number) =>
-        api.post<SystemTemplate>(`/system-templates/${key}/rollback/${versionNumber}`),
+        api.post<UpdateSystemTemplateResponse>(`/system-templates/${key}/rollback/${versionNumber}`),
 
-    reset: (key: string) => api.post<SystemTemplate>(`/system-templates/${key}/reset`),
+    reset: (key: string) => api.post<UpdateSystemTemplateResponse>(`/system-templates/${key}/reset`),
 };

--- a/mobile/src/app/messages/new/page.tsx
+++ b/mobile/src/app/messages/new/page.tsx
@@ -112,7 +112,7 @@ const NAME_FALLBACK_VARIABLES: TemplateInputVariable[] = [
 const PRICE_INFO_FALLBACK_VARIABLES: TemplateInputVariable[] = [
   { key: "name", label: "산모명", required: true, type: "string" },
   { key: "weeks", label: "서비스 주수", required: true, type: "number" },
-  { key: "duration", label: "서비스 기간", required: true, type: "number" },
+  { key: "duration", label: "서비스 기간", required: true, type: "string" },
   { key: "type", label: "바우처 유형", required: true, type: "string" },
   { key: "fullPrice", label: "총 서비스 금액", required: true, type: "currency" },
   { key: "grant", label: "정부지원금", required: true, type: "currency" },

--- a/mobile/src/components/app/messages/forms/service-info-message-form.tsx
+++ b/mobile/src/components/app/messages/forms/service-info-message-form.tsx
@@ -17,7 +17,7 @@ export const ServiceInfoMessageForm = () => {
   const { toast } = useToast();
   const { name, setName } = useFormStore();
   const [generatedMessage, setGeneratedMessage] = useState("");
-  const { data: systemTemplate } = useSystemTemplate("service_info");
+  const { data: systemTemplate } = useSystemTemplate("SERVICE_INFO");
 
   const handleGenerate = () => {
     const message = systemTemplate?.content

--- a/mobile/src/features/system-templates/hooks/use-update-system-template.ts
+++ b/mobile/src/features/system-templates/hooks/use-update-system-template.ts
@@ -3,7 +3,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { systemTemplateService } from '@/services/system-template.service';
 import { systemTemplateKeys } from './useSystemTemplates';
-import type { CustomVariable, SystemTemplate } from '../types';
+import type { CustomVariable, UpdateSystemTemplateResponse } from '../types';
 
 export interface ApiErrorResponse {
   message: string;
@@ -19,7 +19,7 @@ interface UpdateParams {
 export function useUpdateSystemTemplate() {
   const queryClient = useQueryClient();
   
-  return useMutation<SystemTemplate, ApiErrorResponse, UpdateParams>({
+  return useMutation<UpdateSystemTemplateResponse, ApiErrorResponse, UpdateParams>({
     mutationFn: ({ key, content, customVariables }) =>
       systemTemplateService.update(key, content, customVariables).then(r => r.data),
     onSuccess: (_, { key }) => {

--- a/mobile/src/features/system-templates/types.ts
+++ b/mobile/src/features/system-templates/types.ts
@@ -1,41 +1,35 @@
-export interface TemplateVariable {
-    key: string;
-    label: string;
-    type: 'string' | 'number' | 'currency';
-    required: boolean;
-    description?: string;
-}
+export { SYSTEM_TEMPLATE_KEYS } from '@babyjamjam/shared/types/system-template';
 
-export interface CustomVariable {
-    key: string;
-    label: string;
-    required: boolean;
-}
+export type {
+    CustomVariable,
+    PreviewSystemTemplateRequest,
+    PreviewSystemTemplateResponse,
+    RawSystemTemplate,
+    RawSystemTemplateRecord,
+    RawSystemTemplateVersionRecord,
+    ResetSystemTemplateResponse,
+    RollbackSystemTemplateResponse,
+    SystemTemplate,
+    SystemTemplateContract,
+    SystemTemplateKey,
+    SystemTemplateListResponse,
+    SystemTemplateRecord,
+    SystemTemplateVersionDetail,
+    SystemTemplateVersionDetailResponse,
+    SystemTemplateVersionListResponse,
+    SystemTemplateVersionRecord,
+    SystemTemplateVersionSummary,
+    SystemTemplateValidationResult,
+    TemplateVariable,
+    TemplateVariableType,
+    UpdateSystemTemplateRequest,
+    UpdateSystemTemplateResponse,
+    ValidateSystemTemplateRequest,
+    ValidateSystemTemplateResponse,
+} from '@babyjamjam/shared/types/system-template';
 
-export interface SystemTemplate {
-    id: string;
-    templateKey: string;
-    name: string;
-    description: string;
-    content: string;
-    requiredVariables: TemplateVariable[];
-    customVariables: CustomVariable[];
-    updatedAt: string;
-}
-
-export interface VersionHistoryItem {
-    versionNumber: number;
-    createdAt: string;
-    createdBy: string | null;
-}
-
-export interface VersionDetail extends VersionHistoryItem {
-    content: string;
-}
-
-export interface ValidationResult {
-    valid: boolean;
-    missingVariables: string[];
-    unknownVariables: string[];
-    syntaxErrors: string[];
-}
+export type {
+    SystemTemplateVersionDetail as VersionDetail,
+    SystemTemplateVersionSummary as VersionHistoryItem,
+    SystemTemplateValidationResult as ValidationResult,
+} from '@babyjamjam/shared/types/system-template';

--- a/mobile/src/services/system-template.service.ts
+++ b/mobile/src/services/system-template.service.ts
@@ -2,10 +2,14 @@ import { api } from '@/lib/api/client';
 
 import type {
     CustomVariable,
+    PreviewSystemTemplateRequest,
+    PreviewSystemTemplateResponse,
     SystemTemplate,
-    ValidationResult,
-    VersionDetail,
-    VersionHistoryItem,
+    SystemTemplateVersionDetail,
+    SystemTemplateVersionSummary,
+    SystemTemplateValidationResult,
+    UpdateSystemTemplateRequest,
+    UpdateSystemTemplateResponse,
 } from '../features/system-templates/types';
 
 export const systemTemplateService = {
@@ -13,23 +17,30 @@ export const systemTemplateService = {
 
     getByKey: (key: string) => api.get<SystemTemplate>(`/system-templates/${key}`),
 
-    update: (key: string, content: string, customVariables?: CustomVariable[]) =>
-        api.put<SystemTemplate>(`/system-templates/${key}`, { content, customVariables }),
+    update: (key: string, content: string, customVariables?: CustomVariable[]) => {
+        const payload: UpdateSystemTemplateRequest = customVariables
+            ? { content, customVariables }
+            : { content };
+        return api.put<UpdateSystemTemplateResponse>(`/system-templates/${key}`, payload);
+    },
 
     validate: (key: string, content: string) =>
-        api.post<ValidationResult>(`/system-templates/${key}/validate`, { content }),
+        api.post<SystemTemplateValidationResult>(`/system-templates/${key}/validate`, { content }),
 
-    preview: (key: string, data: Record<string, unknown>, content?: string) =>
-        api.post<string>(`/system-templates/${key}/preview`, { content, data }),
+    preview: (key: string, data: Record<string, unknown>, content?: string) => {
+        const payload: PreviewSystemTemplateRequest =
+            content === undefined ? { data } : { content, data };
+        return api.post<PreviewSystemTemplateResponse>(`/system-templates/${key}/preview`, payload);
+    },
 
     getVersions: (key: string) =>
-        api.get<VersionHistoryItem[]>(`/system-templates/${key}/versions`),
+        api.get<SystemTemplateVersionSummary[]>(`/system-templates/${key}/versions`),
 
     getVersionContent: (key: string, versionNumber: number) =>
-        api.get<VersionDetail>(`/system-templates/${key}/versions/${versionNumber}`),
+        api.get<SystemTemplateVersionDetail>(`/system-templates/${key}/versions/${versionNumber}`),
 
     rollback: (key: string, versionNumber: number) =>
-        api.post<SystemTemplate>(`/system-templates/${key}/rollback/${versionNumber}`),
+        api.post<UpdateSystemTemplateResponse>(`/system-templates/${key}/rollback/${versionNumber}`),
 
-    reset: (key: string) => api.post<SystemTemplate>(`/system-templates/${key}/reset`),
+    reset: (key: string) => api.post<UpdateSystemTemplateResponse>(`/system-templates/${key}/reset`),
 };

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,6 +11,7 @@
         "./types/alimtalk": "./src/types/alimtalk.ts",
         "./types/eformsign": "./src/types/eformsign.ts",
         "./types/message": "./src/types/message.ts",
+        "./types/system-template": "./src/types/system-template.ts",
         "./utils": "./src/utils/index.ts",
         "./eslint-plugin": "./eslint-plugin/index.mjs"
     },

--- a/packages/shared/src/types/system-template.ts
+++ b/packages/shared/src/types/system-template.ts
@@ -1,0 +1,139 @@
+// Shared system-template contracts used by both frontend and mobile.
+//
+// The source of truth for these shapes is the backend contract surface:
+// - backend/interface/dto/system-template.dto.ts
+// - backend/domain/constants/system-template-registry.ts
+// - backend/domain/entities/system-template.entity.ts
+// - backend/domain/entities/system-template-version.entity.ts
+// - backend/application/dto/system-template-with-registry.dto.ts
+// - backend/interface/controllers/system-template.controller.ts
+// - backend/application/services/system-template.service.ts
+//
+// Read endpoints return registry-enriched DTOs, while update/rollback/reset
+// endpoints return the raw SystemTemplateEntity. Date-backed values serialize
+// to ISO strings on the wire, so the client-facing response types below use
+// string while Raw* variants retain Date for backend-reference parity.
+
+export const SYSTEM_TEMPLATE_KEYS = [
+  'PRICE_INFO',
+  'GREETING',
+  'THANKS',
+  'SURVEY',
+  'SERVICE_INFO',
+  'REMINDER',
+  'INFO',
+] as const;
+
+export type SystemTemplateKey = (typeof SYSTEM_TEMPLATE_KEYS)[number];
+
+export type TemplateVariableType = 'string' | 'number' | 'currency';
+
+export interface TemplateVariable {
+  key: string;
+  label: string;
+  type: TemplateVariableType;
+  required: boolean;
+  description?: string;
+}
+
+export interface CustomVariable {
+  key: string;
+  label: string;
+  required: boolean;
+}
+
+export interface SystemTemplateContract {
+  key: SystemTemplateKey;
+  name: string;
+  description: string;
+  requiredVariables: TemplateVariable[];
+  defaultContent: string;
+}
+
+export interface RawSystemTemplateRecord {
+  id: string;
+  templateKey: SystemTemplateKey;
+  content: string;
+  customVariables: CustomVariable[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface SystemTemplateRecord {
+  id: string;
+  templateKey: SystemTemplateKey;
+  content: string;
+  customVariables: CustomVariable[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RawSystemTemplate extends RawSystemTemplateRecord {
+  name: string;
+  description: string;
+  requiredVariables: TemplateVariable[];
+}
+
+export interface SystemTemplate extends SystemTemplateRecord {
+  name: string;
+  description: string;
+  requiredVariables: TemplateVariable[];
+}
+
+export interface UpdateSystemTemplateRequest {
+  content: string;
+  customVariables?: CustomVariable[];
+}
+
+export interface ValidateSystemTemplateRequest {
+  content: string;
+}
+
+export interface PreviewSystemTemplateRequest {
+  content?: string;
+  data: Record<string, unknown>;
+}
+
+export interface SystemTemplateValidationResult {
+  valid: boolean;
+  missingVariables: string[];
+  unknownVariables: string[];
+  syntaxErrors: string[];
+}
+
+export interface RawSystemTemplateVersionRecord {
+  id: string;
+  templateId: string;
+  content: string;
+  versionNumber: number;
+  createdBy: string | null;
+  createdAt: Date;
+}
+
+export interface SystemTemplateVersionRecord {
+  id: string;
+  templateId: string;
+  content: string;
+  versionNumber: number;
+  createdBy: string | null;
+  createdAt: string;
+}
+
+export interface SystemTemplateVersionSummary {
+  versionNumber: number;
+  createdAt: string;
+  createdBy: string | null;
+}
+
+export interface SystemTemplateVersionDetail extends SystemTemplateVersionSummary {
+  content: string;
+}
+
+export type SystemTemplateListResponse = SystemTemplate[];
+export type UpdateSystemTemplateResponse = SystemTemplateRecord;
+export type ValidateSystemTemplateResponse = SystemTemplateValidationResult;
+export type PreviewSystemTemplateResponse = string;
+export type SystemTemplateVersionListResponse = SystemTemplateVersionSummary[];
+export type SystemTemplateVersionDetailResponse = SystemTemplateVersionDetail;
+export type RollbackSystemTemplateResponse = SystemTemplateRecord;
+export type ResetSystemTemplateResponse = SystemTemplateRecord;


### PR DESCRIPTION
## Summary

P5.4d — the last type group. Reconciling against backend truth surfaced a **latent production bug**, now fixed: `templateKey` was weakened to `string` in both apps, and three live consumers sent `service_info`/`service-info` — keys the backend's registry rejects (`SERVICE_INFO`). The shared union makes that class of bug a compile error.

| Drift | Resolution |
|---|---|
| `templateKey: string` | Shared `SYSTEM_TEMPLATE_KEYS` union; 3 live consumers fixed |
| Read type dropped `createdAt` | Restored per `SystemTemplateWithRegistryDto` |
| update/rollback/reset typed as enriched read shape | Corrected to raw `SystemTemplateRecord` per the controller |
| validate/preview contracts implicit | Named shared request/response types |
| version list vs detail conflated | Modeled the controller's actual summary/detail split |
| mobile PRICE_INFO `duration: number` | Registry says `string` — fixed |

## Test plan

- [x] Both type-checks exit 0; **632 + 245 tests green**; lint counts unchanged
- [x] Both production builds exit 0 (outside-sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)