### PR TITLE
sec(rls): drop anon public-read policy on bank_account_info (#20)

### DIFF
--- a/backend/prisma/migrations/20260608000000_drop_bank_account_info_anon_read/migration.sql
+++ b/backend/prisma/migrations/20260608000000_drop_bank_account_info_anon_read/migration.sql
@@ -1,0 +1,17 @@
+-- Remove the public anon-read RLS policy on bank_account_info.
+--
+-- The rls_baseline migration reproduced this policy from the live DB and flagged
+-- it as a likely-unintended PII exposure: it grants SELECT on bank account
+-- numbers (accNum) to the Supabase `anon` role, so anyone holding the project's
+-- anon/publishable key can read them via PostgREST.
+--
+-- RLS stays ENABLED on the table; with no anon policy it is default-deny for
+-- anon. The application backend connects with the service role (Prisma over
+-- DATABASE_URL), which bypasses RLS, so its reads/writes are unaffected. No
+-- frontend/mobile path reads this table via the anon key — both apps go through
+-- the authenticated NestJS API (verified 2026-06-08: neither app imports
+-- @supabase/supabase-js nor references a NEXT_PUBLIC_SUPABASE key).
+--
+-- The sibling anon-read policy on voucher_price_info is intentional (public
+-- pricing) and is deliberately left in place.
+DROP POLICY IF EXISTS "Allow public read access on bankAccountInfo" ON "bank_account_info";


### PR DESCRIPTION
Closes a live PII exposure surfaced by the rls_baseline migration: bank account numbers (accNum) were readable by anyone with the Supabase anon/publishable key via PostgREST.

Drops the policy (RLS stays ENABLED → default-deny for anon). Backend uses the service role (bypasses RLS) so app access is unaffected; verified neither frontend nor mobile touches Supabase directly. voucher_price_info's anon-read (public pricing) is left in place.

Takes effect in prod only after the P3.2 migrate-deploy cutover; applies immediately in CI e2e. Dispatching e2e on this branch to prove the migration chain (0_init → rls_baseline → this drop) applies on a fresh DB and the suite stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)