### PR TITLE
fix(alimtalk): scope direct-send log rows to the client's branch

### DIFF
--- a/backend/application/services/aligo.service.ts
+++ b/backend/application/services/aligo.service.ts
@@ -53,6 +53,8 @@ export class AligoService {
         await this.safeSend({
             templateKey: "CLIENT_CREATED",
             receiver: phone.toString(),
+            branchId: client.branchId ?? undefined,
+            clientId: client.id,
             variables: {
                 고객명: client.name,
                 등록일: this.formatDate(new Date()),
@@ -74,6 +76,8 @@ export class AligoService {
         await this.safeSend({
             templateKey: "CONTRACT_SIGNED",
             receiver: phone.toString(),
+            branchId: client.branchId ?? undefined,
+            clientId: client.id,
             variables: {
                 고객명: client.name,
                 계약유형: contractInfo.contractType,
@@ -97,6 +101,8 @@ export class AligoService {
         await this.safeSend({
             templateKey: "CONTRACT_REMINDER_3DAYS",
             receiver: phone.toString(),
+            branchId: client.branchId ?? undefined,
+            clientId: client.id,
             variables: {
                 고객명: client.name,
                 서비스시작일: serviceStartDate,
@@ -117,6 +123,8 @@ export class AligoService {
         await this.safeSend({
             templateKey: "CONTRACT_REMINDER_1DAY",
             receiver: phone.toString(),
+            branchId: client.branchId ?? undefined,
+            clientId: client.id,
             variables: {
                 고객명: client.name,
                 서비스시작일: serviceStartDate,
@@ -137,6 +145,8 @@ export class AligoService {
         await this.safeSend({
             templateKey: "PAYMENT_CONFIRMED",
             receiver: phone.toString(),
+            branchId: client.branchId ?? undefined,
+            clientId: client.id,
             variables: {
                 고객명: client.name,
                 결제금액: this.formatCurrency(paymentInfo.amount),
@@ -162,6 +172,8 @@ export class AligoService {
         await this.safeSend({
             templateKey: "SURVEY_REQUEST",
             receiver: phone.toString(),
+            branchId: client.branchId ?? undefined,
+            clientId: client.id,
             variables: {
                 고객명: client.name,
                 서비스종료일: serviceEndDate,
@@ -188,6 +200,8 @@ export class AligoService {
         await this.safeSend({
             templateKey: "PAYMENT_REMINDER",
             receiver: phone.toString(),
+            branchId: client.branchId ?? undefined,
+            clientId: client.id,
             variables: {
                 고객명: client.name,
                 등록일: registrationDate,

--- a/backend/domain/entities/client.entity.ts
+++ b/backend/domain/entities/client.entity.ts
@@ -65,6 +65,9 @@ export class ClientEntity {
         public dueDate: Date | null = null,
         public createdAt: Date | null = null,
         public areaId: string | null = null,
+        // Owning tenant; populated by ClientMapper on reads so downstream
+        // consumers (e.g. alimtalk log rows) can scope records to the branch.
+        public branchId: string | null = null,
     ) {}
 
     isGoingToCareCenter(): boolean {

--- a/backend/infrastructure/database/mapper/client.mapper.ts
+++ b/backend/infrastructure/database/mapper/client.mapper.ts
@@ -21,6 +21,7 @@ type ClientRow = {
     breastPump: boolean;
     eDocId: string | null;
     areaId?: string | null;
+    branchId?: string | null;
 };
 
 export class ClientMapper {
@@ -46,6 +47,7 @@ export class ClientMapper {
             row.dueDate ?? null,
             row.createdAt ?? null,
             row.areaId ?? null,
+            row.branchId ?? null,
         );
     }
 

--- a/backend/infrastructure/database/repositories/sb.client.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.client.repository.ts
@@ -32,6 +32,9 @@ export class SbClientRepository implements IClientRepository {
             serviceStatus: true,
             breastPump: true,
             eDocId: true,
+            // Tenant key — every where-clause already relies on this column,
+            // and reads must carry it so ClientEntity.branchId is populated.
+            branchId: true,
             ...(supportsCreatedAt ? { createdAt: true } : {}),
             ...(supportsAreaId ? { areaId: true } : {}),
         } as const;

--- a/backend/test/services/aligo.service.spec.ts
+++ b/backend/test/services/aligo.service.spec.ts
@@ -81,10 +81,13 @@ describe("AligoService", () => {
     });
 
     describe("sendContractSignedAlimtalk", () => {
-        it("should send CONTRACT_SIGNED template", async () => {
+        it("should send CONTRACT_SIGNED template scoped to the client's branch", async () => {
             sendAlimtalkUsecase.execute.mockResolvedValue({ code: 0, message: "success" });
 
-            await service.sendContractSignedAlimtalk(createMockClient(), {
+            const client = createMockClient();
+            client.branchId = "branch-1";
+
+            await service.sendContractSignedAlimtalk(client, {
                 contractType: "방문요양",
                 signedDate: "2025-01-14",
                 serviceStartDate: "2025-01-15",
@@ -94,6 +97,11 @@ describe("AligoService", () => {
             expect(sendAlimtalkUsecase.execute).toHaveBeenCalledWith(
                 expect.objectContaining({
                     templateKey: "CONTRACT_SIGNED",
+                    // Regression: omitting branchId/clientId orphans the
+                    // alimtalk_log row — invisible to the tenant-scoped
+                    // GET /alimtalk-logs history.
+                    branchId: "branch-1",
+                    clientId: 1,
                     variables: expect.objectContaining({
                         계약유형: "방문요양",
                         담당자명: "김직원",

--- a/mobile/tests/critical-flows.spec.ts
+++ b/mobile/tests/critical-flows.spec.ts
@@ -70,7 +70,7 @@ test.describe('Critical flows (real backend)', () => {
   test('eformsign completion webhook delivers exactly one alimtalk (replay is idempotent)', async ({
     page,
     context,
-  }) => {
+  }, testInfo) => {
     const authToken = (await context.cookies()).find((c) => c.name === 'auth_token')?.value;
     expect(authToken).toBeTruthy();
     const authHeaders = { Authorization: `Bearer ${authToken}` };
@@ -83,6 +83,29 @@ test.describe('Critical flows (real backend)', () => {
       return rows.length;
     };
 
+    // Provision a fresh document per attempt: the completion claim is a
+    // one-shot state transition, so reusing a seeded document would make
+    // every retry start from "already completed" (duplicate → no alimtalk)
+    // and the test could never pass on retry.
+    const documentId = `e2e-idem-${Date.now()}-r${testInfo.retry}`;
+    const createRes = await page.request.post(`${BACKEND_URL}/eformsign-docs`, {
+      headers: authHeaders,
+      data: {
+        documentId,
+        clientId: 1,
+        statusType: '002',
+        statusDetail: '대기',
+        stepType: '01',
+        stepIndex: '1',
+        stepName: '발송 대기',
+        stepRecipientType: '02',
+        stepRecipientName: '홍테스트',
+        stepRecipientSms: '01012345678',
+        expiredDate: '2027-01-01T00:00:00.000Z',
+      },
+    });
+    expect(createRes.ok()).toBeTruthy();
+
     // Shape must satisfy EformsignWebhookPayloadDto exactly — the global
     // ValidationPipe rejects missing required fields with a 400.
     const webhookPayload = {
@@ -91,8 +114,8 @@ test.describe('Critical flows (real backend)', () => {
       company_id: COMPANY_ID,
       event_type: 'ready_document_pdf',
       ready_document_pdf: {
-        document_id: 'doc-keep-1',
-        document_title: 'doc-keep-1 계약서',
+        document_id: documentId,
+        document_title: `${documentId} 계약서`,
         workflow_seq: 1,
         workflow_name: '완료',
         template_id: 'tpl-test',


### PR DESCRIPTION
## Problem

Run #13 of the real-backend e2e suite surfaced a production bug via the new critical-flow webhook test: the eformsign completion webhook processed end-to-end (claim → link → alimtalk send all logged), yet `GET /alimtalk-logs` never showed the new row.

**Root cause:** every `AligoService` send method builds its dto without `branchId`/`clientId` (`aligo.service.ts`), so `SendAligoAlimtalkUsecase` persists the `alimtalk_log` row with `branchId: null`. `listHistory → findRecentByBranch` filters by strict `branchId` equality — orphaned rows are invisible to the tenant-scoped 발송 내역 list. This affects all seven direct-send paths (client-created, contract-signed, both reminders, payment-confirmed, survey, payment-reminder), not just the webhook flow.

## Fix

- `ClientEntity` gains a trailing optional `branchId` (no positional call-site churn)
- `ClientMapper.toDomain` + `getClientSelect()` carry the column on reads
- `AligoService` passes `branchId: client.branchId` / `clientId: client.id` in all seven send dtos
- `aligo.service.spec.ts` pins the regression on CONTRACT_SIGNED

Parameter-threading through `AlimtalkService.routeToProvider` was rejected: ChannelTalk's reminder methods take `contractLink?: string` in the same position, so a threaded `branchId` would silently flow into `contractLink` through the union-typed dispatch.

## Test hardening

`critical-flows.spec.ts` webhook test now provisions a fresh document per attempt via `POST /eformsign-docs` — the completion claim is a one-shot state transition, so reusing the seeded `doc-keep-1` made every retry start from "duplicate" (no alimtalk possible → retry-poisoned test).

## Verification

- backend type-check ✓, jest 1090 passed / 8 skipped (107 suites) ✓
- mobile type-check ✓
- e2e run #14 dispatched post-merge to confirm the flow goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
