### PR TITLE
fix(feedback): 무로그인 /feedback가 인증 앱셸에 갇혀 /login으로 튕기던 버그 (BJJ-247)

### DIFF
--- a/mobile/src/lib/auth/routes.ts
+++ b/mobile/src/lib/auth/routes.ts
@@ -16,6 +16,11 @@ export function isPublicAuthPath(pathname: string | null | undefined): boolean {
   if (!pathname) return false;
   // Normalize trailing slash
   const normalized = pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+  // No-login 제공기록지 capture (BJJ-247): the dynamic /feedback/[token] route is a public,
+  // shell-free page opened from an SMS link with no auth cookie. Treating it as a public path
+  // keeps the authenticated app shell and the 401 → /login redirect (lib/api/client.ts) from
+  // hijacking it — same "skip auth shell / no login redirect" treatment the auth pages get.
+  if (normalized === "/feedback" || normalized.startsWith("/feedback/")) return true;
   return PUBLIC_AUTH_PATHS.has(normalized);
 }
 


### PR DESCRIPTION
## 요약

머지된 제공기록지 기능(#292)의 **무로그인 `/feedback/[token]` 페이지가 실제로는 열리지 않는 버그**를 Playwright 실검증 중 발견·수정. (BJJ-247 후속)

## 버그

- 루트 `app/layout.tsx`가 **모든 라우트**에 인증 앱셸(`V3Sidebar`/`V3MobileHeader`/`MobileBottomNav`/`NotificationPermissionPrompt`)을 렌더.
- `/feedback`는 인증 쿠키 없이 접근 → 셸 컴포넌트들이 authed API(`/api/client-drafts/count`, `/api/notifications/vapid-key`, `/api/auth/refresh`) 호출 → **401**.
- `lib/api/client.ts`의 인터셉터가 refresh 실패 시 `window.location.href = '/login'`로 **하드 리다이렉트**.
- 미들웨어는 `/feedback`를 public으로 통과시키지만(server-side) **client-side 셸·리다이렉트는 예외가 없어**, 제공인력이 SMS 링크를 열면 폼 대신 로그인 화면으로 튕김.

## 수정 (1줄, 중앙 함수)

`lib/auth/routes.ts`의 `isPublicAuthPath`에 `/feedback` prefix 추가. 이 함수를 이미 네 소비처가 공유하므로 한 곳 수정이 전부에 전파:
| 소비처 | 효과 |
|---|---|
| `lib/api/client.ts` | 401→/login 리다이렉트 예외 |
| `isLayoutExcluded` (`v3-layout`) | 헤더·바텀네비·알림프롬프트 숨김 |
| `useGetAuthUser` | 비로그인 페이지에서 auth fetch 스킵 |
| `conditional-header` | 헤더 숨김 |

## 검증 (Playwright, 로컬 실백엔드 + Postgres)

throwaway worktree(origin/dev) + 로컬 NestJS + 로컬 Postgres에 토큰/스케줄 시드 후 브라우저 전 구간 확인:
1. 링크 유효 → 생년월일 게이트 렌더(셸 없음)
2. `900101` 인증 → 액세스토큰 발급 → 컨텍스트 로드(제공인력 프리필, 총 10회차)
3. 서비스 헤더 저장(DB `service_record`)
4. 회차 오버뷰(순차 게이팅: 1회차만 활성)
5. 산모(①~⑤)/신생아(⑥~⑪)/마무리(기타·특이·결제확인·산모서명) 3그룹 페이지
6. 제출·잠금 → `service_record_day` locked=true·payment=true·서명 기록, 2회차 활성화

## 왜 #292 CI가 못 잡았나

client-side 앱셸 리다이렉트라 `tsc`/jest/미들웨어 유닛테스트로는 안 드러나고 **실제 브라우저 렌더에서만** 발생. e2e도 이 라우트를 돌지 않았음. → 후속으로 `/feedback` 무로그인 접근 회귀 테스트 추가 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PYQv9kETVu4bArbDjT788
