### PR TITLE
fix(auth): unhide 재전송 — set emailVerificationRequired on 403 login error

### DIFF
--- a/frontend/src/app/(auth)/login/actions.ts
+++ b/frontend/src/app/(auth)/login/actions.ts
@@ -135,9 +135,11 @@ export async function loginWithEmail(email: string, password: string, autoLogin 
                 return { success: false, error: "로그인 서버에 연결할 수 없습니다. 백엔드 서버를 확인해 주세요." };
             }
 
+            const apiMessage = axiosError.response?.data?.message;
             return {
                 success: false,
-                error: axiosError.response?.data?.message || "로그인에 실패했습니다."
+                error: apiMessage || "로그인에 실패했습니다.",
+                emailVerificationRequired: apiMessage?.includes("이메일 인증"),
             };
         }
 


### PR DESCRIPTION
What: Sets emailVerificationRequired in the login server action catch block so the email-verification error surfaces the resend UI.

Root cause: The backend returns the email-verification error as HTTP 403 (ForbiddenException, code EMAIL_NOT_VERIFIED). serverAPIClient uses validateStatus (s) => s < 400, so axios rejects on 403 and loginWithEmail lands in the catch block. That block returned the error message but never set emailVerificationRequired — only the bypassed try-block did. So the flag was always falsy and the gated block never rendered: neither the new 재전송 link (#280) nor the prior verify-email link.

Fix: Mirror the try-block detection in the catch block (set emailVerificationRequired from the response message). Touches frontend/src/app/(auth)/login/actions.ts only, +3/-1. No backend change. Completes #280.

Verification: tsc and eslint pass. Will verify on preview by logging in with an unverified account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JERDA2DXRtaNW5AABgDFcY