### PR TITLE
sec(validation): reject undeclared request-body fields (forbidNonWhitelisted)

### DIFF
--- a/backend/infrastructure/pipes/global-validation.pipe.ts
+++ b/backend/infrastructure/pipes/global-validation.pipe.ts
@@ -1,0 +1,37 @@
+import { ArgumentMetadata, Injectable, ValidationPipe } from "@nestjs/common";
+import { EformsignWebhookPayloadDto } from "interface/dto/eformsign-webhook.dto";
+
+/**
+ * Application-wide validation pipe.
+ *
+ * Strict by default: constructed in main.ts with forbidNonWhitelisted so a
+ * request body carrying fields no DTO declares is rejected (400) instead of
+ * silently stripped — mass-assignment / client-server contract-drift hygiene.
+ *
+ * EXEMPT: inbound third-party webhook payloads whose shape we do not control.
+ * NestJS applies a global pipe and any controller/route-level @UsePipes
+ * ADDITIVELY (global first), so a permissive controller pipe cannot relax a
+ * stricter global one — the global 400s before the local pipe runs. Branching
+ * on the parameter's DTO metatype here is the route-agnostic way to carve out
+ * the exemption: exempted DTOs are validated permissively (whitelist still
+ * strips unknown fields, we just don't reject them).
+ */
+@Injectable()
+export class GlobalValidationPipe extends ValidationPipe {
+    // Permissive sibling for exempted DTOs: keeps whitelist stripping + transform
+    // but drops forbidNonWhitelisted so provider-side field additions don't 400.
+    private readonly permissive = new ValidationPipe({ whitelist: true, transform: true });
+
+    // DTOs received from external systems whose payload shape we don't own.
+    // Add a webhook/callback DTO here when it must tolerate undeclared fields.
+    private static readonly PERMISSIVE_DTOS: ReadonlySet<unknown> = new Set<unknown>([
+        EformsignWebhookPayloadDto,
+    ]);
+
+    override async transform(value: unknown, metadata: ArgumentMetadata): Promise<unknown> {
+        if (metadata.metatype && GlobalValidationPipe.PERMISSIVE_DTOS.has(metadata.metatype)) {
+            return this.permissive.transform(value, metadata);
+        }
+        return super.transform(value, metadata);
+    }
+}

--- a/backend/interface/controllers/eformsign-webhook.controller.ts
+++ b/backend/interface/controllers/eformsign-webhook.controller.ts
@@ -7,6 +7,10 @@ import { WebhookGuard } from "infrastructure/auth/webhook.guard";
  * Controller for handling eformsign webhook callbacks
  * This endpoint is called by eformsign when document status changes
  * Protected by bearer token authentication configured in eformsign console
+ *
+ * NOTE: this payload is exempt from the global forbidNonWhitelisted rule via
+ * GlobalValidationPipe (eformsign sends undeclared fields like document.comment
+ * and document.recipients[]). The exemption keys on EformsignWebhookPayloadDto.
  */
 @Controller("webhooks/eformsign")
 @UseGuards(WebhookGuard)

--- a/backend/main.ts
+++ b/backend/main.ts
@@ -1,9 +1,9 @@
 import { NestFactory } from "@nestjs/core";
-import { ValidationPipe } from "@nestjs/common";
 import helmet from "helmet";
 import { AppModule } from "./app.module";
 import cookieParser from "cookie-parser";
 import { PrismaExceptionFilter } from "./infrastructure/filters/prisma-exception.filter";
+import { GlobalValidationPipe } from "./infrastructure/pipes/global-validation.pipe";
 
 // Catch any unhandled errors
 process.on('uncaughtException', (error) => {
@@ -36,7 +36,12 @@ async function bootstrap() {
     const expressApp = app.getHttpAdapter().getInstance();
     expressApp.set("trust proxy", 1);
     app.use(cookieParser());
-    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    // forbidNonWhitelisted turns silently-stripped unknown body fields into
+    // explicit 400s (mass-assignment hardening). GlobalValidationPipe carves out
+    // inbound third-party webhook DTOs (eformsign sends undeclared fields) that
+    // a stricter global pipe would otherwise reject — see the pipe for why a
+    // controller-level override can't do this.
+    app.useGlobalPipes(new GlobalValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }));
     app.useGlobalFilters(new PrismaExceptionFilter());
     // CORS configuration - support production, preview, and development origins
     const allowedOrigins = [

--- a/backend/test/integration/eformsign-webhook.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign-webhook.controller.integration.spec.ts
@@ -1,10 +1,11 @@
-import { INestApplication, ValidationPipe } from "@nestjs/common";
+import { INestApplication } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { ConfigService } from "@nestjs/config";
 import { EformsignWebhookService } from "application/services/eformsign-webhook.service";
 import { WebhookGuard } from "infrastructure/auth/webhook.guard";
 import { EformsignWebhookController } from "interface/controllers/eformsign-webhook.controller";
 import { EformsignWebhookPayloadDto } from "interface/dto/eformsign-webhook.dto";
+import { GlobalValidationPipe } from "infrastructure/pipes/global-validation.pipe";
 import request from "supertest";
 
 describe("EformsignWebhookController (Integration)", () => {
@@ -63,7 +64,10 @@ describe("EformsignWebhookController (Integration)", () => {
             .compile();
 
         app = moduleFixture.createNestApplication();
-        app.useGlobalPipes(new ValidationPipe({ transform: true }));
+        // Mirror the production global pipe (main.ts) so this suite proves the
+        // metatype-based exemption keeps webhooks permissive under the strict
+        // forbidNonWhitelisted policy that applies everywhere else.
+        app.useGlobalPipes(new GlobalValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }));
         await app.init();
 
         webhookService = moduleFixture.get(EformsignWebhookService);
@@ -84,6 +88,41 @@ describe("EformsignWebhookController (Integration)", () => {
         expect(response.status).toBe(200);
         expect(response.body).toEqual({ success: true });
         expect(webhookService.processWebhook).toHaveBeenCalledWith(payload);
+    });
+
+    it("accepts eformsign payloads carrying fields our DTO does not declare", async () => {
+        // Real eformsign webhooks (webhook-example.md) include document.comment
+        // and document.recipients[] — undeclared here. Under the production
+        // global pipe (forbidNonWhitelisted) these would 400; the controller's
+        // own permissive @UsePipes must keep the completion webhook working.
+        webhookService.processWebhook.mockResolvedValue(undefined);
+
+        const payloadWithExtras = {
+            ...payload,
+            document: {
+                ...payload.document,
+                comment: "",
+                recipients: [
+                    {
+                        step_seq: "2",
+                        name: "송진호",
+                        id: "",
+                        sms: { country_code: "+82", phone_number: "1066211878" },
+                        token_id: "e638f0969f634156bb9c32652309017d",
+                        sms_template_index: 0,
+                    },
+                ],
+            },
+        };
+
+        const response = await request(app.getHttpServer())
+            .post("/webhooks/eformsign")
+            .set(authHeader)
+            .send(payloadWithExtras);
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ success: true });
+        expect(webhookService.processWebhook).toHaveBeenCalled();
     });
 
     it("returns retryable failure when webhook processing fails", async () => {


### PR DESCRIPTION
Promotes the global ValidationPipe from silent extra-field stripping to explicit 400s — mass-assignment / contract-drift hygiene (review follow-up #17 item 2).

**Webhook exemption:** real eformsign callbacks carry undeclared fields (`document.comment`, `document.recipients[]`, future provider additions). NestJS applies global + controller pipes additively (global first), so a permissive `@UsePipes` can't relax the global — proven by integration test. `GlobalValidationPipe` branches on the DTO metatype instead, keeping the carve-out route-agnostic.

**Verification:** backend type-check + jest 1091 passed / 8 skipped (incl. a new regression test asserting a webhook payload with undeclared fields still 200s). Dispatching the real-backend e2e suite against this branch before merge to confirm no app route regresses under the stricter pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)