### PR TITLE
fix(backend): PWA notification CTA points at admin.babyjamjam.com

### DIFF
--- a/backend/application/services/pwa-notification-scheduler.service.ts
+++ b/backend/application/services/pwa-notification-scheduler.service.ts
@@ -6,9 +6,21 @@ import { BRANCH_REPOSITORY, IBranchRepository } from "domain/repositories/branch
 
 const TARGET_ROLES = ['admin', 'manager', 'user'];
 const DAYS_THRESHOLD = 7;
-const NOTIFICATION_LOGIN_URL = "https://staff.babyjamjam.com/login";
+
+// Resolve the login URL from the same per-env vars auth.controller's resolveFrontendURL uses,
+// so the email CTA stays in sync with the deployed frontend domain. Fallback covers test/dev
+// runs where the env vars are not set; production picks up PRODUCTION_FRONTEND_URL.
+function resolveNotificationLoginUrl(): string {
+    const nodeEnv = process.env['NODE_ENV'];
+    const base = nodeEnv === "production" ? process.env['PRODUCTION_FRONTEND_URL']
+        : nodeEnv === "preview" ? process.env['PREVIEW_FRONTEND_URL']
+        : process.env['DEVELOPMENT_FRONTEND_URL'];
+    const normalized = (base ?? "https://admin.babyjamjam.com").trim().replace(/\/+$/, "");
+    return `${normalized}/login`;
+}
+
 const NOTIFICATION_EMAIL_CONTEXT = {
-    ctaUrl: NOTIFICATION_LOGIN_URL,
+    ctaUrl: resolveNotificationLoginUrl(),
     ctaLabel: "로그인해서 확인하기",
 };
 

--- a/backend/test/services/pwa-notification-scheduler.service.spec.ts
+++ b/backend/test/services/pwa-notification-scheduler.service.spec.ts
@@ -5,7 +5,7 @@ import { IClientRepository } from "domain/repositories/client.repository.interfa
 
 describe("PwaNotificationSchedulerService", () => {
     const emailTemplateContext = {
-        ctaUrl: "https://staff.babyjamjam.com/login",
+        ctaUrl: "https://admin.babyjamjam.com/login",
         ctaLabel: "로그인해서 확인하기",
     };
     const notificationService = {


### PR DESCRIPTION
The daily PWA summary emails (사용 시작/종료 예정, 계약서 미완료/미발송) were sending recipients to `https://staff.babyjamjam.com/login` — a pre-rebrand domain leftover that the `8cde44d` rebrand commit missed.

Resolved by reading the login base URL from the same per-env vars `auth.controller.resolveFrontendURL` uses (`PRODUCTION_FRONTEND_URL` / `PREVIEW_FRONTEND_URL` / `DEVELOPMENT_FRONTEND_URL`) with `https://admin.babyjamjam.com` as the fallback. Now the CTA stays in sync with whichever frontend is deployed.

Out of scope but related: the **Kakao OAuth** redirect to the old domain was a Railway env-var issue (`PRODUCTION_FRONTEND_URL` / `PRODUCTION_MOBILE_FRONTEND_URL` etc. on the backend still pointing at `staff.babyjamjam.com`), fixed directly on Railway.

## Files

- `backend/application/services/pwa-notification-scheduler.service.ts` — env-driven `resolveNotificationLoginUrl()`.
- `backend/test/services/pwa-notification-scheduler.service.spec.ts` — updated expected `ctaUrl`.

## Validation

- `npx tsc --noEmit` — clean.
- `npx jest test/services/pwa-notification-scheduler.service.spec.ts` — 1/1 passing.
