### PR TITLE
test(e2e): critical flows + review remediations (batch 6)

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -85,6 +85,10 @@ jobs:
       DEVELOPMENT_FRONTEND_URL: http://localhost:3000
       DIRECT_URL: postgresql://postgres@localhost:5432/postgres
       E2E_VENDOR_STUBS: '1'
+      # Webhook guard inputs for the critical-flows spec — e2e-only literals,
+      # not real secrets (the CI backend never talks to real eformsign).
+      EFORMSIGN_COMPANY_ID: e2e-stub-company
+      EFORMSIGN_WEBHOOK_SECRET: e2e-webhook-secret
       JWT_SECRET: ${{ secrets.JWT_SECRET }}
       NODE_ENV: development
       STORAGE_BOOTSTRAP_DISABLED: '1'

--- a/backend/infrastructure/vendor-stubs/e2e-vendor-stubs.ts
+++ b/backend/infrastructure/vendor-stubs/e2e-vendor-stubs.ts
@@ -31,6 +31,7 @@ import {
     GeminiStreamChunk,
 } from "infrastructure/api/gemini-chat.gateway";
 import { VercelGeminiGateway } from "infrastructure/api/vercel-gemini.gateway";
+import type { IGeminiGateway } from "application/services/ai-chat.service";
 
 export const E2E_VENDOR_STUBS_ENV = "E2E_VENDOR_STUBS";
 export const EFORMSIGN_STUB_USER_EMAIL = "e2e-stub@babyjamjam.test";
@@ -497,7 +498,14 @@ export class E2eAligoApiStub implements IAligoApiPort, IAligoSmsApiPort {
     }
 }
 
-export class E2eGeminiGatewayStub {
+/**
+ * Deterministic Gemini double for e2e runs. SCOPE: text streaming only —
+ * it never emits "function_call" (or "error") chunks, so the agentic
+ * tool-execution loop in AIChatService.chatStream is intentionally NOT
+ * exercised under E2E_VENDOR_STUBS=1. Tool-calling regressions are covered
+ * by unit tests, not the e2e suite.
+ */
+export class E2eGeminiGatewayStub implements IGeminiGateway {
     async chat(
         messages: ChatMessage[],
         tools?: FunctionDeclaration[],
@@ -555,7 +563,7 @@ export function createAligoPortClient(configService: ConfigService): IAligoApiPo
         : new AligoApiClient(configService);
 }
 
-export function createGeminiGateway(configService: ConfigService) {
+export function createGeminiGateway(configService: ConfigService): IGeminiGateway {
     if (areE2EVendorStubsEnabled(configService)) {
         return new E2eGeminiGatewayStub();
     }

--- a/backend/test/infrastructure/e2e-vendor-stubs.spec.ts
+++ b/backend/test/infrastructure/e2e-vendor-stubs.spec.ts
@@ -56,6 +56,25 @@ describe("vendor stub factory selection", () => {
         expect(createGeminiGateway(configService)).toBeInstanceOf(VercelGeminiGateway);
     });
 
+    it("prefers the stub over the Vercel flag when both are set (precedence)", () => {
+        const configService = createConfigService({
+            E2E_VENDOR_STUBS: "1",
+            USE_VERCEL_AI_SDK: "true",
+        });
+
+        expect(createGeminiGateway(configService)).toBeInstanceOf(E2eGeminiGatewayStub);
+    });
+
+    it("treats truthy-but-not-'1' stub flag values as OFF (fail-safe)", () => {
+        for (const value of ["true", "yes", " 1"]) {
+            const configService = createConfigService({ E2E_VENDOR_STUBS: value });
+
+            expect(createGeminiGateway(configService)).toBeInstanceOf(GeminiChatGateway);
+            expect(createAligoPortClient(configService)).toBeInstanceOf(AligoApiClient);
+            expect(createEformsignClientRepository(configService)).toBeInstanceOf(EformsignApiClient);
+        }
+    });
+
     it("switches to stubbed vendor clients when E2E_VENDOR_STUBS is on", async () => {
         const configService = createConfigService({
             E2E_VENDOR_STUBS: "1",

--- a/mobile/tests/contracts-skeleton-loading.spec.ts
+++ b/mobile/tests/contracts-skeleton-loading.spec.ts
@@ -191,6 +191,12 @@ test.describe('Contracts Page Skeleton Loading', () => {
     await expect(page.locator('[data-component="mobile-redesign-list-title"]')).toContainText('2건');
   });
 
+  // NOTE (review follow-up, 2026-06-08): a dedicated documents-API error
+  // state does not exist post-redesign (the old MuiAlert tests covered dead
+  // UI). Observed current behavior on a hard documents 500: the eformsign
+  // reauth path ends in a LOGOUT/login redirect — encode no test until the
+  // intended failure UX is decided (tracked as a product/UX finding).
+
   test('shows the current empty-state copy when no contracts exist', async ({ page }) => {
     await page.route('**/api/access-token', async (route) => {
       await route.fulfill({

--- a/mobile/tests/critical-flows.spec.ts
+++ b/mobile/tests/critical-flows.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Critical business flows against the REAL backend (no route mocks).
+ *
+ * These tests MUTATE backend state (sender-approval status transitions,
+ * webhook-driven document completion + alimtalk log rows), so they only run
+ * in CI where the database is a throwaway per-job container seeded by
+ * backend/test/e2e-env/seed-e2e.ts. Never run them against a shared dev DB.
+ *
+ * Serial: flow 1 transitions the branch through "pending" before restoring
+ * "approved"; flow 2's completion alimtalk must not race that window.
+ */
+const BACKEND_URL = process.env.DEVELOPMENT_API_BASE_URL || 'http://127.0.0.1:3001';
+const WEBHOOK_SECRET = process.env.EFORMSIGN_WEBHOOK_SECRET || 'e2e-webhook-secret';
+const COMPANY_ID = process.env.EFORMSIGN_COMPANY_ID || 'e2e-stub-company';
+const BRANCH_ID = '33dbe950-1574-4951-b7b4-92d97ab29512';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Critical flows (real backend)', () => {
+  test.skip(!process.env.CI, 'mutates backend state — CI throwaway database only');
+
+  test('sender approval lifecycle: approved gate open → request → re-approve', async ({
+    page,
+    context,
+  }) => {
+    // 1. Seeded state: branch approved → the sender-approval page shows it
+    //    and the message composer is not blocked by the approval gate.
+    await page.goto('/messages/sender-approval');
+    await expect(page.getByText('승인 완료').first()).toBeVisible({ timeout: 15000 });
+
+    // 2. Drive the backend transitions directly (the admin approve UI lives
+    //    in the staff frontend app, not this mobile app): request → pending,
+    //    owner approve → approved. Auth via the storage-state JWT.
+    const authToken = (await context.cookies()).find((c) => c.name === 'auth_token')?.value;
+    expect(authToken).toBeTruthy();
+    const headers = { Authorization: `Bearer ${authToken}` };
+
+    const requestRes = await page.request.post(
+      `${BACKEND_URL}/settings/message-sender-approval/request`,
+      { headers, data: { senderPhone: '01099998888' } },
+    );
+    expect(requestRes.ok()).toBeTruthy();
+
+    const pendingRes = await page.request.get(
+      `${BACKEND_URL}/settings/message-sender-approval`,
+      { headers },
+    );
+    expect(pendingRes.ok()).toBeTruthy();
+    expect(await pendingRes.json()).toMatchObject({ approvalStatus: 'pending', isApproved: false });
+
+    const approveRes = await page.request.post(
+      `${BACKEND_URL}/settings/message-sender-approval/${BRANCH_ID}/approve`,
+      { headers, data: {} },
+    );
+    expect(approveRes.ok()).toBeTruthy();
+
+    const approvedRes = await page.request.get(
+      `${BACKEND_URL}/settings/message-sender-approval`,
+      { headers },
+    );
+    expect(await approvedRes.json()).toMatchObject({ approvalStatus: 'approved', isApproved: true });
+
+    // 3. The UI gate reflects the restored approval.
+    await page.goto('/messages/sender-approval');
+    await expect(page.getByText('승인 완료').first()).toBeVisible({ timeout: 15000 });
+  });
+
+  test('eformsign completion webhook delivers exactly one alimtalk (replay is idempotent)', async ({
+    page,
+    context,
+  }) => {
+    const authToken = (await context.cookies()).find((c) => c.name === 'auth_token')?.value;
+    expect(authToken).toBeTruthy();
+    const authHeaders = { Authorization: `Bearer ${authToken}` };
+
+    const logCount = async (): Promise<number> => {
+      const res = await page.request.get(`${BACKEND_URL}/alimtalk-logs`, { headers: authHeaders });
+      expect(res.ok()).toBeTruthy();
+      const body = await res.json();
+      const rows: unknown[] = Array.isArray(body) ? body : (body?.data ?? []);
+      return rows.length;
+    };
+
+    const webhookPayload = {
+      webhook_id: 'e2e-idempotency-check',
+      event_type: 'ready_document_pdf',
+      company_id: COMPANY_ID,
+      ready_document_pdf: {
+        document_id: 'doc-keep-1',
+        document_status: 'doc_complete',
+        workflow_seq: 1,
+        workflow_name: '완료',
+      },
+    };
+    const webhookHeaders = {
+      Authorization: `Bearer ${WEBHOOK_SECRET}`,
+      'Content-Type': 'application/json',
+    };
+
+    const before = await logCount();
+
+    // First completion webhook: claims the completion and sends the
+    // contract-signed alimtalk (recorded as a log row; vendor call stubbed).
+    const first = await page.request.post(`${BACKEND_URL}/webhooks/eformsign`, {
+      headers: webhookHeaders,
+      data: webhookPayload,
+    });
+    expect(first.status()).toBe(200);
+    expect(await first.json()).toMatchObject({ success: true });
+
+    await expect.poll(logCount, { timeout: 15000 }).toBe(before + 1);
+
+    // Replayed webhook: the completion claim is already taken — the document
+    // update reports "duplicate" and NO second alimtalk is sent.
+    const replay = await page.request.post(`${BACKEND_URL}/webhooks/eformsign`, {
+      headers: webhookHeaders,
+      data: webhookPayload,
+    });
+    expect(replay.status()).toBe(200);
+
+    // Give any (incorrect) duplicate send time to land before asserting.
+    await page.waitForTimeout(3000);
+    expect(await logCount()).toBe(before + 1);
+
+    // An unauthenticated webhook is rejected outright (guard fail-closed).
+    const badAuth = await page.request.post(`${BACKEND_URL}/webhooks/eformsign`, {
+      headers: { 'Content-Type': 'application/json' },
+      data: webhookPayload,
+    });
+    expect([401, 403]).toContain(badAuth.status());
+  });
+});


### PR DESCRIPTION
## Context

Closes the loop on two things: (1) the adversarial review of the full stabilization delta (#256–#260, two independent reviewers — verdict: **no dishonest weakening**; all value changes verified against src; findings below remediated), and (2) the two implementable P6.3 critical-flow specs. Suite stability is proven separately: runs #9/#10/#11 all green (91 passed, 0 failed, 0 flaky, ~2 min).

## Review remediations

- **Compile-time contract restored** (reviewer HIGH/MEDIUM): `E2eGeminiGatewayStub implements IGeminiGateway` + `createGeminiGateway(): IGeminiGateway` — the aligo/eformsign stubs always had this; the Gemini one didn't, so contract drift was invisible to `tsc`. Scope documented on the stub: text-streaming only, `function_call` chunks intentionally out of e2e scope.
- **Two new stub-selection tests**: dual-flag precedence (stub > `USE_VERCEL_AI_SDK`) and fail-safe flag parsing (`"true"`/`"yes"`/`" 1"` select the REAL clients). Backend jest 1088 → **1090**.
- **Contracts error-state coverage** (reviewer MEDIUM): investigated, intentionally NOT re-added. The deleted tests covered dead MUI alert UI; the *observed* current behavior on a hard documents-500 is a **logout/login redirect** via the eformsign reauth path — that's a product/UX finding (recorded in-file), not a contract to enshrine in a test.

## Critical flows (P6.3) — `mobile/tests/critical-flows.spec.ts`

CI-only (mutates backend state → skips outside the throwaway CI DB), serial:

1. **Sender-approval lifecycle**: seeded approved state gates the UI open → `request` → `pending` → owner `approve` → `approved`, each transition asserted against the real backend.
2. **Webhook idempotency** (the 2.5 guarantee, end-to-end): completion webhook for seeded `doc-keep-1` (Bearer secret + allow-listed `company_id`) → exactly **one** alimtalk log row (aligo vendor-stubbed; log persistence real) → identical replay leaves the count unchanged → unauthenticated webhook rejected fail-closed.
3. mobile-ci e2e env gains `EFORMSIGN_WEBHOOK_SECRET` / `EFORMSIGN_COMPANY_ID` as **e2e-only literals** (no secret material).

Remaining P6.3 scope (documented follow-on): contract-finalize lifecycle — blocked on eformsign stub support for the headless finalize path.

## Verification

backend type-check/lint clean · jest **1090** · mobile type-check/lint clean · flows spec validated by the post-merge CI dispatch (run #12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)