### PR TITLE
fix(frontend): 고객 삭제 실패 사유 안내

### DIFF
--- a/frontend/src/app/(protected)/clients/page.test.tsx
+++ b/frontend/src/app/(protected)/clients/page.test.tsx
@@ -1,0 +1,16 @@
+import fs from "node:fs";
+
+const source = fs.readFileSync(require.resolve("./page"), "utf8");
+
+describe("ClientsPage deletion conflicts", () => {
+  it("should close the confirmation and show the backend conflict guidance", () => {
+    const handler = source.slice(
+      source.indexOf("const handleDeleteConfirm"),
+      source.indexOf("const clearSelectedClientScheduleChange"),
+    );
+
+    expect(handler).toContain("setDeleteTargetClientId(null)");
+    expect(handler).toContain("getApiErrorMessage");
+    expect(source).toContain('dataComponent="clients-delete-error-notification"');
+  });
+});

--- a/frontend/src/app/(protected)/clients/page.tsx
+++ b/frontend/src/app/(protected)/clients/page.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getApiErrorMessage } from "@babyjamjam/shared";
 import {
     Workflow,
     Users,
@@ -46,6 +47,7 @@ import {
 } from "@/components/app/clients/ClientFormDialog";
 import { ClientDetailPanel } from "@/components/app/clients/ClientDetailPanel";
 import { TwoButtonModal } from "@/components/app/ui/TwoButtonModal";
+import { NotificationOneButtonModal } from "@/components/app/ui/NotificationOneButtonModal";
 import { ClientDetailModal } from "@/components/app/clients/ClientDetailModal";
 import { ServiceRecordLinkResetResultModal } from "@/components/app/clients/ServiceRecordLinkResetResultModal";
 import { ServiceScheduleChangeModal } from "@/components/app/clients/ServiceScheduleChangeModal";
@@ -270,6 +272,7 @@ export default function ClientsPage() {
     const [formDialogOpen, setFormDialogOpen] = useState(false);
     const [editingClient, setEditingClient] = useState<Client | null>(null);
     const [deleteTargetClientId, setDeleteTargetClientId] = useState<number | null>(null);
+    const [deleteErrorMessage, setDeleteErrorMessage] = useState<string | null>(null);
     const [resetLinkTargetClientId, setResetLinkTargetClientId] = useState<number | null>(null);
     const [resetServiceRecordUrl, setResetServiceRecordUrl] = useState<string | null>(null);
     const [isResettingLink, setIsResettingLink] = useState(false);
@@ -540,6 +543,13 @@ export default function ClientsPage() {
             setDeleteTargetClientId(null);
         } catch (err) {
             console.error("Failed to delete client:", err);
+            setDeleteTargetClientId(null);
+            setDeleteErrorMessage(
+                getApiErrorMessage(
+                    err,
+                    "고객 삭제에 실패했습니다. 다시 시도해 주세요.",
+                ),
+            );
         }
     };
 
@@ -893,6 +903,18 @@ export default function ClientsPage() {
                 approvalVariant="destructive"
                 isPending={deleteClient.isPending}
                 onApprove={() => void handleDeleteConfirm()}
+            />
+
+            <NotificationOneButtonModal
+                open={deleteErrorMessage !== null}
+                onOpenChange={(open) => {
+                    if (!open) setDeleteErrorMessage(null);
+                }}
+                dataComponent="clients-delete-error-notification"
+                title="고객을 삭제하지 못했습니다."
+                description={deleteErrorMessage ?? ""}
+                isDescriptionVisuallyHidden={false}
+                onAcknowledge={() => setDeleteErrorMessage(null)}
             />
         </PageSection>
     );


### PR DESCRIPTION
## 변경 사항
- 고객 삭제 API가 409를 반환하면 확인 모달을 닫고 서버의 실패 사유를 안내합니다.
- 완료/제출된 제공기록지가 있는 고객의 삭제 제한 정책은 유지합니다.
- 고객 삭제 충돌 안내 회귀 테스트를 추가합니다.

## 검증
- pnpm test --runInBand --runTestsByPath src/app/\(protected\)/clients/page.test.tsx src/app/\(protected\)/employees/page.test.tsx
- pnpm type-check
- pnpm exec eslint src/app/\(protected\)/clients/page.tsx src/app/\(protected\)/clients/page.test.tsx
- NEXT_PUBLIC_API_BASE_URL=https://preview.api.babyjamjam.com pnpm build