### PR TITLE
feat(parity): 영수증 다운로드(프론트) + 메시지 내역 상세 패널(모바일)

### DIFF
--- a/docs/superpowers/plans/2026-06-26-mobile-frontend-parity.md
+++ b/docs/superpowers/plans/2026-06-26-mobile-frontend-parity.md
@@ -1,0 +1,89 @@
+# Mobile ↔ Frontend Parity Implementation Plan
+
+> **For agentic workers:** implement task-by-task; each task ends with an independently testable deliverable.
+
+TL;DR: Give the desktop app mobile's one-tap contract-receipt download (port a small PDF-page-extraction route + a button), and give the mobile app the desktop's tappable message-history detail panel (the data already arrives — make rows open an in-place detail). No backend changes.
+
+**Goal:** Close the two accidental same-URL parity gaps — receipt download on `/contracts` (→ frontend) and the message-history detail panel on `/clients` (→ mobile).
+
+**Architecture:** Two independent tracks. The frontend track ports mobile's `download_files` BFF route (server-side `pdf-lib` page extraction) and surfaces a `영수증 다운로드` button. The mobile track widens one type so the already-fetched message data is exposed, then adds a tappable in-place detail panel reusing the existing `.nav-stack.show-detail` slide.
+
+**Tech stack:** Next.js App Router · TypeScript · React Query · pnpm workspace · pdf-lib · Tailwind (v3 + mobile-redesign design systems).
+
+## Global Constraints
+
+- Commands use path filters: `pnpm --filter ./frontend …` / `pnpm --filter ./mobile …` (old package names silently no-op).
+- Korean conventional commits; commit per task.
+- New DOM carries `data-component` annotations (`mobile-*` prefix on mobile).
+- Mobile type-check: `rm -rf mobile/.next` first if a stale `.next/types` TS2307 false error appears.
+- This session worktree has symlinked `node_modules` → it **cannot** run `next dev`/`build`; visual verification happens in the `dev` env worktree or a Vercel preview. `type-check`/`lint`/`test` run fine here.
+- **No backend changes** in this plan.
+
+---
+
+## Phase 1 — Receipt download → frontend (BJJ-242)
+
+Port mobile's receipt capability to the desktop contract preview so a completed contract can download its single-page receipt PDF.
+
+**In parallel:**
+
+- **1.1 Port the BFF page-extraction route + add pdf-lib** (infra, med)
+  - Add `"pdf-lib": "^1.17.1"` to `frontend/package.json`; run `pnpm install`.
+  - Create `frontend/src/app/api/eformsign/documents/[documentId]/download_files/route.ts` mirroring mobile's route: parse `fileType` + `page`, fetch the full PDF from backend `/api/documents/{id}/download_files` (copy the `serverAPIClient` + auth-header pattern from frontend's existing `preview/route.ts`), extract one page with `pdf-lib` when `page` is set.
+  - Done when: `GET /api/eformsign/documents/<id>/download_files?fileType=document&page=7` returns a 1-page PDF.
+  - Tier: heavy · Sandbox: network · Paths: `frontend/package.json`, `pnpm-lock.yaml`, `frontend/src/app/api/eformsign/documents/[documentId]/download_files/route.ts` · Depends: none
+- **1.2 Add `eformsignApi` URL builders** (feature, low)
+  - Add `getDocumentDownloadUrl` + `getDocumentReceiptDownloadUrl` (`…&page=7`) to `frontend/src/services/api.ts`.
+  - Tier: trivial · Sandbox: local · Paths: `frontend/src/services/api.ts` · Depends: none (runtime needs 1.1)
+- **1.3 Receipt button in the shared preview dialog** (feature, low)
+  - Add optional `receiptDownloadUrl?` / `receiptDownloadFileName?` props; render `영수증 다운로드` beside the existing `다운로드` (L638) when set, reusing `handleDownload`.
+  - Tier: standard · Sandbox: local · Paths: `frontend/src/components/app/documents/shared-document-preview-dialog.tsx` · Depends: none
+
+then ↓
+
+- **1.4 Wire the contract modal + completion gate** (feature, med)
+  - In `ContractDocumentPreviewModal.tsx`, build the receipt URL via `eformsignApi.getDocumentReceiptDownloadUrl(document.id)` and pass it + `receiptDownloadFileName` to the dialog **only when completed**; if the modal's `document` lacks a status field, lift the `category === "completed"` flag from `contracts/page.tsx` (modal invoked ~L1833).
+  - Tier: standard · Sandbox: local · Paths: `frontend/src/components/app/contracts/ContractDocumentPreviewModal.tsx`, `frontend/src/app/(protected)/contracts/page.tsx` · Depends: 1.2, 1.3
+
+## Phase 2 — Message-history panel → mobile (BJJ-241 / BJJ-243)
+
+Make mobile's `알림 발송` message rows tappable, opening an in-place detail panel — the data already arrives via `/alimtalk-logs`.
+
+- **2.1 Widen the notification-log type** (refactor, low)
+  - Add `messageBody`, `errorMessage`, `recipientName` to `ClientNotificationLogRecord` (`client-detail.tsx:411-421`). Because `fetchAllAlimtalkLogs<T>()` casts the raw record, the fields flow through with **no mapping change**.
+  - Tier: trivial · Sandbox: local · Paths: `mobile/src/components/app/clients/client-detail.tsx` · Depends: none
+
+then ↓
+
+- **2.2 Build the message-detail panel component** (feature, med)
+  - New `mobile/src/components/app/clients/client-message-history-detail.tsx` using `InfoCard`/`InfoRow`: `발송 정보` (수신자 / 연락처 / 템플릿 / 채널, + 실패 사유 if failed), status badge, `메시지 내용` (`messageBody`). `data-component="mobile-clients-message-history-detail-*"`.
+  - Tier: standard · Sandbox: local · Paths: `mobile/src/components/app/clients/client-message-history-detail.tsx` · Depends: 2.1
+
+then ↓
+
+- **2.3 Tappable rows + in-place drill-down** (feature, med)
+  - In the `알림 발송` tab, make `DetailDocRow` a `<button>` that sets `selectedNotificationLogId`; swap list → detail with a `← 목록으로` back action via the existing `.nav-stack.show-detail` slide (`redesign.css`, already used by `[data-component="clients"]`).
+  - Tier: standard · Sandbox: local · Paths: `mobile/src/components/app/clients/client-detail.tsx`, `mobile/src/components/app/mobile-redesign/redesign.css` · Depends: 2.1, 2.2
+
+## Phase 3 — Verify & integrate
+
+Prove both tracks green, then visually confirm in an environment that can actually build.
+
+**In parallel:**
+
+- **3.1 Frontend checks** (test, low) — `pnpm --filter ./frontend type-check`; unit tests for the route page-extraction (`page=7` → 1-page PDF; out-of-range → 400/`RangeError`) and the URL builder. Depends: Phase 1.
+- **3.2 Mobile checks** (test, low) — `rm -rf mobile/.next` then `pnpm --filter ./mobile type-check`. Depends: Phase 2.
+
+then ↓
+
+- **3.3 Visual verification** (test, med) — in the `dev` env worktree or a Vercel preview: completed contract → `영수증 다운로드` downloads a single-page receipt; mobile client → `알림 발송` → tap message → detail (recipient/phone/template/channel/content/status; failed shows 실패 사유) → `← 목록으로`. Depends: 3.1, 3.2.
+
+---
+
+## Parallelism summary
+
+Phase 1 (frontend) and Phase 2 (mobile) are fully independent (disjoint apps/files) → run as two concurrent tracks, each as its own unit worktree if dispatched in parallel. Phase 3 gates on both.
+
+## Out of scope (this plan)
+
+Web Share on desktop · retry-failed action on mobile · client-detail header quick-actions (메시지/계약서 발급) · DRY-refactoring the extraction route into `packages/shared` · any whole-app-section parity (tracked under BJJ-240).

--- a/docs/superpowers/specs/2026-06-26-mobile-frontend-parity-design.md
+++ b/docs/superpowers/specs/2026-06-26-mobile-frontend-parity-design.md
@@ -6,7 +6,7 @@
 
 ## Goal
 
-Close two accidental same-URL parity gaps between the **frontend** (desktop staff admin) and **mobile** (m.staff) apps. Both are **UI/client-only** changes — no backend work, and the data each needs already flows to the target app.
+Close two accidental same-URL parity gaps between the **frontend** (desktop staff admin) and **mobile** (m.staff) apps. **Neither needs backend changes.** Port 2 is mobile UI-only (data already flows to mobile). Port 1 is frontend UI **plus a new BFF route** (PDF page-extraction, ported from mobile) and the `pdf-lib` dependency.
 
 ## Non-goals
 
@@ -34,11 +34,17 @@ GET /api/eformsign/documents/{documentId}/download_files?fileType=document&page=
 
 ### Changes
 
-1. **`frontend/src/services/api.ts`** — add to `eformsignApi` (mirror mobile):
+> **Scope correction (found during planning):** frontend has **no** `/download_files` route — only `/preview` (which hardcodes `fileType` and cannot extract a page). The receipt page-extraction is a **BFF concern** (mobile does it with `pdf-lib`), so frontend must gain that route. Backend is still untouched — it returns the full PDF; the BFF extracts the page.
+
+1. **`frontend/package.json`** — add `"pdf-lib": "^1.17.1"` (matches mobile; not currently a frontend dep, not workspace-hoisted), then `pnpm install`.
+2. **Create `frontend/src/app/api/eformsign/documents/[documentId]/download_files/route.ts`** — port mobile's BFF route (`mobile/src/app/api/eformsign/documents/[documentId]/download_files/route.ts`): parse `fileType` + `page` query params, fetch the full PDF from backend `/api/documents/{id}/download_files` (mirror the `serverAPIClient` + auth-header pattern in frontend's existing `preview/route.ts`), and when `page` is set, extract that one page with `pdf-lib`'s `extractSinglePdfPage`.
+3. **`frontend/src/services/api.ts`** — add to `eformsignApi`:
    - `getDocumentDownloadUrl(documentId)` → `/api/eformsign/documents/${encodeURIComponent(documentId)}/download_files?fileType=document`
    - `getDocumentReceiptDownloadUrl(documentId)` → same `+ &page=7`
-2. **`frontend/src/components/app/documents/shared-document-preview-dialog.tsx`** — add optional props `receiptDownloadUrl?: string`, `receiptDownloadFileName?: string`; render a `영수증 다운로드` button beside the existing `다운로드` button (~L638) **only when `receiptDownloadUrl` is set**. Match existing button styling (`Download` icon).
-3. **`frontend/src/components/app/contracts/ContractDocumentPreviewModal.tsx`** — when the document is **completed**, pass `receiptDownloadUrl = eformsignApi.getDocumentReceiptDownloadUrl(document.id)` and `receiptDownloadFileName` = `"<document_name or id> 영수증.pdf"`. Otherwise omit (button hidden).
+4. **`frontend/src/components/app/documents/shared-document-preview-dialog.tsx`** — add optional props `receiptDownloadUrl?: string`, `receiptDownloadFileName?: string`; render a `영수증 다운로드` button beside the existing `다운로드` button (L638) **only when `receiptDownloadUrl` is set** (reuse the existing `handleDownload` link pattern; `Download` icon).
+5. **`frontend/src/components/app/contracts/ContractDocumentPreviewModal.tsx`** — build the receipt URL via `eformsignApi.getDocumentReceiptDownloadUrl(document.id)`, pass it + `receiptDownloadFileName` = `"<document_name or id> 영수증.pdf"` to the dialog **only when completed**. The modal's `document` prop may lack a status field; if so, lift the completion flag to the caller **`frontend/src/app/(protected)/contracts/page.tsx`** (`category === "completed"`, ~L1090) and pass it into the modal (invoked ~L1833).
+
+_DRY note: this duplicates mobile's extraction route. A later cleanup could move `extractSinglePdfPage` + the route into `packages/shared`; deferred here to keep the change parity-focused._
 
 ### Gating
 
@@ -46,9 +52,10 @@ Show the receipt button only when contract/document status is **completed** (mir
 
 ### Verification
 
-- Completed contract → open preview modal → `영수증 다운로드` visible → click downloads `<name> 영수증.pdf`.
+- Unit-test the new BFF route's page-extraction (`page=7` → single-page PDF; out-of-range page → 400/`RangeError`) and the `getDocumentReceiptDownloadUrl` builder.
+- Completed contract → open preview modal → `영수증 다운로드` visible → downloads `<name> 영수증.pdf` (single-page receipt).
 - Non-completed contract → receipt button absent.
-- Frontend `type-check` passes.
+- Frontend `type-check` passes; `pnpm install` resolves `pdf-lib`.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-26-mobile-frontend-parity-design.md
+++ b/docs/superpowers/specs/2026-06-26-mobile-frontend-parity-design.md
@@ -1,0 +1,101 @@
+# Mobile ↔ Frontend Parity — Receipt Download + Message-History Panel
+
+**Date:** 2026-06-26
+**Branch:** `mobile-frontend-parity` (off `dev`)
+**Linear:** [BJJ-240](https://linear.app/jaino-studio/issue/BJJ-240) (parent) · [BJJ-242](https://linear.app/jaino-studio/issue/BJJ-242) (receipt) · [BJJ-241](https://linear.app/jaino-studio/issue/BJJ-241)/[BJJ-243](https://linear.app/jaino-studio/issue/BJJ-243) (message panel)
+
+## Goal
+
+Close two accidental same-URL parity gaps between the **frontend** (desktop staff admin) and **mobile** (m.staff) apps. Both are **UI/client-only** changes — no backend work, and the data each needs already flows to the target app.
+
+## Non-goals
+
+- Not porting whole-app sections that are intentional platform splits (`stats`, `website-admin`, `calls`, `terms`/`privacy`, push settings, …) — tracked separately under BJJ-240.
+- Port 1: **no** Web Share on desktop (download-only — confirmed decision).
+- Port 2: **no** retry-failed action (deferred); **no** client-detail header quick-actions (메시지/계약서 발급) — that is a separate BJJ-241 sub-decision.
+
+---
+
+## Port 1 — Receipt download → frontend (BJJ-242)
+
+### Context
+
+Mobile lets users download the eformsign **receipt PDF** for a completed contract. Frontend only displays a `영수증 발행일` date field — no receipt file.
+
+Backend endpoint is shared and already live (auth via httpOnly cookie):
+
+```
+GET /api/eformsign/documents/{documentId}/download_files?fileType=document&page=7
+```
+
+`page=7` extracts the receipt page; the regular document download omits `&page=7`.
+
+**Reference impl (mobile):** `mobile/src/services/api.ts:334-336`; `mobile/src/app/contracts/page.tsx` (download button ~1336, gate ~1112, filename ~1121).
+
+### Changes
+
+1. **`frontend/src/services/api.ts`** — add to `eformsignApi` (mirror mobile):
+   - `getDocumentDownloadUrl(documentId)` → `/api/eformsign/documents/${encodeURIComponent(documentId)}/download_files?fileType=document`
+   - `getDocumentReceiptDownloadUrl(documentId)` → same `+ &page=7`
+2. **`frontend/src/components/app/documents/shared-document-preview-dialog.tsx`** — add optional props `receiptDownloadUrl?: string`, `receiptDownloadFileName?: string`; render a `영수증 다운로드` button beside the existing `다운로드` button (~L638) **only when `receiptDownloadUrl` is set**. Match existing button styling (`Download` icon).
+3. **`frontend/src/components/app/contracts/ContractDocumentPreviewModal.tsx`** — when the document is **completed**, pass `receiptDownloadUrl = eformsignApi.getDocumentReceiptDownloadUrl(document.id)` and `receiptDownloadFileName` = `"<document_name or id> 영수증.pdf"`. Otherwise omit (button hidden).
+
+### Gating
+
+Show the receipt button only when contract/document status is **completed** (mirror mobile's `category === "completed"`).
+
+### Verification
+
+- Completed contract → open preview modal → `영수증 다운로드` visible → click downloads `<name> 영수증.pdf`.
+- Non-completed contract → receipt button absent.
+- Frontend `type-check` passes.
+
+---
+
+## Port 2 — Message-history detail panel → mobile (BJJ-241 / BJJ-243)
+
+### Context
+
+Frontend's client detail has a **clickable** message-history list → in-panel slide-in `MessageHistoryDetailPanel` (수신자 / 연락처 / 템플릿 / 채널 / 내용 / 상태 / 실패 사유). Mobile renders the same `/alimtalk-logs` data as **static, non-clickable** `DetailDocRow` in the `알림 발송` tab — no detail view.
+
+Data is **shared**: `packages/shared/src/types/alimtalk.ts` `AlimtalkHistoryRecord` carries `messageBody` (L141), `errorMessage` (L145), `recipientName` (L158), `templateKey`, etc. Mobile already fetches the full record via `fetchAllAlimtalkLogs` (`mobile/src/lib/alimtalk/logs.ts`) but **narrows** it to `ClientNotificationLogRecord` (`mobile/src/components/app/clients/client-detail.tsx:411-421`), dropping `messageBody`/`errorMessage`/`recipientName`.
+
+**Reference impl (frontend):** `MessageHistoryDetailPanel.tsx` (props ~50-62, content ~388-424); `frontend/src/app/(protected)/clients/page.tsx` `ClientMessageHistoryList` (~165-292), `ClientMessageDetailSlide` (~294-355).
+
+### Changes
+
+1. **Data widen:**
+   - Extend `ClientNotificationLogRecord` (mobile `client-detail.tsx`) with `messageBody: string`, `errorMessage: string | null`, `recipientName: string | null` (plus channel/template label if not already derivable).
+   - Update the mapping where `notificationLogs` are built (mobile `clients/page.tsx`, from `AlimtalkHistoryRecord`) to carry these fields through.
+2. **New component `ClientMessageHistoryDetail`** (mobile-redesign idiom), built from existing `InfoCard` / `InfoRow` primitives (`mobile-redesign/detail-sheet.tsx`):
+   - `발송 정보` card: 수신자 (recipientName/receiver), 연락처, 템플릿, 채널, 실패 사유 (only if failed).
+   - status badge (sent/failed/pending) — reuse mobile badge tones.
+   - `메시지 내용` card: `messageBody` (`whitespace-pre-wrap`).
+   - `data-component` prefix `mobile-clients-message-history-detail`.
+3. **Interaction (in-place drill-down):**
+   - Make `알림 발송` rows tappable: `DetailDocRow` → a `<button>` with `onClick` that sets `selectedNotificationLogId`.
+   - When a log is selected, the `알림 발송` tab swaps **list → detail** with a `← 목록으로` back button, reusing the existing `.nav-stack.show-detail` slide pattern (`redesign.css` ~1275-1330). **No nested `MobileDetailSheet`.**
+   - State lives within `client-detail` (`selectedNotificationLogId`).
+
+### Scope boundary (YAGNI)
+
+- **Display-only** — no retry-failed action (frontend's panel has `canRetry`/`onRetry`; deferred).
+- Header quick-actions (메시지/계약서 발급) out of scope — separate BJJ-241 sub-decision.
+
+### Verification
+
+- Client detail → `알림 발송` → tap a message → detail shows recipient / phone / template / channel / content / status; failed shows `실패 사유`; `← 목록으로` returns to list.
+- Mobile `type-check` passes (`rm -rf mobile/.next` first if stale-`.next` TS2307 false error — known gotcha).
+- `data-component` annotations present in rendered DOM.
+
+---
+
+## Sequencing
+
+The two ports touch **disjoint apps** (`frontend/` vs `mobile/`) and disjoint files → fully independent. Implement as two commits on this branch (or two PRs). Recommended order: **Port 1 (smaller) first**, then Port 2.
+
+## Testing approach
+
+- **Unit tests** are cheap and worth it for: the Port 1 URL builders, and the Port 2 data-mapping widen. Use TDD there (RED → GREEN).
+- **UI panels:** rely on `type-check` + a visual check on the authenticated screen per the project's visual-verify approach.
+- **Worktree caveat:** this session worktree uses symlinked `node_modules`, which refuses `next dev`/`build` (per known gotcha) — so `type-check`/`lint`/`test` run here, but **visual verification must happen in the `dev` env worktree or a CI preview**, not in this worktree.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,7 @@
     "next": "16.1.6",
     "next-intl": "^4.4.0",
     "passport-jwt": "^4.0.1",
+    "pdf-lib": "^1.17.1",
     "radix-ui": "^1.4.3",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",

--- a/frontend/src/app/(protected)/contracts/page.tsx
+++ b/frontend/src/app/(protected)/contracts/page.tsx
@@ -1835,6 +1835,7 @@ function ContractDetail({
         onClose={() => setIsPreviewOpen(false)}
         document={detailedDocument}
         customerName={customerName}
+        canDownloadReceipt={category === "completed"}
       />
     </DetailPanel>
   );

--- a/frontend/src/app/api/eformsign/documents/[documentId]/download_files/__tests__/route.test.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/download_files/__tests__/route.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { PDFDocument } from "pdf-lib";
+
+import { serverAPIClient } from "@/lib/api/server";
+import { GET } from "../route";
+
+jest.mock("@/lib/api/server", () => ({
+  serverAPIClient: {
+    get: jest.fn(),
+  },
+}));
+
+const mockServerGet = serverAPIClient.get as jest.Mock;
+
+async function createPdf(pageCount: number): Promise<Uint8Array> {
+  const document = await PDFDocument.create();
+
+  for (let index = 0; index < pageCount; index += 1) {
+    document.addPage([300, 400]);
+  }
+
+  return document.save();
+}
+
+function createRequest(url: string): NextRequest {
+  return new NextRequest(url, {
+    headers: {
+      cookie: "auth_token=auth-token; eformsign_access_token=eformsign-token",
+    },
+  });
+}
+
+describe("eformsign document download_files route", () => {
+  beforeEach(() => {
+    mockServerGet.mockReset();
+  });
+
+  it("returns only the requested PDF page when page is provided (receipt = page 7)", async () => {
+    const sourcePdf = await createPdf(8);
+    mockServerGet.mockResolvedValue({
+      status: 200,
+      headers: { "content-type": "application/pdf" },
+      data: sourcePdf,
+    });
+
+    const response = await GET(
+      createRequest("http://localhost/api/eformsign/documents/doc-1/download_files?fileType=document&page=7"),
+      { params: Promise.resolve({ documentId: "doc-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Disposition")).toContain("attachment;");
+    expect(response.headers.get("Content-Disposition")).toContain("doc-1-document-page-7.pdf");
+
+    const outputPdf = await PDFDocument.load(await response.arrayBuffer());
+    expect(outputPdf.getPageCount()).toBe(1);
+  });
+
+  it("rejects page requests beyond the PDF page count", async () => {
+    const sourcePdf = await createPdf(2);
+    mockServerGet.mockResolvedValue({
+      status: 200,
+      headers: { "content-type": "application/pdf" },
+      data: sourcePdf,
+    });
+
+    const response = await GET(
+      createRequest("http://localhost/api/eformsign/documents/doc-1/download_files?fileType=document&page=7"),
+      { params: Promise.resolve({ documentId: "doc-1" }) },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Requested page 7 but PDF only has 2 pages.",
+    });
+  });
+});

--- a/frontend/src/app/api/eformsign/documents/[documentId]/download_files/route.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/download_files/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PDFDocument } from "pdf-lib";
+
+import { serverAPIClient } from "@/lib/api/server";
+import {
+  errorResponse,
+  getAccessToken,
+  getAuthHeaders,
+  getAuthToken,
+  unauthorizedResponse,
+} from "@/lib/api/route-utils";
+
+type EformsignFileType = "document" | "audit_trail";
+
+function normalizeFileType(value: string | null): EformsignFileType {
+  return value === "audit_trail" ? "audit_trail" : "document";
+}
+
+function safeFilenamePart(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 80) || "document";
+}
+
+function parsePageNumber(value: string | null): number | null {
+  if (!value) return null;
+
+  const pageNumber = Number(value);
+  if (!Number.isInteger(pageNumber) || pageNumber < 1) {
+    throw new RangeError("Requested page must be a positive integer.");
+  }
+
+  return pageNumber;
+}
+
+async function extractSinglePdfPage(sourcePdf: Uint8Array, pageNumber: number): Promise<Uint8Array> {
+  const sourceDocument = await PDFDocument.load(sourcePdf);
+  const sourcePageCount = sourceDocument.getPageCount();
+  const sourcePageIndex = pageNumber - 1;
+
+  if (sourcePageIndex >= sourcePageCount) {
+    throw new RangeError(`Requested page ${pageNumber} but PDF only has ${sourcePageCount} pages.`);
+  }
+
+  const receiptDocument = await PDFDocument.create();
+  const [receiptPage] = await receiptDocument.copyPages(sourceDocument, [sourcePageIndex]);
+  receiptDocument.addPage(receiptPage);
+
+  return receiptDocument.save();
+}
+
+/**
+ * Proxies the eformsign document PDF from the backend. With `?page=N`, extracts that single
+ * page (used for the receipt at `page=7`) — mirrors the mobile BFF route. Backend returns the
+ * full PDF; page extraction is a BFF concern.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ documentId: string }> },
+) {
+  const authToken = getAuthToken(request);
+  const accessToken = getAccessToken(request);
+
+  if (!authToken) {
+    return unauthorizedResponse("Authentication required. Please log in.");
+  }
+
+  if (!accessToken) {
+    return unauthorizedResponse("eFormsign access token required. Please authenticate with eFormsign first.");
+  }
+
+  const { documentId } = await params;
+  const { searchParams } = new URL(request.url);
+  const fileType = normalizeFileType(searchParams.get("fileType"));
+  const requestedPageParam = searchParams.get("page");
+
+  try {
+    const requestedPage = parsePageNumber(requestedPageParam);
+    const response = await serverAPIClient.get(
+      `/api/documents/${encodeURIComponent(documentId)}/download_files`,
+      {
+        params: { accessToken, fileType },
+        headers: getAuthHeaders(authToken),
+        responseType: "arraybuffer",
+      },
+    );
+
+    if (response.status >= 400) {
+      return NextResponse.json(
+        { error: `Failed to fetch eformsign document PDF (${response.status})` },
+        { status: response.status },
+      );
+    }
+
+    const contentType = String(response.headers["content-type"] || "application/pdf");
+    const responseBody =
+      response.data instanceof ArrayBuffer
+        ? new Uint8Array(response.data)
+        : new Uint8Array(response.data as ArrayLike<number>);
+    const outputBody = requestedPage
+      ? await extractSinglePdfPage(responseBody, requestedPage)
+      : responseBody;
+    const outputArrayBuffer = outputBody.buffer.slice(
+      outputBody.byteOffset,
+      outputBody.byteOffset + outputBody.byteLength,
+    ) as ArrayBuffer;
+    const dispositionType = requestedPage ? "attachment" : "inline";
+    const filenameSuffix = requestedPage ? `${fileType}-page-${requestedPage}` : fileType;
+
+    return new NextResponse(outputArrayBuffer, {
+      status: response.status,
+      headers: {
+        "Content-Type": requestedPage ? "application/pdf" : contentType,
+        "Content-Disposition": `${dispositionType}; filename="${safeFilenamePart(documentId)}-${filenameSuffix}.pdf"`,
+        "Cache-Control": "private, no-store",
+      },
+    });
+  } catch (error) {
+    if (error instanceof RangeError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    return errorResponse(error, "fetch eformsign document PDF");
+  }
+}

--- a/frontend/src/components/app/contracts/ContractDocumentPreviewModal.tsx
+++ b/frontend/src/components/app/contracts/ContractDocumentPreviewModal.tsx
@@ -6,12 +6,14 @@ import {
   SharedDocumentPreviewDialog,
   type PreviewMetaItem,
 } from "@/components/app/documents/shared-document-preview-dialog";
+import { eformsignApi } from "@/services/api";
 
 interface ContractDocumentPreviewModalProps {
   open: boolean;
   onClose: () => void;
   document: EformsignDocument | null;
   customerName?: string | null;
+  canDownloadReceipt?: boolean;
 }
 
 function formatDate(timestamp: number): string {
@@ -32,6 +34,7 @@ export function ContractDocumentPreviewModal({
   onClose,
   document,
   customerName,
+  canDownloadReceipt = false,
 }: ContractDocumentPreviewModalProps) {
   if (!document) {
     return null;
@@ -77,6 +80,10 @@ export function ContractDocumentPreviewModal({
       previewUrl={getPreviewUrl(document.id)}
       downloadUrl={getPreviewUrl(document.id, true)}
       downloadFileName={`${document.document_name || document.id}.pdf`}
+      receiptDownloadUrl={
+        canDownloadReceipt ? eformsignApi.getDocumentReceiptDownloadUrl(document.id) : undefined
+      }
+      receiptDownloadFileName={`${document.document_name || document.id} 영수증.pdf`}
       overlayLabel="PDF 미리보기"
       previewKey={document.id}
     />

--- a/frontend/src/components/app/documents/shared-document-preview-dialog.tsx
+++ b/frontend/src/components/app/documents/shared-document-preview-dialog.tsx
@@ -637,25 +637,38 @@ export function SharedDocumentPreviewDialog({
           className="justify-end border-t border-border px-6 py-4"
         >
           {!isHwp && (
-            <Button variant="ghost" onClick={handlePrint} disabled={isZoomablePreview && !isPreviewReady}>
+            <Button
+              variant="positive-outline"
+              size="sm"
+              onClick={handlePrint}
+              disabled={isZoomablePreview && !isPreviewReady}
+              className="min-w-[88px] border-v3-primary"
+            >
               <Printer className="mr-2 h-4 w-4" />
               인쇄
             </Button>
           )}
-          {downloadUrl && (
-            <Button onClick={handleDownload} disabled={isZoomablePreview && !isPreviewReady}>
-              <Download className="mr-2 h-4 w-4" />
-              다운로드
-            </Button>
-          )}
           {receiptDownloadUrl && (
             <Button
-              variant="outline"
+              variant="positive-outline"
+              size="sm"
               data-component="contracts-document-preview-receipt-download"
               onClick={() => triggerDownload(receiptDownloadUrl, receiptDownloadFileName)}
+              className="min-w-[88px] border-v3-primary"
             >
               <Download className="mr-2 h-4 w-4" />
-              영수증 다운로드
+              영수증
+            </Button>
+          )}
+          {downloadUrl && (
+            <Button
+              size="sm"
+              onClick={handleDownload}
+              disabled={isZoomablePreview && !isPreviewReady}
+              className="min-w-[88px] hover:translate-y-0 hover:shadow-[0_4px_24px_hsla(214,50%,20%,0.06)]"
+            >
+              <Download className="mr-2 h-4 w-4" />
+              다운로드
             </Button>
           )}
         </DialogFooter>

--- a/frontend/src/components/app/documents/shared-document-preview-dialog.tsx
+++ b/frontend/src/components/app/documents/shared-document-preview-dialog.tsx
@@ -32,6 +32,8 @@ interface SharedDocumentPreviewDialogProps {
   previewUrl: string;
   downloadUrl?: string;
   downloadFileName?: string;
+  receiptDownloadUrl?: string;
+  receiptDownloadFileName?: string;
   imageAlt?: string;
   overlayLabel?: string;
   unsupportedMessage?: ReactNode;
@@ -137,6 +139,8 @@ export function SharedDocumentPreviewDialog({
   previewUrl,
   downloadUrl,
   downloadFileName,
+  receiptDownloadUrl,
+  receiptDownloadFileName,
   imageAlt,
   overlayLabel,
   unsupportedMessage = "Preview not available for this file type",
@@ -419,20 +423,23 @@ export function SharedDocumentPreviewDialog({
     window.document.body.appendChild(iframe);
   };
 
-  const handleDownload = () => {
-    if (!downloadUrl) {
-      return;
-    }
-
+  const triggerDownload = (url: string, fileName?: string) => {
     const link = window.document.createElement("a");
-    link.href = downloadUrl;
-    if (downloadFileName) {
-      link.download = downloadFileName;
+    link.href = url;
+    if (fileName) {
+      link.download = fileName;
     }
     link.target = "_blank";
     window.document.body.appendChild(link);
     link.click();
     window.document.body.removeChild(link);
+  };
+
+  const handleDownload = () => {
+    if (!downloadUrl) {
+      return;
+    }
+    triggerDownload(downloadUrl, downloadFileName);
   };
 
   const renderPreviewAvailabilityMessage = () => {
@@ -639,6 +646,16 @@ export function SharedDocumentPreviewDialog({
             <Button onClick={handleDownload} disabled={isZoomablePreview && !isPreviewReady}>
               <Download className="mr-2 h-4 w-4" />
               다운로드
+            </Button>
+          )}
+          {receiptDownloadUrl && (
+            <Button
+              variant="outline"
+              data-component="contracts-document-preview-receipt-download"
+              onClick={() => triggerDownload(receiptDownloadUrl, receiptDownloadFileName)}
+            >
+              <Download className="mr-2 h-4 w-4" />
+              영수증 다운로드
             </Button>
           )}
         </DialogFooter>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full border-2 border-transparent text-sm font-semibold transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 btn-press",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full border-2 border-transparent text-sm font-semibold cursor-pointer transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 btn-press",
   {
     variants: {
       variant: {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -151,6 +151,12 @@ export const eformsignApi = {
         const { data } = await api.get(`/eformsign/documents/${documentId}`);
         return data;
     },
+    // Browser-navigable BFF URLs (full /api path, used as href/download — NOT via the axios client).
+    getDocumentDownloadUrl: (documentId: string): string =>
+        `/api/eformsign/documents/${encodeURIComponent(documentId)}/download_files?fileType=document`,
+    // Receipt = page 7 of the document PDF, extracted by the download_files BFF route.
+    getDocumentReceiptDownloadUrl: (documentId: string): string =>
+        `/api/eformsign/documents/${encodeURIComponent(documentId)}/download_files?fileType=document&page=7`,
     getLocalDocumentRecord: async (documentId: string) => {
         const { data } = await api.get(`/eformsign-docs/document-id`, {
             params: { documentId },

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -151,10 +151,8 @@ export const eformsignApi = {
         const { data } = await api.get(`/eformsign/documents/${documentId}`);
         return data;
     },
-    // Browser-navigable BFF URLs (full /api path, used as href/download — NOT via the axios client).
-    getDocumentDownloadUrl: (documentId: string): string =>
-        `/api/eformsign/documents/${encodeURIComponent(documentId)}/download_files?fileType=document`,
     // Receipt = page 7 of the document PDF, extracted by the download_files BFF route.
+    // Browser-navigable BFF URL (full /api path, used as href/download — NOT via the axios client).
     getDocumentReceiptDownloadUrl: (documentId: string): string =>
         `/api/eformsign/documents/${encodeURIComponent(documentId)}/download_files?fileType=document&page=7`,
     getLocalDocumentRecord: async (documentId: string) => {

--- a/mobile/src/components/app/clients/client-detail.tsx
+++ b/mobile/src/components/app/clients/client-detail.tsx
@@ -1099,7 +1099,7 @@ export function ClientDetailContent({
               statusLabel: notificationStatusLabel(selectedLog.status),
               statusTone: notificationStatusTone(selectedLog.status),
               sentAtLabel: formatNotificationTime(selectedLog.createdAt),
-              recipientName: selectedLog.recipientName?.trim() || "-",
+              recipientName: selectedLog.recipientName?.trim() || client.name,
               recipientPhone: selectedLog.receiver?.trim() || "-",
               messageBody: selectedLog.messageBody?.trim()
                 ? selectedLog.messageBody

--- a/mobile/src/components/app/clients/client-detail.tsx
+++ b/mobile/src/components/app/clients/client-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode } from "react";
+import { useState, type KeyboardEvent, type ReactNode } from "react";
 import { CircleAlert, FileCheck2, MessageCircle, MoreVertical, SquarePen, Trash2, User } from "lucide-react";
 
 import { Client } from "@/lib/client/types";
@@ -20,6 +20,7 @@ import {
   MobileDetailPage,
   MobileDetailTabPanel,
 } from "@/components/app/mobile-redesign/detail-sheet";
+import { ClientMessageHistoryDetail } from "@/components/app/clients/client-message-history-detail";
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -413,8 +414,11 @@ export interface ClientNotificationLogRecord {
   provider: string;
   templateKey: string;
   receiver: string | null;
+  recipientName: string | null;
   clientId: number | null;
   status: "pending" | "sent" | "failed" | string;
+  messageBody: string;
+  errorMessage: string | null;
   createdAt: string;
   ruleName: string | null;
   variables?: Record<string, unknown> | null;
@@ -430,15 +434,34 @@ function DetailDocRow({
   meta,
   badge,
   tone,
+  onClick,
 }: {
   icon: ReactNode;
   title: string;
   meta: ReactNode;
   badge: string;
   tone: DetailRowTone;
+  onClick?: () => void;
 }) {
+  const interactive = Boolean(onClick);
   return (
-    <div className="doc-row" data-component="mobile-clients-doc-row">
+    <div
+      className={interactive ? "doc-row doc-row-tappable" : "doc-row"}
+      data-component="mobile-clients-doc-row"
+      {...(interactive
+        ? {
+            role: "button" as const,
+            tabIndex: 0,
+            onClick,
+            onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onClick?.();
+              }
+            },
+          }
+        : {})}
+    >
       <div className={`doc-icon doc-icon-${tone}`} data-component="mobile-clients-doc-icon">
         {icon}
       </div>
@@ -568,6 +591,12 @@ export function ClientDetailContent({
   onEdit: (client: Client) => void;
   onDelete: (id: number) => void;
 }) {
+  // Keyed selection so the open message-detail auto-resets when the tab or client changes
+  // (derive-during-render — avoids a setState-in-effect).
+  const detailKey = `${activeTab}:${client.id}`;
+  const [selectedEntry, setSelectedEntry] = useState<{ key: string; log: ClientNotificationLogRecord } | null>(null);
+  const selectedLog = selectedEntry && selectedEntry.key === detailKey ? selectedEntry.log : null;
+
   const group = GROUPS.find((g) => g.match(client)) ?? GROUPS[1];
   const featureLabel = clientFeatureLabel(client);
   const featureLabelTone = clientFeatureLabelTone(client);
@@ -1062,38 +1091,60 @@ export function ClientDetailContent({
       </MobileDetailTabPanel>
 
       <MobileDetailTabPanel name="clients" tabId="alimtalk" activeTab={activeTab}>
-        <InfoCard title="발송 내역">
-          {isNotificationLogsLoading ? (
-            <div className="detail-empty-state" data-component="mobile-clients-alimtalk-loading">
-              발송 내역을 불러오는 중입니다.
-            </div>
-          ) : displayNotificationLogs.length > 0 ? (
-            displayNotificationLogs.map((log) => {
-              const tone = notificationStatusTone(log.status);
-              const channel = notificationChannelLabel(log);
-              return (
-                <DetailDocRow
-                  key={`${channel}-${log.id}`}
-                  icon={
-                    tone === "burgundy" ? (
-                      <CircleAlert size={16} strokeWidth={2.5} />
-                    ) : (
-                      <MessageCircle size={16} strokeWidth={2.5} />
-                    )
-                  }
-                  title={`${channel} · ${notificationTitle(log)}`}
-                  meta={formatNotificationTime(log.createdAt)}
-                  badge={notificationStatusLabel(log.status)}
-                  tone={tone}
-                />
-              );
-            })
-          ) : (
-            <div className="detail-empty-state" data-component="mobile-clients-alimtalk-empty">
-              발송 내역이 없습니다.
-            </div>
-          )}
-        </InfoCard>
+        {selectedLog ? (
+          <ClientMessageHistoryDetail
+            view={{
+              title: notificationTitle(selectedLog),
+              channelLabel: notificationChannelLabel(selectedLog),
+              statusLabel: notificationStatusLabel(selectedLog.status),
+              statusTone: notificationStatusTone(selectedLog.status),
+              sentAtLabel: formatNotificationTime(selectedLog.createdAt),
+              recipientName: selectedLog.recipientName?.trim() || "-",
+              recipientPhone: selectedLog.receiver?.trim() || "-",
+              messageBody: selectedLog.messageBody?.trim()
+                ? selectedLog.messageBody
+                : "내용이 없습니다.",
+              failureReason: selectedLog.errorMessage?.trim()
+                ? selectedLog.errorMessage
+                : null,
+            }}
+            onBack={() => setSelectedEntry(null)}
+          />
+        ) : (
+          <InfoCard title="발송 내역">
+            {isNotificationLogsLoading ? (
+              <div className="detail-empty-state" data-component="mobile-clients-alimtalk-loading">
+                발송 내역을 불러오는 중입니다.
+              </div>
+            ) : displayNotificationLogs.length > 0 ? (
+              displayNotificationLogs.map((log) => {
+                const tone = notificationStatusTone(log.status);
+                const channel = notificationChannelLabel(log);
+                return (
+                  <DetailDocRow
+                    key={`${channel}-${log.id}`}
+                    icon={
+                      tone === "burgundy" ? (
+                        <CircleAlert size={16} strokeWidth={2.5} />
+                      ) : (
+                        <MessageCircle size={16} strokeWidth={2.5} />
+                      )
+                    }
+                    title={`${channel} · ${notificationTitle(log)}`}
+                    meta={formatNotificationTime(log.createdAt)}
+                    badge={notificationStatusLabel(log.status)}
+                    tone={tone}
+                    onClick={() => setSelectedEntry({ key: detailKey, log })}
+                  />
+                );
+              })
+            ) : (
+              <div className="detail-empty-state" data-component="mobile-clients-alimtalk-empty">
+                발송 내역이 없습니다.
+              </div>
+            )}
+          </InfoCard>
+        )}
       </MobileDetailTabPanel>
     </MobileDetailPage>
   );

--- a/mobile/src/components/app/clients/client-message-history-detail.tsx
+++ b/mobile/src/components/app/clients/client-message-history-detail.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { ChevronLeft, CircleAlert, MessageCircle } from "lucide-react";
+
+import { InfoCard, InfoRow } from "@/components/app/mobile-redesign/detail-sheet";
+
+export type MessageHistoryDetailTone =
+  | "green"
+  | "primary"
+  | "orange"
+  | "muted"
+  | "burgundy"
+  | "purple";
+
+export interface ClientMessageHistoryDetailView {
+  title: string;
+  channelLabel: string;
+  statusLabel: string;
+  statusTone: MessageHistoryDetailTone;
+  sentAtLabel: string;
+  recipientName: string;
+  recipientPhone: string;
+  messageBody: string;
+  failureReason: string | null;
+}
+
+/**
+ * Read-only detail view for a single client message-history (alimtalk-log) entry.
+ * Presentational only — the caller resolves the display fields from the log record.
+ * Mirrors the frontend MessageHistoryDetailPanel using mobile-redesign primitives.
+ */
+export function ClientMessageHistoryDetail({
+  view,
+  onBack,
+}: {
+  view: ClientMessageHistoryDetailView;
+  onBack: () => void;
+}) {
+  const isFailed = view.statusTone === "burgundy";
+
+  return (
+    <div className="message-detail pop-up" data-component="mobile-clients-message-history-detail">
+      <button
+        type="button"
+        className="message-detail-back"
+        data-component="mobile-clients-message-history-detail-back"
+        onClick={onBack}
+      >
+        <ChevronLeft size={16} strokeWidth={2.5} />
+        목록으로
+      </button>
+
+      <div className="message-detail-head" data-component="mobile-clients-message-history-detail-head">
+        <div
+          className={`doc-icon doc-icon-${view.statusTone}`}
+          data-component="mobile-clients-message-history-detail-icon"
+        >
+          {isFailed ? (
+            <CircleAlert size={16} strokeWidth={2.5} />
+          ) : (
+            <MessageCircle size={16} strokeWidth={2.5} />
+          )}
+        </div>
+        <div
+          className="message-detail-head-text"
+          data-component="mobile-clients-message-history-detail-head-text"
+        >
+          <div className="message-detail-title" data-component="mobile-clients-message-history-detail-title">
+            {view.title}
+          </div>
+          <div
+            className="message-detail-subtitle"
+            data-component="mobile-clients-message-history-detail-subtitle"
+          >
+            {view.channelLabel} · {view.sentAtLabel}
+          </div>
+        </div>
+        <span
+          className={`badge-mini ${view.statusTone}`}
+          data-component="mobile-clients-message-history-detail-status"
+        >
+          {view.statusLabel}
+        </span>
+      </div>
+
+      <InfoCard title="발송 정보">
+        <InfoRow label="수신자" value={view.recipientName} />
+        <InfoRow label="연락처" value={view.recipientPhone} />
+        <InfoRow label="템플릿" value={view.title} />
+        <InfoRow label="채널" value={view.channelLabel} />
+        {view.failureReason ? (
+          <InfoRow label="실패 사유" value={view.failureReason} tone="burgundy" />
+        ) : null}
+      </InfoCard>
+
+      <InfoCard title="메시지 내용">
+        <p
+          className="message-detail-body"
+          data-component="mobile-clients-message-history-detail-body"
+        >
+          {view.messageBody}
+        </p>
+      </InfoCard>
+    </div>
+  );
+}

--- a/mobile/src/components/app/mobile-redesign/redesign.css
+++ b/mobile/src/components/app/mobile-redesign/redesign.css
@@ -1890,6 +1890,70 @@ body.mobile-all-route .menu-row {
   word-break: break-all;
 }
 
+/* ===== Tappable notification rows + message-history detail (in-place drill-down) ===== */
+.doc-row-tappable {
+  cursor: pointer;
+}
+.doc-row-tappable:hover .doc-title {
+  color: hsl(var(--v3-primary));
+}
+.doc-row-tappable:focus-visible {
+  outline: 2px solid hsl(var(--v3-primary));
+  outline-offset: 2px;
+  border-radius: 8px;
+}
+.message-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.message-detail-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  align-self: flex-start;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: hsl(var(--v3-text-muted));
+  transition: color var(--duration-pop) var(--ease-standard);
+}
+.message-detail-back:hover {
+  color: hsl(var(--v3-primary));
+}
+.message-detail-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.message-detail-head-text {
+  flex: 1;
+  min-width: 0;
+}
+.message-detail-title {
+  font-size: 0.9rem;
+  font-weight: 800;
+  color: hsl(var(--v3-dark));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.message-detail-subtitle {
+  font-size: 0.68rem;
+  color: hsl(var(--v3-text-muted));
+  margin-top: 2px;
+}
+.message-detail-body {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  color: hsl(var(--v3-dark));
+}
+
 /* ===== Files page — page-files.html fidelity overrides ===== */
 [data-component="files"] {
   position: fixed;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,10 +259,13 @@ importers:
         version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-intl:
         specifier: ^4.4.0
-        version: 4.8.3(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        version: 4.8.3(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       passport-jwt:
         specifier: ^4.0.1
         version: 4.0.1
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -446,7 +449,7 @@ importers:
         version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-intl:
         specifier: ^4.4.0
-        version: 4.8.3(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        version: 4.8.3(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       pdf-lib:
         specifier: ^1.17.1
         version: 1.17.1
@@ -11354,8 +11357,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -11377,7 +11380,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11388,21 +11391,21 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11413,7 +11416,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13812,7 +13815,7 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.8.3: {}
 
-  next-intl@4.8.3(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+  next-intl@4.8.3(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@parcel/watcher': 2.5.6


### PR DESCRIPTION
## 요약
모바일↔프론트 same-URL 패리티 갭 2개 해소 (BJJ-240 → BJJ-241/242/243). **백엔드 변경 없음.**

- **프론트 `/contracts` — 영수증 다운로드** (BJJ-242): 완료 계약서 미리보기 모달에 `영수증` 버튼 추가. 모바일과 동일하게 `download_files` BFF 라우트(pdf-lib로 `page=7` 추출)를 포팅하고 `eformsignApi` URL 빌더 추가. 프론트엔 기존에 `/download_files` 라우트가 없어 새로 만듦(`/preview`만 있었음).
- **모바일 `/clients` — 메시지 내역 상세 패널** (BJJ-241/243): 고객 상세 `알림 발송` 탭의 발송 내역 행을 탭하면 수신자/연락처/템플릿/채널/메시지 내용/상태(실패 시 사유)를 보여주는 in-place 상세로 진입(`← 목록으로`). 데이터는 기존 `/alimtalk-logs` 그대로 사용하고 `ClientNotificationLogRecord` 타입만 확장.
- **UI 폴리시**: 미리보기 푸터 버튼 정리(`영수증` 텍스트, `인쇄`·`영수증` primary 보더+텍스트, 너비 `sm`/`min-w-[88px]` 통일, `다운로드` hover lift 제거) + 전역 버튼 `cursor-pointer`(Tailwind v4가 제거한 버튼 기본 포인터 커서 복구).

## 검증
- type-check: frontend ✓ / mobile ✓
- tests: **frontend 328/328**(신규 `download_files` 라우트 테스트 포함) / **mobile 647/647** — 공유 컴포넌트 회귀 없음
- lint: 신규 코드 클린
- Opus diff 리뷰: blocker 없음 (수신자 이름 폴백·미사용 빌더 정리 반영 완료)

## 범위 밖(의도적)
Web Share(데스크톱) · 실패 재발송 · 고객상세 헤더 퀵액션 · 추출 라우트의 `packages/shared` DRY화 · 전체 섹션 패리티(BJJ-240에서 별도 트리아지).

## Linear
BJJ-241, BJJ-242, BJJ-243 (parent BJJ-240)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5zctDTCeNDKxo6EA2aAus
