### PR TITLE
fix(auth): allow login Server Action posts

### DIFF
--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -107,4 +107,68 @@ describe("admin gateway proxy", () => {
     expect(response.headers.get("set-cookie")).toContain("refresh_token=next-refresh");
     fetchMock.mockRestore();
   });
+
+  it("refreshes an expired session when navigating to login", async () => {
+    mockJwtDecode.mockImplementation((token: string) => token === "new-access"
+      ? {
+        sub: "user-1",
+        sid: "session-1",
+        role: "admin",
+        branchId: "branch-1",
+        type: "access",
+        exp: Math.floor(Date.now() / 1000) + 60,
+      }
+      : {
+        sub: "user-1",
+        sid: "session-1",
+        role: "admin",
+        type: "access",
+        exp: Math.floor(Date.now() / 1000) - 60,
+      });
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({
+        accessToken: "new-access",
+        refreshToken: "next-refresh",
+      }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const response = await proxy(new NextRequest("http://localhost/login", {
+      method: "GET",
+      headers: {
+        cookie: "auth_token=expired; refresh_token=current",
+      },
+    }));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("http://localhost/");
+    expect(response.headers.get("set-cookie")).toContain("auth_token=new-access");
+    fetchMock.mockRestore();
+  });
+
+  it("allows login Server Action posts through without refreshing the previous session", async () => {
+    mockJwtDecode.mockReturnValue({
+      sub: "user-1",
+      sid: "session-1",
+      role: "admin",
+      type: "access",
+      exp: Math.floor(Date.now() / 1000) - 60,
+    });
+    const fetchMock = jest.spyOn(global, "fetch");
+
+    const response = await proxy(new NextRequest("http://localhost/login", {
+      method: "POST",
+      headers: {
+        cookie: "auth_token=expired; refresh_token=current",
+        "next-action": "login-action",
+      },
+    }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+    fetchMock.mockRestore();
+  });
 });

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -151,7 +151,13 @@ export async function proxy(request: NextRequest) {
 
   // Skip public routes ("/" needs exact match — startsWith would match every path)
   if (pathname === "/" || PUBLIC_ROUTES.some((route) => pathname.startsWith(route))) {
-    if (pathname.startsWith("/login") && authToken && isAccessTokenExpiredOrInvalid(authToken)) {
+    const isNavigationRequest = request.method === "GET" || request.method === "HEAD";
+    if (
+      pathname.startsWith("/login") &&
+      isNavigationRequest &&
+      authToken &&
+      isAccessTokenExpiredOrInvalid(authToken)
+    ) {
       const loginRefreshToken = request.cookies.get("refresh_token")?.value;
       if (loginRefreshToken) {
         const refreshAttempt = await tryRefreshAuthSession(loginRefreshToken);


### PR DESCRIPTION
## Summary
- restrict expired-session login redirects to GET/HEAD navigation requests
- allow POST /login Server Actions to return their expected response
- add regression coverage for both navigation and Server Action behavior

## Verification
- frontend proxy tests: 8/8
- frontend full tests: 520/520
- typecheck: passed
- lint: 0 errors (140 existing warnings)
- production build: passed
- pnpm audit: 0 high/critical (1 moderate existing)