### PR TITLE
[fix] Restore Railway Preview backend startup

### DIFF
--- a/backend/infrastructure/vendor-stubs/e2e-vendor-stubs.ts
+++ b/backend/infrastructure/vendor-stubs/e2e-vendor-stubs.ts
@@ -350,12 +350,14 @@ export function areE2EVendorStubsEnabled(configService: Pick<ConfigService, "get
  * "Test-like" is NOT just NODE_ENV==="test" — the one place this repo boots
  * main.ts under e2e conditions (.github/workflows/mobile-ci.yml `e2e` job)
  * deliberately sets NODE_ENV=development (only production is special-cased
- * elsewhere) alongside CI=true and E2E_VENDOR_STUBS=1. Jest unit specs never
+ * elsewhere) alongside CI=true, GITHUB_ACTIONS=true, and E2E_VENDOR_STUBS=1. Jest unit specs never
  * invoke bootstrap() at all (see test/e2e/call-inbox.e2e.spec.ts header — the
  * AppModule can't even be built under ts-jest), so NODE_ENV=test alone would
  * never actually cover the real failure mode this guards against. Hence:
- * NODE_ENV==="test" OR CI==="true" (and never for NODE_ENV==="production",
- * which already has its own dedicated guard and must not regress).
+ * NODE_ENV==="test" OR the GitHub Actions CI runtime (and never for
+ * NODE_ENV==="production", which already has its own dedicated guard and must
+ * not regress). CI alone is insufficient because deployment platforms such as
+ * Railway also expose CI=true to production-like preview runtimes.
  */
 export function assertVendorStubsConfigured(configService: Pick<ConfigService, "get">): void {
     const nodeEnv = configService.get<string>("NODE_ENV");
@@ -364,7 +366,8 @@ export function assertVendorStubsConfigured(configService: Pick<ConfigService, "
     }
 
     const isCi = configService.get<string>("CI") === "true";
-    const isTestLikeEnv = nodeEnv === "test" || isCi;
+    const isGitHubActions = configService.get<string>("GITHUB_ACTIONS") === "true";
+    const isTestLikeEnv = nodeEnv === "test" || (isCi && isGitHubActions);
     if (!isTestLikeEnv) {
         return;
     }

--- a/backend/test/infrastructure/e2e-vendor-stubs.spec.ts
+++ b/backend/test/infrastructure/e2e-vendor-stubs.spec.ts
@@ -162,16 +162,27 @@ describe("assertVendorStubsConfigured (boot-time guard)", () => {
         expect(() => assertVendorStubsConfigured(configService)).not.toThrow();
     });
 
-    it("throws when CI=true (the real e2e boot job runs NODE_ENV=development, not test) and the flag is unset", () => {
-        const configService = createBootEnvConfigService({ NODE_ENV: "development", CI: "true" });
+    it("passes in a Railway preview runtime even when the platform exposes CI=true", () => {
+        const configService = createBootEnvConfigService({ NODE_ENV: "preview", CI: "true" });
+
+        expect(() => assertVendorStubsConfigured(configService)).not.toThrow();
+    });
+
+    it("throws in GitHub Actions when the e2e flag is unset", () => {
+        const configService = createBootEnvConfigService({
+            NODE_ENV: "development",
+            CI: "true",
+            GITHUB_ACTIONS: "true",
+        });
 
         expect(() => assertVendorStubsConfigured(configService)).toThrow(/E2E_VENDOR_STUBS=1/);
     });
 
-    it("passes when CI=true and E2E_VENDOR_STUBS=1 (the actual mobile-ci e2e job configuration)", () => {
+    it("passes in GitHub Actions when E2E_VENDOR_STUBS=1", () => {
         const configService = createBootEnvConfigService({
             NODE_ENV: "development",
             CI: "true",
+            GITHUB_ACTIONS: "true",
             E2E_VENDOR_STUBS: "1",
         });
 


### PR DESCRIPTION
## Summary

Restore the Railway Preview backend startup guard that regressed in PR #341.

## Root cause

The boot-time E2E vendor guard treated any non-production runtime with `CI=true` as an E2E environment. Railway Preview exposes that signal, so the backend required `E2E_VENDOR_STUBS=1`, crashed during bootstrap, and returned 502 for login requests.

## Changes

- Restrict the non-test E2E guard to GitHub Actions (`CI=true` and `GITHUB_ACTIONS=true`)
- Restore the Railway Preview regression test
- Preserve the fail-closed E2E behavior for GitHub Actions and `NODE_ENV=test`

## Test Plan

- Targeted regression suite: 14/14 passed
- Backend full suite: 156 suites, 1,557 passed, 8 skipped
- `pnpm type-check`: passed
- `pnpm build`: passed
- `pnpm lint`: 0 errors, 75 existing warnings
- `git diff --check`: passed

## Impact

Preview backend can boot normally without enabling vendor stubs. Production behavior and GitHub Actions E2E protection remain unchanged.