### PR TITLE
Promote dev to preview (fix: unhide 재전송 on email-verification login error)

### DIFF
--- a/frontend/src/app/(auth)/login/actions.ts
+++ b/frontend/src/app/(auth)/login/actions.ts
@@ -135,9 +135,11 @@ export async function loginWithEmail(email: string, password: string, autoLogin 
                 return { success: false, error: "로그인 서버에 연결할 수 없습니다. 백엔드 서버를 확인해 주세요." };
             }
 
+            const apiMessage = axiosError.response?.data?.message;
             return {
                 success: false,
-                error: axiosError.response?.data?.message || "로그인에 실패했습니다."
+                error: apiMessage || "로그인에 실패했습니다.",
+                emailVerificationRequired: apiMessage?.includes("이메일 인증"),
             };
         }
 


### PR DESCRIPTION
Promotes dev -> preview.

Scope (commits ahead of preview):
- #282 fix(auth): set emailVerificationRequired on the 403 login error so the 재전송 resend link actually renders. Completes #280 (the link existed but was gated off by a flag that was never set on the 403 path).

Single file: frontend/src/app/(auth)/login/actions.ts (+3/-1). All checks passed on #282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JERDA2DXRtaNW5AABgDFcY