### PR TITLE
feat: 통화 인박스 변경요청(CLIENT_UPDATE) 원탭 적용 (BJJ-232)

### DIFF
--- a/backend/application/services/call-extraction.prompt.ts
+++ b/backend/application/services/call-extraction.prompt.ts
@@ -1,4 +1,4 @@
-export const CALL_EXTRACTION_PROMPT_VERSION = "v1";
+export const CALL_EXTRACTION_PROMPT_VERSION = "v2";
 
 /** client fields a proposal may target (spec §6) */
 export const PROPOSAL_FIELDS = [
@@ -43,7 +43,7 @@ export function buildCallExtractionPrompt(input: {
     duration(일수, 숫자), careCenter(조리원 이용, boolean), voucherClient(정부지원, boolean),
     startDate(희망 시작일), type 등)
   - CLIENT_SERVICE: 변경 요청된 필드만. 관리사 교체 요청 → field "serviceStatus",
-    value "active_with_replacement_requested". 서비스 종료 요청 → "serviceStatus", "terminated".
+    value "replacement_requested". 서비스 종료 요청 → "serviceStatus", "terminated".
   - OTHER: proposals는 [].
 - 각 proposal: value(날짜는 YYYY-MM-DD, 기간은 일수 숫자, boolean은 true/false),
   evidence(근거가 된 발화 인용, 원문 그대로), confidence("high" | "low").

--- a/backend/application/services/call-inbox.service.ts
+++ b/backend/application/services/call-inbox.service.ts
@@ -1,4 +1,5 @@
 import {
+    BadRequestException,
     ConflictException,
     Injectable,
     Logger,
@@ -8,7 +9,9 @@ import {
 import { PrismaService } from "infrastructure/database/prisma.service";
 import { ClientService } from "application/services/client.service";
 import { normalizePhone } from "application/utils/normalize-phone";
+import { PROPOSAL_FIELDS } from "application/services/call-extraction.prompt";
 import {
+    ConfirmDraftDto,
     ConfirmNewClientDraftDto,
     PatchClientDraftDto,
 } from "interface/dto/call-inbox.dto";
@@ -215,7 +218,16 @@ export class CallInboxService {
         if (draft.type !== "NEW_CLIENT") {
             throw new NotImplementedException("CLIENT_UPDATE confirm ships in Phase 2");
         }
+        return this.confirmNewClientWithDraft(branchId, userId, id, draft, dto);
+    }
 
+    private async confirmNewClientWithDraft(
+        branchId: string,
+        userId: string,
+        id: string,
+        draft: { callRecordId: string },
+        dto: { fields: Record<string, unknown>; suppressGreetingSms?: boolean },
+    ) {
         // optimistic lock BEFORE side effects: only one caller flips PENDING→CONFIRMING
         const locked = await this.prismaService.client_draft.updateMany({
             where: { id, status: "PENDING" },
@@ -278,6 +290,93 @@ export class CallInboxService {
                 return { clientId: createdClientId };
             }
             // create itself failed: roll the lock back so staff can fix input and retry
+            await this.prismaService.client_draft
+                .update({ where: { id }, data: { status: "PENDING" } })
+                .catch(() => undefined);
+            throw error;
+        }
+    }
+
+    /** Unified confirm entry-point: dispatches to NEW_CLIENT or CLIENT_UPDATE path */
+    async confirm(branchId: string, userId: string, id: string, dto: ConfirmDraftDto) {
+        const draft = await this.requirePendingDraft(branchId, id);
+        if (draft.type === "NEW_CLIENT") {
+            if (!dto.fields || typeof dto.fields !== "object") {
+                throw new BadRequestException("fields is required for NEW_CLIENT");
+            }
+            return this.confirmNewClientWithDraft(branchId, userId, id, draft, {
+                fields: dto.fields,
+                suppressGreetingSms: dto.suppressGreetingSms,
+            });
+        }
+        if (draft.type === "CLIENT_UPDATE") {
+            if (!dto.changes || typeof dto.changes !== "object" || Array.isArray(dto.changes)) {
+                throw new BadRequestException("changes is required for CLIENT_UPDATE");
+            }
+            return this.confirmClientUpdate(branchId, userId, id, draft, dto.changes);
+        }
+        throw new BadRequestException(`Unknown draft type: ${draft.type}`);
+    }
+
+    private async confirmClientUpdate(
+        branchId: string,
+        userId: string,
+        id: string,
+        draft: { clientId: number | null; callRecordId: string },
+        rawChanges: Record<string, unknown>,
+    ) {
+        // a. clientId must be set (guard before locking)
+        if (draft.clientId == null) {
+            throw new ConflictException("고객 연결이 필요합니다");
+        }
+        const clientId = draft.clientId;
+
+        // b. filter changes to PROPOSAL_FIELDS allowlist
+        const allowedSet = new Set<string>(PROPOSAL_FIELDS);
+        const filteredChanges: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(rawChanges)) {
+            if (allowedSet.has(key)) filteredChanges[key] = value;
+        }
+        if (Object.keys(filteredChanges).length === 0) {
+            throw new BadRequestException("No valid fields remain after allowlist filtering");
+        }
+
+        // c. optimistic lock PENDING → CONFIRMING
+        const locked = await this.prismaService.client_draft.updateMany({
+            where: { id, status: "PENDING" },
+            data: { status: "CONFIRMING" },
+        });
+        if (locked.count === 0) {
+            throw new ConflictException("Draft already reviewed");
+        }
+
+        let updateApplied = false;
+        try {
+            // d. apply the changes via the validated update path
+            await this.clientService.update(branchId, clientId, filteredChanges as Parameters<typeof this.clientService.update>[2]);
+            updateApplied = true;
+
+            // e. mark CONFIRMED
+            await this.prismaService.client_draft.update({
+                where: { id },
+                data: { status: "CONFIRMED", reviewedById: userId, reviewedAt: new Date() },
+            });
+            return { clientId };
+        } catch (error) {
+            if (updateApplied) {
+                // f. update succeeded but bookkeeping failed — never revert to PENDING
+                this.logger.error(
+                    `Confirm bookkeeping failed after changes applied to client ${clientId} for draft ${id}: ${error}`,
+                );
+                await this.prismaService.client_draft
+                    .update({
+                        where: { id },
+                        data: { status: "CONFIRMED", reviewedById: userId, reviewedAt: new Date() },
+                    })
+                    .catch(() => undefined);
+                return { clientId };
+            }
+            // update itself failed — roll back lock
             await this.prismaService.client_draft
                 .update({ where: { id }, data: { status: "PENDING" } })
                 .catch(() => undefined);

--- a/backend/interface/controllers/client-draft.controller.ts
+++ b/backend/interface/controllers/client-draft.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Param, Patch, Post, Query, Req, UseGuards } from
 import { Request } from "express";
 import { CallInboxService } from "application/services/call-inbox.service";
 import {
+    ConfirmDraftDto,
     ConfirmNewClientDraftDto,
     DiscardClientDraftDto,
     PatchClientDraftDto,
@@ -54,9 +55,9 @@ export class ClientDraftController {
         @CurrentTenant() tenant: { branchId?: string },
         @Req() request: Request & { user?: { userId?: string } },
         @Param("id") id: string,
-        @Body() dto: ConfirmNewClientDraftDto,
+        @Body() dto: ConfirmDraftDto,
     ) {
-        return this.callInboxService.confirmNewClient(
+        return this.callInboxService.confirm(
             tenant.branchId ?? "",
             request.user?.userId ?? "",
             id,

--- a/backend/interface/dto/call-inbox.dto.ts
+++ b/backend/interface/dto/call-inbox.dto.ts
@@ -86,6 +86,27 @@ export class ConfirmNewClientDraftDto {
     suppressGreetingSms?: boolean;
 }
 
+export class ConfirmClientUpdateDraftDto {
+    /** included changes only; keys validated against PROPOSAL_FIELDS in the service */
+    @IsObject()
+    changes!: Record<string, unknown>;
+}
+
+/** Permissive union DTO used by the controller — the service discriminates by draft type */
+export class ConfirmDraftDto {
+    @IsOptional()
+    @IsObject()
+    fields?: Record<string, unknown>;
+
+    @IsOptional()
+    @IsBoolean()
+    suppressGreetingSms?: boolean;
+
+    @IsOptional()
+    @IsObject()
+    changes?: Record<string, unknown>;
+}
+
 export class DiscardClientDraftDto {
     @IsOptional()
     @IsString()

--- a/backend/test/integration/client-draft.controller.integration.spec.ts
+++ b/backend/test/integration/client-draft.controller.integration.spec.ts
@@ -87,7 +87,7 @@ describe("ClientDraftController (Integration)", () => {
     });
 
     it("POST /client-drafts/draft-2/confirm (CLIENT_UPDATE) passes changes through to confirm", async () => {
-        const body = { changes: { startDate: "2026-06-23", serviceStatus: "active_with_replacement_requested" } };
+        const body = { changes: { startDate: "2026-06-23", serviceStatus: "replacement_requested" } };
         callInboxService.confirm.mockResolvedValue({ clientId: 99 });
 
         const res = await request(app.getHttpServer())

--- a/backend/test/integration/client-draft.controller.integration.spec.ts
+++ b/backend/test/integration/client-draft.controller.integration.spec.ts
@@ -1,4 +1,4 @@
-import { INestApplication, ExecutionContext, NotImplementedException } from "@nestjs/common";
+import { INestApplication, ExecutionContext } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import request from "supertest";
 import { ClientDraftController } from "interface/controllers/client-draft.controller";
@@ -10,7 +10,7 @@ describe("ClientDraftController (Integration)", () => {
     let app: INestApplication;
     let callInboxService: jest.Mocked<Pick<
         CallInboxService,
-        "listDrafts" | "countDrafts" | "getDraft" | "patchDraft" | "confirmNewClient" | "discard"
+        "listDrafts" | "countDrafts" | "getDraft" | "patchDraft" | "confirmNewClient" | "confirm" | "discard"
     >>;
 
     const mockGuard = {
@@ -28,6 +28,7 @@ describe("ClientDraftController (Integration)", () => {
             getDraft: jest.fn(),
             patchDraft: jest.fn(),
             confirmNewClient: jest.fn(),
+            confirm: jest.fn(),
             discard: jest.fn(),
         };
 
@@ -67,9 +68,9 @@ describe("ClientDraftController (Integration)", () => {
         expect(callInboxService.getDraft).not.toHaveBeenCalled();
     });
 
-    it("POST /client-drafts/draft-1/confirm calls confirmNewClient with correct args", async () => {
+    it("POST /client-drafts/draft-1/confirm (NEW_CLIENT) calls confirm with correct args", async () => {
         const body = { fields: { name: "김서연", careCenter: false, voucherClient: false, breastPump: false } };
-        callInboxService.confirmNewClient.mockResolvedValue({ clientId: 42 });
+        callInboxService.confirm.mockResolvedValue({ clientId: 42 });
 
         const res = await request(app.getHttpServer())
             .post("/client-drafts/draft-1/confirm")
@@ -77,11 +78,29 @@ describe("ClientDraftController (Integration)", () => {
 
         expect(res.status).toBe(201);
         expect(res.body).toEqual({ clientId: 42 });
-        expect(callInboxService.confirmNewClient).toHaveBeenCalledWith(
+        expect(callInboxService.confirm).toHaveBeenCalledWith(
             "branch-1",
             "user-1",
             "draft-1",
             expect.objectContaining({ fields: body.fields }),
+        );
+    });
+
+    it("POST /client-drafts/draft-2/confirm (CLIENT_UPDATE) passes changes through to confirm", async () => {
+        const body = { changes: { startDate: "2026-06-23", serviceStatus: "active_with_replacement_requested" } };
+        callInboxService.confirm.mockResolvedValue({ clientId: 99 });
+
+        const res = await request(app.getHttpServer())
+            .post("/client-drafts/draft-2/confirm")
+            .send(body);
+
+        expect(res.status).toBe(201);
+        expect(res.body).toEqual({ clientId: 99 });
+        expect(callInboxService.confirm).toHaveBeenCalledWith(
+            "branch-1",
+            "user-1",
+            "draft-2",
+            expect.objectContaining({ changes: body.changes }),
         );
     });
 
@@ -96,15 +115,14 @@ describe("ClientDraftController (Integration)", () => {
         expect(callInboxService.discard).toHaveBeenCalledWith("branch-1", "user-1", "draft-1", "오인식");
     });
 
-    it("NotImplementedException from service propagates as 501", async () => {
-        callInboxService.confirmNewClient.mockRejectedValue(
-            new NotImplementedException("CLIENT_UPDATE confirm ships in Phase 2"),
-        );
+    it("service exceptions propagate with correct HTTP status", async () => {
+        const { ConflictException } = await import("@nestjs/common");
+        callInboxService.confirm.mockRejectedValue(new ConflictException("Draft already reviewed"));
 
         const res = await request(app.getHttpServer())
-            .post("/client-drafts/draft-2/confirm")
-            .send({ fields: { name: "x", careCenter: false, voucherClient: false, breastPump: false } });
+            .post("/client-drafts/draft-3/confirm")
+            .send({ changes: { startDate: "2026-06-23" } });
 
-        expect(res.status).toBe(501);
+        expect(res.status).toBe(409);
     });
 });

--- a/backend/test/services/call-inbox.service.spec.ts
+++ b/backend/test/services/call-inbox.service.spec.ts
@@ -1,4 +1,4 @@
-import { ConflictException, NotFoundException, NotImplementedException } from "@nestjs/common";
+import { BadRequestException, ConflictException, NotFoundException, NotImplementedException } from "@nestjs/common";
 import { CallInboxService } from "application/services/call-inbox.service";
 
 describe("CallInboxService", () => {
@@ -10,7 +10,7 @@ describe("CallInboxService", () => {
         },
         client: { findMany: jest.fn(), findFirst: jest.fn() },
     };
-    const clientService = { create: jest.fn() };
+    const clientService = { create: jest.fn(), update: jest.fn() };
     let service: CallInboxService;
 
     const pendingDraft = {
@@ -109,6 +109,119 @@ describe("CallInboxService", () => {
         await expect(
             service.confirmNewClient("branch-1", "user-1", "draft-1", { fields: { name: "x", careCenter: false, voucherClient: false, breastPump: false } }),
         ).rejects.toThrow(NotImplementedException);
+    });
+
+    // ── confirmClientUpdate / confirm dispatch ────────────────────────────────
+
+    const clientUpdateDraft = {
+        ...pendingDraft,
+        type: "CLIENT_UPDATE",
+        clientId: 142,
+    };
+
+    it("confirmClientUpdate: applies allowlisted changes via ClientService.update and marks CONFIRMED", async () => {
+        prisma.client_draft.findFirst.mockResolvedValue(clientUpdateDraft);
+        prisma.client_draft.updateMany.mockResolvedValue({ count: 1 });
+        clientService.update.mockResolvedValue({});
+        prisma.client_draft.update.mockResolvedValue({});
+
+        const result = await service.confirm("branch-1", "user-1", "draft-1", {
+            changes: { startDate: "2026-06-23", serviceStatus: "active_with_replacement_requested", hairColor: "x" },
+        });
+
+        expect(result).toEqual({ clientId: 142 });
+        // hairColor must be dropped (not in PROPOSAL_FIELDS)
+        expect(clientService.update).toHaveBeenCalledWith("branch-1", 142, {
+            startDate: "2026-06-23",
+            serviceStatus: "active_with_replacement_requested",
+        });
+        expect(prisma.client_draft.update).toHaveBeenCalledWith(expect.objectContaining({
+            where: { id: "draft-1" },
+            data: expect.objectContaining({ status: "CONFIRMED", reviewedById: "user-1" }),
+        }));
+    });
+
+    it("confirmClientUpdate: 409 when no client linked — clientId check happens BEFORE lock", async () => {
+        const unlinkeddraft = { ...clientUpdateDraft, clientId: null };
+        prisma.client_draft.findFirst.mockResolvedValue(unlinkeddraft);
+
+        await expect(
+            service.confirm("branch-1", "user-1", "draft-1", {
+                changes: { startDate: "2026-06-23" },
+            }),
+        ).rejects.toThrow(ConflictException);
+        expect(clientService.update).not.toHaveBeenCalled();
+        expect(prisma.client_draft.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("confirmClientUpdate: 400 when changes empty after allowlist filtering", async () => {
+        prisma.client_draft.findFirst.mockResolvedValue(clientUpdateDraft);
+
+        await expect(
+            service.confirm("branch-1", "user-1", "draft-1", { changes: { hairColor: "blonde" } }),
+        ).rejects.toThrow(BadRequestException);
+        expect(prisma.client_draft.updateMany).not.toHaveBeenCalled();
+        expect(clientService.update).not.toHaveBeenCalled();
+    });
+
+    it("confirmClientUpdate: 409 on lock race (updateMany count 0)", async () => {
+        prisma.client_draft.findFirst.mockResolvedValue(clientUpdateDraft);
+        prisma.client_draft.updateMany.mockResolvedValue({ count: 0 });
+
+        await expect(
+            service.confirm("branch-1", "user-1", "draft-1", { changes: { startDate: "2026-06-23" } }),
+        ).rejects.toThrow(ConflictException);
+        expect(clientService.update).not.toHaveBeenCalled();
+    });
+
+    it("confirmClientUpdate: rolls back to PENDING when ClientService.update throws", async () => {
+        prisma.client_draft.findFirst.mockResolvedValue(clientUpdateDraft);
+        prisma.client_draft.updateMany.mockResolvedValue({ count: 1 });
+        clientService.update.mockRejectedValue(new Error("serviceStatus invalid"));
+
+        await expect(
+            service.confirm("branch-1", "user-1", "draft-1", { changes: { startDate: "2026-06-23" } }),
+        ).rejects.toThrow("serviceStatus invalid");
+        expect(prisma.client_draft.update).toHaveBeenCalledWith({
+            where: { id: "draft-1" },
+            data: { status: "PENDING" },
+        });
+    });
+
+    it("confirmClientUpdate: stays CONFIRMED-path when bookkeeping fails after successful update", async () => {
+        prisma.client_draft.findFirst.mockResolvedValue(clientUpdateDraft);
+        prisma.client_draft.updateMany.mockResolvedValue({ count: 1 });
+        clientService.update.mockResolvedValue({});
+        prisma.client_draft.update
+            .mockRejectedValueOnce(new Error("db blip"))  // CONFIRMED write fails
+            .mockResolvedValueOnce({});                    // re-assert succeeds
+
+        const result = await service.confirm("branch-1", "user-1", "draft-1", {
+            changes: { startDate: "2026-06-23" },
+        });
+
+        expect(result).toEqual({ clientId: 142 });
+        const updateCalls = prisma.client_draft.update.mock.calls;
+        expect(updateCalls.some(([args]: [{ data: { status?: string } }]) => args.data.status === "PENDING")).toBe(false);
+        expect(updateCalls[updateCalls.length - 1]![0].data).toEqual(
+            expect.objectContaining({ status: "CONFIRMED" }),
+        );
+    });
+
+    it("confirm dispatch: NEW_CLIENT without fields → 400", async () => {
+        prisma.client_draft.findFirst.mockResolvedValue(pendingDraft);
+
+        await expect(
+            service.confirm("branch-1", "user-1", "draft-1", { changes: { startDate: "2026-06-23" } }),
+        ).rejects.toThrow(BadRequestException);
+    });
+
+    it("confirm dispatch: CLIENT_UPDATE without changes → 400", async () => {
+        prisma.client_draft.findFirst.mockResolvedValue(clientUpdateDraft);
+
+        await expect(
+            service.confirm("branch-1", "user-1", "draft-1", { fields: { name: "x", careCenter: false, voucherClient: false, breastPump: false } }),
+        ).rejects.toThrow(BadRequestException);
     });
 
     it("discard: PENDING → DISCARDED with reason; 409 when already reviewed", async () => {

--- a/backend/test/services/call-inbox.service.spec.ts
+++ b/backend/test/services/call-inbox.service.spec.ts
@@ -126,14 +126,14 @@ describe("CallInboxService", () => {
         prisma.client_draft.update.mockResolvedValue({});
 
         const result = await service.confirm("branch-1", "user-1", "draft-1", {
-            changes: { startDate: "2026-06-23", serviceStatus: "active_with_replacement_requested", hairColor: "x" },
+            changes: { startDate: "2026-06-23", serviceStatus: "replacement_requested", hairColor: "x" },
         });
 
         expect(result).toEqual({ clientId: 142 });
         // hairColor must be dropped (not in PROPOSAL_FIELDS)
         expect(clientService.update).toHaveBeenCalledWith("branch-1", 142, {
             startDate: "2026-06-23",
-            serviceStatus: "active_with_replacement_requested",
+            serviceStatus: "replacement_requested",
         });
         expect(prisma.client_draft.update).toHaveBeenCalledWith(expect.objectContaining({
             where: { id: "draft-1" },

--- a/backend/test/services/call-processing.service.spec.ts
+++ b/backend/test/services/call-processing.service.spec.ts
@@ -1,4 +1,5 @@
 import { CallProcessingService } from "application/services/call-processing.service";
+import { CALL_EXTRACTION_PROMPT_VERSION } from "application/services/call-extraction.prompt";
 import { CallExtractionResult } from "domain/ports/call-extraction.port";
 
 describe("CallProcessingService", () => {
@@ -82,7 +83,7 @@ describe("CallProcessingService", () => {
             { field: "duration", value: 10, evidence: "10일이요", confidence: "high" },
             { field: "careCenter", value: false, evidence: "조리원은 안 가요", confidence: "high" },
         ]);
-        expect(draftData.extractionMeta).toEqual(expect.objectContaining({ promptVersion: "v1" }));
+        expect(draftData.extractionMeta).toEqual(expect.objectContaining({ promptVersion: CALL_EXTRACTION_PROMPT_VERSION }));
         expect(prisma.call_record.update).toHaveBeenCalledWith(expect.objectContaining({
             data: expect.objectContaining({ callerPhone: "01048217763", callerName: "김서연" }),
         }));
@@ -117,7 +118,7 @@ describe("CallProcessingService", () => {
             category: "CLIENT_SERVICE",
             requestSummary: "관리사 교체 요청",
             proposals: [
-                { field: "serviceStatus", value: "active_with_replacement_requested", evidence: "교체해 주세요", confidence: "high" },
+                { field: "serviceStatus", value: "replacement_requested", evidence: "교체해 주세요", confidence: "high" },
             ],
         }));
 

--- a/docs/api/call-inbox-api.md
+++ b/docs/api/call-inbox-api.md
@@ -1,6 +1,6 @@
 # 통화요약 (Call Inbox) — API Sheet
 
-**Status:** implementation in progress (Phase 1). This file is the **source of truth** for the UI-facing API; implementation must conform or update this sheet in the same PR.
+**Status:** Phase 1 + 변경 적용 (BJJ-232) 구현 완료. This file is the **source of truth** for the UI-facing API; implementation must conform or update this sheet in the same PR.
 **Spec:** `docs/superpowers/specs/2026-06-10-call-inbox-design.md` · **Wireframe:** `docs/mockups/call-inbox-wireframe.html`
 
 ## Conventions
@@ -213,9 +213,16 @@ interface ConfirmNewClientBody {
 // → 201 { clientId: number }
 ```
 
-CLIENT_UPDATE — **501 Not Implemented in Phase 1.** The UI renders the confirm button as disabled for CLIENT_UPDATE drafts. This path ships in Phase 2.
+CLIENT_UPDATE — body carries **only the changed fields** (included proposals after staff review):
 
-Common errors: `409` draft not PENDING (already confirmed/discarded) · `409` "Draft already reviewed" when a concurrent confirm wins the CONFIRMING lock · `422` validation failure (same rules as existing client create/update paths).
+```ts
+interface ConfirmClientUpdateBody {
+  changes: Record<ProposalField, string | number | boolean | null>;  // included changes only; non-allowlist keys dropped server-side; non-empty required
+}
+// → 200 { clientId: number }
+```
+
+Errors: `409` draft not PENDING (already confirmed/discarded) · `409` "Draft already reviewed" when a concurrent confirm wins the CONFIRMING lock · `409` "고객 연결이 필요합니다" (unlinked client — `clientId` not set on draft) · `400` empty or invalid changes · 4xx from client-update validation (same rules as existing client update path).
 
 ### `POST /api/client-drafts/:id/discard`
 
@@ -249,7 +256,8 @@ Body `{ reason?: string }` → `200 { id, status: "DISCARDED" }` · `409` not PE
 | Unknown / foreign-branch resource | 404 |
 | Draft already reviewed (not PENDING) | 409 |
 | Draft already reviewed — concurrent confirm/discard wins CONFIRMING lock | 409 |
+| CLIENT_UPDATE confirm — `clientId` not set on draft (고객 연결이 필요합니다) | 409 |
+| CLIENT_UPDATE confirm — `changes` empty or contains only non-allowlist keys | 400 |
 | Validation failure (body caps, unknown fields) | 400 / 422 |
-| CLIENT_UPDATE confirm (Phase 1) | 501 |
 | Webhook body exceeds 1 mb | 400 (express) |
 | Webhook payload fails DTO validation (cap violations, malformed `recordedAt`) | 400 |

--- a/docs/superpowers/specs/2026-06-10-call-inbox-design.md
+++ b/docs/superpowers/specs/2026-06-10-call-inbox-design.md
@@ -160,7 +160,7 @@ Indexes: `(branchId, createdAt)`, `processingStatus`, `matchedClientId`.
 | `GET /call-records/:id` | Full record: transcript, summary, draft, Drive link |
 | `GET /client-drafts?status=PENDING&page&limit` | Review queue |
 | `PATCH /client-drafts/:id` | Edit proposals / link `clientId` — only while PENDING |
-| `POST /client-drafts/:id/confirm` | NEW_CLIENT: body = staff-final `CreateClientDto`-shaped fields (+ `suppressGreetingSms?`) → existing `ClientService.create`; CLIENT_UPDATE: **501 in Phase 1** (ships in Phase 2; UI renders button disabled). Transactional; 409 unless PENDING; stamps reviewedBy/At |
+| `POST /client-drafts/:id/confirm` | NEW_CLIENT: body = staff-final `CreateClientDto`-shaped fields (+ `suppressGreetingSms?`) → existing `ClientService.create`; CLIENT_UPDATE: body = `{ changes: Record<ProposalField, string\|number\|boolean\|null> }` (included changes only; non-empty required; non-allowlist keys dropped) → existing client update path → `200 { clientId }`. Transactional; 409 unless PENDING; 409 unlinked client; stamps reviewedBy/At |
 | `POST /client-drafts/:id/discard` | `{ reason? }` |
 | `GET /client-drafts/count?status=PENDING` | Cheap count for the nav badge / NotificationBell |
 | `POST /call-records/:id/re-extract` | Phase 2, admin: re-runs extraction; only replaces proposals of a still-PENDING draft |
@@ -206,5 +206,5 @@ Transcripts contain PII and pregnancy/birth-adjacent details — stored in the s
 ## 13. Phasing
 
 - **Phase 1 — intake + 신규상담 (end-to-end value):** schema (3 tables) + `CallIngestGuard` + webhook + extraction + token provisioning endpoints + mobile 검토 대기/통화 기록 + 신규 상담 confirm. n8n template updated.
-- **Phase 2 — 변경요청 + polish:** CLIENT_UPDATE confirm flow, re-extract, NotificationBell integration, client-detail 통화 탭, call-log search polish.
+- **Phase 2 — 변경요청 + polish:** ~~CLIENT_UPDATE confirm flow~~ → shipped 2026-06-10 (BJJ-232), re-extract, NotificationBell integration, client-detail 통화 탭, call-log search polish.
 - **Phase 3 — SaaS self-serve:** branch settings UI for token create/rotate + n8n onboarding guide for branch-operated setups.

--- a/mobile/src/app/api/client-drafts/[id]/confirm/route.ts
+++ b/mobile/src/app/api/client-drafts/[id]/confirm/route.ts
@@ -12,7 +12,7 @@ import {
 
 type RouteParams = { params: Promise<{ id: string }> };
 
-const confirmDraftSchema = z.object({
+const newClientShape = z.object({
     fields: z
         .object({
             name: z.string().min(1).max(10_000),
@@ -23,6 +23,17 @@ const confirmDraftSchema = z.object({
         .passthrough(),
     suppressGreetingSms: z.boolean().optional(),
 });
+
+const clientUpdateShape = z
+    .object({
+        changes: z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()])),
+    })
+    .refine(
+        (obj) => Object.keys(obj.changes).length > 0,
+        { message: "변경 사항이 없습니다." },
+    );
+
+const confirmDraftSchema = z.union([newClientShape, clientUpdateShape]);
 
 // POST /api/client-drafts/[id]/confirm - 초안 확정 (backend 409/501 status preserved)
 export async function POST(request: NextRequest, { params }: RouteParams) {

--- a/mobile/src/components/app/call-inbox/CallReviewSheet.tsx
+++ b/mobile/src/components/app/call-inbox/CallReviewSheet.tsx
@@ -385,11 +385,30 @@ function ClientUpdateReview({
   onClose: () => void;
 }) {
   const { proposals } = draft;
+  const confirmDraft = useConfirmDraft(draft.id);
   const discardDraft = useDiscardDraft(draft.id);
   const patchDraft = usePatchDraft(draft.id);
   const { highlight, jump } = useEvidenceJump();
 
   const isPending = draft.status === "PENDING";
+  const isLinked = draft.clientId != null;
+
+  // per-row include toggles (all ON by default)
+  const [included, setIncluded] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(proposals.map((p) => [p.field, true])),
+  );
+
+  // per-row editable values (seeded from proposal.value)
+  const [editedValues, setEditedValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      proposals
+        .filter((p) => typeof p.value !== "boolean")
+        .map((p) => [p.field, p.value === null || p.value === undefined ? "" : String(p.value)]),
+    ),
+  );
+
+  const includedCount = proposals.filter((p) => included[p.field]).length;
+  const busy = confirmDraft.isPending || discardDraft.isPending;
 
   const handleDiscard = async () => {
     try {
@@ -398,6 +417,37 @@ function ClientUpdateReview({
       onClose();
     } catch {
       toast({ title: "폐기 실패", variant: "destructive" });
+    }
+  };
+
+  const handleApply = async () => {
+    const changes: Record<string, string | number | boolean | null> = {};
+    for (const proposal of proposals) {
+      if (!included[proposal.field]) continue;
+      if (typeof proposal.value === "boolean") {
+        // boolean toggles keep their proposal value (read-only in this view)
+        changes[proposal.field] = proposal.value;
+      } else {
+        const raw = editedValues[proposal.field] ?? "";
+        // coerce numeric fields
+        if (typeof proposal.value === "number") {
+          const n = Number(raw);
+          changes[proposal.field] = Number.isFinite(n) ? n : null;
+        } else {
+          changes[proposal.field] = raw || null;
+        }
+      }
+    }
+
+    try {
+      await confirmDraft.mutateAsync({ changes });
+      toast({ title: `변경 적용 완료 (${includedCount}건)` });
+      onClose();
+    } catch {
+      toast({
+        title: "적용에 실패했습니다. 값을 확인해 주세요.",
+        variant: "destructive",
+      });
     }
   };
 
@@ -437,25 +487,55 @@ function ClientUpdateReview({
           const isLow = proposal.confidence === "low";
           const hasCurrent =
             proposal.currentValue !== null && proposal.currentValue !== undefined;
+          const isIncluded = included[proposal.field] ?? true;
+          const isBool = typeof proposal.value === "boolean";
+
           return (
             <div
               key={proposal.field}
-              className="rounded-xl border border-v3-border p-3"
+              className={`rounded-xl border p-3 ${isIncluded ? "border-v3-border" : "border-v3-border opacity-50"}`}
               data-component="call-inbox-review-diff-row"
             >
               <div className="mb-1 flex items-center justify-between text-[0.72rem] text-v3-text-muted">
                 <span>{FIELD_LABELS[proposal.field] ?? proposal.field}</span>
-                {isLow && <span className="font-bold text-amber-600">⚠ 확신도 낮음</span>}
+                <div className="flex items-center gap-2">
+                  {isLow && <span className="font-bold text-amber-600">⚠ 확신도 낮음</span>}
+                  {isPending && (
+                    <Switch
+                      checked={isIncluded}
+                      onCheckedChange={(checked) =>
+                        setIncluded((prev) => ({ ...prev, [proposal.field]: checked }))
+                      }
+                      aria-label={`${FIELD_LABELS[proposal.field] ?? proposal.field} 포함`}
+                    />
+                  )}
+                </div>
               </div>
-              <div className="flex items-center gap-2 text-[0.85rem]">
-                {hasCurrent && (
-                  <span className="text-v3-text-muted line-through">
-                    {displayValue(proposal.currentValue ?? null)}
-                  </span>
-                )}
-                {hasCurrent && <span className="text-v3-text-muted">→</span>}
-                <span className="font-bold text-v3-orange">{displayValue(proposal.value)}</span>
-              </div>
+              {hasCurrent && (
+                <div className="mb-1 flex items-center gap-2 text-[0.78rem] text-v3-text-muted">
+                  <span className="line-through">{displayValue(proposal.currentValue ?? null)}</span>
+                  <span>→</span>
+                </div>
+              )}
+              {isPending && !isBool ? (
+                <Input
+                  value={editedValues[proposal.field] ?? ""}
+                  disabled={!isIncluded}
+                  onChange={(e) =>
+                    setEditedValues((prev) => ({ ...prev, [proposal.field]: e.target.value }))
+                  }
+                  className="text-[0.85rem]"
+                  aria-label={FIELD_LABELS[proposal.field] ?? proposal.field}
+                />
+              ) : isPending && isBool ? (
+                <div className="flex items-center gap-2 text-[0.85rem]">
+                  <span className="font-bold text-v3-orange">{displayValue(proposal.value)}</span>
+                </div>
+              ) : (
+                <div className="flex items-center gap-2 text-[0.85rem]">
+                  <span className="font-bold text-v3-orange">{displayValue(proposal.value)}</span>
+                </div>
+              )}
               <EvidenceChip
                 proposal={proposal}
                 transcript={draft.callRecord.transcript}
@@ -474,20 +554,20 @@ function ClientUpdateReview({
               label: "폐기",
               variant: "secondary",
               onClick: handleDiscard,
-              disabled: discardDraft.isPending,
+              disabled: busy,
               busy: discardDraft.isPending,
             },
             {
-              label: "변경 적용",
+              label: confirmDraft.isPending
+                ? "적용 중..."
+                : `변경 적용 (${includedCount}건)`,
               variant: "primary",
-              disabled: true,
+              onClick: handleApply,
+              disabled: !isLinked || includedCount === 0 || busy,
+              busy: confirmDraft.isPending,
             },
           ]}
-        >
-          <p className="mt-1 w-full text-center text-[0.7rem] text-v3-text-muted">
-            Phase 2에서 제공
-          </p>
-        </MobileDetailActions>
+        />
       )}
 
       <TranscriptSection draft={draft} highlight={highlight} />

--- a/mobile/src/components/app/call-inbox/CallReviewSheet.tsx
+++ b/mobile/src/components/app/call-inbox/CallReviewSheet.tsx
@@ -62,6 +62,9 @@ const TOGGLE_FIELDS = [
   { field: "breastPump", label: "유축기" },
 ] as const;
 
+// birthday is YYMMDD text, not ISO — keep it out
+const DATE_FIELDS = new Set(["dueDate", "startDate", "endDate"]);
+
 function proposalFor(proposals: Proposal[], field: string): Proposal | undefined {
   return proposals.find((p) => p.field === field);
 }
@@ -519,6 +522,7 @@ function ClientUpdateReview({
               )}
               {isPending && !isBool ? (
                 <Input
+                  type={DATE_FIELDS.has(proposal.field) ? "date" : "text"}
                   value={editedValues[proposal.field] ?? ""}
                   disabled={!isIncluded}
                   onChange={(e) =>

--- a/mobile/src/components/app/call-inbox/__tests__/CallReviewSheet.test.tsx
+++ b/mobile/src/components/app/call-inbox/__tests__/CallReviewSheet.test.tsx
@@ -163,11 +163,21 @@ describe("CallReviewSheet — CLIENT_UPDATE PENDING", () => {
   const updateDetail = {
     ...baseDetail,
     type: "CLIENT_UPDATE" as const,
+    clientId: 7,
+    client: { id: 7, name: "박지영", phone: "01099998888" },
     proposals: [
       {
         field: "startDate",
         value: "2026-07-20",
+        currentValue: "2026-06-01",
         evidence: "7월 20일부터 시작하고 싶어요",
+        confidence: "high" as const,
+      },
+      {
+        field: "endDate",
+        value: "2026-08-20",
+        currentValue: null,
+        evidence: "8월 20일까지요",
         confidence: "high" as const,
       },
     ],
@@ -176,15 +186,20 @@ describe("CallReviewSheet — CLIENT_UPDATE PENDING", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseClientDraft.mockReturnValue({ data: updateDetail, isLoading: false });
+    mockConfirmMutateAsync.mockResolvedValue({ clientId: 7 });
   });
 
-  it("renders Phase 2 notice and disables 변경 적용 button", () => {
+  it("does NOT render Phase 2 notice", () => {
     render(<CallReviewSheet draftId="draft-1" onClose={jest.fn()} />);
 
-    expect(screen.getByText(/Phase 2에서 제공/)).toBeInTheDocument();
+    expect(screen.queryByText(/Phase 2에서 제공/i)).not.toBeInTheDocument();
+  });
+
+  it("enables 변경 적용 button when client is linked and proposals exist", () => {
+    render(<CallReviewSheet draftId="draft-1" onClose={jest.fn()} />);
 
     const applyBtn = screen.getByRole("button", { name: /변경 적용/i });
-    expect(applyBtn).toBeDisabled();
+    expect(applyBtn).not.toBeDisabled();
   });
 
   it("enables the 폐기 button for a pending CLIENT_UPDATE draft", () => {
@@ -192,6 +207,42 @@ describe("CallReviewSheet — CLIENT_UPDATE PENDING", () => {
 
     const discardBtn = screen.getByRole("button", { name: /^폐기$/i });
     expect(discardBtn).not.toBeDisabled();
+  });
+
+  it("calls confirmDraft with only included changes and excludes toggled-off row", async () => {
+    const user = userEvent.setup();
+    render(<CallReviewSheet draftId="draft-1" onClose={jest.fn()} />);
+
+    // Find the include toggles for each diff row — they are Switch components
+    // with aria-label matching the field label
+    const endDateToggle = screen.getByRole("switch", { name: /종료일 포함/i });
+    await user.click(endDateToggle);
+
+    const applyBtn = screen.getByRole("button", { name: /변경 적용/i });
+    await user.click(applyBtn);
+
+    expect(mockConfirmMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        changes: expect.not.objectContaining({ endDate: expect.anything() }),
+      }),
+    );
+    expect(mockConfirmMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        changes: expect.objectContaining({ startDate: "2026-07-20" }),
+      }),
+    );
+  });
+
+  it("disables 변경 적용 button when client is not linked", () => {
+    mockUseClientDraft.mockReturnValue({
+      data: { ...updateDetail, clientId: null, client: null },
+      isLoading: false,
+    });
+
+    render(<CallReviewSheet draftId="draft-1" onClose={jest.fn()} />);
+
+    const applyBtn = screen.getByRole("button", { name: /변경 적용/i });
+    expect(applyBtn).toBeDisabled();
   });
 });
 

--- a/mobile/src/hooks/useCallInbox.ts
+++ b/mobile/src/hooks/useCallInbox.ts
@@ -9,6 +9,7 @@ import type {
     ClientDraftDetail,
     ClientDraftListItem,
     ConfirmDraftBody,
+    ConfirmUpdateBody,
     Paginated,
     Proposal,
 } from "@/lib/call-inbox/types";
@@ -96,7 +97,7 @@ export function usePatchDraft(id: string) {
 export function useConfirmDraft(id: string) {
     const queryClient = useQueryClient();
     return useMutation({
-        mutationFn: async (body: ConfirmDraftBody) => {
+        mutationFn: async (body: ConfirmDraftBody | ConfirmUpdateBody) => {
             const { data } = await api.post(`/client-drafts/${id}/confirm`, body);
             return data as { clientId: number };
         },

--- a/mobile/src/lib/call-inbox/types.ts
+++ b/mobile/src/lib/call-inbox/types.ts
@@ -117,3 +117,7 @@ export interface ConfirmDraftBody {
     };
     suppressGreetingSms?: boolean;
 }
+
+export interface ConfirmUpdateBody {
+    changes: Record<string, string | number | boolean | null>;
+}


### PR DESCRIPTION
## Summary

Completes BJJ-232 by wiring the CLIENT_UPDATE confirm flow end-to-end — the backend `confirmClientUpdate` service method applies allowlist-filtered changes through the existing `clientService.update` path with an optimistic CONFIRMING lock and safe rollback, while the mobile `ClientUpdateReview` UI adds per-row include toggles and editable values that build the `changes` payload. Docs and spec files are kept in sync.

### Backend
- `POST /client-drafts/:id/confirm` now dispatches by draft type: `confirmNewClientWithDraft` (unchanged) or new `confirmClientUpdate` — the 501 for CLIENT_UPDATE is gone
- `confirmClientUpdate`: rejects unlinked drafts (409 "고객 연결이 필요합니다") before locking, filters `changes` against the `PROPOSAL_FIELDS` allowlist (400 if empty after filter), takes the PENDING→CONFIRMING optimistic lock (409 on race), applies via `clientService.update`, then marks CONFIRMED with reviewer bookkeeping
- Orphan-safe rollback: only rolls back to PENDING if the client update itself failed; if the update succeeded but bookkeeping failed, the draft stays CONFIRMED (never re-applies a side effect)
- Extraction prompt v2: serviceStatus value corrected to canonical `replacement_requested`

### Mobile
- `ClientUpdateReview\): per-row include Switch + editable value inputs (native `type="date"` for dueDate/startDate/endDate), `[변경 적용 (N건)]` button live — builds `{ changes }` from included rows with edited values winning
- BFF confirm route accepts the new `{ changes }` body shape (zod union with the NEW_CLIENT shape)
- `useConfirmDraft` invalidates both call-inbox and clients query caches

### Docs
- `docs/api/call-inbox-api.md` + design spec updated: CLIENT_UPDATE confirm contract live, 501 row removed

## Test plan
- [x] Backend jest: call-inbox service 16/16 (allowlist drop, lock order, race 409, rollback semantics), controller integration green, full suite green
- [x] Mobile jest: 12/12 call-inbox suites (include-toggle payload, unlinked disabled state), full suite green
- [x] Both type-checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)