### PR TITLE
fix(auth): unstick Kakao callback spinner under React Strict Mode (local dev)

### DIFF
--- a/frontend/src/features/auth/callback/shared/__tests__/use-callback-page-controller.test.tsx
+++ b/frontend/src/features/auth/callback/shared/__tests__/use-callback-page-controller.test.tsx
@@ -1,0 +1,59 @@
+import { StrictMode } from "react";
+import { render, waitFor } from "@testing-library/react";
+
+import { useCallbackPageController } from "../use-callback-page-controller";
+
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+
+// Controlled per test so we can drive `searchParams.get("code" | "error")`.
+let searchParamValues: Record<string, string | null> = {};
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace, push: mockPush }),
+  useSearchParams: () => ({
+    get: (key: string) => (key in searchParamValues ? searchParamValues[key] : null),
+  }),
+}));
+
+const exchangeTokenMock = jest.fn();
+jest.mock("@/app/(auth)/callback/actions", () => ({
+  exchangeToken: (code: string) => exchangeTokenMock(code),
+}));
+
+// A probe so we can render the hook through `render(<StrictMode>...)`. Note:
+// `renderHook(..., { wrapper: <StrictMode> })` does NOT double-invoke the hook's
+// effect under React 19 — only `render()` inside a <StrictMode> element does,
+// which is the condition this regression depends on.
+function CallbackProbe() {
+  useCallbackPageController();
+  return null;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  searchParamValues = {};
+});
+
+describe("useCallbackPageController", () => {
+  // Regression guard for the dev-only stuck "로그인 중..." spinner. React Strict Mode
+  // runs the effect twice (setup -> cleanup -> setup). The fix must let the second
+  // (live) run navigate, and the single-use code must still be exchanged exactly
+  // once. Before the fix, a per-render ref guard made run #2 bail while run #1
+  // dropped its result as cancelled, so the page never left the spinner.
+  it("navigates to /dashboard under Strict Mode's double-invoked effect", async () => {
+    searchParamValues = { error: null, code: "kakao-auth-code" };
+    exchangeTokenMock.mockResolvedValue({ success: true, requiresBranchSelection: false });
+
+    render(
+      <StrictMode>
+        <CallbackProbe />
+      </StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+    });
+    expect(exchangeTokenMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/auth/callback/shared/use-callback-page-controller.ts
+++ b/frontend/src/features/auth/callback/shared/use-callback-page-controller.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import { AUTH_ROUTES } from "@/lib/auth/routes";
@@ -31,7 +31,6 @@ export function useCallbackPageController() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [error, setError] = useState<string | null>(null);
-  const handledCodeRef = useRef<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -53,13 +52,12 @@ export function useCallbackPageController() {
         return;
       }
 
-      if (handledCodeRef.current === code) {
-        return;
-      }
-
-      handledCodeRef.current = code;
-
       try {
+        // De-duping the single-use code is handled by exchangeTokenOnce's
+        // module-level cache. A per-render ref guard must NOT be added here: under
+        // React Strict Mode (dev) the effect runs twice, and a ref guard makes the
+        // second (live) run bail while the first (cancelled) run drops its result,
+        // leaving the page stuck on the loading spinner.
         const result = await exchangeTokenOnce(code);
 
         if (cancelled) {


### PR DESCRIPTION
## Problem

In **local dev**, after Kakao OAuth redirects back, the desktop callback page (`/callback`) hung forever on the "로그인 중..." spinner — never navigating, never showing an error.

## Root cause

Next.js App Router runs **React Strict Mode**, which double-invokes effects **in development only** (setup → cleanup → setup). In `use-callback-page-controller.ts`, the `handledCodeRef` guard made Strict Mode's **second (live)** effect run bail out immediately, while the **first** run — the one that actually started the token exchange — discarded its result because its cleanup had set `cancelled = true`. So neither run called `router.replace` nor `setError`. Production builds don't double-invoke effects, which is exactly why it only reproduced locally.

(Worth noting: the exchange *succeeded* server-side and set the session cookies before the stall — so while stuck on the spinner, the user was already half-logged-in.)

## Fix

Remove the `handledCodeRef` guard (and its now-orphaned `useRef` import). De-duping the single-use Kakao code is already handled by the module-level `exchangeTokenOnce` cache — strictly better than the ref (the `mobile/` callback has no such guard and never got stuck). Strict Mode's second run now awaits the same cached promise and navigates; the cancelled first run harmlessly drops its result; exactly **one** backend exchange happens.

## Test

Added `__tests__/use-callback-page-controller.test.tsx` — renders the hook under `<StrictMode>` and asserts navigation to `/dashboard` with exactly one exchange. Proven **RED on the old code** (`Number of calls: 0` = the stuck spinner) and **GREEN on the fix**.

> Note for future Strict Mode tests in this repo: `render(<StrictMode>…)` double-invokes effects, but `renderHook(fn, { wrapper: <StrictMode> })` does **not** under React 19 — using the latter silently produces a false green.

## Verification

- `type-check` ✅
- `lint` ✅ (0 errors)
- full frontend jest suite ✅ (56 suites / 307 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bd6cNBQGrMwHRLbNCVyt9p
