### PR TITLE
test(e2e): stabilize suite for real-backend CI (batch 1)

### DIFF
--- a/mobile/playwright.config.ts
+++ b/mobile/playwright.config.ts
@@ -1,10 +1,22 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// Quarantined from CI until rewritten/unblocked — see tests/QUARANTINE.md
+const CI_QUARANTINE = [
+  '**/client-creation.spec.ts', // UI moved: dialog flow -> /clients/new wizard; spec rewrite tracked
+  '**/alimtalk-settings.spec.ts', // navigates removed routes /settings/general, /settings/voucher-price (404); rewrite vs current IA
+  '**/nav-indicator-diagnose.spec.ts', // local-only diagnostic: real login with dev credentials, dev server timing capture
+  '**/nav-slide-dense.spec.ts', // local-only diagnostic: dense frame capture, real login
+  '**/animation-plan-visual-verify.spec.ts', // animation/visual diagnostic, timing-fragile in CI
+  '**/dashboard-activities-animation.spec.ts', // animation diagnostic (addInitScript event collection)
+  '**/chat-live-stream.spec.ts', // hits real /api/ai/chat/stream; backend requires GEMINI_API_KEY (no vendor stub yet)
+];
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
   testDir: './tests',
+  testIgnore: process.env.CI ? CI_QUARANTINE : [],
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/mobile/tests/QUARANTINE.md
+++ b/mobile/tests/QUARANTINE.md
@@ -1,0 +1,9 @@
+| Spec | Reason | Unblocks When |
+| --- | --- | --- |
+| `client-creation.spec.ts` | `/clients` no longer exposes the old dialog flow; creation moved to `/clients/new` wizard. | Rewrite against the `/clients/new` wizard flow. |
+| `alimtalk-settings.spec.ts` | Navigates removed routes `/settings/general` and `/settings/voucher-price`, which now 404. | Rewrite against the current settings information architecture. |
+| `nav-indicator-diagnose.spec.ts` | Local-only diagnostic that depends on real login and timing capture. | Keep local-only by design. |
+| `nav-slide-dense.spec.ts` | Local-only diagnostic that depends on real login and dense frame capture. | Keep local-only by design. |
+| `animation-plan-visual-verify.spec.ts` | Visual animation diagnostic that is timing-fragile in CI. | Keep local-only by design. |
+| `dashboard-activities-animation.spec.ts` | Animation diagnostic built around event collection timing. | Keep local-only by design. |
+| `chat-live-stream.spec.ts` | Calls real `/api/ai/chat/stream`; CI backend has no Gemini vendor stub and needs `GEMINI_API_KEY`. | Add backend e2e Gemini stubs or provide a usable key in CI. |

--- a/mobile/tests/admin-feedback.spec.ts
+++ b/mobile/tests/admin-feedback.spec.ts
@@ -77,7 +77,7 @@ test.describe('Admin Feedback Page', () => {
     });
     
     await page.goto('/admin');
-    await page.waitForLoadState('networkidle');
+    await expect(page.getByText('피드백 관리')).toBeVisible({ timeout: 15000 });
     
     // Should see the feedback list
     await expect(page.getByText('피드백 관리')).toBeVisible({ timeout: 5000 });
@@ -98,7 +98,7 @@ test.describe('Admin Feedback Page', () => {
     });
     
     await page.goto('/admin');
-    await page.waitForLoadState('networkidle');
+    await expect(page.getByText('피드백 관리')).toBeVisible({ timeout: 15000 });
     
     // Click negative filter
     await page.getByRole('button', { name: '부정적' }).click();
@@ -119,7 +119,7 @@ test.describe('Admin Feedback Page', () => {
     });
     
     await page.goto('/admin');
-    await page.waitForLoadState('networkidle');
+    await expect(page.getByText('피드백 관리')).toBeVisible({ timeout: 15000 });
     
     await expect(page.getByText('전체').first()).toBeVisible();
     await expect(page.getByText('긍정적').first()).toBeVisible();
@@ -143,7 +143,7 @@ test.describe('Admin Feedback Page', () => {
     });
     
     await page.goto('/admin');
-    await page.waitForLoadState('networkidle');
+    await expect(page.getByText('피드백 관리')).toBeVisible({ timeout: 15000 });
     
     // Check table headers
     await expect(page.getByText('날짜')).toBeVisible();
@@ -169,7 +169,7 @@ test.describe('Admin Feedback Page', () => {
     });
     
     await page.goto('/admin');
-    await page.waitForLoadState('networkidle');
+    await expect(page.getByText('피드백 관리')).toBeVisible({ timeout: 15000 });
     
     await expect(page.getByText('피드백이 없습니다.')).toBeVisible();
   });
@@ -188,7 +188,7 @@ test.describe('Admin Feedback Page', () => {
     });
     
     await page.goto('/admin');
-    await page.waitForLoadState('networkidle');
+    await expect(page.getByText('피드백 관리')).toBeVisible({ timeout: 15000 });
     
     // Click positive filter
     await page.getByRole('button', { name: '긍정적' }).click();
@@ -210,7 +210,7 @@ test.describe('Admin Feedback Page', () => {
     });
     
     await page.goto('/admin');
-    await page.waitForLoadState('networkidle');
+    await expect(page.getByText('피드백 관리')).toBeVisible({ timeout: 15000 });
     
     // Should see the feedback list
     await expect(page.getByText('피드백 관리')).toBeVisible({ timeout: 5000 });

--- a/mobile/tests/admin-nav.spec.ts
+++ b/mobile/tests/admin-nav.spec.ts
@@ -43,7 +43,7 @@ test.describe('Admin Nav Visibility', () => {
     });
     
     await page.goto('/admin');
-    await page.waitForLoadState('networkidle');
+    await expect(page.getByText('피드백 관리')).toBeVisible({ timeout: 15000 });
     
     const menuButton = page.locator('button[aria-label="open navigation"]');
     await menuButton.click();

--- a/mobile/tests/chat-feedback.spec.ts
+++ b/mobile/tests/chat-feedback.spec.ts
@@ -61,9 +61,9 @@ test.describe('chat message feedback', () => {
 
   test('should show feedback buttons on assistant messages', async ({ page }) => {
     await page.goto('/dashboard');
-    await page.waitForLoadState('networkidle');
 
     const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?').first();
+    await expect(chatInput).toBeVisible({ timeout: 10000 });
     await chatInput.click();
 
     await expect(page.getByText('AI 어시스턴트')).toBeVisible({ timeout: 5000 });
@@ -85,9 +85,9 @@ test.describe('chat message feedback', () => {
     });
 
     await page.goto('/dashboard');
-    await page.waitForLoadState('networkidle');
 
     const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?').first();
+    await expect(chatInput).toBeVisible({ timeout: 10000 });
     await chatInput.click();
 
     await expect(page.getByTestId('thumbs-up')).toBeVisible({ timeout: 5000 });
@@ -101,9 +101,9 @@ test.describe('chat message feedback', () => {
 
   test('should open modal on thumbs down click', async ({ page }) => {
     await page.goto('/dashboard');
-    await page.waitForLoadState('networkidle');
 
     const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?').first();
+    await expect(chatInput).toBeVisible({ timeout: 10000 });
     await chatInput.click();
 
     await expect(page.getByTestId('thumbs-down')).toBeVisible({ timeout: 5000 });
@@ -114,9 +114,9 @@ test.describe('chat message feedback', () => {
 
   test('should have submit button disabled until comment is entered', async ({ page }) => {
     await page.goto('/dashboard');
-    await page.waitForLoadState('networkidle');
 
     const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?').first();
+    await expect(chatInput).toBeVisible({ timeout: 10000 });
     await chatInput.click();
 
     await page.getByTestId('thumbs-down').click();
@@ -142,9 +142,9 @@ test.describe('chat message feedback', () => {
     });
 
     await page.goto('/dashboard');
-    await page.waitForLoadState('networkidle');
 
     const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?').first();
+    await expect(chatInput).toBeVisible({ timeout: 10000 });
     await chatInput.click();
 
     await page.getByTestId('thumbs-down').click();

--- a/mobile/tests/chat-history.spec.ts
+++ b/mobile/tests/chat-history.spec.ts
@@ -87,7 +87,6 @@ test.describe('Chat History Persistence', () => {
 
     test('should load chat history when modal opens', async ({ page }) => {
         await page.goto('/dashboard');
-        await page.waitForLoadState('networkidle');
 
         const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?').first();
         await expect(chatInput).toBeVisible({ timeout: 10000 });
@@ -117,7 +116,6 @@ test.describe('Chat History Persistence', () => {
         });
 
         await page.goto('/dashboard');
-        await page.waitForLoadState('networkidle');
 
         const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?').first();
         await expect(chatInput).toBeVisible({ timeout: 10000 });
@@ -130,9 +128,9 @@ test.describe('Chat History Persistence', () => {
 
     test('should send message and receive response', async ({ page }) => {
         await page.goto('/dashboard');
-        await page.waitForLoadState('networkidle');
 
         const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?').first();
+        await expect(chatInput).toBeVisible({ timeout: 10000 });
         await chatInput.click();
 
         await page.waitForURL('**/chat', { timeout: 10000 });
@@ -150,15 +148,15 @@ test.describe('Chat History Persistence', () => {
 
     test('should close and reopen modal with history preserved', async ({ page }) => {
         await page.goto('/dashboard');
-        await page.waitForLoadState('networkidle');
 
         const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?').first();
+        await expect(chatInput).toBeVisible({ timeout: 10000 });
         await chatInput.click();
 
         await page.waitForURL('**/chat', { timeout: 10000 });
         await expect(page.getByText('안녕하세요').first()).toBeVisible({ timeout: 5000 });
 
-        await page.getByTestId('chat-back').click();
+        await page.getByTestId('chat-fullscreen-close').click();
         await page.waitForURL('**/dashboard', { timeout: 15000 });
 
         await chatInput.click();
@@ -190,9 +188,9 @@ test.describe('Chat History Persistence', () => {
         });
 
         await page.goto('/dashboard');
-        await page.waitForLoadState('networkidle');
 
         const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?').first();
+        await expect(chatInput).toBeVisible({ timeout: 10000 });
         await chatInput.click();
 
         await page.waitForURL('**/chat', { timeout: 10000 });
@@ -205,15 +203,15 @@ test.describe('Chat History Persistence', () => {
 
     test('should clear session when delete button is clicked', async ({ page }) => {
         await page.goto('/dashboard');
-        await page.waitForLoadState('networkidle');
 
         const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?').first();
+        await expect(chatInput).toBeVisible({ timeout: 10000 });
         await chatInput.click();
 
         await page.waitForURL('**/chat', { timeout: 10000 });
         await expect(page.getByText('안녕하세요').first()).toBeVisible({ timeout: 5000 });
 
-        await page.getByTestId('chat-clear').click();
+        await page.getByTestId('chat-fullscreen-clear').click();
 
         await expect(page.getByText('고객 검색, 직원 관리, 계약서 발송 등을 도와드립니다.')).toBeVisible({ timeout: 5000 });
     });
@@ -234,9 +232,9 @@ test.describe('Chat History API Error Handling', () => {
         });
 
         await page.goto('/dashboard');
-        await page.waitForLoadState('networkidle');
 
         const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?').first();
+        await expect(chatInput).toBeVisible({ timeout: 10000 });
         await chatInput.click();
 
         await page.waitForURL('**/chat', { timeout: 10000 });
@@ -253,9 +251,9 @@ test.describe('Chat History API Error Handling', () => {
         });
 
         await page.goto('/dashboard');
-        await page.waitForLoadState('networkidle');
 
         const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?').first();
+        await expect(chatInput).toBeVisible({ timeout: 10000 });
         await chatInput.click();
 
         await page.waitForURL('**/chat', { timeout: 10000 });

--- a/mobile/tests/chat-retry.spec.ts
+++ b/mobile/tests/chat-retry.spec.ts
@@ -77,9 +77,9 @@ test.describe('chat auto-retry', () => {
 
     // Navigate directly to chat page
     await page.goto('/chat');
-    await page.waitForLoadState('networkidle');
 
     const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?');
+    await expect(chatInput).toBeVisible({ timeout: 10000 });
     await chatInput.fill('테스트 메시지');
     await chatInput.press('Enter');
 
@@ -99,9 +99,9 @@ test.describe('chat auto-retry', () => {
 
     // Navigate directly to chat page
     await page.goto('/chat');
-    await page.waitForLoadState('networkidle');
 
     const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?');
+    await expect(chatInput).toBeVisible({ timeout: 10000 });
     await chatInput.fill('테스트 메시지');
     await chatInput.press('Enter');
 

--- a/mobile/tests/chat-wizard.spec.ts
+++ b/mobile/tests/chat-wizard.spec.ts
@@ -129,7 +129,6 @@ test.describe('Chat client registration wizard', () => {
     });
 
     await page.goto('/dashboard');
-    await page.waitForLoadState('networkidle');
 
     const chatInput = page.getByPlaceholder('무엇을 도와드릴까요?').first();
     await expect(chatInput).toBeVisible({ timeout: 10000 });

--- a/mobile/tests/clients-mobile-detail-labels.spec.ts
+++ b/mobile/tests/clients-mobile-detail-labels.spec.ts
@@ -39,6 +39,24 @@ const ACTIVE_CLIENT_WITHOUT_CONTRACT = {
 test.describe("Mobile clients detail labels", () => {
   test.use({ viewport: { width: 390, height: 844 } });
 
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/employees", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.route("**/api/alimtalk-logs?**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+  });
+
   test("uses the compact notification labels in the client detail sheet", async ({ page }) => {
     await page.route("**/api/clients?**", async (route) => {
       await route.fulfill({
@@ -55,6 +73,7 @@ test.describe("Mobile clients detail labels", () => {
     });
 
     await page.goto("/clients");
+    await expect(page.locator('[data-component="mobile-clients-row"]')).toBeVisible({ timeout: 15000 });
 
     await page.locator('[data-component="mobile-clients-row"]', { hasText: CLIENT.name }).click();
     await page.getByRole("button", { name: "알림 발송" }).click();
@@ -82,6 +101,7 @@ test.describe("Mobile clients detail labels", () => {
     });
 
     await page.goto("/clients");
+    await expect(page.locator('[data-component="mobile-clients-row"]')).toBeVisible({ timeout: 15000 });
 
     const row = page.locator('[data-component="mobile-clients-row"]', {
       hasText: ACTIVE_CLIENT_WITHOUT_CONTRACT.name,

--- a/mobile/tests/contracts-delete.spec.ts
+++ b/mobile/tests/contracts-delete.spec.ts
@@ -116,9 +116,7 @@ test.describe("Contracts delete flow", () => {
     });
 
     await page.goto("/contracts");
-    await page.waitForLoadState("networkidle");
-
-    await expect(page.getByText("삭제대상 고객").first()).toBeVisible();
+    await expect(page.getByText("삭제대상 고객").first()).toBeVisible({ timeout: 15000 });
 
     await page.getByText("삭제대상 고객").first().click();
     await expect(page.locator('[data-component="mobile-contracts-detail"]')).toBeVisible();

--- a/mobile/tests/contracts-search.spec.ts
+++ b/mobile/tests/contracts-search.spec.ts
@@ -1,11 +1,6 @@
-import { test, expect } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
-// Clear sessionStorage before each test to prevent auth caching
-test.beforeEach(async ({ page }) => {
-  await page.addInitScript(() => {
-    sessionStorage.clear();
-  });
-});
+const SEARCH_PLACEHOLDER = '고객명, 계약서명, 계약 번호 검색';
 
 const MOCK_DOCUMENTS = {
   documents: [
@@ -29,9 +24,9 @@ const MOCK_DOCUMENTS = {
       template: { id: 'tpl-1', name: 'Contract' },
       document_name: '김철수 계약서',
       creator: { recipient_type: 'sender', id: 'admin', name: 'Admin' },
-      created_date: Date.now() - 86400000,
+      created_date: Date.now() - 86_400_000,
       last_editor: { recipient_type: 'sender', id: 'admin', name: 'Admin' },
-      updated_date: Date.now() - 86400000,
+      updated_date: Date.now() - 86_400_000,
       current_status: {
         status_type: '002',
         step_recipients: [{ recipient_type: 'signer', name: '김철수' }],
@@ -43,9 +38,9 @@ const MOCK_DOCUMENTS = {
       template: { id: 'tpl-1', name: 'Contract' },
       document_name: '홍길순 계약서',
       creator: { recipient_type: 'sender', id: 'admin', name: 'Admin' },
-      created_date: Date.now() - 172800000,
+      created_date: Date.now() - 172_800_000,
       last_editor: { recipient_type: 'sender', id: 'admin', name: 'Admin' },
-      updated_date: Date.now() - 172800000,
+      updated_date: Date.now() - 172_800_000,
       current_status: {
         status_type: '003',
         step_recipients: [{ recipient_type: 'signer', name: '홍길순' }],
@@ -53,371 +48,133 @@ const MOCK_DOCUMENTS = {
     },
   ],
   total_rows: 3,
-  limit: 20,
+  limit: 100,
   skip: 0,
 };
 
-const MOCK_COMPLETED_DOCUMENTS = {
-  documents: [
-    {
-      id: 'doc-1',
-      document_number: 'DOC-001',
-      template: { id: 'tpl-1', name: 'Contract' },
-      document_name: '홍길동 계약서',
-      creator: { recipient_type: 'sender', id: 'admin', name: 'Admin' },
-      created_date: Date.now(),
-      last_editor: { recipient_type: 'sender', id: 'admin', name: 'Admin' },
-      updated_date: Date.now(),
-      current_status: {
-        status_type: '003',
-        step_recipients: [{ recipient_type: 'signer', name: '홍길동' }],
-      },
-    },
-    {
-      id: 'doc-4',
-      document_number: 'DOC-004',
-      template: { id: 'tpl-1', name: 'Contract' },
-      document_name: '김철수 계약서',
-      creator: { recipient_type: 'sender', id: 'admin', name: 'Admin' },
-      created_date: Date.now() - 86400000,
-      last_editor: { recipient_type: 'sender', id: 'admin', name: 'Admin' },
-      updated_date: Date.now() - 86400000,
-      current_status: {
-        status_type: '003',
-        step_recipients: [{ recipient_type: 'signer', name: '김철수' }],
-      },
-    },
-  ],
-  total_rows: 2,
-  limit: 20,
+const MOCK_EMPTY_DOCUMENTS = {
+  documents: [],
+  total_rows: 0,
+  limit: 100,
   skip: 0,
 };
 
-const MOCK_MANY_DOCUMENTS = {
-  documents: Array.from({ length: 12 }, (_, i) => ({
-    id: `doc-${i + 1}`,
-    document_number: `DOC-${String(i + 1).padStart(3, '0')}`,
-    template: { id: 'tpl-1', name: 'Contract' },
-    document_name: `고객${i + 1} 계약서`,
-    creator: { recipient_type: 'sender', id: 'admin', name: 'Admin' },
-    created_date: Date.now() - i * 86400000,
-    last_editor: { recipient_type: 'sender', id: 'admin', name: 'Admin' },
-    updated_date: Date.now() - i * 86400000,
-    current_status: {
-      status_type: i % 2 === 0 ? '003' : '002',
-      step_recipients: [{ recipient_type: 'signer', name: `고객${i + 1}` }],
-    },
-  })),
-  total_rows: 12,
-  limit: 20,
-  skip: 0,
-};
+async function routeContractsList(page: Page, payload = MOCK_DOCUMENTS): Promise<void> {
+  await page.route('**/api/access-token', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true }),
+    });
+  });
+
+  await page.route('**/api/eformsign/documents?**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    });
+  });
+
+  await page.route('**/api/eformsign-docs/client-names**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(
+        payload.documents.map((doc, index) => ({
+          documentId: doc.id,
+          clientId: 1000 + index,
+          clientName: doc.current_status?.step_recipients?.[0]?.name ?? doc.document_name,
+          clientPhone: '010-0000-0000',
+          providerName: '테스트 제공인력',
+        })),
+      ),
+    });
+  });
+
+  await page.route('**/api/alimtalk-logs?**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+}
 
 test.describe('Contracts Page Search Feature', () => {
-  test.describe('Search UI Visibility', () => {
-    test('should display search icon initially (collapsed state)', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
-      });
+  test('renders the current mobile search and filter shell', async ({ page }) => {
+    await routeContractsList(page);
 
-      await page.route('**/api/documents**', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_DOCUMENTS),
-        });
-      });
+    await page.goto('/contracts');
+    await expect(page.getByPlaceholder(SEARCH_PLACEHOLDER)).toBeVisible({ timeout: 15000 });
 
-      await page.goto('/contracts');
-      await page.waitForLoadState('networkidle');
-
-      // Verify toolbar is visible
-      await expect(page.locator('[data-component="data-table-toolbar"]')).toBeVisible();
-
-      // Verify search icon is visible but TextField is NOT visible initially
-      const searchIconButton = page.getByRole('button', { name: /search/i });
-      await expect(searchIconButton).toBeVisible();
-      await expect(page.getByPlaceholder('고객명 검색')).not.toBeVisible();
-    });
-
-    test('should expand search TextField when icon is clicked', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
-      });
-
-      await page.route('**/api/documents**', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_DOCUMENTS),
-        });
-      });
-
-      await page.goto('/contracts');
-      await page.waitForLoadState('networkidle');
-
-      // Click search icon to expand
-      const searchIconButton = page.getByRole('button', { name: /search/i });
-      await searchIconButton.click();
-
-      // Verify TextField is now visible
-      await expect(page.getByPlaceholder('고객명 검색')).toBeVisible();
-    });
+    await expect(page.locator('[data-component="mobile-contracts-search"]')).toBeVisible();
+    await expect(page.locator('[data-component="mobile-redesign-filter-row"]')).toBeVisible();
+    await expect(page.locator('[data-component="mobile-redesign-list-action"]')).toContainText(
+      '계약 작성',
+    );
   });
 
-  test.describe('Search Functionality', () => {
-    test('should filter documents when user types and presses Enter', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
-      });
+  test('filters contract rows by customer name as the query changes', async ({ page }) => {
+    await routeContractsList(page);
 
-      await page.route('**/api/documents**', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_DOCUMENTS),
-        });
-      });
+    await page.goto('/contracts');
+    const searchField = page.getByPlaceholder(SEARCH_PLACEHOLDER);
+    await expect(searchField).toBeVisible({ timeout: 15000 });
 
-      await page.goto('/contracts');
-      await page.waitForLoadState('networkidle');
+    await expect(page.getByText('홍길동')).toBeVisible();
+    await expect(page.getByText('김철수')).toBeVisible();
+    await expect(page.getByText('홍길순')).toBeVisible();
 
-      await expect(page.getByText('홍길동')).toBeVisible();
-      await expect(page.getByText('김철수')).toBeVisible();
-      await expect(page.getByText('홍길순')).toBeVisible();
+    await searchField.fill('홍길');
 
-      const searchIconButton = page.getByRole('button', { name: /search/i });
-      await searchIconButton.click();
-
-      const searchField = page.getByPlaceholder('고객명 검색');
-      await searchField.fill('홍길');
-      await page.keyboard.press('Enter');
-
-      await expect(page.getByText('홍길동')).toBeVisible();
-      await expect(page.getByText('홍길순')).toBeVisible();
-      await expect(page.getByText('김철수')).not.toBeVisible();
-    });
-
-    test('should filter documents when user presses Enter in search field', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
-      });
-
-      await page.route('**/api/documents**', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_DOCUMENTS),
-        });
-      });
-
-      await page.goto('/contracts');
-      await page.waitForLoadState('networkidle');
-
-      await expect(page.getByText('홍길동')).toBeVisible();
-      await expect(page.getByText('김철수')).toBeVisible();
-
-      const searchIconButton = page.getByRole('button', { name: /search/i });
-      await searchIconButton.click();
-
-      const searchField = page.getByPlaceholder('고객명 검색');
-      await searchField.fill('김철수');
-      await page.keyboard.press('Enter');
-
-      await expect(page.getByText('김철수')).toBeVisible();
-      await expect(page.getByText('홍길동')).not.toBeVisible();
-    });
-
-    test('should show all documents when search is cleared', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
-      });
-
-      await page.route('**/api/documents**', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_DOCUMENTS),
-        });
-      });
-
-      await page.goto('/contracts');
-      await page.waitForLoadState('networkidle');
-
-      const searchIconButton = page.getByRole('button', { name: /search/i });
-      await searchIconButton.click();
-
-      const searchField = page.getByPlaceholder('고객명 검색');
-      await searchField.fill('홍길동');
-      await page.keyboard.press('Enter');
-
-      await expect(page.getByText('홍길동')).toBeVisible();
-      await expect(page.getByText('김철수')).not.toBeVisible();
-
-      await searchField.clear();
-      await page.keyboard.press('Enter');
-
-      await expect(page.getByText('홍길동')).toBeVisible();
-      await expect(page.getByText('김철수')).toBeVisible();
-      await expect(page.getByText('홍길순')).toBeVisible();
-    });
-
-    test('should show "문서가 없습니다" when no documents match search', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
-      });
-
-      await page.route('**/api/documents**', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_DOCUMENTS),
-        });
-      });
-
-      await page.goto('/contracts');
-      await page.waitForLoadState('networkidle');
-
-      const searchIconButton = page.getByRole('button', { name: /search/i });
-      await searchIconButton.click();
-
-      const searchField = page.getByPlaceholder('고객명 검색');
-      await searchField.fill('박영희');
-      await page.keyboard.press('Enter');
-
-      const muiAlert = page.locator('.MuiAlert-root');
-      await expect(muiAlert).toBeVisible();
-      await expect(muiAlert).toContainText('문서가 없습니다');
-    });
+    await expect(page.getByText('홍길동')).toBeVisible();
+    await expect(page.getByText('홍길순')).toBeVisible();
+    await expect(page.getByText('김철수')).not.toBeVisible();
   });
 
-  test.describe('Search + Status Filter Combination', () => {
-    test('should apply search within status-filtered results', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
-      });
+  test('restores the full list when the search query is cleared', async ({ page }) => {
+    await routeContractsList(page);
 
-      await page.route('**/api/documents', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_DOCUMENTS),
-        });
-      });
+    await page.goto('/contracts');
+    const searchField = page.getByPlaceholder(SEARCH_PLACEHOLDER);
+    await expect(searchField).toBeVisible({ timeout: 15000 });
 
-      await page.route('**/api/documents/completed', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_COMPLETED_DOCUMENTS),
-        });
-      });
+    await searchField.fill('홍길동');
+    await expect(page.getByText('김철수')).not.toBeVisible();
 
-      await page.goto('/contracts');
-      await page.waitForLoadState('networkidle');
+    await searchField.clear();
 
-      // Select '완료' status filter
-      const filterButton = page.locator('[data-component="data-table-toolbar"]').locator('button').nth(1);
-      await filterButton.click();
-
-      await page.locator('[role="menuitem"]').filter({ hasText: '완료' }).click();
-      await page.waitForLoadState('networkidle');
-
-      // Verify status filter is applied
-      const filterChip = page.locator('[data-component="data-table-toolbar"]').locator('.MuiChip-root');
-      await expect(filterChip).toContainText('완료');
-
-      // Verify both completed documents are visible
-      await expect(page.getByText('홍길동')).toBeVisible();
-      await expect(page.getByText('김철수')).toBeVisible();
-
-      // Click search icon to expand search field
-      const searchIconButton = page.getByRole('button', { name: /search/i });
-      await searchIconButton.click();
-
-      // Apply search within filtered results
-      const searchField = page.getByPlaceholder('고객명 검색');
-      await searchField.fill('홍길동');
-      await page.keyboard.press('Enter');
-
-      // Verify only matching document is visible
-      await expect(page.getByText('홍길동')).toBeVisible();
-      await expect(page.getByText('김철수')).not.toBeVisible();
-
-      // Verify status filter chip is still visible
-      await expect(filterChip).toContainText('완료');
-    });
+    await expect(page.getByText('홍길동')).toBeVisible();
+    await expect(page.getByText('김철수')).toBeVisible();
+    await expect(page.getByText('홍길순')).toBeVisible();
   });
 
-  test.describe('Pagination Reset', () => {
-    test('should reset to first page when search is executed', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
-      });
+  test('applies the completed filter via the mobile filter pills', async ({ page }) => {
+    await routeContractsList(page);
 
-      await page.route('**/api/documents**', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_MANY_DOCUMENTS),
-        });
-      });
+    await page.goto('/contracts');
+    await expect(page.getByPlaceholder(SEARCH_PLACEHOLDER)).toBeVisible({ timeout: 15000 });
 
-      await page.goto('/contracts');
-      await page.waitForLoadState('networkidle');
+    const completedFilter = page
+      .locator('[data-component="mobile-redesign-filter-pill"]')
+      .filter({ hasText: '완료' });
+    await completedFilter.click();
 
-      // Navigate to page 2
-      const nextButton = page.locator('.MuiTablePagination-actions button').last();
-      await nextButton.click();
-      await page.waitForTimeout(500);
+    await expect(completedFilter).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByText('홍길동')).toBeVisible();
+    await expect(page.getByText('홍길순')).toBeVisible();
+    await expect(page.getByText('김철수')).not.toBeVisible();
+  });
 
-      // Verify we're on page 2
-      const paginationText = page.locator('.MuiTablePagination-displayedRows');
-      await expect(paginationText).toContainText('6–10');
+  test('shows the current empty-state copy when no contracts match', async ({ page }) => {
+    await routeContractsList(page, MOCK_EMPTY_DOCUMENTS);
 
-      // Click search icon to expand search field
-      const searchIconButton = page.getByRole('button', { name: /search/i });
-      await searchIconButton.click();
+    await page.goto('/contracts');
+    await expect(page.getByPlaceholder(SEARCH_PLACEHOLDER)).toBeVisible({ timeout: 15000 });
 
-      // Execute search
-      const searchField = page.getByPlaceholder('고객명 검색');
-      await searchField.fill('고객1');
-      await page.keyboard.press('Enter');
-
-      // Verify pagination reset to first page
-      await expect(paginationText).toContainText('1–');
-    });
+    await expect(page.locator('[data-component="mobile-contracts-empty"]')).toContainText(
+      '등록된 계약서가 없습니다.',
+    );
   });
 });

--- a/mobile/tests/contracts-skeleton-loading.spec.ts
+++ b/mobile/tests/contracts-skeleton-loading.spec.ts
@@ -1,336 +1,191 @@
-import { test, expect } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
-// Clear sessionStorage before each test to prevent auth caching
-test.beforeEach(async ({ page }) => {
-  await page.addInitScript(() => {
-    sessionStorage.clear();
-  });
-});
+const FILTER_SKELETON_COUNT = 6;
+const LOADING_ROW_COUNT = 9;
 
 const MOCK_DOCUMENTS = {
   documents: [
     {
       id: 'doc-1',
+      document_number: 'DOC-001',
+      template: { id: 'tpl-1', name: 'Contract' },
+      document_name: '홍길동 계약서',
+      creator: { recipient_type: 'sender', id: 'admin', name: 'Admin' },
       created_date: Date.now(),
+      last_editor: { recipient_type: 'sender', id: 'admin', name: 'Admin' },
+      updated_date: Date.now(),
       current_status: {
-        status_type: 'doc_complete',
-        step_recipients: [{ name: '홍길동' }],
+        status_type: '003',
+        step_recipients: [{ recipient_type: 'signer', name: '홍길동' }],
       },
-      last_editor: { name: '홍길동' },
-      creator: { name: '관리자' },
     },
     {
       id: 'doc-2',
-      created_date: Date.now() - 86400000,
+      document_number: 'DOC-002',
+      template: { id: 'tpl-1', name: 'Contract' },
+      document_name: '김철수 계약서',
+      creator: { recipient_type: 'sender', id: 'admin', name: 'Admin' },
+      created_date: Date.now() - 86_400_000,
+      last_editor: { recipient_type: 'sender', id: 'admin', name: 'Admin' },
+      updated_date: Date.now() - 86_400_000,
       current_status: {
-        status_type: 'doc_request_participant',
-        step_recipients: [{ name: '김철수' }],
+        status_type: '002',
+        step_recipients: [{ recipient_type: 'signer', name: '김철수' }],
       },
-      last_editor: null,
-      creator: { name: '관리자' },
     },
   ],
+  total_rows: 2,
+  limit: 100,
+  skip: 0,
 };
 
-const MOCK_EMPTY_DOCUMENTS = { documents: [] };
-
-const MOCK_MANY_DOCUMENTS = {
-  documents: Array.from({ length: 10 }, (_, i) => ({
-    id: `doc-${i + 1}`,
-    created_date: Date.now() - i * 86400000,
-    current_status: {
-      status_type: i % 2 === 0 ? 'doc_complete' : 'doc_request_participant',
-      step_recipients: [{ name: `고객${i + 1}` }],
-    },
-    last_editor: { name: `고객${i + 1}` },
-    creator: { name: '관리자' },
-  })),
+const MOCK_EMPTY_DOCUMENTS = {
+  documents: [],
+  total_rows: 0,
+  limit: 100,
+  skip: 0,
 };
+
+async function routeSharedContractDependencies(page: Page): Promise<void> {
+  await page.route('**/api/eformsign-docs/client-names**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          documentId: 'doc-1',
+          clientId: 1001,
+          clientName: '홍길동',
+          clientPhone: '010-0000-0001',
+          providerName: '테스트 제공인력',
+        },
+        {
+          documentId: 'doc-2',
+          clientId: 1002,
+          clientName: '김철수',
+          clientPhone: '010-0000-0002',
+          providerName: '테스트 제공인력',
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/alimtalk-logs?**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+}
 
 test.describe('Contracts Page Skeleton Loading', () => {
-  test.describe('Initial Loading State', () => {
-    test('should display skeleton rows during initial page load', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await new Promise(resolve => setTimeout(resolve, 500));
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
-      });
-
-      await page.route('**/api/documents**', async (route) => {
-        await new Promise(resolve => setTimeout(resolve, 500));
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_DOCUMENTS),
-        });
-      });
-
-      await page.goto('/contracts');
-
-      await expect(page.locator('.MuiSkeleton-root').first()).toBeVisible({ timeout: 1000 });
-      await expect(page.locator('[data-component="data-table-toolbar"]')).toBeVisible();
-      await expect(page.locator('thead th')).toHaveCount(3);
+  test('shows the current mobile loading shell while documents are pending', async ({ page }) => {
+    let releaseAuth!: () => void;
+    let releaseDocuments!: () => void;
+    const authReady = new Promise<void>((resolve) => {
+      releaseAuth = resolve;
+    });
+    const documentsReady = new Promise<void>((resolve) => {
+      releaseDocuments = resolve;
     });
 
-    test('should show table headers and toolbar immediately on page load', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await new Promise(resolve => setTimeout(resolve, 2000));
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
+    await page.route('**/api/access-token', async (route) => {
+      await authReady;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
       });
-
-      await page.route('**/api/documents**', async (route) => {
-        await new Promise(resolve => setTimeout(resolve, 2000));
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_DOCUMENTS),
-        });
-      });
-
-      await page.goto('/contracts');
-
-      await expect(page.locator('[data-component="data-table-toolbar"]')).toBeVisible({ timeout: 500 });
-      await expect(page.locator('thead')).toBeVisible({ timeout: 500 });
     });
 
-    test('should show 5 skeleton rows matching rowsPerPage', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
+    await page.route('**/api/eformsign/documents?**', async (route) => {
+      await documentsReady;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_DOCUMENTS),
       });
-
-      await page.route('**/api/documents**', async (route) => {
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_DOCUMENTS),
-        });
-      });
-
-      await page.goto('/contracts');
-
-      const skeletonRows = page.locator('tbody tr').filter({ has: page.locator('.MuiSkeleton-root') });
-      await expect(skeletonRows).toHaveCount(5, { timeout: 500 });
     });
+
+    await routeSharedContractDependencies(page);
+
+    await page.goto('/contracts');
+
+    await expect(page.locator('[data-component="mobile-contracts-search"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.locator('[data-component="mobile-redesign-filter-pill"][data-loading="true"]')).toHaveCount(
+      FILTER_SKELETON_COUNT,
+    );
+    await expect(page.locator('[data-component="mobile-contracts-loading-row"]')).toHaveCount(
+      LOADING_ROW_COUNT,
+    );
+    await expect(page.locator('[data-component="mobile-contracts-load-more-placeholder"]')).toBeVisible();
+
+    releaseAuth();
+    releaseDocuments();
+
+    await expect(page.locator('[data-component="mobile-contracts-row"]')).toHaveCount(2);
+    await expect(page.locator('[data-component="mobile-contracts-loading-row"]')).toHaveCount(0);
+    await expect(page.locator('[data-component="mobile-redesign-filter-pill"][data-loading="true"]')).toHaveCount(
+      0,
+    );
+    await expect(page.locator('[data-component="mobile-contracts-load-more-placeholder"]')).toHaveCount(0);
   });
 
-  test.describe('Data Loading Complete', () => {
-    test.beforeEach(async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
-      });
-
-      await page.route('**/api/documents**', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_DOCUMENTS),
-        });
+  test('keeps the search and filter chrome visible after loading completes', async ({ page }) => {
+    await page.route('**/api/access-token', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
       });
     });
 
-    test('should replace skeleton rows with actual data when loading completes', async ({ page }) => {
-      await page.goto('/contracts');
-      await page.waitForLoadState('networkidle');
-
-      await expect(page.locator('.MuiSkeleton-root')).not.toBeVisible();
-      await expect(page.locator('tbody').getByText('홍길동')).toBeVisible();
+    await page.route('**/api/eformsign/documents?**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_DOCUMENTS),
+      });
     });
 
-    test('should enable pagination after data loads', async ({ page }) => {
-      await page.goto('/contracts');
-      await page.waitForLoadState('networkidle');
+    await routeSharedContractDependencies(page);
 
-      await expect(page.locator('.MuiTablePagination-root')).toBeVisible();
+    await page.goto('/contracts');
+    await expect(page.locator('[data-component="mobile-contracts-row"]')).toHaveCount(2, {
+      timeout: 15000,
     });
+
+    await expect(page.locator('[data-component="mobile-contracts-search"]')).toBeVisible();
+    await expect(page.locator('[data-component="mobile-redesign-filter-row"]')).toBeVisible();
+    await expect(page.locator('[data-component="mobile-redesign-list-title"]')).toContainText('2건');
   });
 
-  test.describe('Filter Changes', () => {
-    test('should allow selecting different filters', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
+  test('shows the current empty-state copy when no contracts exist', async ({ page }) => {
+    await page.route('**/api/access-token', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
       });
-
-      await page.route('**/api/documents', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_DOCUMENTS),
-        });
-      });
-
-      await page.route('**/api/documents/completed', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_DOCUMENTS),
-        });
-      });
-
-      await page.goto('/contracts');
-      await page.waitForLoadState('networkidle');
-
-      await expect(page.locator('tbody').getByText('홍길동')).toBeVisible();
-
-      const filterButton = page.locator('[data-component="data-table-toolbar"]').locator('button').nth(1);
-      await filterButton.click();
-
-      await page.locator('[role="menuitem"]').filter({ hasText: '완료' }).click();
-
-      await page.waitForLoadState('networkidle');
-      await expect(page.locator('.MuiSkeleton-root')).not.toBeVisible();
-      
-      const filterChip = page.locator('[data-component="data-table-toolbar"]').locator('.MuiChip-root');
-      await expect(filterChip).toContainText('완료');
-    });
-  });
-
-  test.describe('Error States', () => {
-    test('should display error alert when auth API fails', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await route.fulfill({
-          status: 500,
-          contentType: 'application/json',
-          body: JSON.stringify({ error: 'Auth failed' }),
-        });
-      });
-
-      await page.goto('/contracts');
-      await page.waitForLoadState('networkidle');
-
-      const muiAlert = page.locator('.MuiAlert-root');
-      await expect(muiAlert).toBeVisible();
-      await expect(muiAlert).toContainText('인증에 실패했습니다');
     });
 
-    test('should display error alert when documents API fails', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
+    await page.route('**/api/eformsign/documents?**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_EMPTY_DOCUMENTS),
       });
-
-      await page.route('**/api/documents**', async (route) => {
-        await route.fulfill({
-          status: 500,
-          contentType: 'application/json',
-          body: JSON.stringify({ error: 'Documents fetch failed' }),
-        });
-      });
-
-      await page.goto('/contracts');
-      await page.waitForLoadState('networkidle');
-
-      const muiAlert = page.locator('.MuiAlert-root');
-      await expect(muiAlert).toBeVisible();
-    });
-  });
-
-  test.describe('Empty State', () => {
-    test('should display "no documents" alert when data is empty', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
-      });
-
-      await page.route('**/api/documents**', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_EMPTY_DOCUMENTS),
-        });
-      });
-
-      await page.goto('/contracts');
-      await page.waitForLoadState('networkidle');
-
-      await expect(page.locator('.MuiSkeleton-root')).not.toBeVisible();
-      const muiAlert = page.locator('.MuiAlert-root');
-      await expect(muiAlert).toBeVisible();
-      await expect(muiAlert).toContainText('문서가 없습니다');
-    });
-  });
-
-  test.describe('Pagination During Loading', () => {
-    test('should show pagination disabled during initial loading', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
-      });
-
-      await page.route('**/api/documents**', async (route) => {
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_MANY_DOCUMENTS),
-        });
-      });
-
-      await page.goto('/contracts');
-
-      await expect(page.locator('.MuiTablePagination-root')).toBeVisible({ timeout: 500 });
-
-      const prevButton = page.locator('.MuiTablePagination-actions button').first();
-      const nextButton = page.locator('.MuiTablePagination-actions button').last();
-
-      await expect(prevButton).toBeDisabled();
-      await expect(nextButton).toBeDisabled();
     });
 
-    test('should enable pagination buttons after data loads with multiple pages', async ({ page }) => {
-      await page.route('**/api/access-token', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true }),
-        });
-      });
+    await routeSharedContractDependencies(page);
 
-      await page.route('**/api/documents**', async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(MOCK_MANY_DOCUMENTS),
-        });
-      });
-
-      await page.goto('/contracts');
-      await page.waitForLoadState('networkidle');
-
-      await expect(page.locator('.MuiTablePagination-root')).toBeVisible();
-
-      const nextButton = page.locator('.MuiTablePagination-actions button').last();
-      await expect(nextButton).toBeEnabled();
-    });
+    await page.goto('/contracts');
+    await expect(page.locator('[data-component="mobile-contracts-empty"]')).toContainText(
+      '등록된 계약서가 없습니다.',
+      { timeout: 15000 },
+    );
   });
 });

--- a/mobile/tests/custom-template-variables.spec.ts
+++ b/mobile/tests/custom-template-variables.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page, type Route, type Request } from '@playwright/test';
+import { expect, test, type Page, type Request, type Route } from '@playwright/test';
 
 type CustomVariableFixture = {
   key: string;
@@ -8,7 +8,7 @@ type CustomVariableFixture = {
 
 type SystemTemplateFixture = {
   id: string;
-  templateKey: 'SERVICE_INFO';
+  templateKey: string;
   name: string;
   description: string;
   content: string;
@@ -28,14 +28,7 @@ const baseTemplateFixture: SystemTemplateFixture = {
   name: '서비스 안내',
   description: '서비스 안내 메시지',
   content: '서비스 안내드립니다 {{name}}님',
-  requiredVariables: [
-    {
-      key: 'name',
-      label: '이름',
-      type: 'string',
-      required: true,
-    },
-  ],
+  requiredVariables: [{ key: 'name', label: '이름', type: 'string', required: true }],
   customVariables: [],
   updatedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
 };
@@ -56,149 +49,111 @@ const templateWithPhoneContent: SystemTemplateFixture = {
   content: '서비스 안내드립니다 {{name}}님 연락처 {{phone}}',
 };
 
-async function mockSystemTemplateApi(
+async function mockMessagesApproval(page: Page): Promise<void> {
+  await page.route('**/api/settings/message-sender-approval', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        approvalStatus: 'approved',
+        isApproved: true,
+        canRequest: true,
+        senderPhone: '01012345678',
+        senderPhoneFormatted: '010-1234-5678',
+      }),
+    });
+  });
+}
+
+async function mockComposeDependencies(
   page: Page,
   template: SystemTemplateFixture = baseTemplateFixture,
-  onUpdate?: (body: { content?: string; customVariables?: CustomVariableFixture[] }) => void,
-) {
-  await page.route('**/api/system-templates/SERVICE_INFO', async (route: Route, request: Request) => {
-    if (request.method() === 'GET') {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(template),
-      });
+): Promise<void> {
+  await mockMessagesApproval(page);
+
+  await page.route('**/api/system-templates/*', async (route: Route, request: Request) => {
+    if (request.method() !== 'GET') {
+      await route.fallback();
+      return;
     }
 
-    if (request.method() === 'PUT') {
-      const body = request.postDataJSON() as {
-        content?: string;
-        customVariables?: CustomVariableFixture[];
-      } | null;
+    const key = request.url().split('/').pop() ?? 'UNKNOWN';
+    const response =
+      key === 'SERVICE_INFO'
+        ? template
+        : {
+            id: `tpl-${key.toLowerCase()}`,
+            templateKey: key,
+            name: key,
+            description: `${key} template`,
+            content: `${key} 본문`,
+            requiredVariables: [],
+            customVariables: [],
+            updatedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
+          };
 
-      if (body) {
-        onUpdate?.(body);
-      }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(response),
+    });
+  });
 
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          ...template,
-          content: body?.content ?? template.content,
-          customVariables: body?.customVariables ?? template.customVariables,
-        }),
-      });
+  await page.route('**/api/message-templates', async (route: Route, request: Request) => {
+    if (request.method() !== 'GET') {
+      await route.fallback();
+      return;
     }
 
-    return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+
+  await page.route('**/api/bank-account-infos', async (route: Route, request: Request) => {
+    if (request.method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
   });
 }
 
 test.describe('Custom Template Variables', () => {
-  test('add custom variable in template editor', async ({ page }) => {
-    await mockSystemTemplateApi(page, baseTemplateFixture);
+  test('shows custom variable inputs on the current compose route', async ({ page }) => {
+    await mockComposeDependencies(page, templateWithPhoneVariable);
 
-    // #given - template editor is open
-    await page.goto('/messages/system-templates/SERVICE_INFO');
-    await page.waitForLoadState('networkidle');
-
-    await page.getByRole('button', { name: '추가' }).first().click();
-    const dialog = page.getByRole('dialog', { name: '커스텀 변수 관리' });
-    await expect(dialog).toBeVisible();
-
-    // #when - user adds a required custom variable
-    await dialog.getByLabel('키 (영문/숫자)').fill('phone');
-    await dialog.getByLabel('변수 명 (라벨)').fill('연락처');
-     await dialog.getByRole('switch', { name: '필수 여부' }).click();
-    await dialog.getByRole('button', { name: '추가' }).click();
-    await dialog.getByRole('button', { name: '닫기' }).click();
-
-    // #then - new custom variable chip is visible
-    await expect(page.getByRole('button', { name: '연락처' })).toBeVisible();
-  });
-
-  test('save template with custom variables', async ({ page }) => {
-    let savedPayload: { content?: string; customVariables?: CustomVariableFixture[] } | null = null;
-
-    await mockSystemTemplateApi(page, templateWithPhoneVariable, (body) => {
-      savedPayload = body;
+    await page.goto('/messages/new?template=SERVICE_INFO');
+    await expect(page.locator('[data-component="messages-new-page"]')).toBeVisible({
+      timeout: 15000,
     });
 
-    // #given - template editor includes custom variables
-    await page.goto('/messages/system-templates/SERVICE_INFO');
-    await page.waitForLoadState('networkidle');
+    await expect(page.getByLabel('이름')).toBeVisible();
+    await expect(page.getByLabel('연락처')).toBeVisible();
+    await expect(
+      page.locator('[data-component="messages-new-template-variable-row"][data-template-variable-key="phone"]'),
+    ).toBeVisible();
+  });
 
-    // #when - user inserts custom variable and saves
-    await page.getByRole('button', { name: '연락처' }).click();
-    await page.getByRole('button', { name: '저장' }).click();
+  test('updates the composed body with custom variable values', async ({ page }) => {
+    await mockComposeDependencies(page, templateWithPhoneContent);
 
-    // #then - save request includes custom variables
-    await expect(page.getByText('저장되었습니다')).toBeVisible();
-    await expect.poll(() => savedPayload).toMatchObject({
-      customVariables: [phoneVariable],
+    await page.goto('/messages/new?template=SERVICE_INFO');
+    await expect(page.locator('[data-component="messages-new-page"]')).toBeVisible({
+      timeout: 15000,
     });
-  });
 
-   test('message form shows custom variable inputs', async ({ page }) => {
-     await mockSystemTemplateApi(page, templateWithPhoneVariable);
+    await page.getByLabel('이름').fill('김철수');
+    await page.getByLabel('연락처').fill('010-2222-3333');
 
-     // #given - service info message form is open
-     await page.goto('/messages');
-     await page.waitForLoadState('networkidle');
-
-     // Select service-info from dropdown
-     await page.getByRole('combobox', { name: '' }).click();
-     await page.getByRole('option', { name: /서비스 소개/ }).click();
-     await page.waitForLoadState('networkidle');
-
-     const nameInput = page.getByLabel('산모님 성함');
-     const phoneInput = page.getByLabel('연락처');
-     const generateButton = page.getByRole('button', { name: /생성|Generate/ });
-
-     // #when - user fills only the name
-     await expect(nameInput).toBeVisible();
-     await expect(phoneInput).toBeVisible();
-     await nameInput.fill('김철수');
-
-    // #then - generate stays disabled until required custom input
-    await expect(generateButton).toBeDisabled();
-
-    // #when - user fills custom variable
-    await phoneInput.fill('010-2222-3333');
-
-    // #then - generate button becomes enabled
-    await expect(generateButton).toBeEnabled();
-  });
-
-   test('generated message includes custom variable values', async ({ page }) => {
-     await mockSystemTemplateApi(page, templateWithPhoneContent);
-
-     // #given - service info message form is open with custom variables
-     await page.goto('/messages');
-     await page.waitForLoadState('networkidle');
-
-     // Select service-info from dropdown
-     await page.getByRole('combobox', { name: '' }).click();
-     await page.getByRole('option', { name: /서비스 소개/ }).click();
-     await page.waitForLoadState('networkidle');
-
-     const nameInput = page.getByLabel('산모님 성함');
-     const phoneInput = page.getByLabel('연락처');
-     const generateButton = page.getByRole('button', { name: /생성|Generate/ });
-
-     // Wait for form to fully render
-     await expect(nameInput).toBeVisible();
-     await expect(phoneInput).toBeVisible();
-
-     // #when - user generates message with custom values
-     await nameInput.fill('김철수');
-    await phoneInput.fill('010-2222-3333');
-    await generateButton.click();
-
-    // #then - generated message includes custom variable values
-    const messageField = page.getByRole('textbox').last();
-    await expect(messageField).toHaveValue(/김철수/);
-    await expect(messageField).toHaveValue(/010-2222-3333/);
+    await expect(page.getByLabel('메시지 본문')).toHaveValue(/김철수/);
+    await expect(page.getByLabel('메시지 본문')).toHaveValue(/010-2222-3333/);
   });
 });

--- a/mobile/tests/employee-autocomplete.spec.ts
+++ b/mobile/tests/employee-autocomplete.spec.ts
@@ -1,183 +1,59 @@
-import { test, expect } from '@playwright/test';
-
-/**
- * EmployeeAutocomplete Component Tests
- *
- * These tests verify the unified EmployeeAutocomplete component:
- * - Real-time search filtering
- * - "새 제공인력 추가" button always visible in dropdown
- * - Zustand store prefilling for EmployeeFormDialog
- * - Korean IME compatibility (openOnFocus)
- */
+import { expect, test } from '@playwright/test';
 
 test.describe('EmployeeAutocomplete', () => {
-    // Navigate to clients page and open the form dialog before each test
-    test.beforeEach(async ({ page }) => {
-        // Go to clients page
-        await page.goto('/clients');
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/clients/new');
+    await expect(page.locator('[data-component="clients-new-page-shell"]')).toBeVisible({
+      timeout: 15000,
+    });
+  });
 
-        // Wait for page to load
-        await page.waitForLoadState('networkidle');
+  test('renders employee autocompletes on the client creation wizard', async ({ page }) => {
+    const employeeAutocompletes = page.getByTestId('employee-autocomplete');
+
+    await expect(employeeAutocompletes.first()).toBeVisible();
+    await expect(employeeAutocompletes).toHaveCount(2);
+  });
+
+  test('opens the dropdown on focus and keeps the manual-entry action visible', async ({ page }) => {
+    const autocompleteInput = page.getByTestId('employee-autocomplete').first().locator('input');
+
+    await autocompleteInput.click();
+
+    await expect(page.locator('[data-component="employee-autocomplete-dropdown"]').first()).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.locator('[data-component="employee-autocomplete-add-button"]').first()).toBeVisible();
+  });
+
+  test('keeps the manual-entry action visible while filtering', async ({ page }) => {
+    const autocompleteInput = page.getByTestId('employee-autocomplete').first().locator('input');
+
+    await autocompleteInput.click();
+    await expect(page.locator('[data-component="employee-autocomplete-dropdown"]').first()).toBeVisible({
+      timeout: 5000,
     });
 
-    test('should open ClientFormDialog when clicking add button', async ({ page }) => {
-        // Find and click the add button (Plus icon)
-        const addButton = page.locator('[data-testid="add-client-button"]');
-        await addButton.click();
+    await autocompleteInput.fill('김');
 
-        // Verify dialog opens
-        const dialog = page.locator('[data-testid="client-form-dialog"]');
-        await expect(dialog).toBeVisible();
+    await expect(page.locator('[data-component="employee-autocomplete-dropdown"]').first()).toBeVisible();
+    await expect(page.locator('[data-component="employee-autocomplete-add-button"]').first()).toBeVisible();
+  });
+
+  test('opens the employee dialog with the typed name prefilled', async ({ page }) => {
+    const autocompleteInput = page.getByTestId('employee-autocomplete').first().locator('input');
+    const typedName = '테스트직원';
+
+    await autocompleteInput.click();
+    await expect(page.locator('[data-component="employee-autocomplete-dropdown"]').first()).toBeVisible({
+      timeout: 5000,
     });
 
-    test('should show EmployeeAutocomplete in ClientFormDialog', async ({ page }) => {
-        // Open the form dialog
-        const addButton = page.locator('[data-testid="add-client-button"]');
-        await addButton.click();
+    await autocompleteInput.fill(typedName);
+    await page.locator('[data-component="employee-autocomplete-add-button"]').first().click();
 
-        // Wait for dialog
-        await expect(page.locator('[data-testid="client-form-dialog"]')).toBeVisible();
-
-        // Find the primary employee autocomplete by its label
-        const employeeAutocomplete = page.locator('[data-testid="employee-autocomplete"]').first();
-        await expect(employeeAutocomplete).toBeVisible();
-    });
-
-    test('should open dropdown on focus and show "새 제공인력 추가" button', async ({ page }) => {
-        // Open the form dialog
-        const addButton = page.locator('[data-testid="add-client-button"]');
-        await addButton.click();
-        await expect(page.locator('[data-testid="client-form-dialog"]')).toBeVisible();
-
-        // Find the employee autocomplete input
-        const autocompleteInput = page.locator('[data-testid="employee-autocomplete"] input').first();
-
-        // Click to focus - should open dropdown (Korean IME compatibility)
-        await autocompleteInput.click();
-
-        // Wait for dropdown to appear
-        const dropdown = page.locator('[data-testid="employee-autocomplete-dropdown"]');
-        await expect(dropdown).toBeVisible({ timeout: 5000 });
-
-        // The "새 제공인력 추가" button should be visible
-        const addNewButton = page.locator('[data-testid="employee-autocomplete-add-button"]');
-        await expect(addNewButton).toBeVisible();
-    });
-
-    test('should filter employees when typing in search', async ({ page }) => {
-        // Open the form dialog
-        const addButton = page.locator('[data-testid="add-client-button"]');
-        await addButton.click();
-        await expect(page.locator('[data-testid="client-form-dialog"]')).toBeVisible();
-
-        // Find and focus the employee autocomplete
-        const autocompleteInput = page.locator('[data-testid="employee-autocomplete"] input').first();
-        await autocompleteInput.click();
-
-        // Wait for dropdown
-        await expect(page.locator('[data-testid="employee-autocomplete-dropdown"]')).toBeVisible({ timeout: 5000 });
-
-        // Type a search term (Korean name)
-        await autocompleteInput.fill('김');
-
-        // Wait a moment for filtering
-        await page.waitForTimeout(300);
-
-        // The dropdown should still be visible with filtered results
-        // Note: Actual filtering depends on employee data in the database
-        await expect(page.locator('[data-testid="employee-autocomplete-dropdown"]')).toBeVisible();
-
-        // The add button should still be visible even with search results
-        const addNewButton = page.locator('[data-testid="employee-autocomplete-add-button"]');
-        await expect(addNewButton).toBeVisible();
-    });
-
-    test('should open EmployeeFormDialog with prefilled name when clicking add button', async ({ page }) => {
-        // Open the form dialog
-        const addButton = page.locator('[data-testid="add-client-button"]');
-        await addButton.click();
-        await expect(page.locator('[data-testid="client-form-dialog"]')).toBeVisible();
-
-        // Find and focus the employee autocomplete
-        const autocompleteInput = page.locator('[data-testid="employee-autocomplete"] input').first();
-        await autocompleteInput.click();
-
-        // Wait for dropdown
-        await expect(page.locator('[data-testid="employee-autocomplete-dropdown"]')).toBeVisible({ timeout: 5000 });
-
-        // Type a name that we want to be prefilled
-        const testName = '테스트직원';
-        await autocompleteInput.fill(testName);
-
-        // Click the "새 제공인력 추가" button
-        const addNewEmployeeButton = page.locator('[data-testid="employee-autocomplete-add-button"]');
-        await addNewEmployeeButton.click();
-
-        // Wait for the EmployeeFormDialog to appear (it's a nested dialog)
-        // Look for the dialog that contains employee form fields
-        await page.waitForTimeout(500);
-
-        // Check that a second dialog opened (EmployeeFormDialog)
-        const dialogs = page.locator('[role="dialog"]');
-        const dialogCount = await dialogs.count();
-
-        // There should be 2 dialogs now (ClientFormDialog + EmployeeFormDialog)
-        expect(dialogCount).toBeGreaterThanOrEqual(2);
-
-        // Find the name input in the EmployeeFormDialog (should be prefilled)
-        // The EmployeeFormDialog should have a text field with the prefilled name
-        const nameInputInEmployeeDialog = page.locator('[role="dialog"]').last().locator('input[type="text"]').first();
-
-        // Verify it has the prefilled value
-        await expect(nameInputInEmployeeDialog).toHaveValue(testName);
-    });
-
-    test('should keep "새 제공인력 추가" button visible even when no matches found', async ({ page }) => {
-        // Open the form dialog
-        const addButton = page.locator('[data-testid="add-client-button"]');
-        await addButton.click();
-        await expect(page.locator('[data-testid="client-form-dialog"]')).toBeVisible();
-
-        // Find and focus the employee autocomplete
-        const autocompleteInput = page.locator('[data-testid="employee-autocomplete"] input').first();
-        await autocompleteInput.click();
-
-        // Wait for dropdown
-        await expect(page.locator('[data-testid="employee-autocomplete-dropdown"]')).toBeVisible({ timeout: 5000 });
-
-        // Type something that won't match any employees
-        await autocompleteInput.fill('존재하지않는이름xyz123');
-
-        // Wait for filtering
-        await page.waitForTimeout(300);
-
-        // The dropdown should still show the add button
-        const addNewButton = page.locator('[data-testid="employee-autocomplete-add-button"]');
-        await expect(addNewButton).toBeVisible();
-
-        // And possibly show "No options" text, but button is always there
-        const noOptionsText = page.getByText('검색 결과가 없습니다');
-        // This may or may not be visible depending on locale
-    });
-});
-
-test.describe('EmployeeAutocomplete in ContractCreationForm', () => {
-    test.beforeEach(async ({ page }) => {
-        // Navigate to contract creation page
-        await page.goto('/messages/contract');
-        await page.waitForLoadState('networkidle');
-    });
-
-    test('should have EmployeeAutocomplete for selecting caretaker', async ({ page }) => {
-        // The contract form should have an employee autocomplete field
-        const employeeAutocomplete = page.locator('[data-testid="employee-autocomplete"]');
-
-        // Check if at least one employee autocomplete exists on the page
-        // Note: This may be further in the form stepper, so we may need to navigate
-        const count = await employeeAutocomplete.count();
-
-        // If not immediately visible, the form might require steps to get there
-        // This is an informational assertion
-        console.log(`Found ${count} EmployeeAutocomplete components on contract form`);
-    });
+    const employeeDialog = page.locator('[data-component="employees-form-dialog"]');
+    await expect(employeeDialog).toBeVisible({ timeout: 5000 });
+    await expect(employeeDialog.locator('#name')).toHaveValue(typedName);
+  });
 });

--- a/mobile/tests/employees-detail-layout.spec.ts
+++ b/mobile/tests/employees-detail-layout.spec.ts
@@ -41,7 +41,9 @@ test.describe("employees mobile detail layout", () => {
     });
 
     await page.goto("/employees");
-    await page.waitForLoadState("networkidle");
+    await expect(page.locator('[data-component="mobile-employees-row"]')).toHaveCount(2, {
+      timeout: 15000,
+    });
 
     const row = page.locator('[data-component="mobile-employees-row"]');
     await expect(row).toHaveCount(2);
@@ -87,11 +89,10 @@ test.describe("employees mobile detail layout", () => {
     await expect(page.locator(".info-card-title", { hasText: "이전 담당" })).toBeHidden();
 
     await page.getByRole("button", { name: "근무 내역" }).click();
-    await expect(page.locator(".info-card-title", { hasText: "이전 담당" })).toBeVisible();
-    await expect(page.getByText("윤정아 · A가1형")).toBeVisible();
-    await expect(page.getByText("5월 9일 (오전) 방문")).toHaveCount(0);
-    await expect(page.getByText("5월 10일 (오전) 예정")).toHaveCount(0);
-    await expect(page.locator(".info-card-title", { hasText: /·\\s*\\d+[명건개]/ })).toHaveCount(0);
+    await expect(page.locator('[data-component="mobile-employees-history-empty"]')).toHaveText(
+      "근무 내역이 없습니다.",
+    );
+    await expect(page.getByText("윤정아 · A가1형")).toHaveCount(0);
   });
 
   test("shows an empty state when the employee has no assigned client", async ({ page }) => {
@@ -109,7 +110,9 @@ test.describe("employees mobile detail layout", () => {
     });
 
     await page.goto("/employees");
-    await page.waitForLoadState("networkidle");
+    await expect(page.locator('[data-component="mobile-employees-row"]')).toHaveCount(2, {
+      timeout: 15000,
+    });
 
     const unassignedRow = page.locator('[data-component="mobile-employees-row"]', {
       hasText: "박지영",

--- a/mobile/tests/mobile-all-menu.spec.ts
+++ b/mobile/tests/mobile-all-menu.spec.ts
@@ -24,6 +24,16 @@ async function restoreAuthCookies(page: Page) {
 test.describe("Mobile nav: center chat + /all menu", () => {
   test.use({ viewport: { width: 390, height: 844 } });
 
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/notifications/vapid-key**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ publicKey: "test-vapid-key" }),
+      });
+    });
+  });
+
   test("all menu uses fixed-size skeletons for fetched values while loading", async ({ page }) => {
     let releaseClients: () => void = () => {};
     let releaseEmployees: () => void = () => {};

--- a/mobile/tests/mobile-messages-filter-skeleton.spec.ts
+++ b/mobile/tests/mobile-messages-filter-skeleton.spec.ts
@@ -5,6 +5,22 @@ const nowIso = new Date().toISOString();
 test.describe("Mobile messages filter skeletons", () => {
   test.use({ viewport: { width: 390, height: 844 } });
 
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/settings/message-sender-approval", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          approvalStatus: "approved",
+          isApproved: true,
+          canRequest: true,
+          senderPhone: "01012345678",
+          senderPhoneFormatted: "010-1234-5678",
+        }),
+      });
+    });
+  });
+
   test("renders whole filter pills as skeletons while message counts load", async ({ page }) => {
     let releaseLogs: () => void = () => {};
     const logsReady = new Promise<void>((resolve) => {

--- a/mobile/tests/notification-bell.spec.ts
+++ b/mobile/tests/notification-bell.spec.ts
@@ -105,11 +105,19 @@ test.describe('Notification Bell Navigation', () => {
       });
     });
 
-    await page.route('**/api/notifications', async (route) => {
+    await page.route('**/api/notifications?**', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify(MOCK_NOTIFICATIONS),
+      });
+    });
+
+    await page.route('**/api/notifications/vapid-key', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ publicKey: 'test-vapid-key' }),
       });
     });
 
@@ -124,15 +132,22 @@ test.describe('Notification Bell Navigation', () => {
 
     await page.route('**/api/notifications/*/read', async (route) => {
       currentUnreadCount = Math.max(0, currentUnreadCount - 1);
+      const notificationId = Number(route.request().url().split('/').slice(-2, -1)[0]);
+      const notification =
+        MOCK_NOTIFICATIONS.find((item) => item.id === notificationId) ?? MOCK_NOTIFICATIONS[0];
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ success: true }),
+        body: JSON.stringify({
+          ...notification,
+          isRead: true,
+          readAt: new Date().toISOString(),
+        }),
       });
     });
 
     await page.goto('/clients');
-    await page.waitForLoadState('networkidle');
+    await expect(page.locator('[data-component="clients"]')).toBeVisible({ timeout: 15000 });
 
     const e2eFlag = await page.evaluate(() => (window as Window & { __E2E_AUTH__?: boolean }).__E2E_AUTH__);
     if (!e2eFlag) {
@@ -140,7 +155,7 @@ test.describe('Notification Bell Navigation', () => {
         (window as Window & { __E2E_AUTH__?: boolean }).__E2E_AUTH__ = true;
       });
       await page.reload();
-      await page.waitForLoadState('networkidle');
+      await expect(page.locator('[data-component="clients"]')).toBeVisible({ timeout: 15000 });
     }
   });
 
@@ -175,7 +190,7 @@ test.describe('Notification Bell Navigation', () => {
     await page.waitForURL(/\/clients\/1/);
 
     await page.goBack();
-    await page.waitForLoadState('networkidle');
+    await expect(page.locator('[data-component="clients"]')).toBeVisible({ timeout: 15000 });
 
     await expect(badge).toHaveText('1');
   });

--- a/mobile/tests/system-template-editor.spec.ts
+++ b/mobile/tests/system-template-editor.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page, type Route, type Request } from '@playwright/test';
+import { expect, test, type Page, type Request, type Route } from '@playwright/test';
 
 const templateFixture = {
   id: 'tpl-thanks',
@@ -6,88 +6,66 @@ const templateFixture = {
   name: '감사',
   description: '감사 메시지',
   content: '감사합니다 {{name}}님',
-  requiredVariables: [
-    {
-      key: 'name',
-      label: '이름',
-      type: 'string',
-      required: true,
-    },
-  ],
+  requiredVariables: [{ key: 'name', label: '이름', type: 'string', required: true }],
   updatedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
 } as const;
 
-async function mockTemplateApi(page: Page) {
-  await page.route('**/api/system-templates/THANKS', async (route: Route, request: Request) => {
-    if (request.method() === 'GET') {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(templateFixture),
-      });
-    }
-
-    if (request.method() === 'PUT') {
-      const body = request.postDataJSON() as { content?: string } | null;
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ ...templateFixture, content: body?.content ?? templateFixture.content }),
-      });
-    }
-
-    return route.continue();
+async function mockMessagesApproval(page: Page): Promise<void> {
+  await page.route('**/api/settings/message-sender-approval', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        approvalStatus: 'approved',
+        isApproved: true,
+        canRequest: true,
+        senderPhone: '01012345678',
+        senderPhoneFormatted: '010-1234-5678',
+      }),
+    });
   });
 }
 
-test.describe('System Template Editor', () => {
+async function mockTemplateApi(page: Page): Promise<void> {
+  await page.route('**/api/system-templates/THANKS', async (route: Route, request: Request) => {
+    if (request.method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(templateFixture),
+    });
+  });
+}
+
+test.describe('System Template Detail', () => {
   test.beforeEach(async ({ page }) => {
+    await mockMessagesApproval(page);
     await mockTemplateApi(page);
     await page.goto('/messages/system-templates/THANKS');
-    await page.waitForLoadState('networkidle');
+    await expect(page.locator('[data-component="messages-system-template-detail"]')).toBeVisible({
+      timeout: 15000,
+    });
   });
 
-  test('should display template content', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /감사 편집/ })).toBeVisible();
-
-    const editor = page.getByRole('textbox');
-    await expect(editor).toHaveValue(templateFixture.content);
+  test('displays the current read-only template content and required variables', async ({ page }) => {
+    await expect(page.getByText('감사', { exact: true })).toBeVisible();
+    await expect(page.getByText('감사 메시지')).toBeVisible();
+    await expect(page.locator('[data-component="messages-system-template-content"]')).toContainText(
+      templateFixture.content,
+    );
+    await expect(page.getByText('필수 변수')).toBeVisible();
+    await expect(page.getByText('이름')).toBeVisible();
   });
 
-  test('should show variable toolbar', async ({ page }) => {
-    await expect(page.getByText('변수 삽입')).toBeVisible();
-    await expect(page.getByRole('button', { name: '이름' })).toBeVisible();
-  });
-
-  test('should insert variable on click', async ({ page }) => {
-    const editor = page.getByRole('textbox');
-    await editor.fill('');
-
-    await page.getByRole('button', { name: '이름' }).click();
-    await expect(editor).toHaveValue('{{name}}');
-  });
-
-  test('should show validation errors', async ({ page }) => {
-    const editor = page.getByRole('textbox');
-    await editor.fill('감사합니다');
-
-    const errorAlert = page.locator('.MuiAlert-root[role="alert"]').filter({ hasText: '필수 변수 누락: {{name}}' });
-    await expect(errorAlert).toBeVisible();
-  });
-
-  test('should disable save when invalid', async ({ page }) => {
-    const editor = page.getByRole('textbox');
-    await editor.fill('감사합니다');
-
-    const saveButton = page.getByRole('button', { name: '저장' });
-    await expect(saveButton).toBeDisabled();
-  });
-
-  test('should save and show success', async ({ page }) => {
-    const saveButton = page.getByRole('button', { name: '저장' });
-    await expect(saveButton).toBeEnabled();
-
-    await saveButton.click();
-    await expect(page.getByText('저장되었습니다')).toBeVisible();
+  test('shows the current mobile-only guidance instead of the old editor UI', async ({ page }) => {
+    await expect(page.getByRole('button', { name: '뒤로' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '이 템플릿으로 보내기' })).toBeVisible();
+    await expect(
+      page.getByText('시스템 템플릿 본문 편집·버전 롤백은 데스크톱에서만 가능합니다.'),
+    ).toBeVisible();
   });
 });

--- a/mobile/tests/system-template-preview.spec.ts
+++ b/mobile/tests/system-template-preview.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page, type Route, type Request } from '@playwright/test';
+import { expect, test, type Page, type Request, type Route } from '@playwright/test';
 
 const templateFixture = {
   id: 'tpl-thanks',
@@ -6,44 +6,105 @@ const templateFixture = {
   name: '감사',
   description: '감사 메시지',
   content: '감사합니다 {{name}}님',
-  requiredVariables: [
-    {
-      key: 'name',
-      label: '이름',
-      type: 'string',
-      required: true,
-    },
-  ],
+  requiredVariables: [{ key: 'name', label: '이름', type: 'string', required: true }],
   updatedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
 } as const;
 
-async function mockTemplateApi(page: Page) {
+async function mockMessagesApproval(page: Page): Promise<void> {
+  await page.route('**/api/settings/message-sender-approval', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        approvalStatus: 'approved',
+        isApproved: true,
+        canRequest: true,
+        senderPhone: '01012345678',
+        senderPhoneFormatted: '010-1234-5678',
+      }),
+    });
+  });
+}
+
+async function mockTemplateRoutes(page: Page): Promise<void> {
   await page.route('**/api/system-templates/THANKS', async (route: Route, request: Request) => {
-    if (request.method() !== 'GET') return route.continue();
-    return route.fulfill({
+    if (request.method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify(templateFixture),
     });
   });
+
+  await page.route('**/api/system-templates/*', async (route: Route, request: Request) => {
+    if (request.method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    const key = request.url().split('/').pop() ?? 'UNKNOWN';
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: `tpl-${key.toLowerCase()}`,
+        templateKey: key,
+        name: key,
+        description: `${key} template`,
+        content: key === 'THANKS' ? templateFixture.content : `${key} 내용`,
+        requiredVariables: [],
+        updatedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
+      }),
+    });
+  });
+
+  await page.route('**/api/message-templates', async (route: Route, request: Request) => {
+    if (request.method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+
+  await page.route('**/api/bank-account-infos', async (route: Route, request: Request) => {
+    if (request.method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
 }
 
-test.describe('System Template Preview', () => {
-  test.beforeEach(async ({ page }) => {
-    await mockTemplateApi(page);
+test.describe('System Template Send CTA', () => {
+  test('navigates to the compose page with the template body prefilled', async ({ page }) => {
+    await mockMessagesApproval(page);
+    await mockTemplateRoutes(page);
+
     await page.goto('/messages/system-templates/THANKS');
-    await page.waitForLoadState('networkidle');
-  });
+    await expect(page.locator('[data-component="messages-system-template-detail"]')).toBeVisible({
+      timeout: 15000,
+    });
 
-  test('should display preview with sample data', async ({ page }) => {
-    await expect(page.getByText('미리보기')).toBeVisible();
-    await expect(page.getByText('홍길동')).toBeVisible();
-  });
+    await page.getByRole('button', { name: '이 템플릿으로 보내기' }).click();
 
-  test('should update preview in real-time', async ({ page }) => {
-    const editor = page.getByRole('textbox');
-    await editor.fill('테스트 {{name}}');
-
-    await expect(page.getByText('테스트 홍길동')).toBeVisible();
+    await expect(page).toHaveURL(/\/messages\/new\?body=/);
+    await expect(page.locator('[data-component="messages-new-page"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByLabel('메시지 본문')).toHaveValue(templateFixture.content);
   });
 });

--- a/mobile/tests/system-template-versions.spec.ts
+++ b/mobile/tests/system-template-versions.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page, type Route, type Request } from '@playwright/test';
+import { expect, test, type Page, type Request, type Route } from '@playwright/test';
 
 const templateFixture = {
   id: 'tpl-thanks',
@@ -6,84 +6,86 @@ const templateFixture = {
   name: '감사',
   description: '감사 메시지',
   content: '감사합니다 {{name}}님',
-  requiredVariables: [
-    {
-      key: 'name',
-      label: '이름',
-      type: 'string',
-      required: true,
-    },
-  ],
+  requiredVariables: [{ key: 'name', label: '이름', type: 'string', required: true }],
   updatedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
 } as const;
 
-const versionsFixture = [
-  {
-    versionNumber: 1,
-    createdAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
-    createdBy: 'tester',
-  },
-  {
-    versionNumber: 2,
-    createdAt: new Date('2026-01-02T00:00:00.000Z').toISOString(),
-    createdBy: 'tester',
-  },
-] as const;
-
-async function mockVersionsApi(page: Page) {
-  await page.route('**/api/system-templates/THANKS', async (route: Route, request: Request) => {
-    if (request.method() !== 'GET') return route.continue();
-    return route.fulfill({
+async function mockMessagesApproval(page: Page): Promise<void> {
+  await page.route('**/api/settings/message-sender-approval', async (route: Route) => {
+    await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(templateFixture),
-    });
-  });
-
-  await page.route('**/api/system-templates/THANKS/versions', async (route: Route, request: Request) => {
-    if (request.method() !== 'GET') return route.continue();
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(versionsFixture),
-    });
-  });
-
-  await page.route('**/api/system-templates/THANKS/rollback/*', async (route: Route, request: Request) => {
-    if (request.method() !== 'POST') return route.continue();
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(templateFixture),
+      body: JSON.stringify({
+        approvalStatus: 'approved',
+        isApproved: true,
+        canRequest: true,
+        senderPhone: '01012345678',
+        senderPhoneFormatted: '010-1234-5678',
+      }),
     });
   });
 }
 
-test.describe('System Template Versions', () => {
-  test.beforeEach(async ({ page }) => {
-    await mockVersionsApi(page);
+async function mockTemplateApi(page: Page): Promise<void> {
+  await page.route('**/api/system-templates/THANKS', async (route: Route, request: Request) => {
+    if (request.method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(templateFixture),
+    });
+  });
+
+  await page.route('**/api/alimtalk-trigger-rules', async (route: Route, request: Request) => {
+    if (request.method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+
+  await page.route('**/api/message-templates', async (route: Route, request: Request) => {
+    if (request.method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+}
+
+test.describe('System Template Detail Secondary Actions', () => {
+  test('surfaces the desktop-only rollback guidance and links to trigger settings', async ({
+    page,
+  }) => {
+    await mockMessagesApproval(page);
+    await mockTemplateApi(page);
+
     await page.goto('/messages/system-templates/THANKS');
-    await page.waitForLoadState('networkidle');
-  });
+    await expect(page.locator('[data-component="messages-system-template-detail"]')).toBeVisible({
+      timeout: 15000,
+    });
 
-  test('should show version history', async ({ page }) => {
-    await page.getByRole('button', { name: '버전 기록' }).click();
+    await expect(
+      page.getByText('시스템 템플릿 본문 편집·버전 롤백은 데스크톱에서만 가능합니다.'),
+    ).toBeVisible();
 
-    await expect(page.getByText('버전 1')).toBeVisible();
-    await expect(page.getByText('버전 2')).toBeVisible();
-  });
+    await page.locator('[data-component="messages-system-template-trigger-link"]').click();
 
-  test('should rollback with confirmation', async ({ page }) => {
-    await page.getByRole('button', { name: '버전 기록' }).click();
-
-    await page.getByTitle('이 버전으로 복원').first().click();
-
-    await expect(page.getByRole('heading', { name: '버전 복원' })).toBeVisible();
-    await expect(page.getByText('복원하시겠습니까?')).toBeVisible();
-
-    await page.getByRole('button', { name: '복원' }).click();
-
-    await expect(page.getByRole('heading', { name: '버전 복원' })).not.toBeVisible();
-    await expect(page.getByText('버전 1')).not.toBeVisible();
+    await expect(page).toHaveURL('/alimtalk');
+    await expect(page.locator('[data-component="alimtalk"]')).toBeVisible({ timeout: 15000 });
   });
 });

--- a/mobile/tests/system-templates-list.spec.ts
+++ b/mobile/tests/system-templates-list.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page, type Route, type Request } from '@playwright/test';
+import { expect, test, type Page, type Request, type Route } from '@playwright/test';
 
 const templatesFixture = [
   {
@@ -7,14 +7,7 @@ const templatesFixture = [
     name: '비용 안내',
     description: '바우처 비용 안내 메시지',
     content: '비용 안내 메시지: {{name}}',
-    requiredVariables: [
-      {
-        key: 'name',
-        label: '이름',
-        type: 'string',
-        required: true,
-      },
-    ],
+    requiredVariables: [{ key: 'name', label: '이름', type: 'string', required: true }],
     updatedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
   },
   {
@@ -26,85 +19,32 @@ const templatesFixture = [
     requiredVariables: [],
     updatedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
   },
-  {
-    id: 'tpl-thanks',
-    templateKey: 'THANKS',
-    name: '감사',
-    description: '감사 메시지',
-    content: '감사합니다 {{name}}님',
-    requiredVariables: [
-      {
-        key: 'name',
-        label: '이름',
-        type: 'string',
-        required: true,
-      },
-    ],
-    updatedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
-  },
-  {
-    id: 'tpl-survey',
-    templateKey: 'SURVEY',
-    name: '설문',
-    description: '설문 요청 메시지',
-    content: '설문 부탁드립니다 {{name}}님',
-    requiredVariables: [
-      {
-        key: 'name',
-        label: '이름',
-        type: 'string',
-        required: true,
-      },
-    ],
-    updatedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
-  },
-  {
-    id: 'tpl-service',
-    templateKey: 'SERVICE_INFO',
-    name: '서비스 안내',
-    description: '서비스 안내 메시지',
-    content: '서비스 안내드립니다 {{name}}님',
-    requiredVariables: [
-      {
-        key: 'name',
-        label: '이름',
-        type: 'string',
-        required: true,
-      },
-    ],
-    updatedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
-  },
-  {
-    id: 'tpl-reminder',
-    templateKey: 'REMINDER',
-    name: '리마인더',
-    description: '리마인더 메시지',
-    content: '리마인더입니다 {{name}}님',
-    requiredVariables: [
-      {
-        key: 'name',
-        label: '이름',
-        type: 'string',
-        required: true,
-      },
-    ],
-    updatedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
-  },
-  {
-    id: 'tpl-info',
-    templateKey: 'INFO',
-    name: '안내',
-    description: '일반 안내 메시지',
-    content: '안내드립니다',
-    requiredVariables: [],
-    updatedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
-  },
 ] as const;
 
-function mockSystemTemplatesApi(page: Page) {
+async function mockMessagesApproval(page: Page): Promise<void> {
+  await page.route('**/api/settings/message-sender-approval', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        approvalStatus: 'approved',
+        isApproved: true,
+        canRequest: true,
+        senderPhone: '01012345678',
+        senderPhoneFormatted: '010-1234-5678',
+      }),
+    });
+  });
+}
+
+function mockSystemTemplatesApi(page: Page): Promise<void> {
   return page.route('**/api/system-templates', async (route: Route, request: Request) => {
-    if (request.method() !== 'GET') return route.continue();
-    return route.fulfill({
+    if (request.method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify(templatesFixture),
@@ -113,13 +53,16 @@ function mockSystemTemplatesApi(page: Page) {
 }
 
 test.describe('Templates List', () => {
-  test('should display templates with type chips', async ({ page }) => {
+  test('shows the current sectioned mobile template list', async ({ page }) => {
+    await mockMessagesApproval(page);
     await mockSystemTemplatesApi(page);
-    
-    // Mock user templates API (empty for this test)
     await page.route('**/api/message-templates', async (route: Route, request: Request) => {
-      if (request.method() !== 'GET') return route.continue();
-      return route.fulfill({
+      if (request.method() !== 'GET') {
+        await route.fallback();
+        return;
+      }
+
+      await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify([]),
@@ -127,44 +70,53 @@ test.describe('Templates List', () => {
     });
 
     await page.goto('/messages/templates');
-    await page.waitForLoadState('networkidle');
+    await expect(page.getByText('템플릿 관리')).toBeVisible({ timeout: 15000 });
 
-    await expect(page.getByRole('heading', { name: '템플릿 관리' })).toBeVisible();
-    
-    // System templates appear with system chip
-    await expect(page.locator('[data-type="system"]').first()).toBeVisible();
-    
-     // Verify template names are displayed
-     await expect(page.getByText('비용 안내', { exact: true })).toBeVisible();
-     await expect(page.getByText('인사(소개)')).toBeVisible();
+    await expect(page.locator('[data-component="messages-templates-search"]')).toBeVisible();
+    await expect(page.locator('[data-component="messages-templates-filters"]')).toBeVisible();
+    await expect(page.locator('[data-component="messages-templates-section-header"]').first()).toContainText(
+      '시스템 자동',
+    );
+    await expect(page.locator('[data-component="messages-templates-row"]')).toHaveCount(2);
+    await expect(page.getByText('비용 안내', { exact: true })).toBeVisible();
+    await expect(page.getByText('인사(소개)', { exact: true })).toBeVisible();
   });
 
-  test('should navigate to system template editor on click', async ({ page }) => {
+  test('navigates to the current system template detail page on click', async ({ page }) => {
+    await mockMessagesApproval(page);
     await mockSystemTemplatesApi(page);
-    
-    // Mock user templates API (empty for this test)
     await page.route('**/api/message-templates', async (route: Route, request: Request) => {
-      if (request.method() !== 'GET') return route.continue();
-      return route.fulfill({
+      if (request.method() !== 'GET') {
+        await route.fallback();
+        return;
+      }
+
+      await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify([]),
       });
     });
-
     await page.route('**/api/system-templates/PRICE_INFO', async (route: Route, request: Request) => {
-      if (request.method() !== 'GET') return route.continue();
-      return route.fulfill({
+      if (request.method() !== 'GET') {
+        await route.fallback();
+        return;
+      }
+
+      await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify(templatesFixture[0]),
       });
     });
 
-     await page.goto('/messages/templates');
-     await page.getByText('비용 안내', { exact: true }).click();
+    await page.goto('/messages/templates');
+    await expect(page.getByText('템플릿 관리')).toBeVisible({ timeout: 15000 });
+
+    await page.getByText('비용 안내', { exact: true }).click();
 
     await expect(page).toHaveURL(/\/messages\/system-templates\/PRICE_INFO/);
-    await expect(page.getByRole('heading', { name: '비용 안내' })).toBeVisible();
+    await expect(page.locator('[data-component="messages-system-template-detail"]')).toBeVisible();
+    await expect(page.getByText('비용 안내', { exact: true })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Context

CI run #5 (27079998884) was the first complete execution of the 266-test Playwright suite against the real-backend stack: **119 passed / 132 failed / 1 flaky / 12 skipped, 1.2h**. Zero backend errors — every failure is spec-level drift against the PR #220 mobile redesign or environment assumptions. This PR lands the mechanical stabilization batch from the failure triage (per-failure logs + the 28 deduped page snapshots from the report artifact).

## Changes

**CI quarantine (7 files, config-level)** — `testIgnore: process.env.CI ? CI_QUARANTINE : []`, full suite still runs locally; each entry documented in `tests/QUARANTINE.md` with its unblock condition:
- `client-creation` (24 fails): tests the removed dialog flow; creation moved to the `/clients/new` wizard → rewrite tracked
- `alimtalk-settings` (12): navigates removed routes `/settings/general`, `/settings/voucher-price` (404 in CI snapshots) → rewrite vs current IA
- 4 animation/timing diagnostics (`nav-indicator-diagnose`, `nav-slide-dense`, `animation-plan-visual-verify`, `dashboard-activities-animation`): local-only by design (real login w/ dev creds, frame capture)
- `chat-live-stream`: hits the live SSE endpoint; backend requires `GEMINI_API_KEY` (only eformsign/aligo have e2e stubs)

**Spec repairs (15 files):**
- chat cluster: `chat-back` → `chat-fullscreen-close`, `chat-clear` → `chat-fullscreen-clear`
- contracts: search placeholder `'고객명 검색'` → `'고객명, 계약서명, 계약 번호 검색'`; dead `data-table-toolbar` anchor → `mobile-contracts-search` / `mobile-redesign-filter-row`; route-mock globs `**/api/documents**` → `**/api/eformsign/documents?**` + companion routes
- `networkidle` eliminated from every non-quarantined spec (app polls → idle never settles; Playwright discourages it) → element-anchored waits
- route-mock drift fixed across skeleton/template/bell/detail specs (`notifications?**`, `vapid-key`, `message-sender-approval` guard stubs, `employees` + `alimtalk-logs` companions)
- `employee-autocomplete`: rewritten against `/clients/new`; dropdown/add-button selected via existing `data-component` attributes — **no production code changes in this PR** (an earlier draft added a MutationObserver testid-stamper to `EmployeeAutocomplete.tsx`; rejected and reverted in favor of selecting what the component already renders)

**Test deletions (38), verified title-by-title against `mobile/src`:** 30 tested UI that no longer exists (MUI table/pagination/alerts on contracts, desktop-only system-template editor/preview/versions — mobile renders read-only detail with "데스크톱에서만 가능합니다"); the 8 still-live behaviors all have equivalent assertions in the rewritten tests.

## Verification

- mobile type-check clean · lint 0 errors · jest **633/633**
- Suite-level proof: next `workflow_dispatch` e2e run measures the residue (dispatched after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)