### PR TITLE
test(e2e): batch 4 — final residue from run #7

### DIFF
--- a/mobile/tests/chat-live-stream.spec.ts
+++ b/mobile/tests/chat-live-stream.spec.ts
@@ -166,7 +166,11 @@ test.describe("Chat live stream smoke", () => {
     await input.press("Enter");
 
     await expect(page.locator('[data-component="chat-wizard-registration"]').first()).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText("산모 등록")).toBeVisible({ timeout: 5000 });
+    // "산모 등록" also appears inside the rendered wizard — scope to the
+    // user's message bubble to avoid a strict-mode violation.
+    await expect(
+      page.locator('[data-component="chat-message-user-bubble"]', { hasText: "산모 등록" }),
+    ).toBeVisible({ timeout: 5000 });
 
     expect(sseCalled).toBe(0);
   });

--- a/mobile/tests/client-creation.spec.ts
+++ b/mobile/tests/client-creation.spec.ts
@@ -157,7 +157,7 @@ test.describe("clients/new wizard", () => {
     await expect(page.locator('[data-component="clients-new-wizard"]')).toBeVisible();
     await expect(page.locator('[data-component="clients-new-navbar-title"]')).toHaveText("새 고객 추가");
     await expect(page.locator('[data-component="clients-new-step-count"]')).toHaveText("1 / 3 단계");
-    await expect(page.getByText("기본 정보")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "기본 정보" })).toBeVisible();
     await expect(page.getByPlaceholder("홍길동")).toBeVisible();
     await expect(page.getByPlaceholder("010-1234-5678")).toBeVisible();
   });

--- a/mobile/tests/contracts-mobile-list-row.spec.ts
+++ b/mobile/tests/contracts-mobile-list-row.spec.ts
@@ -315,7 +315,9 @@ test.describe("Mobile contracts list rows", () => {
     const openedRow = page.locator('[data-component="mobile-contracts-row"]', { hasText: "열람고객" });
     const staleStepRow = page.locator('[data-component="mobile-contracts-row"]', { hasText: "구문서" });
     const sendFailedRow = page.locator('[data-component="mobile-contracts-row"]', { hasText: "전송실패" });
-    const reviewRow = page.locator('[data-component="mobile-contracts-row"]', { hasText: "검토 담당자" });
+    // Row name comes from DOCUMENT_CLIENT_SUMMARIES.clientName ("검토고객"),
+    // not the step recipient name.
+    const reviewRow = page.locator('[data-component="mobile-contracts-row"]', { hasText: "검토고객" });
     const completedRow = page.locator('[data-component="mobile-contracts-row"]', { hasText: "완료고객" });
 
     await expect(waitingRow.locator(".step-label")).toHaveText("3/6 - 이용자 문서 열람 대기");
@@ -561,7 +563,7 @@ test.describe("Mobile contracts list rows", () => {
     await expect(page.locator('[data-component="mobile-contracts-receipt-share"]')).toHaveCount(0);
 
     await page.locator(".sheet-close").click();
-    await page.locator('[data-component="mobile-contracts-row"]', { hasText: "검토 담당자" }).click();
+    await page.locator('[data-component="mobile-contracts-row"]', { hasText: "검토고객" }).click();
     const signAction = page.locator('[data-component="mobile-contracts-sign"]');
     await expect(page.locator('[data-component="mobile-contracts-preview"]')).toBeVisible();
     await expect(signAction).toBeVisible();
@@ -871,12 +873,14 @@ test.describe("Mobile contracts list rows", () => {
     await expect(contractInfo).not.toContainText("마감일");
     await expect(page.locator(".client-detail-badges")).not.toContainText("DOC-WAITING");
 
-    const relatedInfo = page.locator(".info-card", { hasText: "관련 정보" });
-    await expect(relatedInfo).toContainText("제공인력");
-    await expect(relatedInfo).toContainText("실제제공인력");
-    await expect(relatedInfo).toContainText("문서 ID");
-    await expect(relatedInfo).toContainText("doc-waiting");
-    await expect(relatedInfo).not.toContainText("eformsign 코드");
+    // The former combined "관련 정보" card no longer exists: provider fields
+    // render in the 이용자 정보 card, document id in the 계약 정보 card.
+    const userInfo = page.locator(".info-card", { hasText: "이용자 정보" });
+    await expect(userInfo).toContainText("제공인력");
+    await expect(userInfo).toContainText("실제제공인력");
+    await expect(contractInfo).toContainText("문서 ID");
+    await expect(contractInfo).toContainText("doc-waiting");
+    await expect(contractInfo).not.toContainText("eformsign 코드");
   });
 
   test("falls back to provider fields from the detailed eformsign document", async ({ page }) => {
@@ -918,9 +922,10 @@ test.describe("Mobile contracts list rows", () => {
 
     await page.locator('[data-component="mobile-contracts-row"]', { hasText: "대기고객" }).click();
 
-    const relatedInfo = page.locator(".info-card", { hasText: "관련 정보" });
-    await expect(relatedInfo).toContainText("제공인력");
-    await expect(relatedInfo).toContainText("문서제공인력");
+    // Provider fields render in the 이용자 정보 card (no "관련 정보" card).
+    const userInfo = page.locator(".info-card", { hasText: "이용자 정보" });
+    await expect(userInfo).toContainText("제공인력");
+    await expect(userInfo).toContainText("문서제공인력");
   });
 
   test("shows real alimtalk and message delivery logs in the notification tab", async ({ page }) => {

--- a/mobile/tests/contracts-search.spec.ts
+++ b/mobile/tests/contracts-search.spec.ts
@@ -101,6 +101,11 @@ async function routeContractsList(page: Page, payload = MOCK_DOCUMENTS): Promise
   });
 }
 
+// The contract list rows ([data-component="mobile-contracts-row"]) only mount
+// in the mobile layout — at the default desktop viewport the row tree is
+// absent (run #7 evidence: page renders, row count stays 0).
+test.use({ viewport: { width: 390, height: 844 } });
+
 test.describe('Contracts Page Search Feature', () => {
   test('renders the current mobile search and filter shell', async ({ page }) => {
     await routeContractsList(page);

--- a/mobile/tests/contracts-skeleton-loading.spec.ts
+++ b/mobile/tests/contracts-skeleton-loading.spec.ts
@@ -79,6 +79,11 @@ async function routeSharedContractDependencies(page: Page): Promise<void> {
   });
 }
 
+// The contract list rows ([data-component="mobile-contracts-row"]) only mount
+// in the mobile layout — at the default desktop viewport the row tree is
+// absent (run #7 evidence: page renders, row count stays 0).
+test.use({ viewport: { width: 390, height: 844 } });
+
 test.describe('Contracts Page Skeleton Loading', () => {
   test('shows the current mobile loading shell while documents are pending', async ({ page }) => {
     let releaseAuth!: () => void;

--- a/mobile/tests/mobile-messages-filter-skeleton.spec.ts
+++ b/mobile/tests/mobile-messages-filter-skeleton.spec.ts
@@ -114,8 +114,9 @@ test.describe("Mobile messages filter skeletons", () => {
 
     expect(loadedGeometry).toHaveLength(skeletonGeometry.length);
     loadedGeometry.forEach((pill, index) => {
-      expect(Math.abs(pill.y - skeletonGeometry[index].y)).toBeLessThanOrEqual(1);
-      expect(Math.abs(pill.height - skeletonGeometry[index].height)).toBeLessThanOrEqual(1);
+      // 2px tolerance: CI font rendering produces ~1.07px subpixel drift.
+      expect(Math.abs(pill.y - skeletonGeometry[index].y)).toBeLessThanOrEqual(2);
+      expect(Math.abs(pill.height - skeletonGeometry[index].height)).toBeLessThanOrEqual(2);
     });
   });
 });

--- a/mobile/tests/notification-bell.spec.ts
+++ b/mobile/tests/notification-bell.spec.ts
@@ -210,37 +210,7 @@ test.describe('Notification Bell Navigation', () => {
   });
 
 
-  test('splash screen should still appear on initial PWA app launch', async ({ browser }) => {
-    const context = await browser.newContext({
-      viewport: { width: 390, height: 844 },
-      isMobile: true,
-      storageState: undefined,
-    });
-
-    const page = await context.newPage();
-
-    await page.addInitScript(() => {
-      Object.defineProperty(window, 'matchMedia', {
-        writable: true,
-        value: (query: string) => ({
-          matches: query === '(display-mode: standalone)',
-          media: query,
-          onchange: null,
-          addListener: () => {},
-          removeListener: () => {},
-          addEventListener: () => {},
-          removeEventListener: () => {},
-          dispatchEvent: () => false,
-        }),
-      });
-    });
-
-    await page.goto('/');
-
-    await expect(page.locator('img[alt="Splash"]')).toBeVisible({ timeout: 500 });
-    await expect(page.locator('img[alt="Splash"]')).not.toBeVisible({ timeout: 3000 });
-
-    await context.close();
-  });
+  // 'splash screen on PWA launch' test removed: no in-DOM splash exists in src
+  // (only iOS apple-touch-startup-image meta links, which never render in Chromium).
 
 });


### PR DESCRIPTION
## Context

Run #7 (after #258): **42 → 12 failures, 5.4-minute suite** — all chat/admin/autocomplete/templates/all-menu clusters now pass against the real backend. This batch fixes the final 12, each root-caused from the run-#7 artifacts.

## Root causes & fixes

| Spec | Fails | Cause | Fix |
|---|---|---|---|
| contracts-search / contracts-skeleton-loading | 5 | rows render **zero at desktop viewport** — `mobile-contracts-row` is JS-gated to the mobile layout (count 0 = absent from DOM, not CSS-hidden) | `test.use({ viewport: 390×844 })`, matching contracts-mobile-list-row |
| contracts-mobile-list-row | 4 | (a) filtered rows by `검토 담당자`, which only exists in `step_recipients` — the rendered name is `검토고객` (snapshot: `검토고객 5/6 - 제공기관 검토 필요`); (b) asserted a combined `관련 정보` card that no longer exists | (a) filter on `검토고객`; (b) assert against the real `이용자 정보` (provider) + `계약 정보` (document id) cards |
| client-creation | 1 | strict-mode: `기본 정보` matches heading + step indicator | heading-role scope |
| chat-live-stream | 1 | strict-mode: `산모 등록` matches user bubble + rendered wizard | user-bubble scope |
| notification-bell | 1 | PWA splash test asserts an in-DOM `img[alt="Splash"]` that has never existed in src (only iOS `apple-touch-startup-image` meta links — never rendered by Chromium) | dead test deleted |
| mobile-messages-filter-skeleton | 1 | 1px geometry epsilon vs 1.065px CI subpixel drift | 2px tolerance |

## Verification

- mobile type-check clean · lint 0 errors
- filter-skeleton green locally; notification-bell's other tests pass in CI (local failures are the known post-navigation auth wall, untouched by this diff)
- run #8 dispatched after merge measures the result — **expected: 0 real failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)