### PR TITLE
fix(auth): align account onboarding payload

### DIFF
--- a/frontend/src/app/(auth)/onboarding/actions.test.ts
+++ b/frontend/src/app/(auth)/onboarding/actions.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment node
+ */
+import { cookies } from "next/headers";
+
+import { serverAPIClient } from "@/lib/api/server";
+import { completeAccountOnboarding } from "./actions";
+
+jest.mock("next/headers", () => ({
+    cookies: jest.fn(),
+}));
+
+jest.mock("@/lib/api/server", () => ({
+    serverAPIClient: {
+        post: jest.fn(),
+    },
+}));
+
+jest.mock("@/lib/auth/session-cookies", () => ({
+    setAuthSessionCookies: jest.fn(),
+}));
+
+const mockCookies = cookies as jest.MockedFunction<typeof cookies>;
+const mockPost = serverAPIClient.post as jest.Mock;
+
+describe("completeAccountOnboarding", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockCookies.mockResolvedValue({
+            get: jest.fn().mockReturnValue({ value: "pending-token" }),
+            delete: jest.fn(),
+        } as never);
+
+        mockPost.mockResolvedValue({
+            status: 201,
+            data: {
+                accessToken: "access-token",
+                refreshToken: "refresh-token",
+            },
+        });
+    });
+
+    it("sends only fields accepted by the onboarding API contract", async () => {
+        const input = {
+            phone: "010-1234-5678",
+            birthDate: "1990-01-01",
+            branchId: "550e8400-e29b-41d4-a716-446655440000",
+            role: "manager",
+        };
+
+        await completeAccountOnboarding(input);
+
+        expect(mockPost).toHaveBeenCalledWith(
+            "/auth/onboarding/complete",
+            input,
+            {
+                headers: {
+                    "x-pending-onboarding-token": "pending-token",
+                },
+            },
+        );
+    });
+});

--- a/frontend/src/app/(auth)/onboarding/actions.ts
+++ b/frontend/src/app/(auth)/onboarding/actions.ts
@@ -38,10 +38,7 @@ export async function completeAccountOnboarding(
     try {
         const response = await serverAPIClient.post<CompleteAccountOnboardingSuccessResponse>(
             "/auth/onboarding/complete",
-            {
-                ...input,
-                organizationId: input.branchId,
-            },
+            input,
             {
                 headers: {
                     [PENDING_ONBOARDING_TOKEN_HEADER]: pendingOnboardingToken,


### PR DESCRIPTION
## Summary
- remove the legacy `organizationId` alias from account onboarding completion requests
- keep the strict backend DTO whitelist intact
- add a regression test for the exact accepted request contract

## Production impact
Email users whose existing account requires profile completion can submit onboarding without receiving `property organizationId should not exist`.

## Verification
- targeted regression test: pass
- frontend tests: 107 suites / 524 tests pass
- typecheck: pass
- lint: 0 errors / 140 existing warnings
- production build: pass
- dependency audit: no high or critical findings; 1 existing moderate finding

## Security
No backend validation was relaxed. The frontend now sends only DTO-whitelisted fields; no auth, token, cookie, dependency, environment, or schema changes.