### PR TITLE
ci(e2e): 2 CI workers + 90-minute cap so the suite can finish

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -68,7 +68,9 @@ jobs:
     name: playwright e2e (dispatch-only real backend)
     if: github.event_name == 'workflow_dispatch'
     needs: verify
-    timeout-minutes: 60
+    # 90: the full 266-test suite against the real stack needs headroom —
+    # two 60-minute runs were cancelled mid-suite before any report upload.
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     env:
       BASE_URL: http://localhost:3000

--- a/mobile/playwright.config.ts
+++ b/mobile/playwright.config.ts
@@ -11,8 +11,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* 2 workers on CI (matches the runner's cores): 266 tests at 1 worker
+     with retries exceed any sane job timeout against the real backend. */
+  workers: process.env.CI ? 2 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
## Summary

Both dispatch runs of the real-backend e2e job were cancelled at the 60-minute cap **mid-suite** (no report artifact survives a cancellation). The math doesn't work: 266 tests × 1 worker × up to 2 retries against a real stack.

- `workers: 2` on CI (matches the 2-core runner)
- job `timeout-minutes: 90`

Trade-off noted in-code: two workers share one backend+DB, so fixture-mutating specs may interfere — fine for the advisory job; the completed run's report separates real failures from parallelism artifacts and becomes the promotion worklist.

## Test plan

- [x] Mobile type-check clean (config-only change)
- [ ] Post-merge dispatch → first complete report artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)