### PR TITLE
fix(mobile): show schedule change loading modal immediately

### DIFF
--- a/mobile/src/app/(public)/service-record/[token]/page.tsx
+++ b/mobile/src/app/(public)/service-record/[token]/page.tsx
@@ -592,16 +592,21 @@ export default function ServiceRecordPage() {
     }
 
     async function openScheduleChangePreview() {
+        setScheduleChangePreview(null);
+        setScheduleChangeModalOpen(true);
         setScheduleChangeBusy(true);
         try {
             const res = await api("/schedule-change/preview");
             const data = await res.json().catch(() => ({}));
             if (!res.ok) {
+                setScheduleChangeModalOpen(false);
                 setErrorNotificationMessage(data?.error ?? data?.message ?? "일정 변경 정보를 불러오지 못했습니다.");
                 return;
             }
             setScheduleChangePreview(data as ScheduleChangePreview);
-            setScheduleChangeModalOpen(true);
+        } catch {
+            setScheduleChangeModalOpen(false);
+            setErrorNotificationMessage("일정 변경 정보를 불러오지 못했습니다.");
         } finally {
             setScheduleChangeBusy(false);
         }
@@ -957,14 +962,17 @@ export default function ServiceRecordPage() {
                 onApprove={submitDay}
             />
             <MobileTwoButtonModal
-                open={scheduleChangeModalOpen && Boolean(scheduleChangePreview)}
-                title={scheduleChangePreview ? `${scheduleChangePreview.sessionIndex}회차 서비스 일정을 조정할까요?` : "서비스 일정을 조정할까요?"}
+                open={scheduleChangeModalOpen}
+                title={scheduleChangePreview ? `${scheduleChangePreview.sessionIndex}회차 서비스 일정을 조정할까요?` : "서비스 일정 변경"}
                 description={scheduleChangePreview
                     ? `${scheduleChangePreview.sessionIndex}회차 서비스를 ${monthDayKo(scheduleChangePreview.fromDate)}에서 ${monthDayKo(scheduleChangePreview.toDate)}로 변경을 요청할까요? 관리자 승인 후 일정이 조정됩니다.`
-                    : ""}
+                    : "변경 가능한 일정을 확인하고 있어요."}
                 cancelLabel="취소"
-                confirmLabel={scheduleChangeBusy ? "요청 중…" : "승인 요청"}
+                confirmLabel={scheduleChangeBusy
+                    ? scheduleChangePreview ? "요청 중…" : "불러오는 중…"
+                    : "승인 요청"}
                 loading={scheduleChangeBusy}
+                confirmDisabled={!scheduleChangePreview}
                 onOpenChange={(open) => {
                     if (!open) closeScheduleChangeModal();
                 }}

--- a/mobile/src/app/(public)/service-record/__tests__/page.auth.test.tsx
+++ b/mobile/src/app/(public)/service-record/__tests__/page.auth.test.tsx
@@ -14,11 +14,48 @@ jest.mock("@/components/app/ui/ApprovalTwoButtonModal", () => ({
 }));
 
 jest.mock("@/components/app/ui/MobileTwoButtonModal", () => ({
-    MobileTwoButtonModal: () => null,
+    MobileTwoButtonModal: ({
+        open,
+        title,
+        description,
+        loading,
+        confirmLabel,
+        confirmDisabled,
+    }: {
+        open: boolean;
+        title: string;
+        description?: string;
+        loading?: boolean;
+        confirmLabel: string;
+        confirmDisabled?: boolean;
+    }) => open ? (
+        <div
+            role="dialog"
+            aria-busy={loading}
+            data-component="mobile-two-button-modal"
+        >
+            <h2>{title}</h2>
+            <p>{description}</p>
+            <button disabled={loading || confirmDisabled}>{confirmLabel}</button>
+        </div>
+    ) : null,
 }));
 
 jest.mock("@/components/app/ui/NotificationOneButtonModal", () => ({
-    NotificationOneButtonModal: () => null,
+    NotificationOneButtonModal: ({
+        open,
+        title,
+        description,
+    }: {
+        open: boolean;
+        title: string;
+        description: string;
+    }) => open ? (
+        <div role="alertdialog" data-component="service-record-error-notification">
+            <h2>{title}</h2>
+            <p>{description}</p>
+        </div>
+    ) : null,
 }));
 
 jest.mock("@/components/app/service-record/SignaturePad", () => ({
@@ -27,6 +64,16 @@ jest.mock("@/components/app/service-record/SignaturePad", () => ({
 
 const mockUseParams = useParams as jest.Mock;
 const fetchMock = jest.fn();
+
+function deferredResponse() {
+    let resolve!: (response: Response) => void;
+    let reject!: (error: Error) => void;
+    const promise = new Promise<Response>((resolver, rejecter) => {
+        resolve = resolver;
+        reject = rejecter;
+    });
+    return { promise, resolve, reject };
+}
 
 function jsonResponse(data: unknown, status = 200): Response {
     return {
@@ -127,6 +174,60 @@ describe("ServiceRecordPage authentication restoration", () => {
 
         expect(await screen.findByText("제공기록표")).toBeInTheDocument();
         expect(document.querySelector('[data-component="service-record-overview-back"]')).not.toBeInTheDocument();
+    });
+
+    it("opens a loading schedule-change modal before the preview request resolves", async () => {
+        const user = userEvent.setup();
+        const previewResponse = deferredResponse();
+        fetchMock
+            .mockResolvedValueOnce(jsonResponse({ valid: true }))
+            .mockResolvedValueOnce(jsonResponse({
+                ...serviceRecordContext,
+                header: { momName: "홍길동" },
+            }))
+            .mockReturnValueOnce(previewResponse.promise);
+
+        render(<ServiceRecordPage />);
+
+        await user.click(await screen.findByRole("button", { name: "서비스 일정 변경" }));
+
+        expect(screen.getByRole("dialog")).toHaveAttribute("aria-busy", "true");
+        expect(screen.getByRole("heading", { name: "서비스 일정 변경" })).toBeInTheDocument();
+        expect(screen.getByText("변경 가능한 일정을 확인하고 있어요.")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "불러오는 중…" })).toBeDisabled();
+
+        previewResponse.resolve(jsonResponse({
+            sessionIndex: 1,
+            fromDate: "2026-07-20",
+            toDate: "2026-07-21",
+        }));
+
+        expect(await screen.findByRole("heading", { name: "1회차 서비스 일정을 조정할까요?" }))
+            .toBeInTheDocument();
+        expect(screen.getByRole("dialog")).toHaveAttribute("aria-busy", "false");
+        expect(screen.getByRole("button", { name: "승인 요청" })).toBeEnabled();
+    });
+
+    it("closes the loading modal and shows the existing error notice when preview loading fails", async () => {
+        const user = userEvent.setup();
+        const previewResponse = deferredResponse();
+        fetchMock
+            .mockResolvedValueOnce(jsonResponse({ valid: true }))
+            .mockResolvedValueOnce(jsonResponse({
+                ...serviceRecordContext,
+                header: { momName: "홍길동" },
+            }))
+            .mockReturnValueOnce(previewResponse.promise);
+
+        render(<ServiceRecordPage />);
+
+        await user.click(await screen.findByRole("button", { name: "서비스 일정 변경" }));
+        expect(screen.getByRole("dialog")).toHaveAttribute("aria-busy", "true");
+
+        previewResponse.reject(new Error("network unavailable"));
+
+        expect(await screen.findByRole("alertdialog")).toHaveTextContent("일정 변경 정보를 불러오지 못했습니다.");
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
 
     it("maps daily pages to browser history so Back restores the previous wizard page", async () => {

--- a/mobile/src/components/app/ui/MobileTwoButtonModal.test.tsx
+++ b/mobile/src/components/app/ui/MobileTwoButtonModal.test.tsx
@@ -11,6 +11,7 @@ describe("MobileTwoButtonModal", () => {
         description="3회차 서비스 제공 날짜를 조정합니다."
         cancelLabel="취소"
         confirmLabel="일정 변경"
+        loading
         confirmDisabled
         onOpenChange={jest.fn()}
         onCancel={jest.fn()}
@@ -25,6 +26,7 @@ describe("MobileTwoButtonModal", () => {
     expect(screen.getByText("서비스 일정 변경")).toHaveClass("text-base");
     expect(screen.getByText("3회차 서비스 제공 날짜를 조정합니다.")).toHaveClass("text-sm", "leading-5");
     expect(screen.getByLabelText("3회차 서비스 제공 날짜")).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-busy", "true");
     expect(screen.getByRole("button", { name: "일정 변경" })).toBeDisabled();
   });
 });

--- a/mobile/src/components/app/ui/MobileTwoButtonModal.tsx
+++ b/mobile/src/components/app/ui/MobileTwoButtonModal.tsx
@@ -71,6 +71,7 @@ export function MobileTwoButtonModal({
         <DialogPrimitive.Content
           data-component="mobile-two-button-modal"
           data-source-component={SOURCE_COMPONENT}
+          aria-busy={loading}
           className="fixed top-1/2 left-1/2 z-[201] grid w-[calc(100vw-2.5rem)] max-w-[340px] -translate-x-1/2 -translate-y-1/2 gap-3 rounded-2xl border bg-background p-5 shadow-lg outline-none duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95"
         >
           <div


### PR DESCRIPTION
## What changed

- Open the schedule-change modal immediately when the user clicks the action.
- Show a loading title, description, and disabled action while preview data is fetched.
- Replace the loading content with the actual session/date confirmation after the response.
- Close the loading modal and retain the existing error notice when preview loading fails.
- Expose the modal loading state through `aria-busy`.

## Why

The modal previously opened only after the `/schedule-change/preview` request completed, leaving the button disabled with no visible feedback for roughly 1–1.5 seconds.

## Validation

- Mobile focused Jest: 8 tests passed
- Mobile full Jest: 134 suites / 766 tests passed
- Mobile type-check passed
- Mobile production build passed
- Changed-file ESLint passed
- `pnpm audit --prod --audit-level high`: no known vulnerabilities