### PR TITLE
fix(mobile): show Kakao OAuth callback errors

### DIFF
--- a/mobile/src/app/(shell)/(auth)/callback/page.test.tsx
+++ b/mobile/src/app/(shell)/(auth)/callback/page.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import AuthCallbackPage from "./page";
+import { exchangeToken } from "./actions";
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+jest.mock("./actions", () => ({
+  exchangeToken: jest.fn(),
+}));
+
+const mockExchangeToken = jest.mocked(exchangeToken);
+
+describe("AuthCallbackPage", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockReplace.mockReset();
+    mockExchangeToken.mockReset();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it("shows the backend OAuth error instead of reporting a missing authorization code", async () => {
+    mockSearchParams = new URLSearchParams({
+      error: "접근 가능한 지점이 없습니다. 관리자에게 문의해 주세요.",
+    });
+
+    render(<AuthCallbackPage />);
+
+    expect(
+      await screen.findByText("접근 가능한 지점이 없습니다. 관리자에게 문의해 주세요."),
+    ).toBeInTheDocument();
+    await waitFor(() => expect(mockExchangeToken).not.toHaveBeenCalled());
+  });
+
+  it("exchanges a valid authorization code and continues to the dashboard", async () => {
+    mockSearchParams = new URLSearchParams({ code: "one-time-code" });
+    mockExchangeToken.mockResolvedValue({ success: true });
+
+    render(<AuthCallbackPage />);
+
+    await waitFor(() => expect(mockExchangeToken).toHaveBeenCalledWith("one-time-code"));
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/dashboard"));
+  });
+});

--- a/mobile/src/app/(shell)/(auth)/callback/page.tsx
+++ b/mobile/src/app/(shell)/(auth)/callback/page.tsx
@@ -12,10 +12,17 @@ export default function AuthCallbackPage() {
 
     useEffect(() => {
         const exchangeCodeForTokens = async () => {
+            const oauthError = searchParams.get("error");
             const code = searchParams.get("code");
 
             console.log("[Auth Callback] Starting token exchange");
             console.log("[Auth Callback] Code present:", !!code);
+
+            if (oauthError) {
+                console.error("[Auth Callback] OAuth provider returned an error");
+                setError(oauthError);
+                return;
+            }
 
             if (!code) {
                 console.error("[Auth Callback] No code in URL");


### PR DESCRIPTION
## Summary
- display backend/provider OAuth errors before validating the authorization code
- avoid replacing real Kakao login failures with `Authorization Code Required`
- cover both the OAuth error and successful code exchange paths

## Verification
- `pnpm --dir mobile exec jest --runInBand --runTestsByPath "src/app/(shell)/(auth)/callback/page.test.tsx"`
- `pnpm --dir mobile test` (105 suites, 679 tests)
- `pnpm --dir mobile type-check`
- `pnpm --dir mobile lint` (0 errors; existing warnings only)
- `NEXT_PUBLIC_API_BASE_URL=https://api.babyjamjam.com pnpm --dir mobile build`