### PR TITLE
[fix] Add safe legacy demo mode

### DIFF
--- a/frontend/src/app/lib/auth/cookies.ts
+++ b/frontend/src/app/lib/auth/cookies.ts
@@ -1,11 +1,23 @@
-import { serverAPIClient } from "@/app/lib/axios/server";
+import axios from "axios";
 import { cookies } from "next/headers";
 import { cache } from "react";
+
+import type { AuthUser } from "@/app/hooks/useGetAuthUser";
+import { serverAPIClient } from "@/app/lib/axios/server";
+
+const LEGACY_DEMO_USER: AuthUser = {
+  id: "legacy-demo",
+  name: "Legacy Demo",
+};
 
 // React cache()를 사용하여 같은 request cycle 내에서 중복 호출 방지
 // Next.js의 Request Memoization은 native fetch에만 적용되므로
 // axios를 사용하는 경우 수동으로 캐싱 필요
-export const getCurrentUser = cache(async () => {
+export const getCurrentUser = cache(async (): Promise<AuthUser | null> => {
+  if (process.env.LEGACY_DEMO_MODE === "true") {
+    return LEGACY_DEMO_USER;
+  }
+
   try {
     const cookieStore = await cookies();
     const authToken = cookieStore.get('auth_token');
@@ -26,10 +38,16 @@ export const getCurrentUser = cache(async () => {
 
     console.log("[getCurrentUser] User fetched successfully:", data?.name);
     return data;
-  } catch (error: any) {
-    console.error('[getCurrentUser] Failed to fetch user:', error.message);
-    console.error('[getCurrentUser] Error status:', error.response?.status);
-    console.error('[getCurrentUser] Error data:', error.response?.data);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+
+    console.error('[getCurrentUser] Failed to fetch user:', message);
+
+    if (axios.isAxiosError(error)) {
+      console.error('[getCurrentUser] Error status:', error.response?.status);
+      console.error('[getCurrentUser] Error data:', error.response?.data);
+    }
+
     return null;
   }
 });

--- a/frontend/src/app/lib/axios/server.ts
+++ b/frontend/src/app/lib/axios/server.ts
@@ -16,3 +16,11 @@ export const serverAPIClient = axios.create({
     timeout: 60000, // 60 seconds - Railway apps can take time to wake up
     validateStatus: (status) => status < 600, // Accept any status code for better error visibility
 });
+
+serverAPIClient.interceptors.request.use((config) => {
+    if (process.env.LEGACY_DEMO_MODE === "true") {
+        return Promise.reject(new Error("Backend access is disabled in legacy demo mode."));
+    }
+
+    return config;
+});

--- a/frontend/src/app/login/layout.tsx
+++ b/frontend/src/app/login/layout.tsx
@@ -1,0 +1,14 @@
+import { redirect } from "next/navigation";
+import type { ReactNode } from "react";
+
+interface LoginLayoutProps {
+  children: ReactNode;
+}
+
+export default function LoginLayout({ children }: LoginLayoutProps) {
+  if (process.env.LEGACY_DEMO_MODE === "true") {
+    redirect("/dashboard");
+  }
+
+  return children;
+}

--- a/frontend/tests/legacy-demo-mode.spec.ts
+++ b/frontend/tests/legacy-demo-mode.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("legacy demo mode", () => {
+  test.skip(
+    process.env.LEGACY_DEMO_MODE !== "true",
+    "LEGACY_DEMO_MODE must be enabled for this focused suite.",
+  );
+
+  test("redirects the login page to the dashboard without authentication", async ({ page }) => {
+    await page.goto("/login");
+
+    await expect(page).toHaveURL(/\/dashboard$/);
+    await expect(page.getByText("Legacy Demo").first()).toBeVisible();
+  });
+
+  test("blocks backend proxy requests", async ({ request }) => {
+    const responses = await Promise.all([
+      request.get("/api/employees"),
+      request.post("/api/employees", { data: { name: "blocked" } }),
+      request.patch("/api/employees?id=legacy-demo", { data: { name: "blocked" } }),
+      request.delete("/api/employees?id=legacy-demo"),
+    ]);
+
+    for (const response of responses) {
+      expect(response.status()).toBe(500);
+      await expect(response.json()).resolves.toEqual({ error: expect.any(String) });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- allow the isolated legacy frontend to open without Kakao authentication when `LEGACY_DEMO_MODE=true`
- redirect `/login` to `/dashboard` in demo mode
- block all server-side backend proxy calls in demo mode so production data cannot be read or mutated anonymously

## Test Plan
- `pnpm exec eslint src/app/lib/auth/cookies.ts src/app/lib/axios/server.ts src/app/login/layout.tsx tests/legacy-demo-mode.spec.ts`
- `pnpm exec tsc --noEmit`
- `LEGACY_DEMO_MODE=true NEXT_PUBLIC_API_BASE_URL=https://imirae-incheon-back-office-production.up.railway.app pnpm exec next build --webpack`
- `BASE_URL=http://127.0.0.1:3107 LEGACY_DEMO_MODE=true pnpm exec playwright test tests/legacy-demo-mode.spec.ts` (2 passed)

## Rollback
- remove `LEGACY_DEMO_MODE` from the legacy Vercel project to restore normal auth immediately
- revert this PR to remove the dormant code path