### PR TITLE
Promote dev to preview (PWA notification URL hotfix)

### DIFF
--- a/backend/application/services/pwa-notification-scheduler.service.ts
+++ b/backend/application/services/pwa-notification-scheduler.service.ts
@@ -6,9 +6,21 @@ import { BRANCH_REPOSITORY, IBranchRepository } from "domain/repositories/branch
 
 const TARGET_ROLES = ['admin', 'manager', 'user'];
 const DAYS_THRESHOLD = 7;
-const NOTIFICATION_LOGIN_URL = "https://staff.babyjamjam.com/login";
+
+// Resolve the login URL from the same per-env vars auth.controller's resolveFrontendURL uses,
+// so the email CTA stays in sync with the deployed frontend domain. Fallback covers test/dev
+// runs where the env vars are not set; production picks up PRODUCTION_FRONTEND_URL.
+function resolveNotificationLoginUrl(): string {
+    const nodeEnv = process.env['NODE_ENV'];
+    const base = nodeEnv === "production" ? process.env['PRODUCTION_FRONTEND_URL']
+        : nodeEnv === "preview" ? process.env['PREVIEW_FRONTEND_URL']
+        : process.env['DEVELOPMENT_FRONTEND_URL'];
+    const normalized = (base ?? "https://admin.babyjamjam.com").trim().replace(/\/+$/, "");
+    return `${normalized}/login`;
+}
+
 const NOTIFICATION_EMAIL_CONTEXT = {
-    ctaUrl: NOTIFICATION_LOGIN_URL,
+    ctaUrl: resolveNotificationLoginUrl(),
     ctaLabel: "로그인해서 확인하기",
 };
 

--- a/backend/test/services/pwa-notification-scheduler.service.spec.ts
+++ b/backend/test/services/pwa-notification-scheduler.service.spec.ts
@@ -5,7 +5,7 @@ import { IClientRepository } from "domain/repositories/client.repository.interfa
 
 describe("PwaNotificationSchedulerService", () => {
     const emailTemplateContext = {
-        ctaUrl: "https://staff.babyjamjam.com/login",
+        ctaUrl: "https://admin.babyjamjam.com/login",
         ctaLabel: "로그인해서 확인하기",
     };
     const notificationService = {


### PR DESCRIPTION
## Summary

Promotes the latest hotfix from `dev` to `preview`.

## Changes since the last promotion (#276)

- **#278** — `fix(backend): PWA notification CTA points at admin.babyjamjam.com`. The daily PWA summary emails (사용 시작/종료 예정, 계약서 미완료/미발송) were sending recipients to the pre-rebrand `staff.babyjamjam.com/login`. Resolved by reading the login URL from the same per-env vars `auth.controller.resolveFrontendURL` uses, with `https://admin.babyjamjam.com` as the fallback.

## Out of band

The Kakao OAuth redirect to `staff.babyjamjam.com` / `m.staff.babyjamjam.com` was a Railway env-var issue (`PRODUCTION_FRONTEND_URL` / `PREVIEW_FRONTEND_URL` and the `*_MOBILE_*` counterparts on the backend), fixed directly on Railway — no code changes for that part.

## Validation

Inherited from #278:
- `npx tsc --noEmit` — clean.
- `npx jest test/services/pwa-notification-scheduler.service.spec.ts` — 1/1 passing.
- Full PR #278 CI (backend, frontend, root, playwright e2e advisory, Railway, Vercel) — all green on the merged commit `3eaea9e`.
