### PR TITLE
test(e2e): batch 2 — wizard/settings rewrites + Gemini vendor stub

### DIFF
--- a/backend/infrastructure/vendor-stubs/e2e-vendor-stubs.ts
+++ b/backend/infrastructure/vendor-stubs/e2e-vendor-stubs.ts
@@ -23,6 +23,14 @@ import {
 } from "domain/repositories/eformsign.client.interface";
 import { AligoApiClient } from "infrastructure/api/aligo-api.client";
 import { EformsignApiClient } from "infrastructure/api/eformsign-api.client";
+import {
+    ChatMessage,
+    FunctionCall,
+    FunctionDeclaration,
+    GeminiChatGateway,
+    GeminiStreamChunk,
+} from "infrastructure/api/gemini-chat.gateway";
+import { VercelGeminiGateway } from "infrastructure/api/vercel-gemini.gateway";
 
 export const E2E_VENDOR_STUBS_ENV = "E2E_VENDOR_STUBS";
 export const EFORMSIGN_STUB_USER_EMAIL = "e2e-stub@babyjamjam.test";
@@ -32,6 +40,29 @@ export const EFORMSIGN_STUB_TEMPLATE_ID = "tpl-test";
 const EFORMSIGN_STUB_ACCESS_TOKEN = "e2e-stub-token";
 const EFORMSIGN_STUB_REFRESH_TOKEN = "e2e-stub-refresh-token";
 const EFORMSIGN_STUB_API_URL = "https://stub.eformsign.invalid";
+const GEMINI_STUB_PREFIX = "[e2e-stub] ";
+const GEMINI_STUB_MAX_ECHO_LENGTH = 48;
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function normalizeGeminiStubText(value: string | undefined): string {
+    const normalized = (value ?? "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, GEMINI_STUB_MAX_ECHO_LENGTH);
+
+    return normalized || "stub response";
+}
+
+function buildGeminiStubText(messages: ChatMessage[]): string {
+    const lastUserMessage = [...messages]
+        .reverse()
+        .find((message) => message.role === "user")?.content;
+
+    return `${GEMINI_STUB_PREFIX}${normalizeGeminiStubText(lastUserMessage)}`;
+}
 
 type EformsignStubDocument = EformsignApiDocumentResponse & {
     detail_template_info?: {
@@ -466,6 +497,52 @@ export class E2eAligoApiStub implements IAligoApiPort, IAligoSmsApiPort {
     }
 }
 
+export class E2eGeminiGatewayStub {
+    async chat(
+        messages: ChatMessage[],
+        tools?: FunctionDeclaration[],
+    ): Promise<{ text?: string; functionCall?: FunctionCall }> {
+        void tools;
+        return {
+            text: buildGeminiStubText(messages),
+        };
+    }
+
+    async *chatStream(
+        messages: ChatMessage[],
+        tools?: FunctionDeclaration[],
+    ): AsyncGenerator<GeminiStreamChunk> {
+        void tools;
+        const responseText = buildGeminiStubText(messages);
+        const chunks = [
+            GEMINI_STUB_PREFIX,
+            responseText.slice(GEMINI_STUB_PREFIX.length, GEMINI_STUB_PREFIX.length + 12),
+            responseText.slice(GEMINI_STUB_PREFIX.length + 12),
+        ].filter((chunk) => chunk.length > 0);
+
+        await sleep(10);
+        for (const chunk of chunks) {
+            yield { type: "text", content: chunk };
+            await sleep(10);
+        }
+
+        yield { type: "done" };
+    }
+
+    async sendFunctionResult(
+        messages: ChatMessage[],
+        functionName: string,
+        result: unknown,
+        tools?: FunctionDeclaration[],
+    ): Promise<{ text?: string; functionCall?: FunctionCall }> {
+        void tools;
+
+        return {
+            text: `${GEMINI_STUB_PREFIX}${normalizeGeminiStubText(`${functionName} ${JSON.stringify(result)}`)}`,
+        };
+    }
+}
+
 export function createEformsignClientRepository(configService: ConfigService): IEformsignClientRepository {
     return areE2EVendorStubsEnabled(configService)
         ? new E2eEformsignClientStub()
@@ -476,4 +553,17 @@ export function createAligoPortClient(configService: ConfigService): IAligoApiPo
     return areE2EVendorStubsEnabled(configService)
         ? new E2eAligoApiStub()
         : new AligoApiClient(configService);
+}
+
+export function createGeminiGateway(configService: ConfigService) {
+    if (areE2EVendorStubsEnabled(configService)) {
+        return new E2eGeminiGatewayStub();
+    }
+
+    const useVercelAiSdk = configService.get<string>("USE_VERCEL_AI_SDK") === "true";
+    if (useVercelAiSdk) {
+        return new VercelGeminiGateway(configService);
+    }
+
+    return new GeminiChatGateway(configService);
 }

--- a/backend/module/ai-chat.module.ts
+++ b/backend/module/ai-chat.module.ts
@@ -8,6 +8,7 @@ import { CleanupChatSessionsUsecase } from "application/usecases/ai-chat/cleanup
 import { ToolExecutorService } from "application/ai-chat/tool-executor.service";
 import { GeminiChatGateway } from "infrastructure/api/gemini-chat.gateway";
 import { VercelGeminiGateway } from "infrastructure/api/vercel-gemini.gateway";
+import { createGeminiGateway } from "infrastructure/vendor-stubs/e2e-vendor-stubs";
 import { OwnerOrAdminGuard } from "infrastructure/auth/owner-or-admin.guard";
 import { DatabaseModule } from "infrastructure/database/database.module";
 import { ChatSessionModule } from "./chat-session.module";
@@ -40,16 +41,9 @@ export { GEMINI_GATEWAY } from "./ai-chat.tokens";
     ],
     controllers: [AIChatController, AdminFeedbackController],
     providers: [
-        // Feature flag: USE_VERCEL_AI_SDK=true enables the new Vercel AI SDK gateway
         {
             provide: GEMINI_GATEWAY,
-            useFactory: (configService: ConfigService) => {
-                const useVercelAiSdk = configService.get<string>("USE_VERCEL_AI_SDK") === "true";
-                if (useVercelAiSdk) {
-                    return new VercelGeminiGateway(configService);
-                }
-                return new GeminiChatGateway(configService);
-            },
+            useFactory: createGeminiGateway,
             inject: [ConfigService],
         },
         // Keep both gateways available for direct injection if needed

--- a/backend/test/infrastructure/e2e-vendor-stubs.spec.ts
+++ b/backend/test/infrastructure/e2e-vendor-stubs.spec.ts
@@ -2,11 +2,15 @@ import { ConfigService } from "@nestjs/config";
 
 import { AligoApiClient } from "infrastructure/api/aligo-api.client";
 import { EformsignApiClient } from "infrastructure/api/eformsign-api.client";
+import { GeminiChatGateway } from "infrastructure/api/gemini-chat.gateway";
+import { VercelGeminiGateway } from "infrastructure/api/vercel-gemini.gateway";
 import {
     createAligoPortClient,
     createEformsignClientRepository,
+    createGeminiGateway,
     E2eAligoApiStub,
     E2eEformsignClientStub,
+    E2eGeminiGatewayStub,
 } from "infrastructure/vendor-stubs/e2e-vendor-stubs";
 
 function createConfigService(overrides: Record<string, string | undefined> = {}): ConfigService {
@@ -25,6 +29,8 @@ function createConfigService(overrides: Record<string, string | undefined> = {})
                 EFORMSIGN_DOC_API_URL: "https://doc.eformsign.example",
                 EFORMSIGN_PRIVATE_KEY: "00",
                 EFORMSIGN_USER_EMAIL: "staff@example.com",
+                GEMINI_API_KEY: "gemini-key",
+                USE_VERCEL_AI_SDK: "false",
                 ...overrides,
             };
 
@@ -39,6 +45,15 @@ describe("vendor stub factory selection", () => {
 
         expect(createEformsignClientRepository(configService)).toBeInstanceOf(EformsignApiClient);
         expect(createAligoPortClient(configService)).toBeInstanceOf(AligoApiClient);
+        expect(createGeminiGateway(configService)).toBeInstanceOf(GeminiChatGateway);
+    });
+
+    it("keeps the Vercel Gemini gateway path when configured and stubs are off", () => {
+        const configService = createConfigService({
+            USE_VERCEL_AI_SDK: "true",
+        });
+
+        expect(createGeminiGateway(configService)).toBeInstanceOf(VercelGeminiGateway);
     });
 
     it("switches to stubbed vendor clients when E2E_VENDOR_STUBS is on", async () => {
@@ -55,13 +70,16 @@ describe("vendor stub factory selection", () => {
             EFORMSIGN_DOC_API_URL: undefined,
             EFORMSIGN_PRIVATE_KEY: undefined,
             EFORMSIGN_USER_EMAIL: undefined,
+            GEMINI_API_KEY: undefined,
         });
 
         const eformsignClient = createEformsignClientRepository(configService);
         const aligoClient = createAligoPortClient(configService);
+        const geminiGateway = createGeminiGateway(configService);
 
         expect(eformsignClient).toBeInstanceOf(E2eEformsignClientStub);
         expect(aligoClient).toBeInstanceOf(E2eAligoApiStub);
+        expect(geminiGateway).toBeInstanceOf(E2eGeminiGatewayStub);
         await expect(eformsignClient.getAllDocuments("ignored-token")).resolves.toEqual(
             expect.arrayContaining([
                 expect.objectContaining({ id: "doc-create-test" }),
@@ -76,5 +94,19 @@ describe("vendor stub factory selection", () => {
             error_cnt: 0,
             success_cnt: 1,
         });
+
+        const streamEvents: Array<{ type: string; content?: string }> = [];
+        for await (const event of geminiGateway.chatStream([
+            { role: "system", content: "sys" },
+            { role: "user", content: "안녕하세요 반가워요" },
+        ])) {
+            streamEvents.push(event);
+        }
+
+        expect(streamEvents).toEqual([
+            { type: "text", content: "[e2e-stub] " },
+            { type: "text", content: "안녕하세요 반가워요" },
+            { type: "done" },
+        ]);
     });
 });

--- a/mobile/playwright.config.ts
+++ b/mobile/playwright.config.ts
@@ -2,13 +2,10 @@ import { defineConfig, devices } from '@playwright/test';
 
 // Quarantined from CI until rewritten/unblocked — see tests/QUARANTINE.md
 const CI_QUARANTINE = [
-  '**/client-creation.spec.ts', // UI moved: dialog flow -> /clients/new wizard; spec rewrite tracked
-  '**/alimtalk-settings.spec.ts', // navigates removed routes /settings/general, /settings/voucher-price (404); rewrite vs current IA
   '**/nav-indicator-diagnose.spec.ts', // local-only diagnostic: real login with dev credentials, dev server timing capture
   '**/nav-slide-dense.spec.ts', // local-only diagnostic: dense frame capture, real login
   '**/animation-plan-visual-verify.spec.ts', // animation/visual diagnostic, timing-fragile in CI
   '**/dashboard-activities-animation.spec.ts', // animation diagnostic (addInitScript event collection)
-  '**/chat-live-stream.spec.ts', // hits real /api/ai/chat/stream; backend requires GEMINI_API_KEY (no vendor stub yet)
 ];
 
 /**

--- a/mobile/tests/QUARANTINE.md
+++ b/mobile/tests/QUARANTINE.md
@@ -1,9 +1,6 @@
 | Spec | Reason | Unblocks When |
 | --- | --- | --- |
-| `client-creation.spec.ts` | `/clients` no longer exposes the old dialog flow; creation moved to `/clients/new` wizard. | Rewrite against the `/clients/new` wizard flow. |
-| `alimtalk-settings.spec.ts` | Navigates removed routes `/settings/general` and `/settings/voucher-price`, which now 404. | Rewrite against the current settings information architecture. |
 | `nav-indicator-diagnose.spec.ts` | Local-only diagnostic that depends on real login and timing capture. | Keep local-only by design. |
 | `nav-slide-dense.spec.ts` | Local-only diagnostic that depends on real login and dense frame capture. | Keep local-only by design. |
 | `animation-plan-visual-verify.spec.ts` | Visual animation diagnostic that is timing-fragile in CI. | Keep local-only by design. |
 | `dashboard-activities-animation.spec.ts` | Animation diagnostic built around event collection timing. | Keep local-only by design. |
-| `chat-live-stream.spec.ts` | Calls real `/api/ai/chat/stream`; CI backend has no Gemini vendor stub and needs `GEMINI_API_KEY`. | Add backend e2e Gemini stubs or provide a usable key in CI. |

--- a/mobile/tests/alimtalk-settings.spec.ts
+++ b/mobile/tests/alimtalk-settings.spec.ts
@@ -1,196 +1,104 @@
-import { test, expect } from '@playwright/test';
+import { expect, test, type Page } from "@playwright/test";
 
-test.describe('Alimtalk Provider Settings', () => {
-    test.beforeEach(async ({ page }) => {
-        await page.goto('/settings/general');
-        await page.waitForLoadState('networkidle');
+type ProviderValue = "aligo" | "channeltalk" | "none";
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+async function mockNotificationSettingsRoutes(
+  page: Page,
+  options?: {
+    initialProvider?: ProviderValue;
+    onProviderUpdate?: (provider: ProviderValue) => void;
+  }
+) {
+  let providerState: { provider: ProviderValue; updatedAt: string } = {
+    provider: options?.initialProvider ?? "aligo",
+    updatedAt: "2026-06-07T09:00:00.000Z",
+  };
+
+  await page.route("**/api/notifications/vapid-key**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ publicKey: "test-vapid-key" }),
     });
+  });
 
-    test.describe('Page Load', () => {
-        test('should display alimtalk settings section', async ({ page }) => {
-            await expect(page.getByText('알림톡 설정')).toBeVisible();
-            await expect(page.getByText('카카오 알림톡 발송 서비스를 선택합니다.')).toBeVisible();
-        });
+  await page.route("**/api/settings/alimtalk-provider", async (route) => {
+    if (route.request().method() === "PUT") {
+      const { provider } = route.request().postDataJSON() as { provider: ProviderValue };
+      providerState = {
+        provider,
+        updatedAt: "2026-06-07T09:30:00.000Z",
+      };
+      options?.onProviderUpdate?.(provider);
+    }
 
-        test('should display all provider options', async ({ page }) => {
-            await expect(page.getByText('알리고 (Aligo)')).toBeVisible();
-            await expect(page.getByText('채널톡 (Channel Talk)')).toBeVisible();
-            await expect(page.getByText('사용 안함')).toBeVisible();
-        });
-
-        test('should have one option selected by default', async ({ page }) => {
-            const selectedRadio = page.locator('input[type="radio"]:checked');
-            await expect(selectedRadio).toHaveCount(1);
-        });
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(providerState),
     });
+  });
 
-    test.describe('Provider Selection', () => {
-        test('should allow selecting Aligo provider', async ({ page }) => {
-            const aligoRadio = page.getByRole('radio', { name: /알리고/i });
-            await aligoRadio.click();
+}
 
-            await expect(aligoRadio).toBeChecked();
-        });
+test.describe("notification settings surface", () => {
+  test("renders the current /notification provider settings UI", async ({ page }) => {
+    await mockNotificationSettingsRoutes(page);
+    await page.goto("/notification");
 
-        test('should allow selecting Channel Talk provider', async ({ page }) => {
-            const channelTalkRadio = page.getByRole('radio', { name: /채널톡/i });
-            await channelTalkRadio.click();
+    await expect(page.locator('[data-component="notification-settings"]')).toBeVisible();
+    await expect(page.getByText("알림 설정")).toBeVisible();
+    await expect(page.getByText("수신 채널")).toBeVisible();
+    await expect(page.getByText("알림톡 서비스")).toBeVisible();
+    await expect(page.locator('[data-component="settings-alimtalk-provider"]')).toBeVisible();
+    await expect(page.getByRole("radio", { name: "알리고 (Aligo) 선택" })).toBeVisible();
+    await expect(page.getByRole("radio", { name: "채널톡 (Channel Talk) 선택" })).toBeVisible();
+    await expect(page.getByRole("radio", { name: "사용 안함 선택" })).toBeVisible();
+  });
 
-            await expect(channelTalkRadio).toBeChecked();
-        });
+  test("redirects /settings to /notification", async ({ page }) => {
+    await mockNotificationSettingsRoutes(page);
+    await page.goto("/settings");
 
-        test('should allow selecting None (disabled)', async ({ page }) => {
-            const noneRadio = page.getByRole('radio', { name: /사용 안함/i });
-            await noneRadio.click();
+    await expect(page).toHaveURL(/\/notification$/);
+    await expect(page.locator('[data-component="notification-settings"]')).toBeVisible();
+  });
 
-            await expect(noneRadio).toBeChecked();
-        });
+  test("redirects /notifications to /notification", async ({ page }) => {
+    await mockNotificationSettingsRoutes(page);
+    await page.goto("/notifications");
+
+    await expect(page).toHaveURL(/\/notification$/);
+    await expect(page.locator('[data-component="notification-settings"]')).toBeVisible();
+  });
+
+  test("saves provider selection through the current /notification surface", async ({ page }) => {
+    let updatedProvider: ProviderValue | null = null;
+
+    await mockNotificationSettingsRoutes(page, {
+      onProviderUpdate: (provider) => {
+        updatedProvider = provider;
+      },
     });
+    await page.goto("/notification");
 
-    test.describe.serial('Save and Persist', () => {
-        test('should show success message after saving', async ({ page }) => {
-            const aligoRadio = page.getByRole('radio', { name: /알리고/i });
-            const channelTalkRadio = page.getByRole('radio', { name: /채널톡/i });
+    const channelTalkOption = page.getByRole("radio", { name: "채널톡 (Channel Talk) 선택" });
+    await channelTalkOption.click();
 
-            const isChannelTalkAlreadySelected = await channelTalkRadio.isChecked();
-            if (isChannelTalkAlreadySelected) {
-                await aligoRadio.click();
-                await expect(page.getByText('알림톡 설정이 저장되었습니다.')).toBeVisible({ timeout: 5000 });
-                await page.waitForTimeout(300);
-            }
+    await expect(channelTalkOption).toHaveAttribute("aria-checked", "true");
+    await expect(page.locator('[data-component="notification-alimtalk-updated-at"]')).toContainText("마지막 수정:");
+    expect(updatedProvider).toBe("channeltalk");
+  });
 
-            await channelTalkRadio.click();
-            const snackbar = page.getByText('알림톡 설정이 저장되었습니다.');
-            await expect(snackbar).toBeVisible({ timeout: 5000 });
-        });
-
-        test('should persist selection after page reload', async ({ page }) => {
-            const aligoRadio = page.getByRole('radio', { name: /알리고/i });
-            const channelTalkRadio = page.getByRole('radio', { name: /채널톡/i });
-
-            const isChannelTalkAlreadySelected = await channelTalkRadio.isChecked();
-            if (isChannelTalkAlreadySelected) {
-                await aligoRadio.click();
-                await expect(page.getByText('알림톡 설정이 저장되었습니다.')).toBeVisible({ timeout: 5000 });
-                await page.waitForTimeout(500);
-            }
-
-            await channelTalkRadio.click();
-            await expect(page.getByText('알림톡 설정이 저장되었습니다.')).toBeVisible({ timeout: 5000 });
-            await page.waitForTimeout(500);
-
-            await page.reload();
-            await page.waitForLoadState('networkidle');
-
-            const selectedRadio = page.getByRole('radio', { name: /채널톡/i });
-            await expect(selectedRadio).toBeChecked({ timeout: 5000 });
-        });
-
-        test('should persist "none" selection after reload', async ({ page }) => {
-            const noneRadio = page.getByRole('radio', { name: /사용 안함/i });
-            await noneRadio.click();
-
-            await expect(page.getByText('알림톡 설정이 저장되었습니다.')).toBeVisible({ timeout: 5000 });
-            await page.waitForTimeout(500);
-
-            await page.reload();
-            await page.waitForLoadState('networkidle');
-
-            const selectedRadio = page.getByRole('radio', { name: /사용 안함/i });
-            await expect(selectedRadio).toBeChecked({ timeout: 5000 });
-        });
+  test("reflects the mocked saved provider state on first render", async ({ page }) => {
+    await mockNotificationSettingsRoutes(page, {
+      initialProvider: "none",
     });
+    await page.goto("/notification");
 
-    test.describe('UI State', () => {
-        test('should show loading state initially', async ({ page }) => {
-            await page.goto('/settings/general');
-
-            const loadingIndicator = page.locator('.MuiCircularProgress-root');
-            await expect(loadingIndicator).toBeVisible({ timeout: 1000 }).catch(() => {});
-        });
-
-        test('should disable radio buttons while saving', async ({ page }) => {
-            const aligoRadio = page.getByRole('radio', { name: /알리고/i });
-            await aligoRadio.click();
-
-            await expect(page.getByText('알림톡 설정이 저장되었습니다.')).toBeVisible({ timeout: 5000 });
-        });
-
-        test('should display last updated timestamp after save', async ({ page }) => {
-            const aligoRadio = page.getByRole('radio', { name: /알리고/i });
-            const noneRadio = page.getByRole('radio', { name: /사용 안함/i });
-
-            const isAligoSelected = await aligoRadio.isChecked();
-            if (isAligoSelected) {
-                await noneRadio.click();
-            } else {
-                await aligoRadio.click();
-            }
-
-            await expect(page.getByText('알림톡 설정이 저장되었습니다.')).toBeVisible({ timeout: 5000 });
-
-            const timestamp = page.getByText(/마지막 수정:/);
-            await expect(timestamp).toBeVisible({ timeout: 5000 });
-        });
-    });
-
-    test.describe('Navigation', () => {
-        test('should access settings via tab navigation', async ({ page }) => {
-            await page.goto('/settings/voucher-price');
-            await page.waitForLoadState('networkidle');
-
-            const generalTab = page.getByRole('tab', { name: /일반 설정/i });
-            await generalTab.click();
-
-            await expect(page).toHaveURL('/settings/general');
-            await expect(page.getByText('알림톡 설정')).toBeVisible();
-        });
-    });
-});
-
-test.describe('Alimtalk Settings Error Handling', () => {
-    test('should show error message on API failure', async ({ page }) => {
-        await page.route('**/api/settings/alimtalk-provider', (route) => {
-            route.fulfill({
-                status: 500,
-                body: JSON.stringify({ error: 'Internal Server Error' }),
-            });
-        });
-
-        await page.goto('/settings/general');
-        await page.waitForLoadState('networkidle');
-
-        const errorAlert = page.getByText('설정을 불러오는데 실패했습니다.');
-        await expect(errorAlert).toBeVisible();
-    });
-
-    test('should show error snackbar on save failure', async ({ page }) => {
-        await page.route('**/api/settings/alimtalk-provider', (route, request) => {
-            if (request.method() === 'PUT') {
-                route.fulfill({
-                    status: 500,
-                    contentType: 'application/json',
-                    body: JSON.stringify({ error: 'Failed to save' }),
-                });
-            } else {
-                route.continue();
-            }
-        });
-
-        await page.goto('/settings/general');
-        await page.waitForLoadState('networkidle');
-
-        const aligoRadio = page.getByRole('radio', { name: /알리고/i });
-        const noneRadio = page.getByRole('radio', { name: /사용 안함/i });
-
-        const isAligoSelected = await aligoRadio.isChecked();
-        if (isAligoSelected) {
-            await noneRadio.click();
-        } else {
-            await aligoRadio.click();
-        }
-
-        const errorSnackbar = page.getByText('설정 저장에 실패했습니다. 다시 시도해주세요.');
-        await expect(errorSnackbar).toBeVisible({ timeout: 5000 });
-    });
+    await expect(page.getByRole("radio", { name: "사용 안함 선택" })).toHaveAttribute("aria-checked", "true");
+    await expect(page.locator('[data-component="notification-alimtalk-updated-at"]')).toContainText("마지막 수정:");
+  });
 });

--- a/mobile/tests/chat-live-stream.spec.ts
+++ b/mobile/tests/chat-live-stream.spec.ts
@@ -114,41 +114,38 @@ test.describe("Chat live stream smoke", () => {
     });
   });
 
-  test("streams a tool-based response on /chat", async ({ page }) => {
+  test("streams a deterministic Gemini stub response on /chat", async ({ page }) => {
     page.on("console", (msg) => {
       // Useful when debugging auth/stream issues locally.
       if (["warning", "error"].includes(msg.type())) {
-        // eslint-disable-next-line no-console
         console.log(`[browser:${msg.type()}] ${msg.text()}`);
       }
     });
 
     await page.goto("/chat");
-    await expect(page.getByText("AI 어시스턴트")).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('[data-component="chat"]')).toBeVisible({ timeout: 15000 });
 
-    const input = page.getByPlaceholder("무엇을 도와드릴까요?").first();
+    const input = page.locator('[data-component="chat-input"]');
     await expect(input).toBeVisible({ timeout: 10000 });
 
     const start = Date.now();
-    await input.fill("현재 등록된 제공인력은 몇명이야?");
+    await input.fill("안녕하세요");
     await input.press("Enter");
 
-    // Assistant content should stream and include employee/caregiver phrasing + a count.
-    const assistantMessages = page.locator('[data-component="chat-message-assistant"]');
-    await expect(assistantMessages.last()).toContainText(/제공인력|관리사|직원/, { timeout: 15000 });
-    await expect(assistantMessages.last()).toContainText(/\d+\s*명/, { timeout: 15000 });
+    await expect(page.getByLabel("응답 작성 중")).toBeVisible({ timeout: 5000 });
 
-    // Wait for stream completion (blinking cursor removed).
-    await expect(
-      assistantMessages.last().locator(".animate-blink")
-    ).toHaveCount(0, { timeout: 20000 });
+    const assistantMessages = page.locator('[data-component="chat-message-assistant"]');
+    await expect(assistantMessages.last()).toContainText("[e2e-stub]", { timeout: 15000 });
+    await expect(assistantMessages.last()).toContainText("안녕하세요", { timeout: 15000 });
+
+    await expect(page.getByLabel("응답 작성 중")).toHaveCount(0, { timeout: 20000 });
+    await expect(input).toBeEnabled({ timeout: 5000 });
 
     const ttfbMs = Date.now() - start;
-    // eslint-disable-next-line no-console
     console.log(`[chat-live] time-to-first-response-ms=${ttfbMs}`);
   });
 
-  test("quick action chip opens wizard without calling SSE", async ({ page }) => {
+  test("typing the local registration command opens the wizard without calling SSE", async ({ page }) => {
     let sseCalled = 0;
     await page.route("**/api/ai/chat/stream", async (route) => {
       sseCalled += 1;
@@ -160,11 +157,16 @@ test.describe("Chat live stream smoke", () => {
     });
 
     await page.goto("/chat");
-    await expect(page.getByText("AI 어시스턴트")).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('[data-component="chat"]')).toBeVisible({ timeout: 15000 });
 
-    await page.getByRole("button", { name: "산모 등록" }).click();
+    const input = page.locator('[data-component="chat-input"]');
+    await expect(input).toBeVisible({ timeout: 10000 });
+
+    await input.fill("산모 등록");
+    await input.press("Enter");
+
     await expect(page.locator('[data-component="chat-wizard-registration"]').first()).toBeVisible({ timeout: 5000 });
-    await expect(page.getByLabel("이름")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("산모 등록")).toBeVisible({ timeout: 5000 });
 
     expect(sseCalled).toBe(0);
   });

--- a/mobile/tests/client-creation.spec.ts
+++ b/mobile/tests/client-creation.spec.ts
@@ -1,538 +1,245 @@
-import { test, expect } from '@playwright/test';
+import { expect, test, type Page } from "@playwright/test";
 
-/**
- * ClientFormDialog E2E Tests
- *
- * Comprehensive tests for client creation and editing functionality:
- * - Form field validation
- * - Voucher type/duration select boxes
- * - Price auto-fill from API
- * - Toggle switches (voucherClient, careCenter, breastPump)
- * - Employee selection
- * - Date field handling
- */
+const VOUCHER_TYPE = "A가1형";
+const VOUCHER_DURATION = "10";
 
-test.describe('Client Creation Flow', () => {
-    test.beforeEach(async ({ page }) => {
-        await page.goto('/clients');
-        await page.waitForLoadState('networkidle');
+const EMPLOYEES = [
+  {
+    id: 11,
+    name: "테스트직원",
+    workArea: ["인천"],
+    phone: "010-1111-1111",
+    grade: "베스트",
+    openToNextWork: true,
+    registeredDate: "2026-06-01",
+    status: "available",
+  },
+  {
+    id: 12,
+    name: "보조직원",
+    workArea: ["인천"],
+    phone: "010-2222-2222",
+    grade: "프리미엄",
+    openToNextWork: true,
+    registeredDate: "2026-06-01",
+    status: "available",
+  },
+];
+
+const BANK_ACCOUNT_INFOS = [
+  {
+    area: "area-incheon",
+    bankName: "국민은행",
+    accNum: "123-456-7890",
+  },
+];
+
+const VOUCHER_PRICE_INFOS = [
+  {
+    id: 2,
+    type: VOUCHER_TYPE,
+    duration: VOUCHER_DURATION,
+    fullPrice: "1300000",
+    grant: "1000000",
+    actualPrice: "300000",
+  },
+];
+
+type CreateClientPayload = Record<string, unknown>;
+
+async function mockClientsWizardRoutes(page: Page, options?: { onCreate?: (payload: CreateClientPayload) => void }) {
+  await page.route("**/api/notifications/vapid-key**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ publicKey: "test-vapid-key" }),
     });
+  });
 
-    // ============================================
-    // Dialog Open/Close Tests
-    // ============================================
-    test.describe('Dialog Opening', () => {
-        test('should open ClientFormDialog when clicking add button', async ({ page }) => {
-            // Find and click the add button
-            const addButton = page.locator('[data-testid="add-client-button"]');
-            await addButton.click();
-
-            // Verify dialog opens
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-            await expect(dialog).toBeVisible();
-
-            // Verify it's in create mode (check title if visible)
-            await expect(dialog).toContainText(/신규|추가|등록|create/i);
-        });
-
-        test('should close dialog when clicking cancel button', async ({ page }) => {
-            // Open dialog
-            const addButton = page.locator('[data-testid="add-client-button"]');
-            await addButton.click();
-            await expect(page.locator('[data-testid="client-form-dialog"]')).toBeVisible();
-
-            // Click cancel
-            const cancelButton = page.locator('[data-testid="client-form-dialog"]').getByRole('button', { name: /취소|cancel/i });
-            await cancelButton.click();
-
-            // Dialog should be closed
-            await expect(page.locator('[data-testid="client-form-dialog"]')).not.toBeVisible();
-        });
+  await page.route("**/api/employees", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(EMPLOYEES),
     });
+  });
 
-    // ============================================
-    // Form Validation Tests
-    // ============================================
-    test.describe('Form Validation', () => {
-        test.beforeEach(async ({ page }) => {
-            // Open dialog before each validation test
-            const addButton = page.locator('[data-testid="add-client-button"]');
-            await addButton.click();
-            await expect(page.locator('[data-testid="client-form-dialog"]')).toBeVisible();
-        });
-
-        test('should show error when submitting empty form', async ({ page }) => {
-            // Click submit without filling any fields
-            const submitButton = page.locator('[data-testid="client-form-dialog"]').getByRole('button', { name: /등록|생성|create|저장|save/i });
-            await submitButton.click();
-
-            // Should show error alert
-            const errorAlert = page.locator('[data-testid="client-form-dialog"]').locator('[role="alert"]');
-            await expect(errorAlert).toBeVisible({ timeout: 3000 });
-        });
-
-        test('should validate required fields one by one', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-
-            // Fill name only and try to submit
-            const nameInput = dialog.locator('input').first();
-            await nameInput.fill('테스트 산모');
-
-            const submitButton = dialog.getByRole('button', { name: /등록|생성|create/i });
-            await submitButton.click();
-
-            // Should still show error (other fields missing)
-            const errorAlert = dialog.locator('[role="alert"]');
-            await expect(errorAlert).toBeVisible({ timeout: 3000 });
-        });
+  await page.route("**/api/bank-account-infos", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(BANK_ACCOUNT_INFOS),
     });
+  });
 
-    // ============================================
-    // Basic Info Section Tests
-    // ============================================
-    test.describe('Basic Info Section', () => {
-        test.beforeEach(async ({ page }) => {
-            const addButton = page.locator('[data-testid="add-client-button"]');
-            await addButton.click();
-            await expect(page.locator('[data-testid="client-form-dialog"]')).toBeVisible();
-        });
-
-        test('should accept name input', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-            const nameInput = dialog.locator('input').first();
-
-            await nameInput.fill('홍길동');
-            await expect(nameInput).toHaveValue('홍길동');
-        });
-
-        test('should format birthday as YYMMDD', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-
-            // Find birthday input (usually has placeholder YYMMDD)
-            const birthdayInput = dialog.locator('input[placeholder*="YYMMDD"], input').nth(1);
-
-            await birthdayInput.fill('900515');
-            await expect(birthdayInput).toHaveValue('900515');
-
-            // Should not accept more than 6 characters
-            await birthdayInput.fill('19900515');
-            const value = await birthdayInput.inputValue();
-            expect(value.length).toBeLessThanOrEqual(6);
-        });
-
-        test('should format phone number as XXX-XXXX-XXXX', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-
-            // Find phone input (look for placeholder pattern)
-            const phoneInput = dialog.locator('input[placeholder*="010"], input').nth(2);
-
-            // Type raw digits
-            await phoneInput.fill('01012345678');
-
-            // Should be formatted
-            const formattedValue = await phoneInput.inputValue();
-            expect(formattedValue).toMatch(/\d{3}-\d{4}-\d{4}|01012345678/);
-        });
-
-        test('should accept address input', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-
-            // Find address input
-            const inputs = dialog.locator('input[type="text"]');
-            const addressInput = inputs.nth(3);
-
-            await addressInput.fill('인천광역시 연수구 테스트동 123');
-            await expect(addressInput).toHaveValue('인천광역시 연수구 테스트동 123');
-        });
+  await page.route("**/api/clients/check-phone**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ exists: false }),
     });
+  });
 
-    // ============================================
-    // Voucher Type/Duration Select Box Tests
-    // ============================================
-    test.describe('Voucher Type and Duration Select Boxes', () => {
-        test.beforeEach(async ({ page }) => {
-            const addButton = page.locator('[data-testid="add-client-button"]');
-            await addButton.click();
-            await expect(page.locator('[data-testid="client-form-dialog"]')).toBeVisible();
-        });
+  await page.route("**/api/voucher-price-infos/type**", async (route) => {
+    const requestUrl = new URL(route.request().url());
+    const type = requestUrl.searchParams.get("type");
 
-        test('should display voucher type select with grouped options', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-
-            // Find the voucher type select (first dropdown in service section)
-            const voucherTypeSelect = dialog.locator('.MuiSelect-select').first();
-
-            // Click to open
-            await voucherTypeSelect.click();
-
-            // Should show grouped options
-            const listbox = page.locator('[role="listbox"]');
-            await expect(listbox).toBeVisible({ timeout: 3000 });
-
-            // Should have group headers (disabled menu items)
-            const groupHeaders = listbox.locator('[role="option"][aria-disabled="true"]');
-            const headerCount = await groupHeaders.count();
-            expect(headerCount).toBeGreaterThan(0);
-        });
-
-        test('should enable duration select after selecting voucher type', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-
-            // Duration select should be disabled initially
-            const selects = dialog.locator('.MuiFormControl-root').filter({ has: page.locator('.MuiSelect-select') });
-
-            // Click on voucher type select
-            const voucherTypeSelect = selects.first().locator('.MuiSelect-select');
-            await voucherTypeSelect.click();
-
-            // Select a type (e.g., A가-1형)
-            const option = page.locator('[role="option"]').filter({ hasText: 'A가-1형' }).first();
-            await option.click();
-
-            // Wait for API to load duration options
-            await page.waitForTimeout(500);
-
-            // Duration select should now be clickable
-            const durationSelect = dialog.locator('.MuiSelect-select').nth(1);
-            await durationSelect.click();
-
-            // Should show duration options
-            const durationListbox = page.locator('[role="listbox"]');
-            await expect(durationListbox).toBeVisible({ timeout: 3000 });
-        });
-
-        test('should show loading indicator while fetching durations', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-
-            // Click on voucher type select
-            const voucherTypeSelect = dialog.locator('.MuiSelect-select').first();
-            await voucherTypeSelect.click();
-
-            // Select a type
-            const option = page.locator('[role="option"]').filter({ hasText: /A|B|C/ }).first();
-            await option.click();
-
-            // May briefly show loading indicator (timing-dependent)
-            // This is more of a smoke test
-        });
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(type === VOUCHER_TYPE ? VOUCHER_PRICE_INFOS : []),
     });
+  });
 
-    // ============================================
-    // Price Auto-fill Tests
-    // ============================================
-    test.describe('Price Auto-fill', () => {
-        test('should auto-fill prices when type and duration selected', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
+  await page.route("**/api/clients", async (route) => {
+    if (route.request().method() === "POST") {
+      options?.onCreate?.(route.request().postDataJSON() as CreateClientPayload);
 
-            // Open dialog
-            const addButton = page.locator('[data-testid="add-client-button"]');
-            await addButton.click();
-            await expect(dialog).toBeVisible();
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 501,
+          name: "홍테스트 고객",
+        }),
+      });
+      return;
+    }
 
-            // Select voucher type
-            const voucherTypeSelect = dialog.locator('.MuiSelect-select').first();
-            await voucherTypeSelect.click();
-            const typeOption = page.locator('[role="option"]').filter({ hasText: 'A가-1형' }).first();
-            await typeOption.click();
-
-            // Wait for duration options to load
-            await page.waitForTimeout(1000);
-
-            // Select duration
-            const durationSelect = dialog.locator('.MuiSelect-select').nth(1);
-            await durationSelect.click();
-
-            const durationListbox = page.locator('[role="listbox"]');
-            await expect(durationListbox).toBeVisible({ timeout: 5000 });
-
-            const durationOption = page.locator('[role="option"]').filter({ hasText: /\d+일/ }).first();
-            await durationOption.click();
-
-            // Wait for price auto-fill
-            await page.waitForTimeout(500);
-
-            // Price fields should have values (check if not empty)
-            const priceInputs = dialog.locator('input').filter({ has: page.locator('text=원') });
-            // Note: The actual price inputs may be text fields without specific markers
-        });
-
-        test('should show "Auto-filled" chip when prices are auto-filled', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-
-            // Open dialog
-            const addButton = page.locator('[data-testid="add-client-button"]');
-            await addButton.click();
-            await expect(dialog).toBeVisible();
-
-            // Select voucher type and duration
-            const voucherTypeSelect = dialog.locator('.MuiSelect-select').first();
-            await voucherTypeSelect.click();
-            await page.locator('[role="option"]').filter({ hasText: 'A가-1형' }).first().click();
-
-            await page.waitForTimeout(1000);
-
-            const durationSelect = dialog.locator('.MuiSelect-select').nth(1);
-            await durationSelect.click();
-            await expect(page.locator('[role="listbox"]')).toBeVisible({ timeout: 5000 });
-            await page.locator('[role="option"]').filter({ hasText: /\d+일/ }).first().click();
-
-            // Wait for auto-fill
-            await page.waitForTimeout(500);
-
-            // Should show auto-filled indicator chip
-            const autoFilledChip = dialog.locator('.MuiChip-root').filter({ hasText: /자동|auto/i });
-            // The chip may or may not appear depending on locale
-        });
-
-        test('should hide auto-fill chip when user manually edits price', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-
-            // Open dialog and select type/duration to trigger auto-fill
-            const addButton = page.locator('[data-testid="add-client-button"]');
-            await addButton.click();
-            await expect(dialog).toBeVisible();
-
-            const voucherTypeSelect = dialog.locator('.MuiSelect-select').first();
-            await voucherTypeSelect.click();
-            await page.locator('[role="option"]').filter({ hasText: 'A가-1형' }).first().click();
-
-            await page.waitForTimeout(1000);
-
-            const durationSelect = dialog.locator('.MuiSelect-select').nth(1);
-            await durationSelect.click();
-            await expect(page.locator('[role="listbox"]')).toBeVisible({ timeout: 5000 });
-            await page.locator('[role="option"]').filter({ hasText: /\d+일/ }).first().click();
-
-            await page.waitForTimeout(500);
-
-            // Manually edit a price field (find price inputs in the pricing section)
-            // Price inputs are typically labeled with "원" (won) suffix
-            const priceInputs = dialog.locator('input[type="text"]');
-            const priceInputCount = await priceInputs.count();
-            if (priceInputCount > 4) {
-                // Price inputs are usually after the first few text fields (name, birthday, phone, address)
-                await priceInputs.nth(4).fill('1000000');
-            }
-        });
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([]),
     });
+  });
+}
 
-    // ============================================
-    // Toggle Switches (Flags) Tests
-    // ============================================
-    test.describe('Toggle Switches', () => {
-        test.beforeEach(async ({ page }) => {
-            const addButton = page.locator('[data-testid="add-client-button"]');
-            await addButton.click();
-            await expect(page.locator('[data-testid="client-form-dialog"]')).toBeVisible();
-        });
+async function fillStepZero(page: Page) {
+  await page.getByPlaceholder("홍길동").fill("홍테스트 고객");
+  await page.getByPlaceholder("010-1234-5678").fill("01011112222");
+  await page.getByPlaceholder("YYMMDD").nth(0).fill("950101");
+  await page.getByPlaceholder("YYMMDD").nth(1).fill("260615");
+  await page.getByPlaceholder("서울시 강남구...").fill("인천광역시 연수구 테스트로 10");
 
-        test('should have voucherClient toggle defaulted to ON', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
+  await expect(
+    page.locator('[data-component="clients-new-basic-contact-card"] [data-component="clients-new-form-helper"]')
+  ).toContainText("등록 가능한 번호입니다.");
+}
 
-            // Find the switch for voucherClient
-            const voucherSwitch = dialog.locator('[role="checkbox"]').first();
+async function goToStepOne(page: Page) {
+  await fillStepZero(page);
+  await page.locator('[data-component="clients-new-actions"] button').nth(1).click();
+  await expect(page.locator('[data-component="clients-new-voucher-card"]')).toBeVisible();
+  await expect(page.locator('[data-component="clients-new-step-count"]')).toHaveText("2 / 3 단계");
+}
 
-            // Should be checked by default (based on form default value)
-            // Note: The exact state depends on the default value in the form
-        });
+async function fillDeterministicVoucherFields(page: Page) {
+  const voucherTypeSelect = page.locator('[data-component="clients-new-voucher-card"] select').first();
+  await voucherTypeSelect.selectOption(VOUCHER_TYPE);
 
-        test('should toggle careCenter switch', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
+  const durationSelect = page.locator('[data-component="clients-new-duration-select-wrap"] select');
+  await expect(durationSelect.locator(`option[value="${VOUCHER_DURATION}"]`)).toHaveCount(1);
+  await durationSelect.selectOption(VOUCHER_DURATION);
 
-            // Find care center switch (typically labeled with Korean text)
-            const switches = dialog.locator('.MuiSwitch-root');
+  await expect(page.locator('[data-component="clients-new-full-price-input-wrap"] input')).toHaveValue("1,300,000");
+  await expect(page.locator('[data-component="clients-new-grant-input-wrap"] input')).toHaveValue("1,000,000");
+  await expect(page.locator('[data-component="clients-new-actual-price-input-wrap"] input')).toHaveValue("300,000");
+}
 
-            // Toggle the second switch (careCenter)
-            const careCenterSwitch = switches.nth(1);
-            await careCenterSwitch.click();
+test.use({ viewport: { width: 390, height: 844 } });
 
-            // The switch should change state (visual check)
-        });
+test.describe("clients/new wizard", () => {
+  test("renders the wizard shell and the initial basic-info step", async ({ page }) => {
+    await mockClientsWizardRoutes(page);
+    await page.goto("/clients/new");
 
-        test('should toggle breastPump switch', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
+    await expect(page.locator('[data-component="clients-new-page-shell"]')).toBeVisible();
+    await expect(page.locator('[data-component="clients-new-wizard"]')).toBeVisible();
+    await expect(page.locator('[data-component="clients-new-navbar-title"]')).toHaveText("새 고객 추가");
+    await expect(page.locator('[data-component="clients-new-step-count"]')).toHaveText("1 / 3 단계");
+    await expect(page.getByText("기본 정보")).toBeVisible();
+    await expect(page.getByPlaceholder("홍길동")).toBeVisible();
+    await expect(page.getByPlaceholder("010-1234-5678")).toBeVisible();
+  });
 
-            // Find breast pump switch (typically the third toggle)
-            const switches = dialog.locator('.MuiSwitch-root');
+  test("blocks advancing from step 0 while required fields are empty", async ({ page }) => {
+    await mockClientsWizardRoutes(page);
+    await page.goto("/clients/new");
 
-            // Toggle the third switch
-            const breastPumpSwitch = switches.nth(2);
-            await breastPumpSwitch.click();
-        });
+    const primaryButton = page.locator('[data-component="clients-new-actions"] button').nth(1);
+
+    await expect(primaryButton).toBeDisabled();
+    await expect(page.locator('[data-component="clients-new-step-count"]')).toHaveText("1 / 3 단계");
+    await expect(page.locator('[data-component="clients-new-voucher-card"]')).toHaveCount(0);
+  });
+
+  test("advances to step 1 after filling the basic info step", async ({ page }) => {
+    await mockClientsWizardRoutes(page);
+    await page.goto("/clients/new");
+
+    await fillStepZero(page);
+
+    const primaryButton = page.locator('[data-component="clients-new-actions"] button').nth(1);
+    await expect(primaryButton).toBeEnabled();
+    await primaryButton.click();
+
+    await expect(page.locator('[data-component="clients-new-step-count"]')).toHaveText("2 / 3 단계");
+    await expect(page.getByText("서비스 설정")).toBeVisible();
+    await expect(page.locator('[data-component="clients-new-voucher-card"]')).toBeVisible();
+    await expect(page.locator('[data-component="clients-new-pricing-card"]')).toBeVisible();
+  });
+
+  test("renders voucher selects on step 1 and auto-fills prices from mocked voucher data", async ({ page }) => {
+    await mockClientsWizardRoutes(page);
+    await page.goto("/clients/new");
+
+    await goToStepOne(page);
+    await fillDeterministicVoucherFields(page);
+
+    await expect(page.locator('[data-component="clients-new-pricing-card"]')).toContainText("자동입력");
+  });
+
+  test("submits the minimal valid wizard payload and navigates back to /clients", async ({ page }) => {
+    let createdPayload: CreateClientPayload | null = null;
+
+    await mockClientsWizardRoutes(page, {
+      onCreate: (payload) => {
+        createdPayload = payload;
+      },
     });
+    await page.goto("/clients/new");
 
-    // ============================================
-    // Date Fields Tests
-    // ============================================
-    test.describe('Date Fields', () => {
-        test.beforeEach(async ({ page }) => {
-            const addButton = page.locator('[data-testid="add-client-button"]');
-            await addButton.click();
-            await expect(page.locator('[data-testid="client-form-dialog"]')).toBeVisible();
-        });
+    await fillStepZero(page);
+    await page.locator('[data-component="clients-new-actions"] button').nth(1).click();
 
-        test('should accept start date input', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
+    await fillDeterministicVoucherFields(page);
+    await page.locator('[data-component="clients-new-bank-account-select"]').selectOption("area-incheon");
+    await page.locator('[data-component="clients-new-actions"] button').nth(1).click();
 
-            // Find date inputs
-            const dateInputs = dialog.locator('input[type="date"]');
+    await expect(page.locator('[data-component="clients-new-step-count"]')).toHaveText("3 / 3 단계");
+    await expect(page.locator('[data-component="clients-new-contract-status-card"]')).toBeVisible();
 
-            // Fill start date
-            const startDateInput = dateInputs.first();
-            await startDateInput.fill('2025-02-01');
+    await page.locator('[data-component="clients-new-actions"] button').nth(1).click();
 
-            await expect(startDateInput).toHaveValue('2025-02-01');
-        });
-
-        test('should accept end date input', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-
-            // Find date inputs
-            const dateInputs = dialog.locator('input[type="date"]');
-
-            // Fill end date
-            const endDateInput = dateInputs.nth(1);
-            await endDateInput.fill('2025-03-31');
-
-            await expect(endDateInput).toHaveValue('2025-03-31');
-        });
-    });
-
-    // ============================================
-    // Contract/Service Status Tests
-    // ============================================
-    test.describe('Service Status Select', () => {
-        test.beforeEach(async ({ page }) => {
-            const addButton = page.locator('[data-testid="add-client-button"]');
-            await addButton.click();
-            await expect(page.locator('[data-testid="client-form-dialog"]')).toBeVisible();
-        });
-
-        test('should display service status options', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-
-            // Find the service status select (usually labeled as 계약 상태 or similar)
-            // It's typically in the contract section
-            const statusSelect = dialog.locator('.MuiSelect-select').filter({ hasText: /대기|진행|완료|Waiting|Active/i }).first();
-
-            if (await statusSelect.count() > 0) {
-                await statusSelect.click();
-
-                const listbox = page.locator('[role="listbox"]');
-                await expect(listbox).toBeVisible({ timeout: 3000 });
-
-                // Should have status options
-                await expect(listbox.locator('[role="option"]')).toHaveCount(5);
-            }
-        });
-    });
-
-    // ============================================
-    // Employee Selection Integration Tests
-    // ============================================
-    test.describe('Employee Selection', () => {
-        test.beforeEach(async ({ page }) => {
-            const addButton = page.locator('[data-testid="add-client-button"]');
-            await addButton.click();
-            await expect(page.locator('[data-testid="client-form-dialog"]')).toBeVisible();
-        });
-
-        test('should have primary employee autocomplete', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-            const employeeAutocomplete = dialog.locator('[data-testid="employee-autocomplete"]').first();
-
-            await expect(employeeAutocomplete).toBeVisible();
-        });
-
-        test('should have secondary employee autocomplete', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-            const employeeAutocompletes = dialog.locator('[data-testid="employee-autocomplete"]');
-
-            // Should have 2 autocompletes (primary and secondary)
-            await expect(employeeAutocompletes).toHaveCount(2);
-        });
-
-        test('should exclude selected primary employee from secondary options', async ({ page }) => {
-            const dialog = page.locator('[data-testid="client-form-dialog"]');
-
-            // Focus on primary employee autocomplete
-            const primaryAutocomplete = dialog.locator('[data-testid="employee-autocomplete"] input').first();
-            await primaryAutocomplete.click();
-
-            // Wait for dropdown
-            await expect(page.locator('[data-testid="employee-autocomplete-dropdown"]')).toBeVisible({ timeout: 5000 });
-
-            // Type to search
-            await primaryAutocomplete.fill('김');
-            await page.waitForTimeout(300);
-
-            // Select first option if available
-            const firstOption = page.locator('[role="option"]').first();
-            if (await firstOption.count() > 0 && !(await firstOption.getAttribute('aria-disabled'))) {
-                await firstOption.click();
-            }
-
-            // Now the secondary autocomplete should exclude the selected employee
-            // This would require checking the filtered options
-        });
-    });
-});
-
-// ============================================
-// Complete Client Creation Flow Test
-// ============================================
-test.describe('Complete Client Creation Flow', () => {
-    test('should create client with all required fields', async ({ page }) => {
-        await page.goto('/clients');
-        await page.waitForLoadState('networkidle');
-
-        // Open dialog
-        const addButton = page.locator('[data-testid="add-client-button"]');
-        await addButton.click();
-
-        const dialog = page.locator('[data-testid="client-form-dialog"]');
-        await expect(dialog).toBeVisible();
-
-        // Fill basic info
-        const inputs = dialog.locator('input[type="text"]');
-        await inputs.first().fill('테스트 산모'); // name
-        await inputs.nth(1).fill('900515'); // birthday
-        await inputs.nth(2).fill('01012345678'); // phone
-        await inputs.nth(3).fill('인천시 연수구'); // address
-
-        // Select primary employee (type and select)
-        const primaryEmployeeInput = dialog.locator('[data-testid="employee-autocomplete"] input').first();
-        await primaryEmployeeInput.click();
-        await expect(page.locator('[data-testid="employee-autocomplete-dropdown"]')).toBeVisible({ timeout: 5000 });
-        await primaryEmployeeInput.fill('김');
-        await page.waitForTimeout(500);
-
-        // Try to select first matching employee
-        const employeeOption = page.locator('[role="option"]:not([aria-disabled="true"])').first();
-        if (await employeeOption.count() > 0) {
-            await employeeOption.click();
-        }
-
-        // Select voucher type
-        const voucherSelect = dialog.locator('.MuiSelect-select').first();
-        await voucherSelect.click();
-        await page.locator('[role="option"]').filter({ hasText: 'A가-1형' }).first().click();
-
-        // Wait for duration options
-        await page.waitForTimeout(1000);
-
-        // Select duration
-        const durationSelect = dialog.locator('.MuiSelect-select').nth(1);
-        await durationSelect.click();
-        await expect(page.locator('[role="listbox"]')).toBeVisible({ timeout: 5000 });
-        await page.locator('[role="option"]').filter({ hasText: /\d+일/ }).first().click();
-
-        // Fill dates
-        const dateInputs = dialog.locator('input[type="date"]');
-        await dateInputs.first().fill('2025-02-01');
-        await dateInputs.nth(1).fill('2025-03-31');
-
-        // Note: Actual submission would create data, so we skip in E2E test
-        // If needed, add: await submitButton.click();
-    });
+    await expect(page).toHaveURL(/\/clients$/);
+    expect(createdPayload).toEqual(
+      expect.objectContaining({
+        name: "홍테스트 고객",
+        birthday: "950101",
+        dueDate: "2026-06-15",
+        address: "인천광역시 연수구 테스트로 10",
+        phone: "010-1111-2222",
+        type: VOUCHER_TYPE,
+        duration: 10,
+        fullPrice: "1300000",
+        grant: "1000000",
+        actualPrice: "300000",
+        careCenter: false,
+        voucherClient: true,
+        breastPump: false,
+        serviceStatus: "waiting",
+        areaId: "area-incheon",
+      })
+    );
+  });
 });


### PR DESCRIPTION
## Context

Batch 2 of the e2e stabilization (follows #256). Un-quarantines 3 of the 7 parked specs by rewriting them against the current UI and extending the backend e2e vendor-stub layer to cover Gemini.

## Changes

**`client-creation.spec.ts` — rewritten** (the old 24-test dialog suite targeted UI removed by the PR #220 redesign): smoke-level wizard suite against `/clients/new` — shell render, required-field gating, step advancement, voucher price auto-fill, and a happy-path submit asserting the POST payload contract (phone `01011112222`→`010-1111-2222`, date `260615`→`2026-06-15`, price fields, `areaId`) + navigation. All routes mocked (`employees`, `bank-account-infos`, `check-phone`, `voucher-price-infos`, `clients` POST) — runs without writing data anywhere.

**`alimtalk-settings.spec.ts` — rewritten** against the current settings surface on `/notification` (`/settings/general` + `/settings/voucher-price` 404 today; `/settings` redirects to `/notification`).

**Gemini e2e vendor stub (backend)** — `E2eGeminiGatewayStub` with the exact `GeminiChatGateway` surface (`chat` / `chatStream(): AsyncGenerator<GeminiStreamChunk>` / `sendFunctionResult`), deterministic `"[e2e-stub] " + echo` output, never reads `GEMINI_API_KEY`. The `GEMINI_GATEWAY` provider factory moves to `createGeminiGateway` preserving the `USE_VERCEL_AI_SDK` branch: **stub (e2e flag) → vercel (feature flag) → real**. Production boots already reject `E2E_VENDOR_STUBS=1` (main.ts assertion from #255). Stub-selection spec covers all three branches. `chat-live-stream.spec.ts` content assertions aligned to the stub prefix.

**Quarantine ledger** — `CI_QUARANTINE` down to the 4 by-design local diagnostics; `QUARANTINE.md` updated.

## Verification

- backend: type-check clean · lint 0 errors · jest **1088 passed / 107 suites** (+1 stub-selection test)
- mobile: type-check clean · lint 0 errors · jest **633/633**
- Process note: Codex's delivery failed `tsc` (duplicated import block) despite self-reporting a pass — fixed and fully re-verified out-of-sandbox. An e2e `workflow_dispatch` run after merge validates the rewritten specs against the real stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)