### PR TITLE
fix(auth): allow pending account onboarding

### DIFF
--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -171,4 +171,36 @@ describe("admin gateway proxy", () => {
     expect(fetchMock).not.toHaveBeenCalled();
     fetchMock.mockRestore();
   });
+
+  it("allows pending account onboarding navigation without an auth session", async () => {
+    const response = await proxy(new NextRequest("http://localhost/onboarding", {
+      method: "GET",
+      headers: {
+        cookie: "pending_account_onboarding=pending-token",
+      },
+    }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("allows pending account onboarding Server Action posts", async () => {
+    const response = await proxy(new NextRequest("http://localhost/onboarding", {
+      method: "POST",
+      headers: {
+        cookie: "pending_account_onboarding=pending-token",
+        "next-action": "complete-onboarding-action",
+      },
+    }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("keeps onboarding protected when the pending token is missing", async () => {
+    const response = await proxy(new NextRequest("http://localhost/onboarding"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("http://localhost/login");
+  });
 });

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -55,6 +55,8 @@ const AUTH_ONLY_ROUTES = [
   "/select-branch",
 ];
 
+const PENDING_ACCOUNT_ONBOARDING_COOKIE = "pending_account_onboarding";
+
 function isAccessTokenExpiredOrInvalid(token: string): boolean {
   try {
     const decoded = jwtDecode<TokenPayload>(token);
@@ -148,6 +150,13 @@ export async function proxy(request: NextRequest) {
   }
 
   let authToken = request.cookies.get("auth_token")?.value;
+
+  if (
+    pathname === "/onboarding" &&
+    request.cookies.has(PENDING_ACCOUNT_ONBOARDING_COOKIE)
+  ) {
+    return NextResponse.next();
+  }
 
   // Skip public routes ("/" needs exact match — startsWith would match every path)
   if (pathname === "/" || PUBLIC_ROUTES.some((route) => pathname.startsWith(route))) {


### PR DESCRIPTION
## Summary
- allow /onboarding requests through middleware only when the pending-account onboarding cookie exists
- preserve the existing login redirect when the cookie is missing
- cover onboarding GET, Server Action POST, and missing-cookie behavior

## Production evidence
- POST /login returned 200
- client navigated to /onboarding
- middleware redirected /onboarding 307 back to /login

## Verification
- frontend proxy tests: 11/11
- frontend full tests: 523/523
- typecheck: passed
- lint: 0 errors (140 existing warnings)
- production build: passed
- pnpm audit: 0 high/critical (1 existing moderate)