### PR TITLE
fix(mobile): allow service records outside service date

### DIFF
--- a/mobile/src/app/(public)/service-record/[token]/page.tsx
+++ b/mobile/src/app/(public)/service-record/[token]/page.tsx
@@ -9,7 +9,6 @@ import { NotificationOneButtonModal } from "@/components/app/ui/NotificationOneB
 import { SignaturePad } from "@/components/app/service-record/SignaturePad";
 import { DEFAULT_PROVIDER_NAME, ProviderInfo } from "@/components/service-record/provider-info";
 import { isBusinessDayKr, isoDateInKorea, nextBusinessDayKr } from "@/lib/date/business-days";
-import { IS_DEV_DEPLOYMENT } from "@/lib/env";
 
 /* ───────────────────────── form definition (mirrors the 제공기록지) ───────────────────────── */
 
@@ -160,13 +159,11 @@ const hasDisplayValue = (value: unknown): boolean => {
     return true;
 };
 
-export function canEditDailyRecord(
-    editing: boolean,
+export function isServiceDateMismatch(
     serviceDate: string,
     today = isoDateInKorea(),
-    allowDateMismatch = IS_DEV_DEPLOYMENT,
 ): boolean {
-    return allowDateMismatch || editing || serviceDate === today;
+    return serviceDate !== today;
 }
 
 interface DayButtonState {
@@ -555,10 +552,6 @@ export default function ServiceRecordPage() {
 
     async function submitDay() {
         const serviceDate = (draft["_date"] as string) ?? defaultDate(day);
-        if (!canEditDailyRecord(editing, serviceDate)) {
-            setErrorNotificationMessage("제공일자가 오늘과 달라 제출할 수 없습니다. 서비스 제공 당일에 기록해 주세요.");
-            return;
-        }
         setBusy(true);
         try {
             const currentSession = ctx?.sessions.find((session) => session.sessionIndex === day);
@@ -647,7 +640,7 @@ export default function ServiceRecordPage() {
             return (
                 <div data-component="service-record-options" className="opts">
                     {it.opts!.map((o) => (
-                        <button type="button" key={o} aria-pressed={Array.isArray(v) && (v as string[]).includes(o)} disabled={!canEditCurrentRecord} className={`opt ${Array.isArray(v) && (v as string[]).includes(o) ? "sel" : ""}`} onClick={() => toggleMulti(it.key, o)}>
+                        <button type="button" key={o} aria-pressed={Array.isArray(v) && (v as string[]).includes(o)} className={`opt ${Array.isArray(v) && (v as string[]).includes(o) ? "sel" : ""}`} onClick={() => toggleMulti(it.key, o)}>
                             <span className="box">✓</span>{o}
                         </button>
                     ))}
@@ -659,13 +652,13 @@ export default function ServiceRecordPage() {
                 <>
                     <div data-component="service-record-radio-options" className="opts">
                         {it.opts!.map((o) => (
-                            <button type="button" key={o} aria-pressed={v === o} disabled={!canEditCurrentRecord} className={`opt radio ${v === o ? "sel" : ""}`} onClick={() => setField(it.key, o)}>
+                            <button type="button" key={o} aria-pressed={v === o} className={`opt radio ${v === o ? "sel" : ""}`} onClick={() => setField(it.key, o)}>
                                 <span className="box">●</span>{o}
                             </button>
                         ))}
                     </div>
                     {it.type === "stool" && v === "이상변" && (
-                        <input className="in" style={{ marginTop: 8 }} placeholder="색깔 등 (이상변 시)" disabled={!canEditCurrentRecord}
+                        <input className="in" style={{ marginTop: 8 }} placeholder="색깔 등 (이상변 시)"
                             value={(draft[`${it.key}_color`] as string) ?? ""} onChange={(e) => setField(`${it.key}_color`, e.target.value)} />
                     )}
                 </>
@@ -677,7 +670,7 @@ export default function ServiceRecordPage() {
                     {it.counts!.map((c) => (
                         <div data-component="service-record-count-row" className="segnum" key={c.k}>
                             <span>{c.label}</span>
-                            <input type="number" aria-label={c.label} inputMode={c.k === "temp" ? "decimal" : "numeric"} min="0" step={c.k === "temp" ? "0.1" : "1"} disabled={!canEditCurrentRecord} value={((draft[`${it.key}_${c.k}`] as string) ?? "")} onChange={(e) => setField(`${it.key}_${c.k}`, e.target.value)} />
+                            <input type="number" aria-label={c.label} inputMode={c.k === "temp" ? "decimal" : "numeric"} min="0" step={c.k === "temp" ? "0.1" : "1"} value={((draft[`${it.key}_${c.k}`] as string) ?? "")} onChange={(e) => setField(`${it.key}_${c.k}`, e.target.value)} />
                             <span>{c.unit}</span>
                         </div>
                     ))}
@@ -688,12 +681,12 @@ export default function ServiceRecordPage() {
             const placeholder = it.key === "etcService"
                 ? "추가사항에 대한 기록 필요 시 기재"
                 : "서비스 제공 관련 특이사항 기록 필요 시 기재";
-            return <textarea className="ta" disabled={!canEditCurrentRecord} value={(v as string) ?? ""} onChange={(e) => setField(it.key, e.target.value)} placeholder={placeholder} />;
+            return <textarea className="ta" value={(v as string) ?? ""} onChange={(e) => setField(it.key, e.target.value)} placeholder={placeholder} />;
         }
         if (it.type === "confirm") {
             return (
                 <div data-component="service-record-confirm-options" className="opts">
-                    <button type="button" aria-pressed={Boolean(v)} disabled={!canEditCurrentRecord} className={`opt ${v ? "sel" : ""}`} onClick={() => setField(it.key, !v)}>
+                    <button type="button" aria-pressed={Boolean(v)} className={`opt ${v ? "sel" : ""}`} onClick={() => setField(it.key, !v)}>
                         <span className="box">✓</span>결제 확인 완료
                     </button>
                 </div>
@@ -705,7 +698,7 @@ export default function ServiceRecordPage() {
     const currentDayPage = DAY_PAGES[pageIdx] ?? DAY_PAGES[0];
     const isMomConfirmationPage = Boolean(currentDayPage.confirmation);
     const currentServiceDate = ((draft["_date"] as string | undefined) || defaultDate(day));
-    const canEditCurrentRecord = canEditDailyRecord(editing, currentServiceDate);
+    const hasServiceDateMismatch = isServiceDateMismatch(currentServiceDate);
     const currentSession = ctx?.sessions.find((session) => session.sessionIndex === day);
     const existingMomSignature = currentSession?.clientSignature ?? null;
     const signatureValue = existingMomSignature ?? clientSignature;
@@ -812,7 +805,7 @@ export default function ServiceRecordPage() {
                 {screen === "overview" && ctx && (
                     <>
                         <div data-component="service-record-overview-title" className="step-title">제공기록표</div>
-                        <p className="muted">서비스 제공 기록은 해당 날짜에만 기록이 가능합니다. 제출된 기록은 눌러서 수정할 수 있습니다.</p>
+                        <p data-component="mobile_service-record_overview_help" className="muted">제출된 기록은 눌러서 수정할 수 있습니다.</p>
                         <div data-component="service-record-day-grid" className="days">
                             {Array.from({ length: ctx.totalSessions }, (_, i) => i + 1).map((d) => {
                                 const done = lockedDays.has(d);
@@ -867,9 +860,9 @@ export default function ServiceRecordPage() {
                                 <input type="date" className="in dateinput" value={currentServiceDate} min={day <= 1 ? (ctx?.startDate?.slice(0, 10) ?? undefined) : defaultDate(day)} onChange={(e) => setField("_date", e.target.value)} />
                             </div>
                         )}
-                        {!editing && !canEditCurrentRecord && (
+                        {!editing && hasServiceDateMismatch && (
                             <div data-component="service-record-date-mismatch-notice" className="notice">
-                                <span>서비스 제공일자({monthDayKo(currentServiceDate)})가 오늘과 달라 입력할 수 없습니다. 서비스 제공 당일에 기록해 주세요.</span>
+                                <span>서비스 제공일자({monthDayKo(currentServiceDate)})가 오늘과 달라요. 한번 더 확인해 주세요.</span>
                             </div>
                         )}
                         <div data-component="service-record-day-title" className="step-title">{currentDayPage.title}</div>
@@ -915,13 +908,13 @@ export default function ServiceRecordPage() {
                         )}
                         {isMomConfirmationPage ? (
                             <div data-component="service-record-confirmation-action" className="nav confirmation-nav">
-                                <button className="btn submit" disabled={busy || !canEditCurrentRecord || !signatureValue} onClick={() => setSubmitModalOpen(true)}>확인</button>
+                                <button className="btn submit" disabled={busy || !signatureValue} onClick={() => setSubmitModalOpen(true)}>확인</button>
                             </div>
                         ) : (
                             <div data-component="service-record-nav" className="nav">
                                 <button
                                     className="btn primary"
-                                    disabled={!canEditCurrentRecord || !isCurrentPageComplete}
+                                    disabled={!isCurrentPageComplete}
                                     onClick={() => navigateTo("day", {
                                         mode: "push",
                                         day,

--- a/mobile/src/app/(public)/service-record/__tests__/page.auth.test.tsx
+++ b/mobile/src/app/(public)/service-record/__tests__/page.auth.test.tsx
@@ -115,6 +115,41 @@ describe("ServiceRecordPage authentication restoration", () => {
         expect(screen.getByDisplayValue("작성 중인 기록")).toBeInTheDocument();
     });
 
+    it("allows entry for a different service date while showing a warning", async () => {
+        const user = userEvent.setup();
+        window.sessionStorage.setItem("daily-service-record-draft:link-token", JSON.stringify({
+            header: { momName: "홍길동" },
+            day: 1,
+            pageIdx: 0,
+            draft: {
+                _date: "2026-07-20",
+                perineum: ["이상없음"],
+                breast: ["이상없음"],
+                excretion: ["이상없음"],
+                sitzBath: "실시",
+                meals_meal: "1",
+                meals_snack: "1",
+            },
+        }));
+        fetchMock
+            .mockResolvedValueOnce(jsonResponse({ valid: true }))
+            .mockResolvedValueOnce(jsonResponse({
+                ...serviceRecordContext,
+                totalSessions: 2,
+                header: { momName: "홍길동" },
+            }));
+
+        render(<ServiceRecordPage />);
+
+        expect(await screen.findByText("제공기록표")).toBeInTheDocument();
+        await user.click(screen.getByRole("button", { name: "기록 시작" }));
+
+        expect(document.querySelector('[data-component="service-record-date-mismatch-notice"]'))
+            .toHaveTextContent("서비스 제공일자(2026.07.20)가 오늘과 달라요. 한번 더 확인해 주세요.");
+        expect(screen.getAllByRole("button", { name: /이상없음/ })[0]).toBeEnabled();
+        expect(screen.getByRole("button", { name: "다음" })).toBeEnabled();
+    });
+
     it("does not allow navigation back to submitted service information from the overview", async () => {
         fetchMock
             .mockResolvedValueOnce(jsonResponse({ valid: true }))

--- a/mobile/src/app/(public)/service-record/__tests__/page.helpers.test.ts
+++ b/mobile/src/app/(public)/service-record/__tests__/page.helpers.test.ts
@@ -1,21 +1,12 @@
-import { canEditDailyRecord, isDayButtonDisabled } from "../[token]/page";
+import { isDayButtonDisabled, isServiceDateMismatch } from "../[token]/page";
 
-describe("canEditDailyRecord", () => {
-    it("allows an existing record to be edited outside the service date", () => {
-        expect(canEditDailyRecord(true, "2026-07-14", "2026-07-15")).toBe(true);
+describe("isServiceDateMismatch", () => {
+    it("detects when the service date differs from today", () => {
+        expect(isServiceDateMismatch("2026-07-14", "2026-07-15")).toBe(true);
     });
 
-    it("keeps the same-day gate for a new record", () => {
-        expect(canEditDailyRecord(false, "2026-07-14", "2026-07-15")).toBe(false);
-        expect(canEditDailyRecord(false, "2026-07-15", "2026-07-15")).toBe(true);
-    });
-
-    it("allows a new record outside the service date when the dev override is enabled", () => {
-        expect(canEditDailyRecord(false, "2026-07-14", "2026-07-15", true)).toBe(true);
-    });
-
-    it("keeps the same-day gate when the dev override is disabled", () => {
-        expect(canEditDailyRecord(false, "2026-07-14", "2026-07-15", false)).toBe(false);
+    it("does not flag today's service date", () => {
+        expect(isServiceDateMismatch("2026-07-15", "2026-07-15")).toBe(false);
     });
 });
 

--- a/mobile/tests/service-record-final-flow.spec.ts
+++ b/mobile/tests/service-record-final-flow.spec.ts
@@ -54,6 +54,40 @@ test("백엔드 서비스 일수만큼 제공기록표를 생성한다", async (
   await expect(page.locator('[data-component="service-record-day-number"]').filter({ hasText: "20" })).toHaveCount(1);
 });
 
+test("서비스 제공일자가 오늘과 달라도 경고만 표시하고 기록을 작성한다", async ({ page }) => {
+  const token = "service-date-mismatch-warning";
+
+  await mockShellRequests(page);
+  await page.route(`**/api/service-record/${token}/link`, (route) => route.fulfill({ json: { valid: true } }));
+  await page.route(`**/api/service-record/${token}/verify`, (route) => route.fulfill({ status: 201, json: { ok: true, accessToken: "access-token" } }));
+  await page.route(`**/api/service-record/${token}/context`, (route) => route.fulfill({
+    json: {
+      org: { name: "테스트 제공기관", hours: "" },
+      employee: { id: 1, name: "김제공" },
+      client: { id: 1, name: "테스트 고객" },
+      totalSessions: 2,
+      startDate: "2026-07-20",
+      header,
+      sessions: [],
+      recordStatus: "IN_PROGRESS",
+    },
+  }));
+
+  await page.goto(`/service-record/${token}`);
+  await expect(page.getByText("서비스 제공 기록은 해당 날짜에만 기록이 가능합니다.", { exact: false })).toHaveCount(0);
+  await page.getByRole("button", { name: "기록 시작" }).click();
+
+  await expect(page.locator('[data-component="service-record-date-mismatch-notice"]'))
+    .toHaveText("서비스 제공일자(2026.07.20)가 오늘과 달라요. 한번 더 확인해 주세요.");
+  await expect(page.getByRole("button", { name: "열상" })).toBeEnabled();
+  await page.getByRole("button", { name: "열상" }).click();
+  await page.getByLabel("식사").fill("3");
+  await page.getByLabel("간식").fill("2");
+  await page.getByRole("button", { name: "다음", exact: true }).click();
+
+  await expect(page.locator('[data-component="service-record-day-title"]')).toHaveText("신생아 기록");
+});
+
 test("마지막 회차 제출 후 별도 버튼 없이 최종 제출을 완료한다", async ({ page }) => {
   const token = "final-service-record";
   let headerSaved = false;


### PR DESCRIPTION
## Summary
- allow service-record entry and submission when the selected service date differs from today
- keep the date mismatch notice as a warning with the requested Korean copy
- remove the contradictory overview copy that said records were limited to the service date
- preserve submitted/finalized record locks

## Verification
- `pnpm test --runInBand` (134 suites, 763 tests)
- changed-file ESLint
- `pnpm type-check`
- `NEXT_PUBLIC_API_BASE_URL=http://localhost:3001 pnpm build`
- Playwright: date mismatch warning remains visible, fields are enabled, and navigation reaches the next daily-record page

## Security
- no auth, token, environment, dependency, or backend authorization changes
- no hardcoded secrets or dangerous execution patterns introduced