### PR TITLE
fix(client): preserve electronic documents on deletion

### DIFF
--- a/.github/workflows/database-patches.yml
+++ b/.github/workflows/database-patches.yml
@@ -393,7 +393,6 @@ jobs:
     if: >-
       always() &&
       (
-        (github.event_name == 'push' && github.ref_name == 'preview' && needs['apply-preview'].result == 'success') ||
         (github.event_name == 'push' && github.ref_name == 'main') ||
         (github.event_name == 'workflow_dispatch' && inputs.target == 'production')
       )

--- a/.github/workflows/database-patches.yml
+++ b/.github/workflows/database-patches.yml
@@ -135,6 +135,14 @@ jobs:
         working-directory: backend
         run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260721090000_make_branch_owner_nullable/migration.sql
 
+      - name: Preserve electronic documents on client deletion
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260723090000_preserve_electronic_documents_on_client_delete/migration.sql
+
+      - name: Verify client deletion document preservation
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-client-delete-document-preservation.sql
+
   apply-preview:
     name: apply preview database patches
     if: >-
@@ -370,6 +378,14 @@ jobs:
       - name: Apply branch owner nullable patch
         working-directory: backend
         run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260721090000_make_branch_owner_nullable/migration.sql
+
+      - name: Preserve electronic documents on client deletion
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260723090000_preserve_electronic_documents_on_client_delete/migration.sql
+
+      - name: Verify client deletion document preservation
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-client-delete-document-preservation.sql
 
   apply-production:
     name: apply production database patches
@@ -611,3 +627,11 @@ jobs:
       - name: Apply branch owner nullable patch
         working-directory: backend
         run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260721090000_make_branch_owner_nullable/migration.sql
+
+      - name: Preserve electronic documents on client deletion
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260723090000_preserve_electronic_documents_on_client_delete/migration.sql
+
+      - name: Verify client deletion document preservation
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-client-delete-document-preservation.sql

--- a/backend/application/services/client.service.ts
+++ b/backend/application/services/client.service.ts
@@ -676,6 +676,7 @@ export class ClientService {
         });
         const latestContractStatusMap = new Map<number, string>();
         for (const doc of contractDocs) {
+            if (doc.clientId === null) continue;
             if (!latestContractStatusMap.has(doc.clientId)) {
                 latestContractStatusMap.set(doc.clientId, doc.statusType);
             }

--- a/backend/application/usecases/client/delete-client.usecase.ts
+++ b/backend/application/usecases/client/delete-client.usecase.ts
@@ -1,10 +1,10 @@
 import { ConflictException, Inject, Injectable, NotFoundException } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
 import { CLIENT_REPOSITORY, IClientRepository } from "domain/repositories/client.repository.interface";
-import { ClientHasCompletedServiceRecordError } from "domain/errors/client-has-completed-service-record.error";
 
-const COMPLETED_SERVICE_RECORD_MESSAGE =
-    "완료된 제공기록지가 있는 고객은 삭제할 수 없습니다. 서비스 종료 처리를 이용해 주세요.";
+export const CLIENT_DELETE_CONFLICT_CODE = "CLIENT_DELETE_CONFLICT";
+export const CLIENT_DELETE_CONFLICT_MESSAGE =
+    "연결된 데이터로 인해 고객을 삭제할 수 없습니다. 잠시 후 다시 시도해 주세요.";
 
 function isForeignKeyViolation(error: unknown): boolean {
     return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2003";
@@ -26,14 +26,14 @@ export class DeleteClientUsecase {
         try {
             await this.clientRepository.delete(branchid, id);
         } catch (error) {
-            if (error instanceof ClientHasCompletedServiceRecordError) {
-                throw new ConflictException(COMPLETED_SERVICE_RECORD_MESSAGE);
-            }
-            // Defense-in-depth: if some other FK still blocks the delete (e.g. a
-            // race that slipped past the repository's own pre-check), surface it
-            // as the same clear 409 instead of an unexplained 500.
+            // Defense-in-depth for any relation not covered by the document-
+            // preservation migration. The API route only exposes this coded,
+            // allowlisted message and never forwards raw database details.
             if (isForeignKeyViolation(error)) {
-                throw new ConflictException(COMPLETED_SERVICE_RECORD_MESSAGE);
+                throw new ConflictException({
+                    code: CLIENT_DELETE_CONFLICT_CODE,
+                    message: CLIENT_DELETE_CONFLICT_MESSAGE,
+                });
             }
             throw error;
         }

--- a/backend/application/usecases/eformsign-doc/create-and-send-service-record-snapshot.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/create-and-send-service-record-snapshot.usecase.ts
@@ -302,7 +302,7 @@ export class CreateAndSendServiceRecordSnapshotUsecase {
             const firstSessionIndex = chunk.days[0]!.sessionIndex;
             const lastSessionIndex = chunk.days.at(-1)!.sessionIndex;
             const documentName = this.caseDocumentName(
-                record.client.name,
+                record.client?.name || record.momName?.trim() || "삭제된 고객",
                 record.id,
                 record.formVersion,
                 chunkIndex,

--- a/backend/application/usecases/eformsign-doc/link-document-to-client.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/link-document-to-client.usecase.ts
@@ -31,7 +31,9 @@ export class LinkDocumentToClientUsecase {
         }
 
         const client = await this.resolveClientByRecipientPhone(branchid, doc)
-            ?? await this.clientRepository.findById(branchid, doc.clientId);
+            ?? (doc.clientId === null
+                ? null
+                : await this.clientRepository.findById(branchid, doc.clientId));
         if (!client) {
             throw new NotFoundException(`Client for document ${documentId} not found`);
         }

--- a/backend/application/usecases/eformsign-doc/sync-client-end-date.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/sync-client-end-date.usecase.ts
@@ -75,6 +75,10 @@ export class SyncClientEndDateUsecase {
                 this.logger.warn(`eformsign_doc not found for ${documentId}; cannot sync client.endDate.`);
                 return;
             }
+            if (doc.clientId === null) {
+                this.logger.log(`Document ${documentId} belongs to a deleted client; skipping endDate sync.`);
+                return;
+            }
 
             const client = await this.clientRepository.findById(branchId, doc.clientId);
             if (!client) {

--- a/backend/application/usecases/eformsign-doc/update-client-contract-status.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/update-client-contract-status.usecase.ts
@@ -42,6 +42,10 @@ export class UpdateClientContractStatusUsecase {
         if (!doc) {
             throw new NotFoundException(`Document ${documentId} not found`);
         }
+        if (doc.clientId === null) {
+            this.logger.log(`Document ${documentId} belongs to a deleted client; skipping contract status sync`);
+            return;
+        }
 
         const client = await this.clientRepository.findById(branchid, doc.clientId);
         if (!client) {

--- a/backend/domain/entities/eformsign-doc.entity.ts
+++ b/backend/domain/entities/eformsign-doc.entity.ts
@@ -34,7 +34,7 @@ interface EformsignDocProps {
     // expired example: true
     expired: boolean;
     // FK to client
-    clientId: number;
+    clientId: number | null;
     // document classification. null means an older/unclassified row.
     documentKind?: EformsignDocumentKind | null;
     // FK to employee_schedule for service feedback snapshots.
@@ -91,8 +91,11 @@ export class EformsignDocEntity {
             throw new Error("EformsignDocEntity: expired must be a boolean");
         }
 
-        if (typeof this.props.clientId !== "number" || this.props.clientId <= 0) {
-            throw new Error("EformsignDocEntity: clientId must be a positive number");
+        if (
+            this.props.clientId !== null
+            && (typeof this.props.clientId !== "number" || this.props.clientId <= 0)
+        ) {
+            throw new Error("EformsignDocEntity: clientId must be null or a positive number");
         }
 
         if (
@@ -127,7 +130,7 @@ export class EformsignDocEntity {
     get stepRecipientSms(): string { return this.props.stepRecipientSms; }
     get expiredDate(): Date { return this.props.expiredDate; }
     get expired(): boolean { return this.props.expired; }
-    get clientId(): number { return this.props.clientId; }
+    get clientId(): number | null { return this.props.clientId; }
     get documentKind(): EformsignDocumentKind | null { return this.props.documentKind ?? null; }
     get employeeScheduleId(): number | null { return this.props.employeeScheduleId ?? null; }
     get templateId(): string | null { return this.props.templateId ?? null; }

--- a/backend/domain/errors/client-has-completed-service-record.error.ts
+++ b/backend/domain/errors/client-has-completed-service-record.error.ts
@@ -1,6 +1,0 @@
-export class ClientHasCompletedServiceRecordError extends Error {
-    constructor(message = "Client has a completed or submitted service record") {
-        super(message);
-        this.name = "ClientHasCompletedServiceRecordError";
-    }
-}

--- a/backend/domain/repositories/eformsign-doc.repository.interface.ts
+++ b/backend/domain/repositories/eformsign-doc.repository.interface.ts
@@ -2,7 +2,7 @@ import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
 
 export interface EformsignDocClientSummary {
     documentId: string;
-    clientId: number;
+    clientId: number | null;
     clientName: string;
     clientPhone: string | null;
     providerName: string | null;

--- a/backend/infrastructure/database/mapper/eformsign-doc.mapper.ts
+++ b/backend/infrastructure/database/mapper/eformsign-doc.mapper.ts
@@ -15,7 +15,7 @@ type EformsignDocRow = {
     stepRecipientSms: string;
     expiredDate: Date;
     expired: boolean;
-    clientId: number;
+    clientId: number | null;
     documentKind: string | null;
     employeeScheduleId: number | null;
     templateId: string | null;

--- a/backend/infrastructure/database/repositories/sb.client.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.client.repository.ts
@@ -10,9 +10,6 @@ import { PrismaService } from "infrastructure/database/prisma.service";
 import { ClientMapper } from "infrastructure/database/mapper/client.mapper";
 import { hasColumn } from "infrastructure/database/schema-capabilities";
 import { normalizePhone } from "application/utils/normalize-phone";
-import { ClientHasCompletedServiceRecordError } from "domain/errors/client-has-completed-service-record.error";
-
-export { ClientHasCompletedServiceRecordError };
 
 @Injectable()
 export class SbClientRepository implements IClientRepository {
@@ -214,43 +211,15 @@ export class SbClientRepository implements IClientRepository {
     }
 
     async delete(branchid: string, id: number): Promise<void> {
-        await this.prismaService.$transaction(async (tx) => {
-            // service_record_case.clientId is unique — a client owns at most one case.
-            const serviceRecordCase = await tx.service_record_case.findUnique({
-                where: { clientId: id },
-                select: { id: true, completedAt: true },
-            });
-
-            if (serviceRecordCase) {
-                if (serviceRecordCase.completedAt) {
-                    throw new ClientHasCompletedServiceRecordError();
-                }
-
-                const submittedDayCount = await tx.service_record_day.count({
-                    where: {
-                        serviceRecordCaseId: serviceRecordCase.id,
-                        submittedAt: { not: null },
-                    },
-                });
-                if (submittedDayCount > 0) {
-                    throw new ClientHasCompletedServiceRecordError();
-                }
-
-                // No submitted/completed history — safe to remove the case.
-                // service_record_day / service_record_assignment / snapshot chunks
-                // cascade via FK (onDelete: Cascade); service_record_token,
-                // service_record (legacy header), and eformsign_doc reference the
-                // case with onDelete: SetNull, so they survive as orphan-safe rows.
-                await tx.service_record_case.delete({ where: { id: serviceRecordCase.id } });
-            }
-
-            const result = await tx.client.deleteMany({
-                where: { id, branchId: branchid },
-            });
-            if (result.count === 0) {
-                throw new Error("Client not found for branch");
-            }
+        // service_record_case.clientId and eformsign_doc.clientId are SetNull.
+        // Deleting only the tenant-scoped client preserves completed electronic
+        // documents and their snapshot data while removing live client data.
+        const result = await this.prismaService.client.deleteMany({
+            where: { id, branchId: branchid },
         });
+        if (result.count === 0) {
+            throw new Error("Client not found for branch");
+        }
     }
 
     async findByStartDate(branchid: string, date: Date): Promise<ClientEntity[]> {

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -173,22 +173,25 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
         const clientIds = Array.from(
             new Set(docs.map((d) => d.clientId).filter((id): id is number => id != null)),
         );
-        if (clientIds.length === 0) return [];
-        const clients = await this.prismaService.client.findMany({
-            where: { id: { in: clientIds } },
-            select: { id: true, name: true, phone: true },
-        });
-        const schedules = await this.prismaService.employee_schedule.findMany({
-            where: {
-                clientId: { in: clientIds },
-                branchId: branchid,
-                replaced: false,
-            },
-            include: {
-                primaryEmployee: true,
-            },
-            orderBy: { id: "desc" },
-        });
+        const clients = clientIds.length > 0
+            ? await this.prismaService.client.findMany({
+                where: { id: { in: clientIds } },
+                select: { id: true, name: true, phone: true },
+            })
+            : [];
+        const schedules = clientIds.length > 0
+            ? await this.prismaService.employee_schedule.findMany({
+                where: {
+                    clientId: { in: clientIds },
+                    branchId: branchid,
+                    replaced: false,
+                },
+                include: {
+                    primaryEmployee: true,
+                },
+                orderBy: { id: "desc" },
+            })
+            : [];
         const clientById = new Map(clients.map((c) => [c.id, c]));
         const providerByClientId = new Map<number, string>();
         for (const schedule of schedules) {
@@ -197,20 +200,22 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
             }
         }
         return docs
-            .filter((d) => d.documentId && d.clientId != null && clientById.has(d.clientId))
+            .filter((d) => Boolean(d.documentId))
             .map((d) => {
-                const client = clientById.get(d.clientId!)!;
+                const client = d.clientId == null ? undefined : clientById.get(d.clientId);
                 const contractRecipientName = d.stepRecipientName.trim();
                 const serviceRecordMomName = d.serviceRecordCase?.momName?.trim() ?? "";
                 const clientName = d.documentKind === "service_record_snapshot"
-                    ? serviceRecordMomName || client.name
-                    : contractRecipientName || client.name;
+                    ? serviceRecordMomName || client?.name || contractRecipientName || "삭제된 고객"
+                    : contractRecipientName || client?.name || "삭제된 고객";
                 return {
                     documentId: d.documentId,
-                    clientId: client.id,
+                    clientId: d.clientId ?? null,
                     clientName,
-                    clientPhone: client.phone ?? null,
-                    providerName: providerByClientId.get(d.clientId!) ?? null,
+                    clientPhone: client?.phone ?? null,
+                    providerName: d.clientId == null
+                        ? null
+                        : providerByClientId.get(d.clientId) ?? null,
                 };
             });
     }

--- a/backend/prisma/migrations/20260723090000_preserve_electronic_documents_on_client_delete/migration.sql
+++ b/backend/prisma/migrations/20260723090000_preserve_electronic_documents_on_client_delete/migration.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+-- Customer master data may be physically deleted, while completed electronic
+-- document snapshots remain branch-owned records. Both references therefore
+-- become nullable and are detached by PostgreSQL during client deletion.
+ALTER TABLE "eformsign_doc"
+    DROP CONSTRAINT IF EXISTS "eformsign_doc_client_id_fkey";
+ALTER TABLE "service_record_case"
+    DROP CONSTRAINT IF EXISTS "service_record_case_client_id_fkey";
+
+ALTER TABLE "eformsign_doc"
+    ALTER COLUMN "client_id" DROP NOT NULL;
+ALTER TABLE "service_record_case"
+    ALTER COLUMN "client_id" DROP NOT NULL;
+
+ALTER TABLE "eformsign_doc"
+    ADD CONSTRAINT "eformsign_doc_client_id_fkey"
+    FOREIGN KEY ("client_id") REFERENCES "client"("id")
+    ON DELETE SET NULL ON UPDATE NO ACTION NOT VALID;
+ALTER TABLE "service_record_case"
+    ADD CONSTRAINT "service_record_case_client_id_fkey"
+    FOREIGN KEY ("client_id") REFERENCES "client"("id")
+    ON DELETE SET NULL ON UPDATE NO ACTION NOT VALID;
+
+ALTER TABLE "eformsign_doc"
+    VALIDATE CONSTRAINT "eformsign_doc_client_id_fkey";
+ALTER TABLE "service_record_case"
+    VALIDATE CONSTRAINT "service_record_case_client_id_fkey";
+
+COMMIT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -177,7 +177,7 @@ model eformsign_doc {
   stepRecipientSms           String                         @map("step_recipient_sms")
   expiredDate                DateTime                       @map("expired_date") @db.Timestamptz(6)
   expired                    Boolean                        @default(false)
-  clientId                   Int                            @map("client_id")
+  clientId                   Int?                           @map("client_id")
   branchId                   String?                        @map("branch_id") @db.Uuid
   documentKind               String?                        @map("document_kind")
   employeeScheduleId         Int?                           @map("employee_schedule_id")
@@ -186,7 +186,7 @@ model eformsign_doc {
   snapshotVersion            Int?                           @map("snapshot_version")
   snapshotChunkIndex         Int?                           @map("snapshot_chunk_index")
   clientByEDocId             client?                        @relation("client_e_doc_idToeformsign_doc")
-  client                     client                         @relation("eformsign_doc_client_idToclient", fields: [clientId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  client                     client?                        @relation("eformsign_doc_client_idToclient", fields: [clientId], references: [id], onDelete: SetNull, onUpdate: NoAction)
   employeeSchedule           employee_schedule?             @relation(fields: [employeeScheduleId], references: [id], onDelete: SetNull, onUpdate: NoAction)
   serviceRecordCase          service_record_case?           @relation(fields: [serviceRecordCaseId], references: [id], onDelete: SetNull, onUpdate: NoAction)
   serviceRecordSnapshotChunk service_record_snapshot_chunk?
@@ -788,7 +788,7 @@ model service_record_day {
 model service_record_case {
   id                    String                          @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   branchId              String                          @map("branch_id") @db.Uuid
-  clientId              Int                             @unique @map("client_id")
+  clientId              Int?                            @unique @map("client_id")
   status                String                          @default("WAITING_FOR_DETAILS")
   startDate             DateTime?                       @map("start_date") @db.Date
   endDate               DateTime?                       @map("end_date") @db.Date
@@ -812,7 +812,7 @@ model service_record_case {
   createdAt             DateTime                        @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt             DateTime                        @updatedAt @map("updated_at") @db.Timestamptz(6)
   branch                branch                          @relation(fields: [branchId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  client                client                          @relation(fields: [clientId], references: [id], onDelete: Restrict, onUpdate: NoAction)
+  client                client?                         @relation(fields: [clientId], references: [id], onDelete: SetNull, onUpdate: NoAction)
   assignments           service_record_assignment[]
   days                  service_record_day[]
   serviceRecordTokens        service_record_token[]

--- a/backend/prisma/scripts/verify-client-delete-document-preservation.sql
+++ b/backend/prisma/scripts/verify-client-delete-document-preservation.sql
@@ -1,0 +1,38 @@
+DO $$
+DECLARE
+    relation_name TEXT;
+BEGIN
+    FOREACH relation_name IN ARRAY ARRAY['eformsign_doc', 'service_record_case']
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = relation_name
+              AND column_name = 'client_id'
+              AND is_nullable = 'YES'
+        ) THEN
+            RAISE EXCEPTION '%.client_id must be nullable', relation_name;
+        END IF;
+    END LOOP;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'eformsign_doc_client_id_fkey'
+          AND confdeltype = 'n'
+          AND convalidated
+    ) THEN
+        RAISE EXCEPTION 'eformsign_doc.client_id FK must be validated ON DELETE SET NULL';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'service_record_case_client_id_fkey'
+          AND confdeltype = 'n'
+          AND convalidated
+    ) THEN
+        RAISE EXCEPTION 'service_record_case.client_id FK must be validated ON DELETE SET NULL';
+    END IF;
+END $$;

--- a/backend/test/repositories/sb.client.repository.spec.ts
+++ b/backend/test/repositories/sb.client.repository.spec.ts
@@ -673,36 +673,18 @@ describe("SbClientRepository", () => {
     // delete
     // ============================================
     describe("delete", () => {
-        const createTxMock = () => ({
-            service_record_case: {
-                findUnique: jest.fn().mockResolvedValue(null),
-                delete: jest.fn(),
-            },
-            service_record_day: {
-                count: jest.fn().mockResolvedValue(0),
-            },
-            client: {
-                deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
-            },
-        });
-
-        let tx: ReturnType<typeof createTxMock>;
-
         beforeEach(() => {
-            tx = createTxMock();
-            (prisma as unknown as { $transaction: jest.Mock }).$transaction = jest
-                .fn()
-                .mockImplementation(async (cb: (txClient: unknown) => Promise<unknown>) => cb(tx));
+            clientModel.deleteMany.mockResolvedValue({ count: 1 });
         });
 
         describe("given a valid client id", () => {
-            it("should delete the client inside a transaction", async () => {
+            it("should delete only the tenant-scoped client", async () => {
                 // Act
                 await repository.delete(branchId, 4);
 
                 // Assert
-                expect(tx.client.deleteMany).toHaveBeenCalledTimes(1);
-                expect(tx.client.deleteMany).toHaveBeenCalledWith({
+                expect(clientModel.deleteMany).toHaveBeenCalledTimes(1);
+                expect(clientModel.deleteMany).toHaveBeenCalledWith({
                     where: { id: 4, branchId: branchId },
                 });
             });
@@ -714,7 +696,7 @@ describe("SbClientRepository", () => {
                 await repository.delete(branchId, id);
 
                 // Assert
-                expect(tx.client.deleteMany).toHaveBeenCalledWith({
+                expect(clientModel.deleteMany).toHaveBeenCalledWith({
                     where: { id, branchId: branchId },
                 });
             });

--- a/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
@@ -109,6 +109,21 @@ describe("SbEformsignDocRepository", () => {
         expect(result?.documentKind).toBeNull();
     });
 
+    it("reconstitutes an orphaned document with a null clientId", async () => {
+        eformsignDocModel.findFirst.mockResolvedValue({
+            ...legacyRow,
+            clientId: null,
+            documentKind: "service_record_snapshot",
+            employeeScheduleId: null,
+            templateId: "template-1",
+        });
+
+        const result = await repository.findByDocumentId("branch-1", "doc-1");
+
+        expect(result?.clientId).toBeNull();
+        expect(result?.documentKind).toBe("service_record_snapshot");
+    });
+
     it("retries status updates without pending classification columns", async () => {
         eformsignDocModel.updateMany
             .mockRejectedValueOnce(pendingColumnError)
@@ -179,5 +194,38 @@ describe("SbEformsignDocRepository", () => {
                 providerName: null,
             },
         ]);
+    });
+
+    it("keeps orphaned completed documents visible after their client is deleted", async () => {
+        const clientFindMany = jest.fn().mockResolvedValue([]);
+        const scheduleFindMany = jest.fn().mockResolvedValue([]);
+        eformsignDocModel.findMany.mockResolvedValue([
+            {
+                documentId: "service-record-doc-orphan",
+                clientId: null,
+                stepRecipientName: "전자문서 수신자",
+                documentKind: "service_record_snapshot",
+                serviceRecordCase: { momName: "보존된 산모명" },
+            },
+        ]);
+        repository = new SbEformsignDocRepository({
+            eformsign_doc: eformsignDocModel,
+            client: { findMany: clientFindMany },
+            employee_schedule: { findMany: scheduleFindMany },
+        } as unknown as PrismaService);
+
+        const result = await repository.findClientNamesByBranch("branch-1");
+
+        expect(result).toEqual([
+            {
+                documentId: "service-record-doc-orphan",
+                clientId: null,
+                clientName: "보존된 산모명",
+                clientPhone: null,
+                providerName: null,
+            },
+        ]);
+        expect(clientFindMany).not.toHaveBeenCalled();
+        expect(scheduleFindMany).not.toHaveBeenCalled();
     });
 });

--- a/backend/test/usecases/client/delete-client.usecase.spec.ts
+++ b/backend/test/usecases/client/delete-client.usecase.spec.ts
@@ -68,13 +68,9 @@ describe("DeleteClientUsecase", () => {
     });
 
     // ============================================
-    // P1-10: service_record_case FK guard (SbClientRepository + mocked PrismaService)
-    //
-    // client -> service_record_case is onDelete: Restrict (schema.prisma). These
-    // tests exercise the real SbClientRepository.delete() transaction (not the
-    // in-memory mock above) so the completed/submitted-record guard and the
-    // residual P2003 defense-in-depth are actually covered end-to-end through
-    // the usecase.
+    // Physical client deletion preserves completed electronic-document history.
+    // The database owns the SetNull behavior; the repository must not inspect or
+    // delete service_record_case rows before deleting the tenant-scoped client.
     // ============================================
     describe("execute (against SbClientRepository + mocked PrismaService)", () => {
         const branchId = "org-1";
@@ -115,17 +111,11 @@ describe("DeleteClientUsecase", () => {
             clientModel = { findFirst: jest.fn(), deleteMany: jest.fn() };
             serviceRecordCaseModel = { findUnique: jest.fn(), delete: jest.fn() };
             serviceRecordDayModel = { count: jest.fn() };
-
-            const tx = {
+            prisma = {
                 client: clientModel,
                 service_record_case: serviceRecordCaseModel,
                 service_record_day: serviceRecordDayModel,
-            };
-
-            prisma = {
-                client: clientModel,
                 $queryRawUnsafe: jest.fn().mockResolvedValue([{ exists: true }]),
-                $transaction: jest.fn((callback: (tx: unknown) => unknown) => callback(tx)),
             } as unknown as PrismaService;
 
             repository = new SbClientRepository(prisma);
@@ -134,61 +124,30 @@ describe("DeleteClientUsecase", () => {
             clientModel.findFirst.mockResolvedValue(clientRow());
         });
 
-        it("(a) throws 409 and deletes nothing when the case has a submitted day", async () => {
-            serviceRecordCaseModel.findUnique.mockResolvedValue({ id: "case-1", completedAt: null });
-            serviceRecordDayModel.count.mockResolvedValue(1);
+        it("deletes the client without touching its completed service-record case", async () => {
+            clientModel.deleteMany.mockResolvedValue({ count: 1 });
 
-            await expect(usecase.execute(branchId, clientId)).rejects.toThrow(ConflictException);
-            await expect(usecase.execute(branchId, clientId)).rejects.toThrow(
-                "완료된 제공기록지가 있는 고객은 삭제할 수 없습니다. 서비스 종료 처리를 이용해 주세요.",
-            );
+            await usecase.execute(branchId, clientId);
 
-            expect(serviceRecordCaseModel.delete).not.toHaveBeenCalled();
-            expect(clientModel.deleteMany).not.toHaveBeenCalled();
-        });
-
-        it("(a) throws 409 and deletes nothing when the case itself is completed", async () => {
-            serviceRecordCaseModel.findUnique.mockResolvedValue({
-                id: "case-1",
-                completedAt: new Date("2024-05-01T00:00:00.000Z"),
+            expect(clientModel.deleteMany).toHaveBeenCalledWith({
+                where: { id: clientId, branchId },
             });
-
-            await expect(usecase.execute(branchId, clientId)).rejects.toThrow(ConflictException);
-
-            // Short-circuits on completedAt before even counting submitted days.
+            expect(serviceRecordCaseModel.findUnique).not.toHaveBeenCalled();
+            expect(serviceRecordCaseModel.delete).not.toHaveBeenCalled();
             expect(serviceRecordDayModel.count).not.toHaveBeenCalled();
-            expect(serviceRecordCaseModel.delete).not.toHaveBeenCalled();
-            expect(clientModel.deleteMany).not.toHaveBeenCalled();
         });
 
-        it("(b) deletes the empty case and the client when there is no completed/submitted history", async () => {
-            serviceRecordCaseModel.findUnique.mockResolvedValue({ id: "case-1", completedAt: null });
-            serviceRecordDayModel.count.mockResolvedValue(0);
-            serviceRecordCaseModel.delete.mockResolvedValue({ id: "case-1" });
+        it("deletes the client directly when it has no electronic-document history", async () => {
             clientModel.deleteMany.mockResolvedValue({ count: 1 });
 
             await usecase.execute(branchId, clientId);
 
-            expect(serviceRecordCaseModel.delete).toHaveBeenCalledWith({ where: { id: "case-1" } });
             expect(clientModel.deleteMany).toHaveBeenCalledWith({
                 where: { id: clientId, branchId },
             });
         });
 
-        it("(b) deletes the client directly when it has no service_record_case at all", async () => {
-            serviceRecordCaseModel.findUnique.mockResolvedValue(null);
-            clientModel.deleteMany.mockResolvedValue({ count: 1 });
-
-            await usecase.execute(branchId, clientId);
-
-            expect(serviceRecordCaseModel.delete).not.toHaveBeenCalled();
-            expect(clientModel.deleteMany).toHaveBeenCalledWith({
-                where: { id: clientId, branchId },
-            });
-        });
-
-        it("(c) converts a residual P2003 foreign key violation into 409 (defense-in-depth)", async () => {
-            serviceRecordCaseModel.findUnique.mockResolvedValue(null);
+        it("converts a residual P2003 foreign key violation into a coded safe 409", async () => {
             clientModel.deleteMany.mockRejectedValue(
                 new Prisma.PrismaClientKnownRequestError("Foreign key constraint failed", {
                     code: "P2003",
@@ -196,14 +155,16 @@ describe("DeleteClientUsecase", () => {
                 }),
             );
 
-            await expect(usecase.execute(branchId, clientId)).rejects.toThrow(ConflictException);
-            await expect(usecase.execute(branchId, clientId)).rejects.toThrow(
-                "완료된 제공기록지가 있는 고객은 삭제할 수 없습니다. 서비스 종료 처리를 이용해 주세요.",
-            );
+            const error = await usecase.execute(branchId, clientId).catch((caught) => caught);
+
+            expect(error).toBeInstanceOf(ConflictException);
+            expect((error as ConflictException).getResponse()).toEqual({
+                code: "CLIENT_DELETE_CONFLICT",
+                message: "연결된 데이터로 인해 고객을 삭제할 수 없습니다. 잠시 후 다시 시도해 주세요.",
+            });
         });
 
         it("rethrows unrelated errors untouched", async () => {
-            serviceRecordCaseModel.findUnique.mockResolvedValue(null);
             clientModel.deleteMany.mockRejectedValue(new Error("boom"));
 
             await expect(usecase.execute(branchId, clientId)).rejects.toThrow("boom");

--- a/backend/test/usecases/eformsign-doc/link-document-to-client.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/link-document-to-client.usecase.spec.ts
@@ -29,7 +29,7 @@ describe("LinkDocumentToClientUsecase", () => {
         );
 
     const createDoc = (overrides: Partial<{
-        clientId: number;
+        clientId: number | null;
         documentKind: EformsignDocEntity["documentKind"];
         stepRecipientSms: string;
     }> = {}): EformsignDocEntity =>
@@ -48,7 +48,7 @@ describe("LinkDocumentToClientUsecase", () => {
             stepRecipientSms: overrides.stepRecipientSms ?? "010-1234-5678",
             expiredDate: new Date("2026-08-01T00:00:00.000Z"),
             expired: false,
-            clientId: overrides.clientId ?? 7,
+            clientId: overrides.clientId === undefined ? 7 : overrides.clientId,
             documentKind: overrides.documentKind ?? EFORMSIGN_DOCUMENT_KIND.CONTRACT,
             employeeScheduleId: null,
             templateId: null,
@@ -102,6 +102,20 @@ describe("LinkDocumentToClientUsecase", () => {
         expect(eformsignDocRepository.update).not.toHaveBeenCalled();
         expect(documentClient.eDocId).toBe(documentId);
         expect(clientRepository.update).toHaveBeenCalledWith(branchId, documentClient);
+    });
+
+    it("can relink an orphaned contract document by its recipient phone", async () => {
+        const phoneMatchedClient = createClient(12, "01012345678");
+        eformsignDocRepository.findByDocumentId.mockResolvedValue(createDoc({ clientId: null }));
+        clientRepository.findByPhone.mockResolvedValue(phoneMatchedClient);
+
+        await expect(usecase.execute(branchId, documentId)).resolves.toBeUndefined();
+
+        expect(eformsignDocRepository.update).toHaveBeenCalledWith(
+            branchId,
+            expect.objectContaining({ clientId: 12, documentId }),
+        );
+        expect(clientRepository.findById).not.toHaveBeenCalled();
     });
 
     it("does not link service feedback snapshot documents to the client contract pointer", async () => {

--- a/backend/test/usecases/eformsign-doc/service-record-case-snapshot.spec.ts
+++ b/backend/test/usecases/eformsign-doc/service-record-case-snapshot.spec.ts
@@ -180,6 +180,19 @@ describe("client-owned service record snapshot", () => {
         ]);
     });
 
+    it("uses the preserved mom-name snapshot when the client row has been deleted", () => {
+        const { usecase } = setup();
+        const record = {
+            ...makeRecord(),
+            clientId: null,
+            client: null,
+        } as unknown as ReturnType<typeof makeRecord>;
+
+        const chunks = callBuildCaseChunks(usecase, record, BASE_ONLY_TIERS, BASE_ONLY_TEMPLATE_BY_TIER);
+
+        expect(chunks[0]?.documentName).toContain("김산모");
+    });
+
     it("throws the not-configured error when the base 5회 template env is missing", () => {
         const usecase = new CreateAndSendServiceRecordSnapshotUsecase(
             {} as never,

--- a/backend/test/usecases/eformsign-doc/sync-client-end-date.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/sync-client-end-date.usecase.spec.ts
@@ -185,6 +185,27 @@ describe("SyncClientEndDateUsecase", () => {
         expect(warnSpy).toHaveBeenCalled();
     });
 
+    it("should skip client sync when the document belongs to a deleted client", async () => {
+        eformsignClient.getDocument.mockResolvedValue(
+            createDocumentResponse([
+                { id: "계약 종료 년도", value: "2026", type: "text" },
+                { id: "계약 종료 월", value: "05", type: "text" },
+                { id: "계약 종료 일", value: "17", type: "text" },
+            ]),
+        );
+        eformsignDocRepository.findByDocumentId.mockResolvedValue(
+            EformsignDocEntity.reconstitute({
+                ...createDocEntity().toJSON(),
+                clientId: null,
+            }),
+        );
+
+        await expect(usecase.execute(branchId, documentId, accessToken)).resolves.toBeUndefined();
+
+        expect(clientRepository.findById).not.toHaveBeenCalled();
+        expect(clientRepository.update).not.toHaveBeenCalled();
+    });
+
     it("should swallow getDocument errors and log them", async () => {
         eformsignClient.getDocument.mockRejectedValue(new Error("fetch failed"));
 

--- a/backend/test/usecases/eformsign-doc/update-client-contract-status.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/update-client-contract-status.usecase.spec.ts
@@ -1,0 +1,53 @@
+import {
+    CONTRACT_STATUS,
+    UpdateClientContractStatusUsecase,
+} from "application/usecases/eformsign-doc/update-client-contract-status.usecase";
+import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
+
+describe("UpdateClientContractStatusUsecase", () => {
+    const eformsignDocRepository = {
+        findByDocumentId: jest.fn(),
+    };
+    const clientRepository = {
+        findById: jest.fn(),
+        update: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("keeps an orphaned completed document without trying to update a deleted client", async () => {
+        eformsignDocRepository.findByDocumentId.mockResolvedValue(
+            EformsignDocEntity.reconstitute({
+                id: 1,
+                documentId: "doc-orphan",
+                createdDate: new Date("2026-07-01T00:00:00.000Z"),
+                updatedDate: new Date("2026-07-02T00:00:00.000Z"),
+                statusType: "050",
+                statusDetail: "완료",
+                stepType: "05",
+                stepIndex: "1",
+                stepName: "이용자",
+                stepRecipientType: "05",
+                stepRecipientName: "보존된 고객명",
+                stepRecipientSms: "01012345678",
+                expiredDate: new Date("2026-08-01T00:00:00.000Z"),
+                expired: false,
+                clientId: null,
+                documentKind: "contract",
+            }),
+        );
+        const usecase = new UpdateClientContractStatusUsecase(
+            eformsignDocRepository as never,
+            clientRepository as never,
+        );
+
+        await expect(
+            usecase.execute("branch-1", "doc-orphan", CONTRACT_STATUS.COMPLETED, true),
+        ).resolves.toBeUndefined();
+
+        expect(clientRepository.findById).not.toHaveBeenCalled();
+        expect(clientRepository.update).not.toHaveBeenCalled();
+    });
+});

--- a/docs/adr/ADR-002-preserve-electronic-documents-on-client-deletion.md
+++ b/docs/adr/ADR-002-preserve-electronic-documents-on-client-deletion.md
@@ -1,0 +1,64 @@
+# ADR-002: Preserve electronic documents when deleting a client
+
+## Status
+
+Accepted
+
+## Context
+
+Client deletion was blocked when a completed or submitted service record existed.
+The business rule now requires the client master record to be removable while the
+completed 제공기록지 remains available in the electronic-document screen.
+
+`eformsign_doc.client_id` previously cascaded from `client`, and
+`service_record_case.client_id` previously restricted deletion. Those two rules
+made the requested lifecycle impossible.
+
+## Decision
+
+1. `eformsign_doc.client_id` and `service_record_case.client_id` are nullable.
+2. Both foreign keys use `ON DELETE SET NULL`.
+3. Client deletion removes only the tenant-scoped `client` row. Existing schedule
+   cascades continue, while service-record cases and electronic documents remain.
+4. The electronic-document list derives display names from immutable document or
+   service-record snapshots when the live client is absent.
+5. Completed-record snapshots, including fields required to render the signed
+   record, remain part of the retained electronic document. Mutable client master
+   data is no longer available through the deleted client relation.
+6. Residual foreign-key failures use the stable `CLIENT_DELETE_CONFLICT` code.
+   The frontend maps that code to fixed safe copy and never exposes raw database
+   constraint details.
+
+## Alternatives Considered
+
+1. Soft-delete the client.
+   - Rejected because the requested behavior is deletion of customer information,
+     and the existing product does not consistently exclude soft-deleted clients.
+2. Copy all document data to a new archive table before deletion.
+   - Rejected because electronic documents and service-record cases already hold
+     the durable snapshots needed for rendering.
+3. Keep blocking completed clients.
+   - Rejected because it conflicts with the revised business rule.
+
+## Consequences
+
+### Positive
+
+- Completed 제공기록지 documents remain visible after client deletion.
+- Client deletion no longer depends on service-record completion state.
+- Branch ownership remains on retained records, preserving tenant isolation.
+
+### Negative
+
+- Document consumers must handle a null `clientId`.
+- Historical document snapshots may retain personal data required for the signed
+  record and must follow the electronic-document retention policy.
+
+### Risks and rollback
+
+- Deploy the database patch before backend code that deletes completed clients.
+- Verification checks both nullability and validated `SET NULL` actions.
+- Rollback requires first relinking or explicitly removing every row whose
+  `client_id` is null; only then can the old `NOT NULL`, cascade, and restrict
+  constraints be restored. Automatic destructive rollback is intentionally not
+  provided.

--- a/docs/adr/ADR-003-refresh-app-session-after-api-401.md
+++ b/docs/adr/ADR-003-refresh-app-session-after-api-401.md
@@ -1,0 +1,58 @@
+# ADR-003: Refresh the application session after an API 401
+
+## Status
+
+Accepted
+
+## Context
+
+Access tokens expire after 15 minutes. Protected page navigation can refresh an
+expired session, but browser calls under `/api` bypass that navigation path. A
+long-lived page therefore redirected to login as soon as its first API request
+received 401, even when a valid refresh cookie existed.
+
+## Decision
+
+1. Add `POST /api/auth/refresh` as a same-origin session refresh route.
+2. The route reads the HTTP-only refresh cookie, rotates tokens through the
+   backend, and writes HTTP-only session cookies. Tokens are never returned to
+   browser JavaScript.
+3. The Axios response interceptor performs at most one app-session refresh for a
+   failed request and then retries the original request once.
+4. Concurrent 401 responses in one browser context share a single refresh
+   promise, preventing refresh-token rotation races.
+5. Authentication endpoints and already retried requests are not refreshed
+   recursively. Eformsign token refresh remains a separate mechanism.
+6. A rejected refresh clears local session cookies and redirects to login. A
+   transient upstream failure is surfaced without clearing the session.
+
+## Alternatives Considered
+
+1. Increase the access-token lifetime.
+   - Rejected because it weakens the short-lived access-token security boundary.
+2. Refresh on a timer.
+   - Rejected because background timers are unreliable in suspended tabs and
+     create unnecessary refresh traffic.
+3. Redirect immediately on every 401.
+   - Rejected because a valid refresh session should keep the user signed in.
+
+## Consequences
+
+### Positive
+
+- Long-lived pages recover transparently after access-token expiry.
+- Refresh tokens remain inaccessible to client JavaScript.
+- One refresh and one replay bound prevents infinite retry loops.
+
+### Negative
+
+- A failed request may take one additional network round trip.
+- Multi-tab refresh races still rely on the backend's concurrent-replay policy;
+  single-flight coordination applies within each JavaScript context.
+
+### Risks and rollback
+
+- The refresh route is same-origin, cookie-based, `SameSite=Lax`, and returns
+  `Cache-Control: no-store`.
+- Rollback removes the interceptor branch and route; page-navigation refresh
+  behavior remains unchanged.

--- a/frontend/src/app/api/auth/refresh/route.test.ts
+++ b/frontend/src/app/api/auth/refresh/route.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment node
+ */
+import { cookies } from "next/headers";
+import { NextRequest } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+import { POST } from "./route";
+
+jest.mock("next/headers", () => ({
+    cookies: jest.fn(),
+}));
+
+jest.mock("@/lib/api/server", () => ({
+    serverAPIClient: {
+        post: jest.fn(),
+    },
+}));
+
+const mockCookies = cookies as jest.MockedFunction<typeof cookies>;
+const mockServerPost = serverAPIClient.post as jest.Mock;
+const cookieStore = {
+    set: jest.fn(),
+    delete: jest.fn(),
+};
+
+function createRequest(cookie = "refresh_token=old-refresh; auto_login=1"): NextRequest {
+    return new NextRequest("http://localhost/api/auth/refresh", {
+        method: "POST",
+        headers: { cookie },
+    });
+}
+
+describe("POST /api/auth/refresh", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockCookies.mockResolvedValue(cookieStore as never);
+    });
+
+    it("rotates the HTTP-only session cookies without returning tokens in the body", async () => {
+        mockServerPost.mockResolvedValue({
+            data: {
+                accessToken: "new-access",
+                refreshToken: "new-refresh",
+            },
+        });
+
+        const response = await POST(createRequest());
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({ success: true });
+        expect(mockServerPost).toHaveBeenCalledWith("/auth/refresh-token", {
+            refreshToken: "old-refresh",
+        });
+        expect(cookieStore.set).toHaveBeenCalledWith(
+            "auth_token",
+            "new-access",
+            expect.objectContaining({ httpOnly: true, path: "/" }),
+        );
+        expect(cookieStore.set).toHaveBeenCalledWith(
+            "refresh_token",
+            "new-refresh",
+            expect.objectContaining({ httpOnly: true, path: "/" }),
+        );
+    });
+
+    it("returns 401 without contacting the backend when the refresh cookie is missing", async () => {
+        const response = await POST(createRequest("auto_login=1"));
+
+        expect(response.status).toBe(401);
+        await expect(response.json()).resolves.toEqual({
+            error: "Session refresh required",
+            code: "AUTH_REFRESH_REQUIRED",
+        });
+        expect(mockServerPost).not.toHaveBeenCalled();
+    });
+
+    it("clears the local session when the refresh token is rejected", async () => {
+        mockServerPost.mockRejectedValue({ response: { status: 401, data: { error: "Unauthorized" } } });
+
+        const response = await POST(createRequest());
+
+        expect(response.status).toBe(401);
+        expect(cookieStore.delete).toHaveBeenCalledWith("auth_token");
+        expect(cookieStore.delete).toHaveBeenCalledWith("refresh_token");
+        expect(cookieStore.delete).toHaveBeenCalledWith("auto_login");
+        await expect(response.json()).resolves.toEqual({
+            error: "Session refresh failed",
+            code: "AUTH_REFRESH_FAILED",
+        });
+    });
+
+    it("keeps session cookies on a transient upstream failure", async () => {
+        mockServerPost.mockRejectedValue({ response: { status: 503 } });
+
+        const response = await POST(createRequest());
+
+        expect(response.status).toBe(502);
+        expect(cookieStore.delete).not.toHaveBeenCalled();
+        await expect(response.json()).resolves.toEqual({
+            error: "Session refresh failed",
+            code: "AUTH_REFRESH_FAILED",
+        });
+    });
+});

--- a/frontend/src/app/api/auth/refresh/route.ts
+++ b/frontend/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,65 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+import { getUpstreamErrorStatus, logUpstreamError } from "@/lib/api/route-utils";
+import { clearAuthSessionCookies, setAuthSessionCookies } from "@/lib/auth/session-cookies";
+import { AUTH_COOKIE_NAMES } from "@/lib/auth/session-policy";
+
+interface RefreshResponse {
+    accessToken?: unknown;
+    refreshToken?: unknown;
+}
+
+function isAutoLoginEnabled(value: string | undefined): boolean {
+    return value !== "0" && value !== "false";
+}
+
+export async function POST(request: NextRequest) {
+    const refreshToken = request.cookies.get(AUTH_COOKIE_NAMES.refreshToken)?.value;
+    if (!refreshToken) {
+        return NextResponse.json(
+            { error: "Session refresh required", code: "AUTH_REFRESH_REQUIRED" },
+            { status: 401 },
+        );
+    }
+
+    try {
+        const response = await serverAPIClient.post<RefreshResponse>("/auth/refresh-token", {
+            refreshToken,
+        });
+        const accessToken = response.data.accessToken;
+        const rotatedRefreshToken = response.data.refreshToken;
+        if (typeof accessToken !== "string" || typeof rotatedRefreshToken !== "string") {
+            throw new Error("Auth refresh response is missing tokens");
+        }
+
+        const cookieStore = await cookies();
+        setAuthSessionCookies(cookieStore, {
+            accessToken,
+            refreshToken: rotatedRefreshToken,
+            autoLogin: isAutoLoginEnabled(
+                request.cookies.get(AUTH_COOKIE_NAMES.autoLogin)?.value,
+            ),
+        });
+
+        const result = NextResponse.json({ success: true });
+        result.headers.set("Cache-Control", "no-store, max-age=0");
+        return result;
+    } catch (error) {
+        const status = getUpstreamErrorStatus(error);
+        logUpstreamError("refresh app session", error);
+
+        if (status === 401) {
+            const cookieStore = await cookies();
+            clearAuthSessionCookies(cookieStore);
+        }
+
+        const result = NextResponse.json(
+            { error: "Session refresh failed", code: "AUTH_REFRESH_FAILED" },
+            { status: status === 401 ? 401 : 502 },
+        );
+        result.headers.set("Cache-Control", "no-store, max-age=0");
+        return result;
+    }
+}

--- a/frontend/src/app/api/clients/[id]/route.test.ts
+++ b/frontend/src/app/api/clients/[id]/route.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+import { DELETE } from "./route";
+
+jest.mock("@/lib/api/server", () => ({
+    serverAPIClient: {
+        delete: jest.fn(),
+    },
+}));
+
+const mockDelete = serverAPIClient.delete as jest.Mock;
+
+function createRequest(): NextRequest {
+    return new NextRequest("http://localhost/api/clients/75", {
+        method: "DELETE",
+        headers: { cookie: "auth_token=access-token" },
+    });
+}
+
+describe("DELETE /api/clients/[id]", () => {
+    beforeEach(() => {
+        mockDelete.mockReset();
+    });
+
+    it("passes through the allowlisted safe detail for a coded delete conflict", async () => {
+        mockDelete.mockRejectedValue({
+            response: {
+                status: 409,
+                data: {
+                    error: "Conflict",
+                    code: "CLIENT_DELETE_CONFLICT",
+                    message: "연결된 데이터로 인해 고객을 삭제할 수 없습니다. 잠시 후 다시 시도해 주세요.",
+                },
+            },
+        });
+
+        const response = await DELETE(createRequest(), {
+            params: Promise.resolve({ id: "75" }),
+        });
+
+        expect(response.status).toBe(409);
+        await expect(response.json()).resolves.toEqual({
+            error: "연결된 데이터로 인해 고객을 삭제할 수 없습니다. 잠시 후 다시 시도해 주세요.",
+            code: "CLIENT_DELETE_CONFLICT",
+        });
+    });
+
+    it("does not expose an unrecognized upstream conflict message", async () => {
+        mockDelete.mockRejectedValue({
+            response: {
+                status: 409,
+                data: {
+                    error: "Conflict",
+                    message: "relation client_private_internal_fkey failed",
+                },
+            },
+        });
+
+        const response = await DELETE(createRequest(), {
+            params: Promise.resolve({ id: "75" }),
+        });
+
+        expect(response.status).toBe(409);
+        await expect(response.json()).resolves.toEqual({
+            error: "연결된 정보 때문에 고객을 삭제할 수 없습니다. 잠시 후 다시 시도해 주세요.",
+            code: "CLIENT_DELETE_CONFLICT",
+        });
+    });
+});

--- a/frontend/src/app/api/clients/[id]/route.ts
+++ b/frontend/src/app/api/clients/[id]/route.ts
@@ -1,8 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import { serverAPIClient } from "@/lib/api/server";
-import { errorResponse } from "@/lib/api/route-utils";
+import { errorResponse, getUpstreamErrorStatus, logUpstreamError } from "@/lib/api/route-utils";
 
 type RouteParams = { params: Promise<{ id: string }> };
+
+const CLIENT_DELETE_CONFLICT_CODE = "CLIENT_DELETE_CONFLICT";
+const CLIENT_DELETE_CONFLICT_MESSAGE =
+    "연결된 데이터로 인해 고객을 삭제할 수 없습니다. 잠시 후 다시 시도해 주세요.";
+const CLIENT_DELETE_CONFLICT_FALLBACK =
+    "연결된 정보 때문에 고객을 삭제할 수 없습니다. 잠시 후 다시 시도해 주세요.";
+
+function getUpstreamErrorCode(error: unknown): unknown {
+    if (!error || typeof error !== "object" || !("response" in error)) return undefined;
+    const response = (error as { response?: { data?: unknown } }).response;
+    if (!response?.data || typeof response.data !== "object") return undefined;
+    return (response.data as { code?: unknown }).code;
+}
 
 // Helper to get auth token from request
 function getAuthToken(request: NextRequest): string | null {
@@ -73,6 +86,19 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
         });
         return NextResponse.json({ success: true });
     } catch (error) {
+        if (getUpstreamErrorStatus(error) === 409) {
+            const isAllowlistedConflict = getUpstreamErrorCode(error) === CLIENT_DELETE_CONFLICT_CODE;
+            logUpstreamError("delete client", error);
+            return NextResponse.json(
+                {
+                    error: isAllowlistedConflict
+                        ? CLIENT_DELETE_CONFLICT_MESSAGE
+                        : CLIENT_DELETE_CONFLICT_FALLBACK,
+                    code: CLIENT_DELETE_CONFLICT_CODE,
+                },
+                { status: 409 },
+            );
+        }
         return errorResponse(error, "delete client");
     }
 }

--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -5,9 +5,11 @@ type AxiosMockInternals = {
     requestInterceptorUse: jest.Mock;
     responseInterceptorUse: jest.Mock;
     apiPost: jest.Mock;
+    barePost: jest.Mock;
 };
 type AxiosFunctionMock = jest.Mock & {
     create: jest.Mock;
+    post: jest.Mock;
     __mockApi: AxiosMockInternals;
 };
 
@@ -15,7 +17,9 @@ jest.mock("axios", () => {
     const requestInterceptorUse = jest.fn();
     const responseInterceptorUse = jest.fn();
     const apiPost = jest.fn();
+    const barePost = jest.fn();
     const mockAxios = jest.fn() as AxiosFunctionMock;
+    mockAxios.post = barePost;
     mockAxios.create = jest.fn(() => ({
         interceptors: {
             request: { use: requestInterceptorUse },
@@ -27,6 +31,7 @@ jest.mock("axios", () => {
         requestInterceptorUse,
         responseInterceptorUse,
         apiPost,
+        barePost,
     };
 
     return {
@@ -37,7 +42,10 @@ jest.mock("axios", () => {
 
 import "../client";
 
-type RetryableRequestConfig = AxiosRequestConfig & { _retry?: boolean };
+type RetryableRequestConfig = AxiosRequestConfig & {
+    _retry?: boolean;
+    _appAuthRetry?: boolean;
+};
 const mockAxios = axios as unknown as AxiosFunctionMock;
 
 function getResponseRejectedHandler(): (err: AxiosError) => Promise<unknown> {
@@ -58,9 +66,25 @@ function createNetworkError(config: RetryableRequestConfig): AxiosError {
     } as AxiosError;
 }
 
+function createUnauthorizedError(config: RetryableRequestConfig): AxiosError {
+    return {
+        name: "AxiosError",
+        message: "Request failed with status code 401",
+        config,
+        response: {
+            status: 401,
+            data: { error: "Unauthorized" },
+        },
+        isAxiosError: true,
+        toJSON: () => ({}),
+    } as AxiosError;
+}
+
 describe("api client network retry", () => {
     beforeEach(() => {
         mockAxios.mockClear();
+        mockAxios.__mockApi.barePost.mockReset();
+        window.history.replaceState({}, "", "/login");
     });
 
     it("should retry GET network errors exactly once", async () => {
@@ -99,6 +123,68 @@ describe("api client network retry", () => {
         await expect(getResponseRejectedHandler()(error)).rejects.toBe(error);
 
         expect(originalRequest._retry).toBeUndefined();
+        expect(mockAxios).not.toHaveBeenCalled();
+    });
+});
+
+describe("api client app-session refresh", () => {
+    beforeEach(() => {
+        mockAxios.mockClear();
+        mockAxios.__mockApi.barePost.mockReset();
+        window.history.replaceState({}, "", "/login");
+    });
+
+    it("refreshes once and retries the original non-eformsign request", async () => {
+        mockAxios.__mockApi.barePost.mockResolvedValue({ data: { success: true } });
+        const originalRequest: RetryableRequestConfig = {
+            method: "GET",
+            url: "/message-logs",
+        };
+
+        await getResponseRejectedHandler()(createUnauthorizedError(originalRequest));
+
+        expect(originalRequest._appAuthRetry).toBe(true);
+        expect(mockAxios.__mockApi.barePost).toHaveBeenCalledTimes(1);
+        expect(mockAxios.__mockApi.barePost).toHaveBeenCalledWith(
+            "/api/auth/refresh",
+            undefined,
+            { withCredentials: true },
+        );
+        expect(mockAxios).toHaveBeenCalledWith(originalRequest);
+    });
+
+    it("shares one refresh across concurrent 401 responses and retries both originals", async () => {
+        let resolveRefresh: (() => void) | undefined;
+        mockAxios.__mockApi.barePost.mockImplementation(
+            () => new Promise((resolve) => {
+                resolveRefresh = () => resolve({ data: { success: true } });
+            }),
+        );
+        const firstRequest: RetryableRequestConfig = { method: "GET", url: "/clients" };
+        const secondRequest: RetryableRequestConfig = { method: "GET", url: "/message-logs" };
+
+        const first = getResponseRejectedHandler()(createUnauthorizedError(firstRequest));
+        const second = getResponseRejectedHandler()(createUnauthorizedError(secondRequest));
+        resolveRefresh?.();
+        await Promise.all([first, second]);
+
+        expect(mockAxios.__mockApi.barePost).toHaveBeenCalledTimes(1);
+        expect(mockAxios).toHaveBeenCalledTimes(2);
+        expect(mockAxios).toHaveBeenCalledWith(firstRequest);
+        expect(mockAxios).toHaveBeenCalledWith(secondRequest);
+    });
+
+    it("does not start another refresh after the retried request returns 401", async () => {
+        const originalRequest: RetryableRequestConfig = {
+            method: "GET",
+            url: "/message-logs",
+            _appAuthRetry: true,
+        };
+        const error = createUnauthorizedError(originalRequest);
+
+        await expect(getResponseRejectedHandler()(error)).rejects.toBe(error);
+
+        expect(mockAxios.__mockApi.barePost).not.toHaveBeenCalled();
         expect(mockAxios).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -18,6 +18,7 @@ export const api = axios.create({
 // Token refresh state management
 let isRefreshing = false;
 let isRedirectingToLogin = false;
+let appAuthRefreshPromise: Promise<void> | null = null;
 let failedQueue: Array<{
     resolve: (value?: unknown) => void;
     reject: (reason?: unknown) => void;
@@ -37,6 +38,13 @@ const EFORMSIGN_REQUEST_PATHS = [
     "/api/generate-staff-document",
     "/generate-signature",
     "/api/generate-signature",
+] as const;
+
+const APP_AUTH_NON_RETRY_PATHS = [
+    "/auth/login",
+    "/auth/token",
+    "/auth/refresh",
+    "/auth/logout",
 ] as const;
 
 const processQueue = (error: AxiosError | null = null) => {
@@ -67,6 +75,22 @@ function isEformsignRefreshPath(pathname: string): boolean {
 
 function isEformsignRequestPath(pathname: string): boolean {
     return EFORMSIGN_REQUEST_PATHS.some((path) => pathname === path || pathname.startsWith(path));
+}
+
+function isAppAuthNonRetryPath(pathname: string): boolean {
+    return APP_AUTH_NON_RETRY_PATHS.some((path) => pathname === path || pathname.endsWith(path));
+}
+
+function refreshAppAuthSession(): Promise<void> {
+    if (!appAuthRefreshPromise) {
+        appAuthRefreshPromise = axios
+            .post("/api/auth/refresh", undefined, { withCredentials: true })
+            .then(() => undefined)
+            .finally(() => {
+                appAuthRefreshPromise = null;
+            });
+    }
+    return appAuthRefreshPromise;
 }
 
 function isAppAuthRequiredError(error: AxiosError): boolean {
@@ -109,7 +133,10 @@ api.interceptors.request.use(
 api.interceptors.response.use(
     (res) => res,
     async (err: AxiosError) => {
-        const originalRequest = err.config as AxiosRequestConfig & { _retry?: boolean };
+        const originalRequest = err.config as AxiosRequestConfig & {
+            _retry?: boolean;
+            _appAuthRetry?: boolean;
+        };
         const originalRequestMethod = (originalRequest?.method ?? "get").toLowerCase();
 
         // Network error - single retry
@@ -128,23 +155,20 @@ api.interceptors.response.use(
             }
         }
 
-        // 401 Unauthorized - handle eformsign token refresh only for eformsign-related endpoints
+        // 401 Unauthorized - refresh the relevant session once, then replay the request.
         if (err.response?.status === 401 && originalRequest && !originalRequest._retry) {
             const requestPath = getRequestPath(originalRequest);
             const isEformsignEndpoint = isEformsignRequestPath(requestPath);
+            const isAppAuthFailure = isAppAuthRequiredError(err);
             
-            // Don't retry token refresh endpoints themselves
-            if (isEformsignRefreshPath(requestPath)) {
+            // Don't retry an eformsign refresh failure unless the actual failure
+            // is the application's expired login session.
+            if (isEformsignRefreshPath(requestPath) && !isAppAuthFailure) {
                 return Promise.reject(err);
             }
 
             // For eformsign endpoints, try token refresh
-            if (isEformsignEndpoint) {
-                if (isAppAuthRequiredError(err)) {
-                    redirectToLoginOnce();
-                    return Promise.reject(err);
-                }
-
+            if (isEformsignEndpoint && !isAppAuthFailure) {
                 if (isRefreshing) {
                     return new Promise((resolve, reject) => {
                         failedQueue.push({ resolve, reject });
@@ -176,11 +200,23 @@ api.interceptors.response.use(
                     isRefreshing = false;
                 }
             }
-            
-            // For non-eformsign 401 errors (main auth failure), redirect to login
-            // But don't redirect if already on an auth page (login, register, etc.)
-            redirectToLoginOnce();
-            return Promise.reject(err);
+
+            if (originalRequest._appAuthRetry || isAppAuthNonRetryPath(requestPath)) {
+                redirectToLoginOnce();
+                return Promise.reject(err);
+            }
+
+            originalRequest._appAuthRetry = true;
+            try {
+                await refreshAppAuthSession();
+                return axios(originalRequest);
+            } catch (refreshError) {
+                captureApiError(refreshError);
+                if ((refreshError as AxiosError | undefined)?.response?.status === 401) {
+                    redirectToLoginOnce();
+                }
+                return Promise.reject(refreshError);
+            }
         }
 
         captureApiError(err);

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -15,7 +15,7 @@ export const api = axios.create({
     withCredentials: true,
 });
 
-// Token refresh state management
+// Keep eformsign token refresh and application-session refresh single-flight independently.
 let isRefreshing = false;
 let isRedirectingToLogin = false;
 let appAuthRefreshPromise: Promise<void> | null = null;

--- a/packages/shared/src/types/eformsign.ts
+++ b/packages/shared/src/types/eformsign.ts
@@ -208,7 +208,7 @@ export interface EformsignAuthStatusResponse {
 
 export interface EformsignDocClientSummary {
   documentId: string;
-  clientId: number;
+  clientId: number | null;
   clientName: string;
   clientPhone: string | null;
   providerName: string | null;


### PR DESCRIPTION
## Summary
- allow physical client deletion while preserving completed service-record/eformsign documents via nullable SetNull relations
- return allowlisted safe detail for client-delete 409 responses with API-route coverage
- refresh the app session once on general API 401 responses and retry the original request with single-flight coordination

## Database rollout
- apply `20260723090000_preserve_electronic_documents_on_client_delete` before relying on deletion behavior
- verify nullable columns and validated ON DELETE SET NULL constraints with `verify-client-delete-document-preservation.sql`
- rollback requires relinking or removing null-client document rows before restoring NOT NULL constraints

## Verification
- backend targeted tests: 33 passed
- frontend targeted tests: 12 passed
- backend/frontend/mobile type-check passed
- Prisma schema validate passed
- backend/frontend production builds passed
- lint passed with existing warnings only
- security review: no token exposure, one refresh/retry bound, branch scoping preserved