### PR TITLE
fix(messages): preserve history retry metadata in Preview

### DIFF
--- a/backend/application/services/sms-retry.service.ts
+++ b/backend/application/services/sms-retry.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Logger } from "@nestjs/common";
+import { ConflictException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { AligoService } from "application/services/aligo.service";
 import { MessageSenderApprovalService } from "application/services/message-sender-approval.service";
 import { maskPhone } from "application/utils/mask";
@@ -18,6 +18,24 @@ export class SmsRetryService {
         private readonly aligoService: AligoService,
         private readonly messageSenderApprovalService: MessageSenderApprovalService,
     ) {}
+
+    async retryById(branchId: string, logId: number): Promise<MessageLogEntity> {
+        const log = await this.logRepository.findByIdInBranch(branchId, logId);
+        if (!log || log.provider !== "aligo_sms") {
+            throw new NotFoundException("재발송할 메시지 기록을 찾을 수 없습니다.");
+        }
+
+        if (log.status !== "failed") {
+            throw new ConflictException("실패한 메시지만 재발송할 수 있습니다.");
+        }
+
+        const scheduledLog = await this.logRepository.scheduleFailedForRetry(branchId, logId);
+        if (!scheduledLog) {
+            throw new ConflictException("이미 재발송이 진행 중입니다.");
+        }
+
+        return scheduledLog;
+    }
 
     async retry(log: MessageLogEntity): Promise<void> {
         if (log.branchId) {

--- a/backend/domain/repositories/message-log.repository.interface.ts
+++ b/backend/domain/repositories/message-log.repository.interface.ts
@@ -3,6 +3,8 @@ import { MessageLogEntity } from "domain/entities/message-log.entity";
 export interface IMessageLogRepository {
     save(log: MessageLogEntity): Promise<MessageLogEntity>;
     update(log: MessageLogEntity): Promise<MessageLogEntity>;
+    findByIdInBranch(branchId: string, id: number): Promise<MessageLogEntity | null>;
+    scheduleFailedForRetry(branchId: string, id: number): Promise<MessageLogEntity | null>;
     findSentTriggerJobIds(jobIds: string[]): Promise<Set<string>>;
     findPendingRetries(): Promise<MessageLogEntity[]>;
     findRetryableServiceRecordSmsByScheduleId(scheduleId: number): Promise<MessageLogEntity[]>;

--- a/backend/infrastructure/database/repositories/sb.message-log.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.message-log.repository.ts
@@ -28,6 +28,35 @@ export class SbMessageLogRepository implements IMessageLogRepository {
         return MessageLogMapper.toDomain(row);
     }
 
+    async findByIdInBranch(branchId: string, id: number): Promise<MessageLogEntity | null> {
+        const row = await this.prisma.message_log.findFirst({
+            where: { id, branchId },
+        });
+        return row ? MessageLogMapper.toDomain(row) : null;
+    }
+
+    async scheduleFailedForRetry(branchId: string, id: number): Promise<MessageLogEntity | null> {
+        const retryAt = new Date(Date.now());
+        const result = await this.prisma.message_log.updateMany({
+            where: {
+                id,
+                branchId,
+                provider: "aligo_sms",
+                status: "failed",
+            },
+            data: {
+                status: "pending",
+                nextRetryAt: retryAt,
+            },
+        });
+
+        if (result.count !== 1) {
+            return null;
+        }
+
+        return this.findByIdInBranch(branchId, id);
+    }
+
     async findSentTriggerJobIds(jobIds: string[]): Promise<Set<string>> {
         if (jobIds.length === 0) {
             return new Set<string>();

--- a/backend/interface/controllers/message-trigger.controller.ts
+++ b/backend/interface/controllers/message-trigger.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Delete, Get, Param, Patch, Post, Query, UseGuards } f
 import { JwtGuard } from "infrastructure/auth/jwt.guard";
 import { CurrentTenant, TenantGuard } from "infrastructure/tenant";
 import { MessageTriggerService } from "application/services/message-trigger.service";
+import { SmsRetryService } from "application/services/sms-retry.service";
 import {
     MessageTriggerEventType,
     MessageTriggerRecipientType,
@@ -15,7 +16,10 @@ import { parseInteger } from "interface/parse-integer";
 @Controller()
 @UseGuards(JwtGuard, TenantGuard)
 export class MessageTriggerController {
-    constructor(private readonly triggerService: MessageTriggerService) {}
+    constructor(
+        private readonly triggerService: MessageTriggerService,
+        private readonly smsRetryService: SmsRetryService,
+    ) {}
 
     @Get("message-trigger-rules")
     listRules(@CurrentTenant() tenant: { branchId?: string }) {
@@ -43,6 +47,17 @@ export class MessageTriggerController {
             tenant.branchId ?? "",
             parseInteger(limit, "limit", { defaultValue: 200, min: 1, max: 500 }),
             parseInteger(skip, "skip", { defaultValue: 0, min: 0 }),
+        );
+    }
+
+    @Post("message-logs/:id/retry")
+    retryHistory(
+        @CurrentTenant() tenant: { branchId?: string },
+        @Param("id") id: string,
+    ) {
+        return this.smsRetryService.retryById(
+            tenant.branchId ?? "",
+            parseInteger(id, "id", { min: 1 }),
         );
     }
 

--- a/backend/test/integration/message-trigger.controller.integration.spec.ts
+++ b/backend/test/integration/message-trigger.controller.integration.spec.ts
@@ -17,6 +17,7 @@ import {
     type MessageTriggerTemplateCatalogItem,
 } from "domain/constants/message-trigger-catalog";
 import { MessageTriggerRuleEntity } from "domain/entities/message-trigger-rule.entity";
+import { SmsRetryService } from "application/services/sms-retry.service";
 
 describe("MessageTriggerController (Integration)", () => {
     type RuleOverrides = Partial<{
@@ -43,6 +44,9 @@ describe("MessageTriggerController (Integration)", () => {
         updateRule: jest.Mock;
         deleteRule: jest.Mock;
         listTemplates: jest.Mock;
+    };
+    let smsRetryService: {
+        retryById: jest.Mock;
     };
 
     const branchId = "org-1";
@@ -152,6 +156,9 @@ describe("MessageTriggerController (Integration)", () => {
             deleteRule: jest.fn(),
             listTemplates: jest.fn(),
         };
+        smsRetryService = {
+            retryById: jest.fn(),
+        };
 
         const mockAuthGuard = {
             canActivate: (context: ExecutionContext) => {
@@ -178,6 +185,10 @@ describe("MessageTriggerController (Integration)", () => {
                 {
                     provide: MessageTriggerService,
                     useValue: triggerService,
+                },
+                {
+                    provide: SmsRetryService,
+                    useValue: smsRetryService,
                 },
             ],
         })
@@ -252,6 +263,35 @@ describe("MessageTriggerController (Integration)", () => {
 
             expect(response.status).toBe(200);
             expect(triggerService.listHistory).toHaveBeenCalledWith(branchId, 25, 50);
+        });
+    });
+
+    describe("POST /message-logs/:id/retry", () => {
+        it("schedules the branch-owned history log for retry", async () => {
+            smsRetryService.retryById.mockResolvedValue({
+                id: 77,
+                status: "pending",
+                templateKey: "service_record_link_sms",
+            });
+
+            const response = await request(app.getHttpServer())
+                .post("/message-logs/77/retry");
+
+            expect(response.status).toBe(201);
+            expect(response.body).toMatchObject({
+                id: 77,
+                status: "pending",
+                templateKey: "service_record_link_sms",
+            });
+            expect(smsRetryService.retryById).toHaveBeenCalledWith(branchId, 77);
+        });
+
+        it("rejects an invalid log id before retrying", async () => {
+            const response = await request(app.getHttpServer())
+                .post("/message-logs/not-a-number/retry");
+
+            expect(response.status).toBe(400);
+            expect(smsRetryService.retryById).not.toHaveBeenCalled();
         });
     });
 

--- a/backend/test/repositories/sb.message-log.repository.spec.ts
+++ b/backend/test/repositories/sb.message-log.repository.spec.ts
@@ -3,7 +3,9 @@ import { PrismaService } from "infrastructure/database/prisma.service";
 
 describe("SbMessageLogRepository", () => {
     const createMockPrismaMessageLog = () => ({
+        findFirst: jest.fn(),
         findMany: jest.fn(),
+        updateMany: jest.fn(),
     });
 
     let messageLogModel: ReturnType<typeof createMockPrismaMessageLog>;
@@ -45,6 +47,71 @@ describe("SbMessageLogRepository", () => {
                 select: { triggerJobId: true },
             });
             expect(result).toEqual(new Set(["job-1", "job-3"]));
+        });
+    });
+
+    describe("scheduleFailedForRetry", () => {
+        it("atomically schedules only the branch-owned failed SMS log", async () => {
+            const retryAt = new Date("2026-07-23T02:25:00.000Z");
+            const nowSpy = jest.spyOn(Date, "now").mockReturnValue(retryAt.getTime());
+            messageLogModel.updateMany.mockResolvedValue({ count: 1 });
+            messageLogModel.findFirst.mockResolvedValue({
+                id: 77,
+                branchId: "branch-1",
+                provider: "aligo_sms",
+                templateKey: "service_record_link_sms",
+                triggerJobId: "job-1",
+                receiver: "01012345678",
+                clientId: 3,
+                recipientName: "나세정",
+                recipientPhone: "01012345678",
+                messageBody: "제공기록지 작성 링크",
+                variables: {},
+                status: "pending",
+                aligoMid: null,
+                errorMessage: "발송 실패",
+                attempts: 1,
+                lastAttemptAt: new Date("2026-07-23T02:20:00.000Z"),
+                nextRetryAt: retryAt,
+                createdAt: new Date("2026-07-23T02:20:00.000Z"),
+                updatedAt: retryAt,
+            });
+
+            const result = await repository.scheduleFailedForRetry("branch-1", 77);
+
+            expect(messageLogModel.updateMany).toHaveBeenCalledWith({
+                where: {
+                    id: 77,
+                    branchId: "branch-1",
+                    provider: "aligo_sms",
+                    status: "failed",
+                },
+                data: {
+                    status: "pending",
+                    nextRetryAt: retryAt,
+                },
+            });
+            expect(messageLogModel.findFirst).toHaveBeenCalledWith({
+                where: { id: 77, branchId: "branch-1" },
+            });
+            expect(result).toMatchObject({
+                id: 77,
+                branchId: "branch-1",
+                templateKey: "service_record_link_sms",
+                recipientName: "나세정",
+                status: "pending",
+                nextRetryAt: retryAt,
+            });
+            nowSpy.mockRestore();
+        });
+
+        it("does not fetch a log when the failed-state claim loses a race", async () => {
+            messageLogModel.updateMany.mockResolvedValue({ count: 0 });
+
+            const result = await repository.scheduleFailedForRetry("branch-1", 77);
+
+            expect(result).toBeNull();
+            expect(messageLogModel.findFirst).not.toHaveBeenCalled();
         });
     });
 });

--- a/backend/test/services/sms-retry.service.spec.ts
+++ b/backend/test/services/sms-retry.service.spec.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException } from "@nestjs/common";
+import { ConflictException, ForbiddenException, NotFoundException } from "@nestjs/common";
 import { AligoService } from "application/services/aligo.service";
 import { MessageSenderApprovalService } from "application/services/message-sender-approval.service";
 import { SmsRetryService } from "application/services/sms-retry.service";
@@ -7,6 +7,8 @@ import { IMessageLogRepository } from "domain/repositories/message-log.repositor
 
 describe("SmsRetryService", () => {
     const createMockLogRepository = () => ({
+        scheduleFailedForRetry: jest.fn(),
+        findByIdInBranch: jest.fn(),
         update: jest.fn(),
     });
     const createMockAligoService = () => ({
@@ -106,6 +108,56 @@ describe("SmsRetryService", () => {
                 nextRetryAt: null,
             }),
         );
+    });
+
+    it("schedules the original branch-owned log without sending concurrently with the retry worker", async () => {
+        const log = createSmsRetryLog();
+        logRepository.findByIdInBranch.mockResolvedValue(log);
+        logRepository.scheduleFailedForRetry.mockImplementation(async () => {
+            log.status = "pending";
+            log.nextRetryAt = new Date(0);
+            return log;
+        });
+
+        const result = await service.retryById(
+            "11111111-1111-1111-1111-111111111111",
+            77,
+        );
+
+        expect(logRepository.findByIdInBranch).toHaveBeenCalledWith(
+            "11111111-1111-1111-1111-111111111111",
+            77,
+        );
+        expect(logRepository.scheduleFailedForRetry).toHaveBeenCalledWith(
+            "11111111-1111-1111-1111-111111111111",
+            77,
+        );
+        expect(aligoService.sendSms).not.toHaveBeenCalled();
+        expect(result).toBe(log);
+        expect(result.templateKey).toBe("client_greeting_sms");
+        expect(result.status).toBe("pending");
+        expect(result.nextRetryAt).toEqual(new Date(0));
+    });
+
+    it("does not reveal or retry a log owned by another branch", async () => {
+        logRepository.findByIdInBranch.mockResolvedValue(null);
+
+        await expect(service.retryById("branch-2", 77)).rejects.toThrow(NotFoundException);
+
+        expect(logRepository.scheduleFailedForRetry).not.toHaveBeenCalled();
+        expect(aligoService.sendSms).not.toHaveBeenCalled();
+    });
+
+    it("rejects a duplicate manual retry when another request already claimed the log", async () => {
+        const log = createSmsRetryLog();
+        logRepository.findByIdInBranch.mockResolvedValue(log);
+        logRepository.scheduleFailedForRetry.mockResolvedValue(null);
+
+        await expect(
+            service.retryById("11111111-1111-1111-1111-111111111111", 77),
+        ).rejects.toThrow(ConflictException);
+
+        expect(aligoService.sendSms).not.toHaveBeenCalled();
     });
 
     it("schedules another five-minute retry when an automatic SMS retry is still rejected", async () => {

--- a/frontend/src/app/(protected)/messages/page.tsx
+++ b/frontend/src/app/(protected)/messages/page.tsx
@@ -27,6 +27,7 @@ import { useSystemTemplate } from "@/features/system-templates/hooks";
 import type { SystemTemplateKey } from "@/features/system-templates/types";
 import {
   useMessageHistory,
+  useRetryMessageHistory,
   useUpcomingMessageTriggerJobs,
 } from "@/features/message-triggers/hooks/use-message-triggers";
 import {
@@ -41,7 +42,6 @@ import type {
   TriggerRecipientType,
   UpcomingMessageTriggerJob,
 } from "@/features/message-triggers/types";
-import { messageDeliveryApi } from "@/services/api";
 import { CustomTemplateForm } from "@/components/app/messages/forms/custom-template-form";
 import {
   getMessageHistoryEmptyStateCopy,
@@ -1253,9 +1253,9 @@ function MessageHistorySection() {
   const [relativeDateFilter, setRelativeDateFilter] = useState<MessageHistoryRelativeDateFilter>("all");
   const [dateYear, setDateYear] = useState("");
   const [dateMonth, setDateMonth] = useState("");
-  const [isRetrying, setIsRetrying] = useState(false);
   const deferredSearchValue = useDeferredValue(searchValue);
   const { data: historyData = [], isLoading, isError } = useMessageHistory();
+  const { mutateAsync: retryHistory, isPending: isRetrying } = useRetryMessageHistory();
   const { data: clients = [] } = useAllClients();
   const { toast } = useToast();
   const smsHistoryData = useMemo(
@@ -1336,31 +1336,27 @@ function MessageHistorySection() {
   }, [filteredRecords, selectedRecordId]);
 
   const canRetry = !!selectedRecord
-    && selectedRecord.status !== "sent"
-    && selectedRecord.status !== "canceled";
+    && typeof selectedRecord.id === "number"
+    && selectedRecord.status === "failed";
 
   const handleRetry = useCallback(async () => {
-    if (!selectedRecord) return;
+    if (!selectedRecord || typeof selectedRecord.id !== "number") return;
 
-    setIsRetrying(true);
     try {
-      await messageDeliveryApi.sendSms({
-        receiver: selectedRecord.recipientPhone,
-        recipientName: selectedRecord.recipientName,
-        message: selectedRecord.messagePreview,
-        msgType: "AUTO",
-      });
+      const retriedRecord = await retryHistory(selectedRecord.id);
 
-      toast({ description: "재발송 요청을 전송했습니다." });
+      if (retriedRecord.status === "failed") {
+        throw new Error(retriedRecord.errorMessage || "메시지 재발송에 실패했습니다.");
+      }
+
+      toast({ description: "재발송 요청을 등록했습니다." });
     } catch (error) {
       toast({
         variant: "destructive",
         description: error instanceof Error ? error.message : "재발송 요청 중 오류가 발생했습니다.",
       });
-    } finally {
-      setIsRetrying(false);
     }
-  }, [selectedRecord, toast]);
+  }, [retryHistory, selectedRecord, toast]);
 
   return (
     <SplitLayout

--- a/frontend/src/app/api/message-logs/[id]/retry/route.test.ts
+++ b/frontend/src/app/api/message-logs/[id]/retry/route.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment node
+ */
+import { AxiosError, AxiosHeaders } from "axios";
+import { NextRequest } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+
+import { POST } from "./route";
+
+jest.mock("@/lib/api/server", () => ({
+    serverAPIClient: {
+        post: jest.fn(),
+    },
+}));
+
+const mockPost = serverAPIClient.post as jest.Mock;
+
+function createRequest(authenticated = true) {
+    return new NextRequest("http://localhost/api/message-logs/77/retry", {
+        method: "POST",
+        headers: authenticated ? { cookie: "auth_token=token-1" } : {},
+    });
+}
+
+describe("POST /api/message-logs/[id]/retry", () => {
+    beforeEach(() => {
+        mockPost.mockReset();
+    });
+
+    it("forwards the authenticated retry to the backend", async () => {
+        mockPost.mockResolvedValue({
+            status: 201,
+            data: { id: 77, status: "pending", templateKey: "service_record_link_sms" },
+        });
+
+        const response = await POST(createRequest(), {
+            params: Promise.resolve({ id: "77" }),
+        });
+
+        expect(response.status).toBe(201);
+        expect(await response.json()).toMatchObject({ id: 77, status: "pending" });
+        expect(mockPost).toHaveBeenCalledWith(
+            "/message-logs/77/retry",
+            {},
+            { headers: { Authorization: "Bearer token-1" } },
+        );
+    });
+
+    it("preserves a backend conflict response", async () => {
+        mockPost.mockRejectedValue(
+            new AxiosError("Conflict", "ERR_BAD_RESPONSE", undefined, undefined, {
+                status: 409,
+                statusText: "Conflict",
+                headers: {},
+                config: { headers: new AxiosHeaders() },
+                data: { message: "이미 재발송이 진행 중입니다." },
+            }),
+        );
+
+        const response = await POST(createRequest(), {
+            params: Promise.resolve({ id: "77" }),
+        });
+
+        expect(response.status).toBe(409);
+        expect(await response.json()).toEqual({ message: "이미 재발송이 진행 중입니다." });
+    });
+
+    it("requires authentication before forwarding", async () => {
+        const response = await POST(createRequest(false), {
+            params: Promise.resolve({ id: "77" }),
+        });
+
+        expect(response.status).toBe(401);
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/app/api/message-logs/[id]/retry/route.ts
+++ b/frontend/src/app/api/message-logs/[id]/retry/route.ts
@@ -1,0 +1,34 @@
+import { isAxiosError } from "axios";
+import { NextRequest, NextResponse } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+    const token = request.cookies.get("auth_token")?.value;
+    if (!token) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    try {
+        const response = await serverAPIClient.post(
+            `/message-logs/${encodeURIComponent(id)}/retry`,
+            {},
+            { headers: { Authorization: `Bearer ${token}` } },
+        );
+
+        return NextResponse.json(response.data ?? {}, { status: response.status });
+    } catch (error) {
+        if (isAxiosError(error) && error.response) {
+            return NextResponse.json(error.response.data ?? { error: "Request failed" }, {
+                status: error.response.status,
+            });
+        }
+
+        console.error("message history retry failed:", error);
+        return NextResponse.json({ error: "Failed to retry message" }, { status: 500 });
+    }
+}

--- a/frontend/src/features/message-triggers/api/message-triggers.api.ts
+++ b/frontend/src/features/message-triggers/api/message-triggers.api.ts
@@ -33,4 +33,6 @@ export const messageTriggersApi = {
         api.get<MessageLogRecord[]>("/message-logs", {
             params: { limit },
         }),
+    retryHistory: (id: number) =>
+        api.post<MessageLogRecord>(`/message-logs/${id}/retry`),
 };

--- a/frontend/src/features/message-triggers/hooks/use-message-history-retry.test.ts
+++ b/frontend/src/features/message-triggers/hooks/use-message-history-retry.test.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { messageTriggersApi } from "../api/message-triggers.api";
+import { messageTriggerKeys } from "./keys";
+import { useRetryMessageHistory } from "./use-message-triggers";
+
+jest.mock("@tanstack/react-query", () => ({
+  useMutation: jest.fn((options) => options),
+  useQuery: jest.fn(),
+  useQueryClient: jest.fn(),
+}));
+
+jest.mock("../api/message-triggers.api", () => ({
+  messageTriggersApi: {
+    retryHistory: jest.fn(),
+  },
+}));
+
+describe("useRetryMessageHistory", () => {
+  const invalidateQueries = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useMutation as jest.Mock).mockImplementation((options) => options);
+    (useQueryClient as jest.Mock).mockReturnValue({ invalidateQueries });
+  });
+
+  it("retries the selected history log by id and refreshes history", async () => {
+    jest.mocked(messageTriggersApi.retryHistory).mockResolvedValue({
+      data: { id: 77, status: "sent" },
+    } as never);
+    const mutation = useRetryMessageHistory() as unknown as {
+      mutationFn: (id: number) => Promise<unknown>;
+      onSuccess: () => void;
+    };
+
+    await mutation.mutationFn(77);
+    mutation.onSuccess();
+
+    expect(messageTriggersApi.retryHistory).toHaveBeenCalledWith(77);
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: messageTriggerKeys.history(),
+    });
+  });
+});

--- a/frontend/src/features/message-triggers/hooks/use-message-triggers.ts
+++ b/frontend/src/features/message-triggers/hooks/use-message-triggers.ts
@@ -103,6 +103,18 @@ export function useMessageHistory(limit = 200) {
     });
 }
 
+export function useRetryMessageHistory() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (id: number) =>
+            messageTriggersApi.retryHistory(id).then((response) => response.data),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: messageTriggerKeys.history() });
+        },
+    });
+}
+
 export function useCreateMessageTriggerRule() {
     const queryClient = useQueryClient();
 


### PR DESCRIPTION
## 목적

메시지 발송 기록 재발송 시 원본 제목·수신자·고객 연결이 달라지는 문제를 Preview 환경에 배포합니다.

## 변경

- 새 수동 SMS 로그 대신 원본 실패 로그를 재시도 대기로 원자 전환
- 원본 템플릿, 수신자, 고객 연결, 메시지 본문 보존
- 지점 소유권 검증과 중복 재시도 차단
- 브라우저용 Next.js 재발송 프록시 추가
- 수동 요청과 5분 자동 재시도의 동시 Aligo 호출 제거

## 기준

최신 `preview`의 기존 핫픽스를 유지한 상태에서 PR #354의 단일 수정 커밋만 적용했습니다. PR #356은 브랜치 간 기존 차이로 대체됩니다.

## 검증

- Backend regression: 28 tests passed
- Frontend retry/proxy regression: 4 tests passed
- Backend/frontend type-check: passed
- PR #354의 전체 CI, 인증 E2E, 보안 검사 통과
- 실제 SMS 발송은 수행하지 않음
