### PR TITLE
fix: apply surviving findings from the full-delta adversarial review

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -15,7 +15,7 @@ on:
   # so it must report on every PR — path-filtered required checks block
   # merges as eternally "expected" when the paths don't match.
   pull_request:
-    branches: [ main, dev, preview, "feature/**", "fix/**" ]
+    branches: [ main, dev, preview, "feature/**", "fix/**", "ci/**" ]
 
 jobs:
   verify:

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -45,6 +45,11 @@ jobs:
       - name: Type check
         run: pnpm --filter babyjamjam-admin run type-check
 
+      # The shared package is otherwise only type-checked transitively through
+      # its consumers; an orphaned export would ship green (review finding).
+      - name: Type check shared package
+        run: pnpm --filter @babyjamjam/shared run type-check
+
       - name: Lint
         run: pnpm --filter babyjamjam-admin run lint
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,9 @@ build/
 backend/dist/
 backend/node_modules/
 backend/prisma/generated/
-backend/prisma/schema.prisma
+# schema.prisma is tracked and load-bearing (drift guard, prisma generate,
+# migration authoring) — review finding: a tracked-but-ignored file silently
+# falls out of git after a stray `git rm --cached`/recreate. Never ignore it.
 backend/prisma/seed.ts
 
 # misc

--- a/backend/main.ts
+++ b/backend/main.ts
@@ -20,6 +20,17 @@ process.on('unhandledRejection', (reason, promise) => {
 };
 
 async function bootstrap() {
+    // Belt-and-suspenders (review finding): the e2e-only switches must never
+    // ride into a production boot — they disable vendor egress and the
+    // storage bucket bootstrap.
+    if (process.env["NODE_ENV"] === "production") {
+        for (const flag of ["E2E_VENDOR_STUBS", "STORAGE_BOOTSTRAP_DISABLED"]) {
+            if (process.env[flag] === "1") {
+                throw new Error(`${flag}=1 is not allowed when NODE_ENV=production`);
+            }
+        }
+    }
+
     const app = await NestFactory.create(AppModule);
     app.use(helmet());
     const expressApp = app.getHttpAdapter().getInstance();

--- a/mobile/src/hooks/useClients.ts
+++ b/mobile/src/hooks/useClients.ts
@@ -2,6 +2,7 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
+import { dashboardQueryKeys } from "@/hooks/useDashboardAnalytics";
 import type { 
     Client, 
     CreateClientDto, 
@@ -103,6 +104,9 @@ export function useCreateClient() {
         onSuccess: () => {
             // Invalidate all client queries (lists + details) using prefix match
             queryClient.invalidateQueries({ queryKey: clientQueryKeys.all });
+            // Dashboard summary counters derive from clients (review finding:
+            // with staleTime 60s they otherwise show stale counts post-mutation).
+            queryClient.invalidateQueries({ queryKey: dashboardQueryKeys.analytics() });
         },
     });
 }
@@ -123,6 +127,7 @@ export function useUpdateClient() {
             queryClient.invalidateQueries({ 
                 queryKey: clientQueryKeys.detail(variables.id) 
             });
+            queryClient.invalidateQueries({ queryKey: dashboardQueryKeys.analytics() });
         },
     });
 }
@@ -159,6 +164,7 @@ export function useDeleteClient() {
         },
         onSettled: () => {
             queryClient.invalidateQueries({ queryKey: clientQueryKeys.all });
+            queryClient.invalidateQueries({ queryKey: dashboardQueryKeys.analytics() });
         },
     });
 }

--- a/mobile/src/services/api.test.ts
+++ b/mobile/src/services/api.test.ts
@@ -105,4 +105,30 @@ describe("eformsignApi.authenticate", () => {
         await expect(apiModule.eformsignApi.authenticate(6)).resolves.toEqual({ success: true });
         expect(mockPost).toHaveBeenCalledTimes(5);
     });
+
+    it("resumes automatic retries after the stop cooldown elapses", async () => {
+        // Review finding: a permanent stop stranded read-only document views
+        // (no force-auth action available) until a full page reload.
+        const { apiModule, mockPost } = await loadApiModule();
+        mockPost
+            .mockRejectedValueOnce(createAxiosServerError(503))
+            .mockRejectedValueOnce(createAxiosServerError(503))
+            .mockRejectedValueOnce(createAxiosServerError(503))
+            .mockResolvedValueOnce({ data: { success: true } });
+
+        await expect(apiModule.eformsignApi.authenticate(1)).rejects.toBeInstanceOf(AxiosError);
+        jest.setSystemTime(new Date("2026-06-07T00:00:30.001Z"));
+        await expect(apiModule.eformsignApi.authenticate(2)).rejects.toBeInstanceOf(AxiosError);
+        jest.setSystemTime(new Date("2026-06-07T00:01:00.002Z"));
+        await expect(apiModule.eformsignApi.authenticate(3)).rejects.toBeInstanceOf(AxiosError);
+        await expect(apiModule.eformsignApi.authenticate(4)).rejects.toBeInstanceOf(
+            apiModule.EformsignAuthAutoRetryStoppedError,
+        );
+
+        // Five minutes after the pause began, background auth tries again
+        // on its own and a success clears the breaker entirely.
+        jest.setSystemTime(new Date("2026-06-07T00:06:00.003Z"));
+        await expect(apiModule.eformsignApi.authenticate(5)).resolves.toEqual({ success: true });
+        expect(mockPost).toHaveBeenCalledTimes(4);
+    });
 });

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -55,9 +55,13 @@ const DEFAULT_EFORMSIGN_LIMIT = 100;
 const DEFAULT_EFORMSIGN_SKIP = 0;
 const MAX_EFORMSIGN_AUTH_5XX_ATTEMPTS = 3;
 const EFORMSIGN_AUTH_5XX_BACKOFF_MS = 30_000;
+// Review finding: a permanent stop stranded read-only document views for the
+// tab lifetime (only contract write actions force-reset). The stop is now a
+// cooldown so background auth resumes on its own once the vendor recovers.
+const EFORMSIGN_AUTH_STOP_COOLDOWN_MS = 5 * 60_000;
 
 let consecutiveEformsignAuthServerFailures = 0;
-let isAutomaticEformsignAuthStopped = false;
+let automaticEformsignAuthStoppedUntil = 0;
 let nextAutomaticEformsignAuthAttemptAt = 0;
 
 export class EformsignAuthAutoRetryStoppedError extends Error {
@@ -73,7 +77,7 @@ function isServerErrorStatus(status?: number): status is number {
 
 function resetEformsignAuthFailureState(): void {
     consecutiveEformsignAuthServerFailures = 0;
-    isAutomaticEformsignAuthStopped = false;
+    automaticEformsignAuthStoppedUntil = 0;
     nextAutomaticEformsignAuthAttemptAt = 0;
 }
 
@@ -82,13 +86,15 @@ function assertAutomaticEformsignAuthAllowed(force = false): void {
         return;
     }
 
-    if (isAutomaticEformsignAuthStopped) {
+    const now = Date.now();
+
+    if (now < automaticEformsignAuthStoppedUntil) {
         throw new EformsignAuthAutoRetryStoppedError(
             "Eformsign authentication auto-retries are paused after repeated server errors.",
         );
     }
 
-    if (Date.now() < nextAutomaticEformsignAuthAttemptAt) {
+    if (now < nextAutomaticEformsignAuthAttemptAt) {
         throw new EformsignAuthAutoRetryStoppedError(
             "Eformsign authentication is backing off after a recent server error.",
         );
@@ -104,7 +110,10 @@ function recordEformsignAuthFailure(error: unknown): void {
     nextAutomaticEformsignAuthAttemptAt = Date.now() + EFORMSIGN_AUTH_5XX_BACKOFF_MS;
 
     if (consecutiveEformsignAuthServerFailures >= MAX_EFORMSIGN_AUTH_5XX_ATTEMPTS) {
-        isAutomaticEformsignAuthStopped = true;
+        // Pause (not permanently stop) automatic attempts; a later failure
+        // after the cooldown re-arms the pause, a success clears everything.
+        automaticEformsignAuthStoppedUntil = Date.now() + EFORMSIGN_AUTH_STOP_COOLDOWN_MS;
+        consecutiveEformsignAuthServerFailures = MAX_EFORMSIGN_AUTH_5XX_ATTEMPTS - 1;
     }
 }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -25,7 +25,7 @@
         "zod": "^4.3.6"
     },
     "peerDependencies": {
-        "next": "16.1.6"
+        "next": "^16"
     },
     "devDependencies": {
         "next": "16.1.6",


### PR DESCRIPTION
## Summary

Closes out the goal's review requirement: a five-lens adversarial review (security regressions · behavior preservation · test integrity · CI/config · plan completeness) over the full remediation delta `2f093093..dev` (36 PRs). **Verdict: no critical/high code regressions; tests unweakened; every non-gated plan task verified landed.** This PR lands every surviving actionable finding:

| Lens | Finding | Fix |
|---|---|---|
| Behavior (MED) | Client mutations never invalidated `["dashboard","analytics"]` — counters disagreed with the list ≤60s post-mutation (pre-existing, exposed by P4.5's staleTime) | All three mutations invalidate analytics |
| Behavior (MED) | Breaker's permanent stop stranded read-only document views for the tab lifetime (only contract writes force-reset) | Stop → 5-minute cooldown; background auth self-heals; resume test added |
| Security (LOW) | E2E flags could theoretically ride into a prod boot | `main.ts` assertion refuses both flags under `NODE_ENV=production` |
| CI/config (MED) | `.gitignore` still ignored the tracked, load-bearing `schema.prisma` | Ignore dropped with explanatory comment |
| CI/config (MED) | `next: "16.1.6"` exact-pin peer = three-file lockstep bump | Peer relaxed to `^16` (dev pin kept) |
| CI/config (MED) | `@babyjamjam/shared` never type-checked in its own right | Dedicated step in mobile-ci verify |
| CI/config (LOW) | frontend-ci PR branches missing `ci/**` | Parity restored |

Deferred with rationale (tracked): `forbidNonWhitelisted` (needs its own behavior pass), `document.storagePath` unique constraint + TOCTOU (post-cutover migration), `bank_account_info` anon-policy drop (operator gate), Vercel env-scope verification for the mobile project (operator checklist — the middleware fail-fast is designed, but Production AND Preview scopes must carry `NEXT_PUBLIC_API_BASE_URL`).

## Test plan

- [x] Mobile: type-check, lint 0 errors, **633 tests green** (incl. new resume-after-cooldown case)
- [x] Backend: tsc clean, lint 0 errors, **1087 tests green**
- [x] Lockfile refreshed for the peer-range change

🤖 Generated with [Claude Code](https://claude.com/claude-code)