### PR TITLE
[fix] restore legacy Kakao onboarding flow

### DIFF
--- a/frontend/playwright.unit.config.ts
+++ b/frontend/playwright.unit.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "auth-token-response.spec.ts",
+  reporter: "list",
+  workers: 1,
+});

--- a/frontend/src/app/api/auth/token/route.ts
+++ b/frontend/src/app/api/auth/token/route.ts
@@ -4,6 +4,8 @@ import { serverAPIClient } from "@/app/lib/axios/server";
 import { AxiosError } from "axios";
 import { jwtDecode } from "jwt-decode";
 
+import { classifyTokenExchangeResponse } from "@/app/auth/callback/token-response";
+
 interface TokenPayload {
     sub: string;
     role: string | null;
@@ -17,7 +19,6 @@ interface APIErrorResponse {
 }
 
 const isProduction = process.env.NODE_ENV === "production";
-const API_URL = isProduction ? process.env.NEXT_PUBLIC_API_BASE_URL : process.env.DEVELOPMENT_API_BASE_URL;
 
 export async function POST(request: NextRequest) {
     try {
@@ -29,19 +30,48 @@ export async function POST(request: NextRequest) {
         }
 
         const { data } = await serverAPIClient.post("/auth/token", { code });
-
         const cookieStore = await cookies();
+        const result = classifyTokenExchangeResponse(data);
+
+        if (result.kind === "account-onboarding" || result.kind === "kakao-onboarding") {
+            const pendingCookieName = result.kind === "account-onboarding"
+                ? "pending_account_onboarding"
+                : "pending_kakao_signup";
+            const stalePendingCookieName = result.kind === "account-onboarding"
+                ? "pending_kakao_signup"
+                : "pending_account_onboarding";
+
+            cookieStore.set(pendingCookieName, result.pendingToken, {
+                httpOnly: true,
+                secure: isProduction,
+                sameSite: "lax",
+                path: "/",
+                maxAge: 30 * 60,
+            });
+            cookieStore.delete(stalePendingCookieName);
+            cookieStore.delete("auth_token");
+            cookieStore.delete("refresh_token");
+
+            return NextResponse.json({
+                onboardingRequired: true,
+                onboardingRoute: result.onboardingRoute,
+            });
+        }
+
+        if (result.kind !== "authenticated") {
+            return NextResponse.json({ error: "Token Exchange Failed" }, { status: 502 });
+        }
 
         let role = "user";
         try {
-            const decoded = jwtDecode<TokenPayload>(data.accessToken);
+            const decoded = jwtDecode<TokenPayload>(result.accessToken);
             role = decoded.role || "user";
         }
         catch {
             console.error("Failed to decode token");
         }
 
-        cookieStore.set("auth_token", data.accessToken, {
+        cookieStore.set("auth_token", result.accessToken, {
             httpOnly: true,
             secure: true,  // Must be true with sameSite: 'none'
             sameSite: "none",  // Required for mobile browsers during OAuth redirects
@@ -49,7 +79,7 @@ export async function POST(request: NextRequest) {
             maxAge: role === "owner" ? 30 * 24 * 60 * 60 : 3 * 24 * 60 * 60,
         })
 
-        cookieStore.set("refresh_token", data.refreshToken, {
+        cookieStore.set("refresh_token", result.refreshToken, {
             httpOnly: true,
             secure: true,  // Must be true with sameSite: 'none'
             sameSite: "none",  // Required for mobile browsers during OAuth redirects
@@ -67,7 +97,7 @@ export async function POST(request: NextRequest) {
             console.error("Error Name:", error.name);
             console.error("Error Message:", error.message);
             if ('code' in error) {
-                console.error("Error Code:", (error as any).code);
+                console.error("Error Code:", (error as { code?: unknown }).code);
             }
         }
 

--- a/frontend/src/app/auth/callback/actions.ts
+++ b/frontend/src/app/auth/callback/actions.ts
@@ -5,6 +5,8 @@ import { serverAPIClient } from "@/app/lib/axios/server";
 import { AxiosError } from "axios";
 import { jwtDecode } from "jwt-decode";
 
+import { classifyTokenExchangeResponse } from "./token-response";
+
 interface TokenPayload {
     sub: string;
     role: string | null;
@@ -17,7 +19,13 @@ interface APIErrorResponse {
     error: string;
 }
 
-export async function exchangeToken(code: string): Promise<{ success: boolean; error?: string }> {
+export async function exchangeToken(code: string): Promise<{
+    success: boolean;
+    error?: string;
+    requiresBranchSelection?: boolean;
+    onboardingRequired?: boolean;
+    onboardingRoute?: "/kakao/onboarding" | "/onboarding";
+}> {
     try {
         console.log("[Server Action] Exchanging token for code");
         
@@ -25,19 +33,49 @@ export async function exchangeToken(code: string): Promise<{ success: boolean; e
             return { success: false, error: "Authorization Code Required" };
         }
 
-        const { data } = await serverAPIClient.post("/auth/token", { code });
-
         const cookieStore = await cookies();
+        const { data } = await serverAPIClient.post("/auth/token", { code });
+        const result = classifyTokenExchangeResponse(data);
+
+        if (result.kind === "account-onboarding" || result.kind === "kakao-onboarding") {
+            const pendingCookieName = result.kind === "account-onboarding"
+                ? "pending_account_onboarding"
+                : "pending_kakao_signup";
+            const stalePendingCookieName = result.kind === "account-onboarding"
+                ? "pending_kakao_signup"
+                : "pending_account_onboarding";
+
+            cookieStore.set(pendingCookieName, result.pendingToken, {
+                httpOnly: true,
+                secure: process.env.NODE_ENV === "production",
+                sameSite: "lax",
+                path: "/",
+                maxAge: 30 * 60,
+            });
+            cookieStore.delete(stalePendingCookieName);
+            cookieStore.delete("auth_token");
+            cookieStore.delete("refresh_token");
+
+            return {
+                success: true,
+                onboardingRequired: true,
+                onboardingRoute: result.onboardingRoute,
+            };
+        }
+
+        if (result.kind !== "authenticated") {
+            return { success: false, error: "Token Exchange Failed" };
+        }
 
         let role = "user";
         try {
-            const decoded = jwtDecode<TokenPayload>(data.accessToken);
+            const decoded = jwtDecode<TokenPayload>(result.accessToken);
             role = decoded.role || "user";
         } catch {
             console.error("[Server Action] Failed to decode token");
         }
 
-        cookieStore.set("auth_token", data.accessToken, {
+        cookieStore.set("auth_token", result.accessToken, {
             httpOnly: true,
             secure: true,
             sameSite: "lax", // Changed to lax for same-origin navigation
@@ -45,7 +83,7 @@ export async function exchangeToken(code: string): Promise<{ success: boolean; e
             maxAge: role === "owner" ? 30 * 24 * 60 * 60 : 3 * 24 * 60 * 60,
         });
 
-        cookieStore.set("refresh_token", data.refreshToken, {
+        cookieStore.set("refresh_token", result.refreshToken, {
             httpOnly: true,
             secure: true,
             sameSite: "lax", // Changed to lax for same-origin navigation
@@ -54,7 +92,13 @@ export async function exchangeToken(code: string): Promise<{ success: boolean; e
         });
 
         console.log("[Server Action] Token exchange successful");
-        return { success: true };
+        cookieStore.delete("pending_kakao_signup");
+        cookieStore.delete("pending_account_onboarding");
+
+        return {
+            success: true,
+            requiresBranchSelection: result.requiresBranchSelection,
+        };
     } catch (error) {
         console.error("[Server Action] Token Exchange Error:", error);
 
@@ -82,4 +126,3 @@ export async function exchangeToken(code: string): Promise<{ success: boolean; e
         };
     }
 }
-

--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -6,13 +6,38 @@ import { Box, Typography } from "@mui/material";
 import { MoonLoader } from "react-spinners";
 import { exchangeToken } from "./actions";
 
+type ExchangeTokenResult = Awaited<ReturnType<typeof exchangeToken>>;
+
+const exchangeTokenPromises = new Map<string, Promise<ExchangeTokenResult>>();
+
+function exchangeTokenOnce(code: string): Promise<ExchangeTokenResult> {
+    const existingPromise = exchangeTokenPromises.get(code);
+    if (existingPromise) {
+        return existingPromise;
+    }
+
+    const promise = exchangeToken(code).finally(() => {
+        setTimeout(() => exchangeTokenPromises.delete(code), 60_000);
+    });
+    exchangeTokenPromises.set(code, promise);
+    return promise;
+}
+
 export default function AuthCallbackPage() {
     const router = useRouter();
     const searchParams = useSearchParams();
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
+        let cancelled = false;
+
         const exchangeCodeForTokens = async () => {
+            const callbackError = searchParams.get("error");
+            if (callbackError) {
+                setError(callbackError);
+                return;
+            }
+
             const code = searchParams.get("code");
 
             console.log("[Auth Callback] Starting token exchange");
@@ -28,7 +53,11 @@ export default function AuthCallbackPage() {
                 console.log("[Auth Callback] Using server action for token exchange");
                 
                 // Use server action - bypasses Safari's client-side restrictions
-                const result = await exchangeToken(code);
+                const result = await exchangeTokenOnce(code);
+
+                if (cancelled) {
+                    return;
+                }
                 
                 if (!result.success) {
                     console.error("[Auth Callback] Token exchange failed:", result.error);
@@ -36,8 +65,11 @@ export default function AuthCallbackPage() {
                     return;
                 }
 
-                console.log("[Auth Callback] Token exchange successful");
-                console.log("[Auth Callback] Redirecting to dashboard");
+                if (result.onboardingRequired) {
+                    router.replace(result.onboardingRoute || "/kakao/onboarding");
+                    return;
+                }
+
                 router.replace("/dashboard");
             }
             catch (err) {
@@ -46,7 +78,11 @@ export default function AuthCallbackPage() {
                 setError("네트워크 오류가 발생했습니다. 다시 시도해 주세요.");
             }
         }
-        exchangeCodeForTokens();
+        void exchangeCodeForTokens();
+
+        return () => {
+            cancelled = true;
+        };
     }, [searchParams, router]);
 
     if (error) {

--- a/frontend/src/app/auth/callback/token-response.ts
+++ b/frontend/src/app/auth/callback/token-response.ts
@@ -1,0 +1,70 @@
+export type TokenExchangeClassification =
+  | {
+      kind: "authenticated";
+      accessToken: string;
+      refreshToken: string;
+      requiresBranchSelection: boolean;
+    }
+  | {
+      kind: "account-onboarding";
+      onboardingRoute: "/onboarding";
+      pendingToken: string;
+    }
+  | {
+      kind: "kakao-onboarding";
+      onboardingRoute: "/kakao/onboarding";
+      pendingToken: string;
+    }
+  | { kind: "invalid" };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function classifyTokenExchangeResponse(
+  value: unknown,
+): TokenExchangeClassification {
+  if (!isRecord(value)) {
+    return { kind: "invalid" };
+  }
+
+  if (
+    typeof value.accessToken === "string"
+    && typeof value.refreshToken === "string"
+  ) {
+    return {
+      kind: "authenticated",
+      accessToken: value.accessToken,
+      refreshToken: value.refreshToken,
+      requiresBranchSelection: Boolean(
+        value.requiresBranchSelection || value.requiresOrgSelection,
+      ),
+    };
+  }
+
+  if (
+    value.onboardingRequired === true
+    && value.onboardingRoute === "/onboarding"
+    && typeof value.pendingAccountOnboardingToken === "string"
+  ) {
+    return {
+      kind: "account-onboarding",
+      onboardingRoute: "/onboarding",
+      pendingToken: value.pendingAccountOnboardingToken,
+    };
+  }
+
+  if (
+    value.onboardingRequired === true
+    && value.onboardingRoute === "/kakao/onboarding"
+    && typeof value.pendingSignupToken === "string"
+  ) {
+    return {
+      kind: "kakao-onboarding",
+      onboardingRoute: "/kakao/onboarding",
+      pendingToken: value.pendingSignupToken,
+    };
+  }
+
+  return { kind: "invalid" };
+}

--- a/frontend/src/app/auth/onboarding/LegacyOnboardingForm.tsx
+++ b/frontend/src/app/auth/onboarding/LegacyOnboardingForm.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { Alert, Box, Button, CircularProgress, MenuItem, Paper, TextField, Typography } from "@mui/material";
+import { useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { completeLegacyOnboarding } from "./actions";
+
+interface LegacyOnboardingFormProps {
+  mode: "account" | "kakao";
+  email?: string;
+  name?: string;
+  initialPhone?: string;
+  initialBirthDate?: string;
+  initialBranchId?: string;
+  initialRole?: "admin" | "manager" | "user";
+}
+
+interface BranchOption {
+  id: string;
+  name: string;
+}
+
+const ROLE_OPTIONS = [
+  { value: "admin", label: "관리자" },
+  { value: "manager", label: "매니저" },
+  { value: "user", label: "사용자" },
+] as const;
+
+export function LegacyOnboardingForm({
+  mode,
+  email,
+  name,
+  initialPhone = "",
+  initialBirthDate = "",
+  initialBranchId = "",
+  initialRole,
+}: LegacyOnboardingFormProps) {
+  const router = useRouter();
+  const [branches, setBranches] = useState<BranchOption[]>([]);
+  const [phone, setPhone] = useState(initialPhone);
+  const [birthDate, setBirthDate] = useState(initialBirthDate);
+  const [branchId, setBranchId] = useState(initialBranchId);
+  const [role, setRole] = useState<"admin" | "manager" | "user" | "">(initialRole || "");
+  const [error, setError] = useState<string | null>(null);
+  const [isLoadingBranches, setIsLoadingBranches] = useState(true);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    fetch("/api/auth/branches/all")
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error("지점 목록을 불러오지 못했습니다.");
+        }
+        return response.json() as Promise<BranchOption[]>;
+      })
+      .then(setBranches)
+      .catch((requestError: unknown) => {
+        setError(requestError instanceof Error ? requestError.message : "지점 목록을 불러오지 못했습니다.");
+      })
+      .finally(() => setIsLoadingBranches(false));
+  }, []);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    if (!/^01[016789]-?\d{3,4}-?\d{4}$/.test(phone)) {
+      setError("유효한 전화번호를 입력해 주세요.");
+      return;
+    }
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(birthDate)) {
+      setError("생년월일을 YYYY-MM-DD 형식으로 입력해 주세요.");
+      return;
+    }
+    if (!branchId || !role) {
+      setError("지점과 역할을 선택해 주세요.");
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await completeLegacyOnboarding(mode, {
+        phone,
+        birthDate,
+        branchId,
+        role,
+      });
+      if (!result.success) {
+        setError(result.error || "계정 정보를 저장하지 못했습니다.");
+        return;
+      }
+      router.replace("/messages/price-info");
+      router.refresh();
+    });
+  };
+
+  return (
+    <Box sx={{ minHeight: "100vh", display: "grid", placeItems: "center", p: 2, bgcolor: "grey.50" }}>
+      <Paper component="main" elevation={2} sx={{ width: "100%", maxWidth: 480, p: { xs: 3, sm: 4 } }}>
+        <Typography variant="h5" component="h1" fontWeight={700} gutterBottom>
+          계정 정보 추가
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+          API 기능을 사용하려면 비어 있는 계정 정보를 입력해 주세요.
+        </Typography>
+
+        {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+        <Box component="form" onSubmit={handleSubmit} sx={{ display: "grid", gap: 2 }}>
+          <TextField label="이메일" value={email || ""} disabled fullWidth />
+          <TextField label="이름" value={name || ""} disabled fullWidth />
+          <TextField
+            label="전화번호"
+            value={phone}
+            onChange={(event) => setPhone(event.target.value)}
+            placeholder="010-1234-5678"
+            fullWidth
+            required
+          />
+          <TextField
+            label="생년월일"
+            value={birthDate}
+            onChange={(event) => setBirthDate(event.target.value)}
+            placeholder="1990-01-01"
+            fullWidth
+            required
+          />
+          <TextField
+            select
+            label="지점"
+            value={branchId}
+            onChange={(event) => setBranchId(event.target.value)}
+            disabled={isLoadingBranches}
+            fullWidth
+            required
+          >
+            {branches.map((branch) => (
+              <MenuItem key={branch.id} value={branch.id}>{branch.name}</MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            select
+            label="역할"
+            value={role}
+            onChange={(event) => setRole(event.target.value as typeof role)}
+            fullWidth
+            required
+          >
+            {ROLE_OPTIONS.map((option) => (
+              <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
+            ))}
+          </TextField>
+          <Button type="submit" variant="contained" size="large" disabled={isPending || isLoadingBranches}>
+            {isPending ? <CircularProgress size={22} color="inherit" /> : "저장하고 계속하기"}
+          </Button>
+        </Box>
+      </Paper>
+    </Box>
+  );
+}

--- a/frontend/src/app/auth/onboarding/actions.ts
+++ b/frontend/src/app/auth/onboarding/actions.ts
@@ -1,0 +1,100 @@
+"use server";
+
+import { AxiosError } from "axios";
+import { jwtDecode } from "jwt-decode";
+import { cookies } from "next/headers";
+
+import { serverAPIClient } from "@/app/lib/axios/server";
+import { classifyTokenExchangeResponse } from "@/app/auth/callback/token-response";
+
+type OnboardingMode = "account" | "kakao";
+
+interface OnboardingInput {
+  phone: string;
+  birthDate: string;
+  branchId: string;
+  role: "admin" | "manager" | "user";
+}
+
+interface TokenPayload {
+  role?: string | null;
+}
+
+const ACCOUNT_COOKIE = "pending_account_onboarding";
+const KAKAO_COOKIE = "pending_kakao_signup";
+
+export async function completeLegacyOnboarding(
+  mode: OnboardingMode,
+  input: OnboardingInput,
+): Promise<{ success: boolean; error?: string }> {
+  const cookieStore = await cookies();
+  const pendingCookieName = mode === "account" ? ACCOUNT_COOKIE : KAKAO_COOKIE;
+  const pendingToken = cookieStore.get(pendingCookieName)?.value;
+
+  if (!pendingToken) {
+    return { success: false, error: "가입 세션이 만료되었습니다. 다시 로그인해 주세요." };
+  }
+
+  const endpoint = mode === "account"
+    ? "/auth/onboarding/complete"
+    : "/auth/kakao/complete-signup";
+  const headerName = mode === "account"
+    ? "x-pending-onboarding-token"
+    : "x-pending-signup-token";
+
+  try {
+    const { data } = await serverAPIClient.post(endpoint, {
+      ...input,
+      organizationId: input.branchId,
+    }, {
+      headers: { [headerName]: pendingToken },
+    });
+    const result = classifyTokenExchangeResponse(data);
+
+    if (result.kind !== "authenticated") {
+      return { success: false, error: "계정 정보를 저장하지 못했습니다." };
+    }
+
+    let role = "user";
+    try {
+      role = jwtDecode<TokenPayload>(result.accessToken).role || "user";
+    } catch {
+      role = "user";
+    }
+
+    cookieStore.set("auth_token", result.accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: role === "owner" ? 30 * 24 * 60 * 60 : 3 * 24 * 60 * 60,
+    });
+    cookieStore.set("refresh_token", result.refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: 7 * 24 * 60 * 60,
+    });
+    cookieStore.delete(ACCOUNT_COOKIE);
+    cookieStore.delete(KAKAO_COOKIE);
+
+    return { success: true };
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      const responseData = error.response?.data as { message?: string } | undefined;
+      if (error.response?.status === 401) {
+        cookieStore.delete(pendingCookieName);
+      }
+      return {
+        success: false,
+        error: responseData?.message || "계정 정보를 저장하지 못했습니다.",
+      };
+    }
+
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "계정 정보를 저장하지 못했습니다.",
+    };
+  }
+}

--- a/frontend/src/app/kakao/onboarding/page.tsx
+++ b/frontend/src/app/kakao/onboarding/page.tsx
@@ -1,0 +1,41 @@
+import { AxiosError } from "axios";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { serverAPIClient } from "@/app/lib/axios/server";
+import { LegacyOnboardingForm } from "@/app/auth/onboarding/LegacyOnboardingForm";
+
+interface PendingKakaoProfile {
+  email?: string;
+  name?: string;
+}
+
+export default async function KakaoOnboardingPage() {
+  const cookieStore = await cookies();
+  const pendingToken = cookieStore.get("pending_kakao_signup")?.value;
+
+  if (!pendingToken) {
+    redirect("/login");
+  }
+
+  let profile: PendingKakaoProfile;
+  try {
+    const { data } = await serverAPIClient.get<PendingKakaoProfile>("/auth/kakao/pending-signup", {
+      headers: { "x-pending-signup-token": pendingToken },
+    });
+    profile = data;
+  } catch (error) {
+    if (error instanceof AxiosError && error.response?.status === 401) {
+      redirect("/login");
+    }
+    throw error;
+  }
+
+  return (
+    <LegacyOnboardingForm
+      mode="kakao"
+      email={profile.email}
+      name={profile.name}
+    />
+  );
+}

--- a/frontend/src/app/lib/auth/cookies.ts
+++ b/frontend/src/app/lib/auth/cookies.ts
@@ -30,13 +30,18 @@ export const getCurrentUser = cache(async (): Promise<AuthUser | null> => {
     }
 
     // Send token as Bearer token in Authorization header
-    const { data } = await serverAPIClient.get(`/auth/me`, {
+    const { data } = await serverAPIClient.get<AuthUser>(`/auth/me`, {
       headers: {
         Authorization: `Bearer ${authToken.value}`,
       },
     });
 
-    console.log("[getCurrentUser] User fetched successfully:", data?.name);
+    if (!data?.id) {
+      console.error("[getCurrentUser] Invalid user response");
+      return null;
+    }
+
+    console.log("[getCurrentUser] User fetched successfully:", data.name);
     return data;
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : "Unknown error";

--- a/frontend/src/app/lib/axios/server.ts
+++ b/frontend/src/app/lib/axios/server.ts
@@ -14,7 +14,7 @@ export const serverAPIClient = axios.create({
         "Content-Type": "application/json",
     },
     timeout: 60000, // 60 seconds - Railway apps can take time to wake up
-    validateStatus: (status) => status < 600, // Accept any status code for better error visibility
+    validateStatus: (status) => status < 400,
 });
 
 serverAPIClient.interceptors.request.use((config) => {

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -1,0 +1,49 @@
+import { AxiosError } from "axios";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { serverAPIClient } from "@/app/lib/axios/server";
+import { LegacyOnboardingForm } from "@/app/auth/onboarding/LegacyOnboardingForm";
+
+interface PendingAccountProfile {
+  email?: string;
+  name?: string;
+  phone?: string;
+  birthDate?: string;
+  branchId?: string;
+  role?: "admin" | "manager" | "user";
+}
+
+export default async function AccountOnboardingPage() {
+  const cookieStore = await cookies();
+  const pendingToken = cookieStore.get("pending_account_onboarding")?.value;
+
+  if (!pendingToken) {
+    redirect("/login");
+  }
+
+  let profile: PendingAccountProfile;
+  try {
+    const { data } = await serverAPIClient.get<PendingAccountProfile>("/auth/onboarding/pending", {
+      headers: { "x-pending-onboarding-token": pendingToken },
+    });
+    profile = data;
+  } catch (error) {
+    if (error instanceof AxiosError && error.response?.status === 401) {
+      redirect("/login");
+    }
+    throw error;
+  }
+
+  return (
+    <LegacyOnboardingForm
+      mode="account"
+      email={profile.email}
+      name={profile.name}
+      initialPhone={profile.phone}
+      initialBirthDate={profile.birthDate}
+      initialBranchId={profile.branchId}
+      initialRole={profile.role}
+    />
+  );
+}

--- a/frontend/tests/auth-token-response.spec.ts
+++ b/frontend/tests/auth-token-response.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+
+import { classifyTokenExchangeResponse } from "../src/app/auth/callback/token-response";
+
+test.describe("legacy auth token response", () => {
+  test("classifies an access-token response", () => {
+    expect(classifyTokenExchangeResponse({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+    })).toEqual({
+      kind: "authenticated",
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      requiresBranchSelection: false,
+    });
+  });
+
+  test("classifies existing-account onboarding", () => {
+    expect(classifyTokenExchangeResponse({
+      onboardingRequired: true,
+      onboardingRoute: "/onboarding",
+      pendingAccountOnboardingToken: "pending-account-token",
+    })).toEqual({
+      kind: "account-onboarding",
+      onboardingRoute: "/onboarding",
+      pendingToken: "pending-account-token",
+    });
+  });
+
+  test("classifies Kakao signup onboarding", () => {
+    expect(classifyTokenExchangeResponse({
+      onboardingRequired: true,
+      onboardingRoute: "/kakao/onboarding",
+      pendingSignupToken: "pending-signup-token",
+    })).toEqual({
+      kind: "kakao-onboarding",
+      onboardingRoute: "/kakao/onboarding",
+      pendingToken: "pending-signup-token",
+    });
+  });
+
+  test("rejects a response without tokens or onboarding data", () => {
+    expect(classifyTokenExchangeResponse({ message: "Unauthorized" })).toEqual({
+      kind: "invalid",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- treat backend token-exchange errors as failures instead of writing invalid cookies
- preserve Kakao/account onboarding responses and complete onboarding inside the legacy app
- return users to the price-info API surface after onboarding

## Test Plan
- Playwright token-response contract: 4 passed
- frontend TypeScript: passed
- changed-file ESLint: passed
- Next.js production build (webpack): passed

## Security
- pending onboarding tokens stay in httpOnly Secure SameSite=Lax cookies
- OAuth client/state allowlist remains unchanged
- no dependency or environment changes