### PR TITLE
fix(migration): prod DB 패치 재실행 호환 (document_kind·backfill 타임스탬프)

### DIFF
--- a/backend/prisma/migrations/20260709100000_link_eformsign_and_message_relations/migration.sql
+++ b/backend/prisma/migrations/20260709100000_link_eformsign_and_message_relations/migration.sql
@@ -48,7 +48,9 @@ BEGIN
     SELECT 1
     FROM "eformsign_doc" AS d
     WHERE d."document_kind" IS NOT NULL
-      AND d."document_kind" NOT IN ('contract', 'service_feedback_snapshot')
+      -- 'service_record_snapshot' allowed too: DBs that received post-rename app
+      -- writes before this patch ran (e.g. production) already contain the new value.
+      AND d."document_kind" NOT IN ('contract', 'service_feedback_snapshot', 'service_record_snapshot')
   ) THEN
     RAISE EXCEPTION 'eformsign_doc contains unsupported document_kind values';
   END IF;
@@ -195,7 +197,7 @@ BEGIN
   ) THEN
     ALTER TABLE "eformsign_doc"
       ADD CONSTRAINT "eformsign_doc_document_kind_check"
-      CHECK ("document_kind" IS NULL OR "document_kind" IN ('contract', 'service_feedback_snapshot'));
+      CHECK ("document_kind" IS NULL OR "document_kind" IN ('contract', 'service_feedback_snapshot', 'service_record_snapshot'));
   END IF;
 
   IF NOT EXISTS (

--- a/backend/prisma/migrations/20260713000000_add_client_service_record_case/migration.sql
+++ b/backend/prisma/migrations/20260713000000_add_client_service_record_case/migration.sql
@@ -207,7 +207,7 @@ CREATE INDEX IF NOT EXISTS "idx_eformsign_doc_service_record_case_id" ON "eforms
 
 INSERT INTO "service_record_case" (
     "branch_id", "client_id", "start_date", "end_date", "required_session_count",
-    "finalization_due_at", "status"
+    "finalization_due_at", "status", "created_at", "updated_at"
 )
 SELECT
     resolved."branch_id",
@@ -226,7 +226,9 @@ SELECT
             THEN 'WAITING_FOR_ASSIGNMENT'
         WHEN c."start_date" > CURRENT_DATE THEN 'SCHEDULED'
         ELSE 'IN_PROGRESS'
-    END
+    END,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
 FROM "client" c
 LEFT JOIN LATERAL (
     SELECT COALESCE(
@@ -265,7 +267,8 @@ ON CONFLICT ("client_id") DO UPDATE SET
 
 INSERT INTO "service_record_assignment" (
     "branch_id", "service_record_case_id", "schedule_id", "employee_id",
-    "employee_name_snapshot", "employee_phone_snapshot", "start_date", "end_date"
+    "employee_name_snapshot", "employee_phone_snapshot", "start_date", "end_date",
+    "created_at", "updated_at"
 )
 SELECT
     COALESCE(s."branch_id", rc."branch_id"),
@@ -275,7 +278,9 @@ SELECT
     e."name",
     e."phone",
     s."start_date",
-    s."end_date"
+    s."end_date",
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
 FROM "employee_schedule" s
 JOIN "service_record_case" rc ON rc."client_id" = s."client_id"
 JOIN "employee" e ON e."id" = s."primary_employee_id"


### PR DESCRIPTION
prod 패치 체인 실측 실패 2건 수정: 0709 가드가 rename 이후 값('service_record_snapshot')을 거부하던 것, 0713 backfill이 default 제거된 updated_at을 채우지 않던 것(7/16 preview 실패 원인). 로컬 재현 픽스처로 2회 실행·backfill 실증 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D62mzFoKWuqPDa8RMVeEri