### PR TITLE
fix(backend): SMS partial-retry + CONFIRMING sweep race

### DIFF
--- a/backend/application/services/call-extraction-retry-scheduler.service.ts
+++ b/backend/application/services/call-extraction-retry-scheduler.service.ts
@@ -83,12 +83,22 @@ export class CallExtractionRetrySchedulerService {
             // Under the confirm flow's ordering, clientId+CONFIRMED land in one atomic update,
             // so a swept draft never has a client silently attached; re-confirm shows the
             // phoneMatchesExistingClient warning if a client did get created.
+            //
+            // Compare against confirmingStartedAt (set on PENDING→CONFIRMING) rather than
+            // createdAt — otherwise an in-flight confirm on a draft created hours ago would
+            // be immediately eligible for revert, racing the live confirm and allowing
+            // duplicate client-change application. Pre-migration CONFIRMING rows
+            // (confirmingStartedAt IS NULL) fall back to createdAt so they aren't stranded.
+            const staleThreshold = new Date(Date.now() - STUCK_CONFIRMING_MS);
             const sweptDrafts = await this.prismaService.client_draft.updateMany({
                 where: {
                     status: "CONFIRMING",
-                    createdAt: { lt: new Date(Date.now() - STUCK_CONFIRMING_MS) },
+                    OR: [
+                        { confirmingStartedAt: { lt: staleThreshold } },
+                        { confirmingStartedAt: null, createdAt: { lt: staleThreshold } },
+                    ],
                 },
-                data: { status: "PENDING" },
+                data: { status: "PENDING", confirmingStartedAt: null },
             });
             if (sweptDrafts.count > 0) {
                 this.logger.warn(

--- a/backend/application/services/call-inbox.service.ts
+++ b/backend/application/services/call-inbox.service.ts
@@ -228,10 +228,12 @@ export class CallInboxService {
         draft: { callRecordId: string },
         dto: { fields: Record<string, unknown>; suppressGreetingSms?: boolean },
     ) {
-        // optimistic lock BEFORE side effects: only one caller flips PENDING→CONFIRMING
+        // optimistic lock BEFORE side effects: only one caller flips PENDING→CONFIRMING.
+        // confirmingStartedAt anchors the stuck-CONFIRMING sweep so a slow confirm
+        // running shortly after a long-pending draft cannot be reverted mid-flight.
         const locked = await this.prismaService.client_draft.updateMany({
             where: { id, status: "PENDING" },
-            data: { status: "CONFIRMING" },
+            data: { status: "CONFIRMING", confirmingStartedAt: new Date() },
         });
         if (locked.count === 0) {
             throw new ConflictException("Draft already reviewed");
@@ -266,7 +268,7 @@ export class CallInboxService {
 
             await this.prismaService.client_draft.update({
                 where: { id },
-                data: { status: "CONFIRMED", clientId: client.id, reviewedById: userId, reviewedAt: new Date() },
+                data: { status: "CONFIRMED", clientId: client.id, reviewedById: userId, reviewedAt: new Date(), confirmingStartedAt: null },
             });
             await this.prismaService.call_record.update({
                 where: { id: draft.callRecordId },
@@ -284,14 +286,14 @@ export class CallInboxService {
                 await this.prismaService.client_draft
                     .update({
                         where: { id },
-                        data: { status: "CONFIRMED", clientId: createdClientId, reviewedById: userId, reviewedAt: new Date() },
+                        data: { status: "CONFIRMED", clientId: createdClientId, reviewedById: userId, reviewedAt: new Date(), confirmingStartedAt: null },
                     })
                     .catch(() => undefined);
                 return { clientId: createdClientId };
             }
             // create itself failed: roll the lock back so staff can fix input and retry
             await this.prismaService.client_draft
-                .update({ where: { id }, data: { status: "PENDING" } })
+                .update({ where: { id }, data: { status: "PENDING", confirmingStartedAt: null } })
                 .catch(() => undefined);
             throw error;
         }
@@ -341,10 +343,13 @@ export class CallInboxService {
             throw new BadRequestException("No valid fields remain after allowlist filtering");
         }
 
-        // c. optimistic lock PENDING → CONFIRMING
+        // c. optimistic lock PENDING → CONFIRMING.
+        // confirmingStartedAt anchors the stuck-CONFIRMING sweep against this transition,
+        // not the draft's createdAt, so an in-flight confirm cannot be reverted by the
+        // sweep just because the draft has been sitting around for a while.
         const locked = await this.prismaService.client_draft.updateMany({
             where: { id, status: "PENDING" },
-            data: { status: "CONFIRMING" },
+            data: { status: "CONFIRMING", confirmingStartedAt: new Date() },
         });
         if (locked.count === 0) {
             throw new ConflictException("Draft already reviewed");
@@ -359,7 +364,7 @@ export class CallInboxService {
             // e. mark CONFIRMED
             await this.prismaService.client_draft.update({
                 where: { id },
-                data: { status: "CONFIRMED", reviewedById: userId, reviewedAt: new Date() },
+                data: { status: "CONFIRMED", reviewedById: userId, reviewedAt: new Date(), confirmingStartedAt: null },
             });
             return { clientId };
         } catch (error) {
@@ -371,14 +376,14 @@ export class CallInboxService {
                 await this.prismaService.client_draft
                     .update({
                         where: { id },
-                        data: { status: "CONFIRMED", reviewedById: userId, reviewedAt: new Date() },
+                        data: { status: "CONFIRMED", reviewedById: userId, reviewedAt: new Date(), confirmingStartedAt: null },
                     })
                     .catch(() => undefined);
                 return { clientId };
             }
             // update itself failed — roll back lock
             await this.prismaService.client_draft
-                .update({ where: { id }, data: { status: "PENDING" } })
+                .update({ where: { id }, data: { status: "PENDING", confirmingStartedAt: null } })
                 .catch(() => undefined);
             throw error;
         }

--- a/backend/interface/controllers/message-delivery.controller.ts
+++ b/backend/interface/controllers/message-delivery.controller.ts
@@ -131,9 +131,20 @@ export class MessageDeliveryController {
         triggerType: string,
     ) {
         const isAccepted = this.isAcceptedSmsResult(result);
+        const isPartial = this.isPartialSuccessSmsResult(result);
         const status = isAccepted
             ? triggerType === "scheduled" ? "pending" : "sent"
             : "failed";
+        // Aligo's response gives success_cnt / error_cnt but no per-recipient breakdown,
+        // so on a partial-success batch we cannot identify which numbers failed. Retrying
+        // the original comma-joined receiver list would resend to the already-delivered
+        // recipients and produce duplicates, so we disable auto-retry for partial successes
+        // and surface a failed log to staff for manual handling.
+        const errorMessage = isAccepted
+            ? null
+            : isPartial
+                ? `부분 발송 (성공 ${Number(result.response.success_cnt ?? 0)}건 / 실패 ${Number(result.response.error_cnt ?? 0)}건). 실패 수신자를 식별할 수 없어 자동 재전송을 중단했습니다. 실패자에게 수동으로 재발송해 주세요.`
+                : result.response.message;
         await this.prisma.alimtalk_log.create({
             data: {
                 branchId: branchId || null,
@@ -153,10 +164,10 @@ export class MessageDeliveryController {
                 },
                 status,
                 aligoMid: result.response.msg_id ? String(result.response.msg_id) : null,
-                errorMessage: isAccepted ? null : result.response.message,
+                errorMessage,
                 attempts: 1,
                 lastAttemptAt: new Date(),
-                nextRetryAt: isAccepted ? null : this.nextRetryAt(),
+                nextRetryAt: isAccepted || isPartial ? null : this.nextRetryAt(),
             },
         });
     }
@@ -207,6 +218,15 @@ export class MessageDeliveryController {
             resultCode === 1 &&
             errorCount === 0
         );
+    }
+
+    private isPartialSuccessSmsResult(
+        result: Awaited<ReturnType<AligoService["sendSms"]>>,
+    ) {
+        const resultCode = Number(result.response.result_code);
+        const errorCount = Number(result.response.error_cnt ?? 0);
+        const successCount = Number(result.response.success_cnt ?? 0);
+        return resultCode === 1 && errorCount > 0 && successCount > 0;
     }
 
     private countSmsRecipients(receiver: string): number {

--- a/backend/prisma/migrations/20260621000000_add_client_draft_confirming_started_at/migration.sql
+++ b/backend/prisma/migrations/20260621000000_add_client_draft_confirming_started_at/migration.sql
@@ -1,0 +1,10 @@
+-- Track when a client_draft transitions PENDING -> CONFIRMING so the stuck-CONFIRMING
+-- sweep can compare against that moment instead of the draft's createdAt. With createdAt,
+-- a draft created N minutes ago that just now entered CONFIRMING is immediately eligible
+-- for reset, opening a race where an in-flight confirm can be reverted to PENDING and
+-- re-applied (duplicate client / duplicate update).
+-- Additive-only: nullable column, no default, no backfill required. Pre-existing rows in
+-- CONFIRMING (if any) fall through the sweep's null-branch which retains the old createdAt
+-- behavior so they are not stranded.
+ALTER TABLE "client_draft"
+    ADD COLUMN "confirming_started_at" TIMESTAMPTZ(6);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -593,6 +593,7 @@ model client_draft {
   reviewedAt     DateTime?   @map("reviewed_at") @db.Timestamptz(6)
   discardReason  String?     @map("discard_reason")
   createdAt      DateTime    @default(now()) @map("created_at") @db.Timestamptz(6)
+  confirmingStartedAt DateTime? @map("confirming_started_at") @db.Timestamptz(6)
   callRecord     call_record @relation(fields: [callRecordId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   branch         branch      @relation(fields: [branchId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   client         client?     @relation(fields: [clientId], references: [id], onDelete: SetNull, onUpdate: NoAction)

--- a/backend/test/interface/controllers/message-delivery.controller.spec.ts
+++ b/backend/test/interface/controllers/message-delivery.controller.spec.ts
@@ -221,6 +221,46 @@ describe("MessageDeliveryController", () => {
         });
     });
 
+    it("should not schedule auto-retry on partial-success batches (would duplicate to already-delivered recipients)", async () => {
+        jest.spyOn(Date, "now").mockReturnValue(new Date("2026-06-05T09:20:00.000Z").getTime());
+        aligoService.sendSms.mockResolvedValue({
+            request: {
+                senderPhone: "0212345678",
+                receiver: "01012345678,01099999999",
+                msgType: "SMS",
+                testModeYn: "N",
+            },
+            response: {
+                result_code: 1,
+                message: "일부 수신번호 형식이 올바르지 않습니다.",
+                success_cnt: 1,
+                error_cnt: 1,
+                msg_type: "SMS",
+            },
+        });
+
+        await expect(
+            controller.sendSms(
+                { branchId: "org-1" },
+                {
+                    receiver: "01012345678,01099999999",
+                    message: "테스트 발송 본문",
+                    title: "안내",
+                    triggerType: "immediate",
+                    msgType: "AUTO",
+                },
+            ),
+        ).rejects.toThrow(BadGatewayException);
+
+        expect(prismaService.alimtalk_log.create).toHaveBeenCalledWith({
+            data: expect.objectContaining({
+                status: "failed",
+                nextRetryAt: null,
+                errorMessage: expect.stringContaining("부분 발송"),
+            }),
+        });
+    });
+
     it("should record a failed log and reject when Aligo rejects the SMS request before returning a result body", async () => {
         jest.spyOn(Date, "now").mockReturnValue(new Date("2026-06-05T09:20:00.000Z").getTime());
         aligoService.sendSms.mockRejectedValue(

--- a/backend/test/services/call-extraction-retry-scheduler.service.spec.ts
+++ b/backend/test/services/call-extraction-retry-scheduler.service.spec.ts
@@ -42,8 +42,14 @@ describe("CallExtractionRetrySchedulerService", () => {
         await scheduler.retryFailedExtractions();
         expect(processingService.processCallRecord).not.toHaveBeenCalled();
         expect(prisma.client_draft.updateMany).toHaveBeenCalledWith({
-            where: { status: "CONFIRMING", createdAt: { lt: expect.any(Date) } },
-            data: { status: "PENDING" },
+            where: {
+                status: "CONFIRMING",
+                OR: [
+                    { confirmingStartedAt: { lt: expect.any(Date) } },
+                    { confirmingStartedAt: null, createdAt: { lt: expect.any(Date) } },
+                ],
+            },
+            data: { status: "PENDING", confirmingStartedAt: null },
         });
     });
 
@@ -69,8 +75,14 @@ describe("CallExtractionRetrySchedulerService", () => {
         await scheduler.retryFailedExtractions();
 
         expect(prisma.client_draft.updateMany).toHaveBeenCalledWith({
-            where: { status: "CONFIRMING", createdAt: { lt: expect.any(Date) } },
-            data: { status: "PENDING" },
+            where: {
+                status: "CONFIRMING",
+                OR: [
+                    { confirmingStartedAt: { lt: expect.any(Date) } },
+                    { confirmingStartedAt: null, createdAt: { lt: expect.any(Date) } },
+                ],
+            },
+            data: { status: "PENDING", confirmingStartedAt: null },
         });
     });
 });

--- a/backend/test/services/call-inbox.service.spec.ts
+++ b/backend/test/services/call-inbox.service.spec.ts
@@ -73,7 +73,7 @@ describe("CallInboxService", () => {
         ).rejects.toThrow("areaId invalid");
         expect(prisma.client_draft.update).toHaveBeenCalledWith({
             where: { id: "draft-1" },
-            data: { status: "PENDING" },
+            data: { status: "PENDING", confirmingStartedAt: null },
         });
     });
 
@@ -184,7 +184,7 @@ describe("CallInboxService", () => {
         ).rejects.toThrow("serviceStatus invalid");
         expect(prisma.client_draft.update).toHaveBeenCalledWith({
             where: { id: "draft-1" },
-            data: { status: "PENDING" },
+            data: { status: "PENDING", confirmingStartedAt: null },
         });
     });
 


### PR DESCRIPTION
Addresses the two real Codex review findings on #276 so the dev→preview promotion picks them up.

## Summary

- **#1 (P1) — Suppress auto-retry on partial-success SMS batches.** Aligo's response gives `success_cnt` / `error_cnt` with no per-recipient breakdown, so on a partial batch we cannot identify which numbers failed. The previous behavior persisted the full comma-joined receiver list with `nextRetryAt` set, so the alimtalk retry scheduler would resend the whole batch — duplicating SMS to recipients Aligo had already delivered to. Now: partial-success batches log as `failed` with `nextRetryAt: null` and an errorMessage explaining auto-retry was disabled, so staff can re-send manually only to the affected recipients.
- **#2 (P2) — Anchor CONFIRMING sweep on transition time, not `createdAt`.** The stuck-CONFIRMING sweep was using `client_draft.createdAt < now - 10min`, which allowed an in-flight `confirm()` on a draft created hours ago to be immediately eligible for revert — racing the live confirm and permitting duplicate client creation / duplicate update application. New nullable column `confirming_started_at` is set inside the PENDING → CONFIRMING `updateMany` and cleared on every exit; the sweep compares against this instead. Pre-migration CONFIRMING rows (`confirmingStartedAt IS NULL`) fall back to the old `createdAt` comparison so nothing is stranded.

Codex's third finding (queued phone-only recipient message goes stale on template edit) was reviewed and deemed correct as-is per product intent.

## Files

- `backend/interface/controllers/message-delivery.controller.ts` + spec — partial-success handling.
- `backend/prisma/migrations/20260621000000_add_client_draft_confirming_started_at/migration.sql` — additive, nullable column.
- `backend/prisma/schema.prisma` — `confirmingStartedAt` field.
- `backend/application/services/call-inbox.service.ts` — set on PENDING→CONFIRMING, clear on CONFIRMED / rollback to PENDING (both NEW_CLIENT and CLIENT_UPDATE flows).
- `backend/application/services/call-extraction-retry-scheduler.service.ts` + spec — sweep uses `confirmingStartedAt` with `createdAt` fallback for legacy rows.
- `backend/test/services/call-inbox.service.spec.ts` — updated rollback-shape expectations.

## Validation

Local:
- `npx prisma generate` — clean.
- `npx tsc --noEmit` — clean.
- `npx eslint <touched files>` — clean.
- `npx jest` — 120 suites / 1187 tests pass (8 skipped, same as baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)