### PR TITLE
test(e2e): batch 5 — contracts route-mock glob was the real culprit

### DIFF
--- a/mobile/tests/contracts-search.spec.ts
+++ b/mobile/tests/contracts-search.spec.ts
@@ -60,6 +60,25 @@ const MOCK_EMPTY_DOCUMENTS = {
 };
 
 async function routeContractsList(page: Page, payload = MOCK_DOCUMENTS): Promise<void> {
+  // Mock the auth identity so the run doesn't depend on the backend having
+  // the storage-state user (local dev DBs lack it; the auth check otherwise
+  // races the test and kills the page at a random point).
+  for (const authPattern of ['**/api/auth/me', '**/auth/me']) {
+    await page.route(authPattern, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'test-user',
+          name: '테스트 사용자',
+          email: 'test@example.com',
+          profile_image: '',
+          role: 'admin',
+        }),
+      });
+    });
+  }
+
   await page.route('**/api/access-token', async (route) => {
     await route.fulfill({
       status: 200,
@@ -68,7 +87,9 @@ async function routeContractsList(page: Page, payload = MOCK_DOCUMENTS): Promise
     });
   });
 
-  await page.route('**/api/eformsign/documents?**', async (route) => {
+  // Broad glob (no '?'): the page lists via /eformsign/documents AND the
+  // /in-progress + /completed subpaths — a query-requiring glob matches none.
+  await page.route('**/api/eformsign/documents**', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -157,7 +178,7 @@ test.describe('Contracts Page Search Feature', () => {
 
     await searchField.clear();
 
-    await expect(page.getByText('홍길동')).toBeVisible();
+    await expect(page.getByText('홍길동')).toBeVisible({ timeout: 10000 });
     await expect(page.getByText('김철수')).toBeVisible();
     await expect(page.getByText('홍길순')).toBeVisible();
   });

--- a/mobile/tests/contracts-skeleton-loading.spec.ts
+++ b/mobile/tests/contracts-skeleton-loading.spec.ts
@@ -47,6 +47,25 @@ const MOCK_EMPTY_DOCUMENTS = {
 };
 
 async function routeSharedContractDependencies(page: Page): Promise<void> {
+  // Mock the auth identity so the run doesn't depend on the backend having
+  // the storage-state user (local dev DBs lack it; the auth check otherwise
+  // races the test and kills the page at a random point).
+  for (const authPattern of ['**/api/auth/me', '**/auth/me']) {
+    await page.route(authPattern, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'test-user',
+          name: '테스트 사용자',
+          email: 'test@example.com',
+          profile_image: '',
+          role: 'admin',
+        }),
+      });
+    });
+  }
+
   await page.route('**/api/eformsign-docs/client-names**', async (route) => {
     await route.fulfill({
       status: 200,
@@ -104,7 +123,8 @@ test.describe('Contracts Page Skeleton Loading', () => {
       });
     });
 
-    await page.route('**/api/eformsign/documents?**', async (route) => {
+    // Broad glob: the page also lists via /in-progress and /completed subpaths.
+    await page.route('**/api/eformsign/documents**', async (route) => {
       await documentsReady;
       await route.fulfill({
         status: 200,
@@ -131,7 +151,9 @@ test.describe('Contracts Page Skeleton Loading', () => {
     releaseAuth();
     releaseDocuments();
 
-    await expect(page.locator('[data-component="mobile-contracts-row"]')).toHaveCount(2);
+    await expect(page.locator('[data-component="mobile-contracts-row"]')).toHaveCount(2, {
+      timeout: 15000,
+    });
     await expect(page.locator('[data-component="mobile-contracts-loading-row"]')).toHaveCount(0);
     await expect(page.locator('[data-component="mobile-redesign-filter-pill"][data-loading="true"]')).toHaveCount(
       0,
@@ -148,7 +170,8 @@ test.describe('Contracts Page Skeleton Loading', () => {
       });
     });
 
-    await page.route('**/api/eformsign/documents?**', async (route) => {
+    // Broad glob: the page also lists via /in-progress and /completed subpaths.
+    await page.route('**/api/eformsign/documents**', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -177,7 +200,8 @@ test.describe('Contracts Page Skeleton Loading', () => {
       });
     });
 
-    await page.route('**/api/eformsign/documents?**', async (route) => {
+    // Broad glob: the page also lists via /in-progress and /completed subpaths.
+    await page.route('**/api/eformsign/documents**', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',


### PR DESCRIPTION
## Context

Run #8 (after #259): **12 → 5 failures, 4.0-minute suite, zero flaky.** All 5 share one signature: `mobile-contracts-row` count 0 in `contracts-search` + `contracts-skeleton-loading` — even at the mobile viewport, which falsified batch 4's viewport theory (`contracts-mobile-list-row` proves rows mount at 390px).

## Root cause

The two failing files mocked the documents list with `'**/api/eformsign/documents?**'` — a glob that **requires a query string**. The page lists via `/eformsign/documents` plus the `/in-progress` and `/completed` subpaths (`services/api.ts:324,338,342`) — the `?`-glob matches none of them. The fixture never reached the page; the run-8 snapshot shows the page fully rendered with **전체 0**. The always-passing contracts file used the broad `'**/api/eformsign/documents**'` from day one. Both files now match it.

Also: auth-identity mocks added to both shared helpers (parity with chat/admin specs — removes the dependency on the storage-state user existing in the backend, true in CI but not against local dev DBs), and post-release row-count assertions get explicit timeouts.

## Verification

- type-check clean · lint 0 errors
- both files pass locally in isolation; with the glob fixed the rows demonstrably land (the prior 0-row state is structurally impossible now — the mock intercepts every list-shaped call)
- run #9 dispatched after merge; if CI disagrees with local, file-level quarantine is the documented fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)