### PR TITLE
feat(sidebar): upward account dropdown (지점 변경 / 로그아웃)

### DIFF
--- a/frontend/src/components/app/v3/SidebarAccountMenu.tsx
+++ b/frontend/src/components/app/v3/SidebarAccountMenu.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import React from "react";
+import { useRouter } from "next/navigation";
+import { Building2, ChevronUp, LogOut } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
+
+interface SidebarAccountMenuProps {
+  name: string;
+  roleLabel: string;
+  profileImage?: string | null;
+  initials: string;
+}
+
+const ITEM_BASE =
+  "flex w-full items-center gap-[calc(12px*var(--v3-ui-scale,1))] rounded-xl border border-transparent px-[calc(10px*var(--v3-ui-scale,1))] py-[calc(9px*var(--v3-ui-scale,1))] text-left transition-colors";
+const ICON_WRAP =
+  "flex h-[calc(36px*var(--v3-ui-scale,1))] w-[calc(36px*var(--v3-ui-scale,1))] shrink-0 items-center justify-center rounded-xl";
+const ICON_SIZE = "h-[calc(18px*var(--v3-ui-scale,1))] w-[calc(18px*var(--v3-ui-scale,1))]";
+const ITEM_LABEL =
+  "truncate text-[calc(13.6px*var(--v3-ui-scale,1))] font-semibold text-gray-900";
+const ITEM_SUB = "truncate text-[calc(11.2px*var(--v3-ui-scale,1))] text-v3-text-muted";
+
+/**
+ * Account menu in the sidebar footer. The profile card is the trigger; the menu
+ * (지점 변경 / 로그아웃) lives in the *same* container and expands upward —
+ * the footer sits in `mt-auto` of a flex column, so growing the container pushes
+ * the menu up into the freed nav space.
+ */
+export function SidebarAccountMenu({
+  name,
+  roleLabel,
+  profileImage,
+  initials,
+}: SidebarAccountMenuProps) {
+  const router = useRouter();
+  const [open, setOpen] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+
+    const handleOutside = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+
+    document.addEventListener("mousedown", handleOutside);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  const navigate = (href: string) => {
+    setOpen(false);
+    router.push(href);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      data-component="sidebar-account-menu"
+      data-state={open ? "open" : "closed"}
+      className={cn(
+        "flex flex-col gap-[calc(2px*var(--v3-ui-scale,1))] rounded-2xl border p-[calc(6px*var(--v3-ui-scale,1))] transition-all",
+        open
+          ? "border-v3-border bg-white shadow-v3-hover"
+          : "border-v3-border/50 bg-v3-dim-white/50"
+      )}
+    >
+      {/* Menu list — collapses upward via grid-rows 0fr→1fr */}
+      <div
+        role="menu"
+        aria-label="계정 메뉴"
+        aria-hidden={!open}
+        className={cn(
+          "grid transition-all duration-300 ease-out",
+          open ? "grid-rows-[1fr] opacity-100" : "pointer-events-none grid-rows-[0fr] opacity-0"
+        )}
+      >
+        <div className="flex min-h-0 flex-col gap-[calc(2px*var(--v3-ui-scale,1))] overflow-hidden">
+          <button
+            type="button"
+            role="menuitem"
+            tabIndex={open ? 0 : -1}
+            onClick={() => navigate("/select-branch")}
+            className={cn(ITEM_BASE, "hover:border-v3-border hover:bg-v3-dim-white")}
+          >
+            <span className={cn(ICON_WRAP, "bg-v3-primary-light text-v3-primary")}>
+              <Building2 className={ICON_SIZE} strokeWidth={2} />
+            </span>
+            <span className="flex min-w-0 flex-col">
+              <span className={ITEM_LABEL}>지점 변경</span>
+              <span className={ITEM_SUB}>다른 지점으로 전환</span>
+            </span>
+          </button>
+
+          <button
+            type="button"
+            role="menuitem"
+            tabIndex={open ? 0 : -1}
+            onClick={() => navigate("/logout")}
+            className={cn(ITEM_BASE, "group/logout hover:border-transparent hover:bg-v3-burgundy/10")}
+          >
+            <span className={cn(ICON_WRAP, "bg-v3-burgundy/10 text-v3-burgundy")}>
+              <LogOut className={ICON_SIZE} strokeWidth={2} />
+            </span>
+            <span className="flex min-w-0 flex-col">
+              <span className={cn(ITEM_LABEL, "group-hover/logout:text-v3-burgundy")}>로그아웃</span>
+              <span className={ITEM_SUB}>계정에서 나가기</span>
+            </span>
+          </button>
+
+          <div
+            aria-hidden="true"
+            className="mx-[calc(8px*var(--v3-ui-scale,1))] mb-[calc(3px*var(--v3-ui-scale,1))] mt-[calc(5px*var(--v3-ui-scale,1))] h-px bg-v3-border"
+          />
+        </div>
+      </div>
+
+      {/* Trigger — the profile card */}
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="group flex w-full cursor-pointer items-center gap-[calc(12px*var(--v3-ui-scale,1))] rounded-xl border border-transparent px-[calc(10px*var(--v3-ui-scale,1))] py-[calc(9px*var(--v3-ui-scale,1))] text-left transition-colors hover:bg-white"
+      >
+        <Avatar className="h-[calc(40px*var(--v3-ui-scale,1))] w-[calc(40px*var(--v3-ui-scale,1))] shrink-0 rounded-full shadow-inner">
+          <AvatarImage src={profileImage || ""} alt="" />
+          <AvatarFallback className="bg-gradient-to-br from-v3-primary to-blue-600 text-[calc(14px*var(--v3-ui-scale,1))] font-bold text-white">
+            {initials}
+          </AvatarFallback>
+        </Avatar>
+        <span className="flex min-w-0 flex-col">
+          <span className="truncate text-[calc(13.6px*var(--v3-ui-scale,1))] font-semibold text-gray-900 transition-colors group-hover:text-v3-primary">
+            {name}
+          </span>
+          <span className="truncate text-[calc(11.2px*var(--v3-ui-scale,1))] text-v3-text-muted">
+            {roleLabel}
+          </span>
+        </span>
+        <ChevronUp
+          className={cn(
+            "ml-auto shrink-0 transition-transform duration-300",
+            ICON_SIZE,
+            open ? "rotate-180 text-v3-primary" : "rotate-0 text-v3-text-muted"
+          )}
+          strokeWidth={2}
+        />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/app/v3/V3Sidebar.tsx
+++ b/frontend/src/components/app/v3/V3Sidebar.tsx
@@ -26,7 +26,7 @@ import { useLocale } from "@/providers/LocaleProvider";
 import { t } from "@/lib/i18n/translations";
 import { ROLES } from "@/lib/constants/roles";
 import { SidebarNotifications } from "@/components/app/v3/SidebarNotifications";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { SidebarAccountMenu } from "@/components/app/v3/SidebarAccountMenu";
 import { useConsultationInquiries } from "@/hooks/useConsultationInquiries";
 import { useV3UiScaleStyle } from "./useV3UiScale";
 
@@ -275,22 +275,16 @@ export const V3Sidebar = () => {
       </nav>
 
       <div className="mt-auto p-[calc(16px*var(--v3-ui-scale,1))]" data-component="sidebar-profile">
-        <div className="group flex cursor-pointer items-center gap-[calc(12px*var(--v3-ui-scale,1))] rounded-2xl border border-v3-border/50 bg-v3-dim-white/50 p-[calc(12px*var(--v3-ui-scale,1))] transition-all hover:bg-white hover:shadow-v3-hover">
-          <Avatar className="h-[calc(40px*var(--v3-ui-scale,1))] w-[calc(40px*var(--v3-ui-scale,1))] shrink-0 rounded-full shadow-inner">
-            <AvatarImage src={user?.profileImage || ""} alt={user?.name || "사용자"} />
-            <AvatarFallback className="bg-gradient-to-br from-v3-primary to-blue-600 text-[calc(14px*var(--v3-ui-scale,1))] font-bold text-white">
-              {initials}
-            </AvatarFallback>
-          </Avatar>
-          <div className="flex min-w-0 flex-col">
-            <span className="truncate text-[calc(13.6px*var(--v3-ui-scale,1))] font-semibold text-gray-900 transition-colors group-hover:text-v3-primary">
-              {user?.name || "GUEST"}
-            </span>
-            <span className="truncate text-[calc(11.2px*var(--v3-ui-scale,1))] text-v3-text-muted">
-              {user?.role ? t(locale, `roles.${user.role}`) || t(locale, "roles.unknown") : t(locale, "roles.unknown")}
-            </span>
-          </div>
-        </div>
+        <SidebarAccountMenu
+          name={user?.name || "GUEST"}
+          roleLabel={
+            user?.role
+              ? t(locale, `roles.${user.role}`) || t(locale, "roles.unknown")
+              : t(locale, "roles.unknown")
+          }
+          profileImage={user?.profileImage}
+          initials={initials}
+        />
       </div>
     </aside>
   );

--- a/frontend/src/components/app/v3/__tests__/SidebarAccountMenu.test.tsx
+++ b/frontend/src/components/app/v3/__tests__/SidebarAccountMenu.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SidebarAccountMenu } from "../SidebarAccountMenu";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const defaultProps = {
+  name: "송진호",
+  roleLabel: "오너",
+  profileImage: "",
+  initials: "송진",
+};
+
+function renderMenu(props: Partial<typeof defaultProps> = {}) {
+  return render(<SidebarAccountMenu {...defaultProps} {...props} />);
+}
+
+const getTrigger = () => screen.getByRole("button", { name: /송진호/ });
+
+beforeEach(() => {
+  mockPush.mockClear();
+});
+
+describe("SidebarAccountMenu", () => {
+  it("renders the profile trigger collapsed by default", () => {
+    renderMenu();
+    expect(getTrigger()).toHaveAttribute("aria-expanded", "false");
+    // Collapsed: menu items are hidden from the accessibility tree.
+    expect(screen.queryByRole("menuitem", { name: /로그아웃/ })).toBeNull();
+  });
+
+  it("opens the menu when the trigger is clicked", () => {
+    renderMenu();
+    fireEvent.click(getTrigger());
+    expect(getTrigger()).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("menuitem", { name: /지점 변경/ })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /로그아웃/ })).toBeInTheDocument();
+  });
+
+  it("toggles back to closed on a second trigger click", () => {
+    renderMenu();
+    fireEvent.click(getTrigger());
+    fireEvent.click(getTrigger());
+    expect(getTrigger()).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("navigates to /select-branch and closes when 지점 변경 is chosen", () => {
+    renderMenu();
+    fireEvent.click(getTrigger());
+    fireEvent.click(screen.getByRole("menuitem", { name: /지점 변경/ }));
+    expect(mockPush).toHaveBeenCalledWith("/select-branch");
+    expect(getTrigger()).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("navigates to /logout when 로그아웃 is chosen", () => {
+    renderMenu();
+    fireEvent.click(getTrigger());
+    fireEvent.click(screen.getByRole("menuitem", { name: /로그아웃/ }));
+    expect(mockPush).toHaveBeenCalledWith("/logout");
+  });
+
+  it("closes when Escape is pressed", () => {
+    renderMenu();
+    fireEvent.click(getTrigger());
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(getTrigger()).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("closes when clicking outside the component", () => {
+    renderMenu();
+    fireEvent.click(getTrigger());
+    fireEvent.mouseDown(document.body);
+    expect(getTrigger()).toHaveAttribute("aria-expanded", "false");
+  });
+});


### PR DESCRIPTION
## 요약

사이드바 하단의 정적 프로필 카드를 클릭 가능한 **계정 드롭다운**으로 교체했습니다. 카드를 클릭하면 **같은 컨테이너 안에서 메뉴가 위로 펼쳐지며** `지점 변경` / `로그아웃` 항목을 보여줍니다.

붙여주신 디자인을 HTML 목업으로 반복 합의한 뒤 실제 컴포넌트로 옮긴 작업입니다.

## 동작

- **트리거** = 기존 프로필 카드(아바타 + 이름 + 역할). 우측 chevron이 열림 시 180° 회전.
- **위로 펼침** — 풋터가 flex 컬럼의 `mt-auto`라 컨테이너가 커지면 자연스럽게 위(nav 공간)로 확장됩니다. 별도 absolute/portal 없이 한 컨테이너에 카드+메뉴가 함께 들어갑니다. (`grid-rows 0fr→1fr` 높이 애니메이션)
- **지점 변경** → `/select-branch` (기존 지점 선택 페이지로 이동, 오너는 다중 지점 보유)
- **로그아웃** → `/logout` (기존 로그아웃 라우트, 세션 정리 후 `/login`)
- Escape / 바깥 클릭으로 닫힘.

## 구현

- 신규 `frontend/src/components/app/v3/SidebarAccountMenu.tsx` (단일 컨테이너, 위로 펼침, 키보드/바깥클릭 닫힘)
- `V3Sidebar.tsx`는 인라인 카드 → `<SidebarAccountMenu />` 로 교체 (이제 미사용이 된 `Avatar` import 제거)
- Radix `DropdownMenu`는 portal 기반 floating 팝업이라 "카드+메뉴 단일 컨테이너 / 위로 펼침" 디자인과 맞지 않아 직접 구현.

## 검증

- `type-check` ✅ / `eslint` ✅ (0 error)
- 신규 단위 테스트 7개(열기/닫기 토글, 두 항목 네비게이션, Escape, 바깥 클릭) → 전체 **313 tests green**
- **실제 앱 시각 검증**(localhost:3000 + dev 백엔드, 인천점 로그인): 컨테이너가 위로 확장(top 687→597, bottom 740 고정), 메뉴가 카드 위에 위치, 단일 컨테이너가 둘을 모두 포함 — geometry로 확인.

## 비고

- `지점 변경`/`로그아웃` 라우팅은 기존 메커니즘 재사용(추정 아님 — 코드 확인). 항목 라벨/보조설명/순서는 목업 그대로이며 조정 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyEoxehgpHH9TrzDC7EVeJ