### PR TITLE
fix(auth): inline 재전송 link on email-verification login error

### DIFF
--- a/frontend/src/features/auth/login/desktop/login-page-desktop.tsx
+++ b/frontend/src/features/auth/login/desktop/login-page-desktop.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import Link from "next/link";
-
 import { AuthInlineLink } from "@/components/auth/auth-inline-link";
 import { AuthPanel } from "@/components/auth/auth-panel";
 import { FormField } from "@/components/auth/form-field";
@@ -25,10 +23,12 @@ export function LoginPageDesktop() {
     serverError,
     isLoading,
     emailVerificationRequired,
+    isResendingVerification,
     setAutoLogin,
     setRememberId,
     handleChange,
     handleSubmit,
+    handleResendVerification,
     clearServerError,
   } = useLoginPageController();
 
@@ -56,12 +56,22 @@ export function LoginPageDesktop() {
             {serverError}
             {emailVerificationRequired ? (
               <div data-component="login-error-verify-email" className="mt-2">
-                <Link
-                  href="/verify-email"
-                  className="text-destructive underline hover:no-underline"
-                >
-                  인증 이메일 재발송
-                </Link>
+                {isResendingVerification ? (
+                  "재전송 중..."
+                ) : (
+                  <>
+                    이메일이 오지 않았다면{" "}
+                    <button
+                      type="button"
+                      data-component="login-resend-verification-link"
+                      onClick={handleResendVerification}
+                      className="text-destructive underline hover:no-underline"
+                    >
+                      재전송
+                    </button>
+                    을 눌러주세요.
+                  </>
+                )}
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
## What
On the **desktop** login screen, when login fails with "이메일 인증이 필요합니다. 이메일을 확인해주세요.", the error now shows a second line:

> 이메일이 오지 않았다면 **재전송**을 눌러주세요.

**재전송** is an inline link that resends the registration verification email in place (via the existing `handleResendVerification`), instead of the previous behavior that navigated to `/verify-email`. It shows "재전송 중..." while sending and reuses the existing alert for the result message.

## Why
The whole resend pipeline already existed — backend `POST /auth/resend-verification`, the `resendVerification` API client, the controller's `handleResendVerification`, and the **mobile** login already wired it inline. Desktop was the only surface still navigating away.

> Context: registration/verification emails were silently not being delivered on preview/dev because `RESEND_API_KEY` had been dropped from the Railway envs (a key rotation). That is fixed separately by restoring the key, so this resend flow now actually delivers.

## Scope
- **Desktop only** (`frontend/src/features/auth/login/desktop/login-page-desktop.tsx`). Mobile already does inline resend and was intentionally left unchanged.
- No backend changes.
- Removed the now-unused `next/link` import.

## Verification
- `tsc --noEmit` ✅
- `eslint` ✅ (no warnings)
- Live visual pending on preview: register an unverified email → log in → trigger this error → click **재전송** → confirm the email lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JERDA2DXRtaNW5AABgDFcY
