### PR TITLE
[fix] Return legacy Kakao login to legacy app

### DIFF
--- a/frontend/src/app/api/auth/kakao/route.ts
+++ b/frontend/src/app/api/auth/kakao/route.ts
@@ -1,8 +1,8 @@
 import { redirect } from "next/navigation";
 
 const isProduction = process.env.NODE_ENV === "production";
-const API_URL = isProduction ? process.env.NEXT_PUBLIC_API_URL : process.env.DEVELOPMENT_API_URL;
+const API_URL = isProduction ? process.env.NEXT_PUBLIC_API_BASE_URL : process.env.DEVELOPMENT_API_BASE_URL;
 
 export async function GET() {
-    redirect(`${API_URL}/auth/kakao`);
+    redirect(`${API_URL}/auth/kakao?client=legacy`);
 }

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -33,7 +33,7 @@ const LoginPage = () => {
                 },
               }}
               onClick={() => {
-                window.location.href = `${API_BASE_URL}/auth/kakao`;
+                window.location.href = `${API_BASE_URL}/auth/kakao?client=legacy`;
               }}
             >
               {t(locale, "login.kakao-login")}


### PR DESCRIPTION
## Summary
- start Kakao OAuth with the allowlisted `client=legacy` target
- use the canonical API base variable in the local auth route

## Test Plan
- `pnpm --dir frontend exec tsc --noEmit`
- changed-file ESLint
- `NEXT_PUBLIC_API_BASE_URL=https://api.babyjamjam.com LEGACY_DEMO_MODE=false pnpm --dir frontend exec next build --webpack`

## Related
- depends on the backend legacy callback PR being deployed first