### PR TITLE
fix(messages): keep failed and retry history separate in Preview

### DIFF
--- a/backend/application/services/sms-retry.service.ts
+++ b/backend/application/services/sms-retry.service.ts
@@ -20,43 +20,52 @@ export class SmsRetryService {
     ) {}
 
     async retryById(branchId: string, logId: number): Promise<MessageLogEntity> {
-        const log = await this.logRepository.findByIdInBranch(branchId, logId);
-        if (!log || log.provider !== "aligo_sms") {
+        const sourceLog = await this.logRepository.findByIdInBranch(branchId, logId);
+        if (!sourceLog || sourceLog.provider !== "aligo_sms") {
             throw new NotFoundException("재발송할 메시지 기록을 찾을 수 없습니다.");
         }
 
-        if (log.status !== "failed") {
+        if (sourceLog.status !== "failed") {
             throw new ConflictException("실패한 메시지만 재발송할 수 있습니다.");
         }
 
-        const scheduledLog = await this.logRepository.scheduleFailedForRetry(branchId, logId);
-        if (!scheduledLog) {
+        const retryLog = await this.retry(sourceLog);
+        if (!retryLog) {
             throw new ConflictException("이미 재발송이 진행 중입니다.");
         }
 
-        return scheduledLog;
+        return retryLog;
     }
 
-    async retry(log: MessageLogEntity): Promise<void> {
-        if (log.branchId) {
+    async retry(sourceLog: MessageLogEntity): Promise<MessageLogEntity | null> {
+        const retryLog = await this.logRepository.startRetryAttempt(
+            sourceLog,
+            this.createRetryAttempt(sourceLog),
+        );
+        if (!retryLog) {
+            this.logger.warn(`[Retry] SMS log ${sourceLog.id} was already claimed`);
+            return null;
+        }
+
+        if (retryLog.branchId) {
             try {
-                await this.messageSenderApprovalService.ensureApproved(log.branchId);
+                await this.messageSenderApprovalService.ensureApproved(retryLog.branchId);
             } catch (approvalError) {
                 const reason = approvalError instanceof Error ? approvalError.message : String(approvalError);
-                this.logger.warn(`[Retry] SMS blocked by approval gate for log ${log.id} (branchId=${log.branchId}): ${reason}`);
-                log.status = "failed";
-                log.errorMessage = reason;
-                log.attempts += 1;
-                log.lastAttemptAt = new Date(Date.now());
-                log.nextRetryAt = null;
-                await this.logRepository.update(log);
-                return;
+                this.logger.warn(`[Retry] SMS blocked by approval gate for log ${retryLog.id} (branchId=${retryLog.branchId}): ${reason}`);
+                retryLog.status = "failed";
+                retryLog.errorMessage = reason;
+                retryLog.attempts += 1;
+                retryLog.lastAttemptAt = new Date(Date.now());
+                retryLog.nextRetryAt = null;
+                await this.logRepository.update(retryLog);
+                return retryLog;
             }
         }
 
         try {
-            const rawScheduledDate = this.stringVariable(log, "scheduledDate");
-            const rawScheduledTime = this.stringVariable(log, "scheduledTime");
+            const rawScheduledDate = this.stringVariable(retryLog, "scheduledDate");
+            const rawScheduledTime = this.stringVariable(retryLog, "scheduledTime");
             const scheduleInstantMs = rawScheduledDate && rawScheduledTime
                 ? this.parseKstScheduleMs(rawScheduledDate, rawScheduledTime)
                 : null;
@@ -66,40 +75,71 @@ export class SmsRetryService {
             const scheduledTime = isScheduledInFuture ? rawScheduledTime : undefined;
 
             const result = await this.aligoService.sendSms({
-                senderPhone: this.stringVariable(log, "senderPhone"),
-                receiver: log.receiver,
-                message: log.messageBody,
-                recipientName: log.recipientName ?? this.stringVariable(log, "recipientName") ?? undefined,
-                title: this.stringVariable(log, "title") ?? undefined,
-                msgType: this.smsMessageTypeVariable(log, "msgType"),
+                senderPhone: this.stringVariable(retryLog, "senderPhone"),
+                receiver: retryLog.receiver,
+                message: retryLog.messageBody,
+                recipientName: retryLog.recipientName ?? this.stringVariable(retryLog, "recipientName") ?? undefined,
+                title: this.stringVariable(retryLog, "title") ?? undefined,
+                msgType: this.smsMessageTypeVariable(retryLog, "msgType"),
                 ...(scheduledDate ? { scheduledDate } : {}),
                 ...(scheduledTime ? { scheduledTime } : {}),
-                ...(this.booleanVariable(log, "testMode") ? { testMode: true } : {}),
+                ...(this.booleanVariable(retryLog, "testMode") ? { testMode: true } : {}),
             });
 
             if (!this.isAcceptedSmsResult(result)) {
-                this.markSmsRetryFailed(log, result.response.message || "문자 발송 요청이 실패했습니다.");
-                await this.logRepository.update(log);
-                this.logger.warn(`[Retry] SMS retry rejected for log ${log.id}: ${result.response.message}`);
-                return;
+                this.markSmsRetryFailed(retryLog, result.response.message || "문자 발송 요청이 실패했습니다.");
+                await this.logRepository.update(retryLog);
+                this.logger.warn(`[Retry] SMS retry rejected for log ${retryLog.id}: ${result.response.message}`);
+                return retryLog;
             }
 
             if (isScheduledInFuture) {
-                log.status = "pending";
-                log.aligoMid = result.response.msg_id ? String(result.response.msg_id) : null;
-                log.lastAttemptAt = new Date(Date.now());
-                log.nextRetryAt = null;
-                log.attempts += 1;
+                retryLog.status = "pending";
+                retryLog.aligoMid = result.response.msg_id ? String(result.response.msg_id) : null;
+                retryLog.lastAttemptAt = new Date(Date.now());
+                retryLog.nextRetryAt = null;
+                retryLog.attempts += 1;
             } else {
-                log.markSent(result.response.msg_id ? String(result.response.msg_id) : undefined);
+                retryLog.markSent(result.response.msg_id ? String(result.response.msg_id) : undefined);
             }
-            await this.logRepository.update(log);
-            this.logger.log(`[Retry] Successfully resent SMS ${log.templateKey} to ${maskPhone(log.receiver)}`);
+            await this.logRepository.update(retryLog);
+            this.logger.log(`[Retry] Successfully resent SMS ${retryLog.templateKey} to ${maskPhone(retryLog.receiver)}`);
+            return retryLog;
         } catch (error) {
-            this.markSmsRetryFailed(log, error instanceof Error ? error.message : String(error));
-            await this.logRepository.update(log);
-            this.logger.warn(`[Retry] Failed SMS attempt ${log.attempts} for log ${log.id}: ${error}`);
+            this.markSmsRetryFailed(retryLog, error instanceof Error ? error.message : String(error));
+            await this.logRepository.update(retryLog);
+            this.logger.warn(`[Retry] Failed SMS attempt ${retryLog.attempts} for log ${retryLog.id}: ${error}`);
+            return retryLog;
         }
+    }
+
+    private createRetryAttempt(sourceLog: MessageLogEntity): MessageLogEntity {
+        const now = new Date(Date.now());
+        return MessageLogEntity.reconstitute(
+            0,
+            sourceLog.branchId,
+            sourceLog.provider,
+            sourceLog.templateKey,
+            sourceLog.triggerJobId,
+            sourceLog.receiver,
+            sourceLog.clientId,
+            sourceLog.messageBody,
+            {
+                ...sourceLog.variables,
+                retryOfLogId: String(sourceLog.id),
+                retryAttempt: String(sourceLog.attempts + 1),
+            },
+            "pending",
+            null,
+            null,
+            sourceLog.attempts,
+            null,
+            null,
+            now,
+            now,
+            sourceLog.recipientName,
+            sourceLog.recipientPhone,
+        );
     }
 
     private parseKstScheduleMs(date: string, time: string): number | null {

--- a/backend/domain/repositories/message-log.repository.interface.ts
+++ b/backend/domain/repositories/message-log.repository.interface.ts
@@ -3,8 +3,11 @@ import { MessageLogEntity } from "domain/entities/message-log.entity";
 export interface IMessageLogRepository {
     save(log: MessageLogEntity): Promise<MessageLogEntity>;
     update(log: MessageLogEntity): Promise<MessageLogEntity>;
+    startRetryAttempt(
+        sourceLog: MessageLogEntity,
+        retryLog: MessageLogEntity,
+    ): Promise<MessageLogEntity | null>;
     findByIdInBranch(branchId: string, id: number): Promise<MessageLogEntity | null>;
-    scheduleFailedForRetry(branchId: string, id: number): Promise<MessageLogEntity | null>;
     findSentTriggerJobIds(jobIds: string[]): Promise<Set<string>>;
     findPendingRetries(): Promise<MessageLogEntity[]>;
     findRetryableServiceRecordSmsByScheduleId(scheduleId: number): Promise<MessageLogEntity[]>;

--- a/backend/infrastructure/database/repositories/sb.message-log.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.message-log.repository.ts
@@ -28,33 +28,42 @@ export class SbMessageLogRepository implements IMessageLogRepository {
         return MessageLogMapper.toDomain(row);
     }
 
+    async startRetryAttempt(
+        sourceLog: MessageLogEntity,
+        retryLog: MessageLogEntity,
+    ): Promise<MessageLogEntity | null> {
+        return this.prisma.$transaction(async (transaction) => {
+            const claimedAt = new Date(Date.now());
+            const claimed = await transaction.message_log.updateMany({
+                where: {
+                    id: sourceLog.id,
+                    branchId: sourceLog.branchId,
+                    status: sourceLog.status,
+                    nextRetryAt: sourceLog.nextRetryAt,
+                    updatedAt: sourceLog.updatedAt,
+                },
+                data: {
+                    nextRetryAt: null,
+                    updatedAt: claimedAt,
+                },
+            });
+
+            if (claimed.count !== 1) {
+                return null;
+            }
+
+            const row = await transaction.message_log.create({
+                data: MessageLogMapper.toPrismaCreate(retryLog),
+            });
+            return MessageLogMapper.toDomain(row);
+        });
+    }
+
     async findByIdInBranch(branchId: string, id: number): Promise<MessageLogEntity | null> {
         const row = await this.prisma.message_log.findFirst({
             where: { id, branchId },
         });
         return row ? MessageLogMapper.toDomain(row) : null;
-    }
-
-    async scheduleFailedForRetry(branchId: string, id: number): Promise<MessageLogEntity | null> {
-        const retryAt = new Date(Date.now());
-        const result = await this.prisma.message_log.updateMany({
-            where: {
-                id,
-                branchId,
-                provider: "aligo_sms",
-                status: "failed",
-            },
-            data: {
-                status: "pending",
-                nextRetryAt: retryAt,
-            },
-        });
-
-        if (result.count !== 1) {
-            return null;
-        }
-
-        return this.findByIdInBranch(branchId, id);
     }
 
     async findSentTriggerJobIds(jobIds: string[]): Promise<Set<string>> {

--- a/backend/test/repositories/sb.message-log.repository.spec.ts
+++ b/backend/test/repositories/sb.message-log.repository.spec.ts
@@ -1,8 +1,10 @@
 import { SbMessageLogRepository } from "infrastructure/database/repositories/sb.message-log.repository";
 import { PrismaService } from "infrastructure/database/prisma.service";
+import { MessageLogEntity } from "domain/entities/message-log.entity";
 
 describe("SbMessageLogRepository", () => {
     const createMockPrismaMessageLog = () => ({
+        create: jest.fn(),
         findFirst: jest.fn(),
         findMany: jest.fn(),
         updateMany: jest.fn(),
@@ -14,7 +16,10 @@ describe("SbMessageLogRepository", () => {
 
     beforeEach(() => {
         messageLogModel = createMockPrismaMessageLog();
-        prisma = { message_log: messageLogModel } as unknown as PrismaService;
+        prisma = {
+            message_log: messageLogModel,
+            $transaction: jest.fn(async (callback) => callback({ message_log: messageLogModel })),
+        } as unknown as PrismaService;
         repository = new SbMessageLogRepository(prisma);
     });
 
@@ -50,11 +55,106 @@ describe("SbMessageLogRepository", () => {
         });
     });
 
-    describe("scheduleFailedForRetry", () => {
-        it("atomically schedules only the branch-owned failed SMS log", async () => {
-            const retryAt = new Date("2026-07-23T02:25:00.000Z");
-            const nowSpy = jest.spyOn(Date, "now").mockReturnValue(retryAt.getTime());
+    describe("startRetryAttempt", () => {
+        const source = MessageLogEntity.reconstitute(
+            77,
+            "11111111-1111-1111-1111-111111111111",
+            "aligo_sms",
+            "service_record_link_sms",
+            "job-1",
+            "01012345678",
+            7,
+            "message",
+            {},
+            "failed",
+            null,
+            "등록되지 않은 발신번호입니다.",
+            1,
+            new Date("2026-07-22T17:13:11.000Z"),
+            new Date("2026-07-22T17:18:11.000Z"),
+            new Date("2026-07-22T17:13:11.000Z"),
+        );
+        const retryDraft = MessageLogEntity.reconstitute(
+            0,
+            source.branchId,
+            source.provider,
+            source.templateKey,
+            source.triggerJobId,
+            source.receiver,
+            source.clientId,
+            source.messageBody,
+            { retryOfLogId: "77", retryAttempt: "2" },
+            "pending",
+            null,
+            null,
+            1,
+            null,
+            null,
+            new Date("2026-07-22T17:18:11.000Z"),
+        );
+
+        it("should clear only the source retry schedule and create a separate attempt", async () => {
+            const claimedAt = new Date("2026-07-22T17:18:12.000Z");
+            const nowSpy = jest.spyOn(Date, "now").mockReturnValue(claimedAt.getTime());
             messageLogModel.updateMany.mockResolvedValue({ count: 1 });
+            messageLogModel.create.mockResolvedValue({
+                id: 78,
+                branchId: retryDraft.branchId,
+                provider: retryDraft.provider,
+                templateKey: retryDraft.templateKey,
+                triggerJobId: retryDraft.triggerJobId,
+                receiver: retryDraft.receiver,
+                clientId: retryDraft.clientId,
+                recipientName: null,
+                recipientPhone: retryDraft.receiver,
+                messageBody: retryDraft.messageBody,
+                variables: retryDraft.variables,
+                status: "pending",
+                aligoMid: null,
+                errorMessage: null,
+                attempts: 1,
+                lastAttemptAt: null,
+                nextRetryAt: null,
+                createdAt: retryDraft.createdAt,
+                updatedAt: retryDraft.createdAt,
+            });
+
+            const result = await repository.startRetryAttempt(source, retryDraft);
+
+            expect(messageLogModel.updateMany).toHaveBeenCalledWith({
+                where: {
+                    id: 77,
+                    branchId: source.branchId,
+                    status: "failed",
+                    nextRetryAt: source.nextRetryAt,
+                    updatedAt: source.updatedAt,
+                },
+                data: {
+                    nextRetryAt: null,
+                    updatedAt: claimedAt,
+                },
+            });
+            expect(messageLogModel.create).toHaveBeenCalled();
+            expect(result).toEqual(expect.objectContaining({ id: 78, status: "pending" }));
+            expect(source).toEqual(expect.objectContaining({
+                id: 77,
+                status: "failed",
+                errorMessage: "등록되지 않은 발신번호입니다.",
+            }));
+            nowSpy.mockRestore();
+        });
+
+        it("should not create a duplicate attempt when the source was already claimed", async () => {
+            messageLogModel.updateMany.mockResolvedValue({ count: 0 });
+
+            await expect(repository.startRetryAttempt(source, retryDraft)).resolves.toBeNull();
+
+            expect(messageLogModel.create).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("findByIdInBranch", () => {
+        it("returns only a log owned by the requested branch", async () => {
             messageLogModel.findFirst.mockResolvedValue({
                 id: 77,
                 branchId: "branch-1",
@@ -67,51 +167,26 @@ describe("SbMessageLogRepository", () => {
                 recipientPhone: "01012345678",
                 messageBody: "제공기록지 작성 링크",
                 variables: {},
-                status: "pending",
+                status: "failed",
                 aligoMid: null,
                 errorMessage: "발송 실패",
                 attempts: 1,
                 lastAttemptAt: new Date("2026-07-23T02:20:00.000Z"),
-                nextRetryAt: retryAt,
+                nextRetryAt: null,
                 createdAt: new Date("2026-07-23T02:20:00.000Z"),
-                updatedAt: retryAt,
+                updatedAt: new Date("2026-07-23T02:20:00.000Z"),
             });
 
-            const result = await repository.scheduleFailedForRetry("branch-1", 77);
+            const result = await repository.findByIdInBranch("branch-1", 77);
 
-            expect(messageLogModel.updateMany).toHaveBeenCalledWith({
-                where: {
-                    id: 77,
-                    branchId: "branch-1",
-                    provider: "aligo_sms",
-                    status: "failed",
-                },
-                data: {
-                    status: "pending",
-                    nextRetryAt: retryAt,
-                },
-            });
             expect(messageLogModel.findFirst).toHaveBeenCalledWith({
                 where: { id: 77, branchId: "branch-1" },
             });
             expect(result).toMatchObject({
                 id: 77,
                 branchId: "branch-1",
-                templateKey: "service_record_link_sms",
-                recipientName: "나세정",
-                status: "pending",
-                nextRetryAt: retryAt,
+                status: "failed",
             });
-            nowSpy.mockRestore();
-        });
-
-        it("does not fetch a log when the failed-state claim loses a race", async () => {
-            messageLogModel.updateMany.mockResolvedValue({ count: 0 });
-
-            const result = await repository.scheduleFailedForRetry("branch-1", 77);
-
-            expect(result).toBeNull();
-            expect(messageLogModel.findFirst).not.toHaveBeenCalled();
         });
     });
 });

--- a/backend/test/services/sms-retry.service.spec.ts
+++ b/backend/test/services/sms-retry.service.spec.ts
@@ -7,7 +7,7 @@ import { IMessageLogRepository } from "domain/repositories/message-log.repositor
 
 describe("SmsRetryService", () => {
     const createMockLogRepository = () => ({
-        scheduleFailedForRetry: jest.fn(),
+        startRetryAttempt: jest.fn(),
         findByIdInBranch: jest.fn(),
         update: jest.fn(),
     });
@@ -45,6 +45,28 @@ describe("SmsRetryService", () => {
             new Date("2026-06-05T09:20:00.000Z"),
             new Date("2026-06-05T09:20:00.000Z"),
         );
+    const persistRetryAttempt = (_source: MessageLogEntity, draft: MessageLogEntity) =>
+        MessageLogEntity.reconstitute(
+            78,
+            draft.branchId,
+            draft.provider,
+            draft.templateKey,
+            draft.triggerJobId,
+            draft.receiver,
+            draft.clientId,
+            draft.messageBody,
+            draft.variables,
+            draft.status,
+            draft.aligoMid,
+            draft.errorMessage,
+            draft.attempts,
+            draft.lastAttemptAt,
+            draft.nextRetryAt,
+            draft.createdAt,
+            draft.updatedAt,
+            draft.recipientName,
+            draft.recipientPhone,
+        );
 
     let service: SmsRetryService;
     let logRepository: ReturnType<typeof createMockLogRepository>;
@@ -56,6 +78,7 @@ describe("SmsRetryService", () => {
         logRepository = createMockLogRepository();
         aligoService = createMockAligoService();
         messageSenderApprovalService = createMockMessageSenderApprovalService();
+        logRepository.startRetryAttempt.mockImplementation(persistRetryAttempt);
         service = new SmsRetryService(
             logRepository as unknown as IMessageLogRepository,
             aligoService as unknown as AligoService,
@@ -70,7 +93,7 @@ describe("SmsRetryService", () => {
         jest.clearAllMocks();
     });
 
-    it("retries failed automatic SMS logs with the original sender and message", async () => {
+    it("creates a new sent history item without overwriting the original failed item", async () => {
         const log = createSmsRetryLog();
         aligoService.sendSms.mockResolvedValue({
             request: {
@@ -99,24 +122,53 @@ describe("SmsRetryService", () => {
             title: "인사 메시지",
             msgType: "AUTO",
         });
+        expect(logRepository.startRetryAttempt).toHaveBeenCalledWith(
+            log,
+            expect.objectContaining({
+                id: 0,
+                status: "pending",
+                attempts: 1,
+                variables: expect.objectContaining({
+                    retryOfLogId: "77",
+                    retryAttempt: "2",
+                }),
+            }),
+        );
         expect(logRepository.update).toHaveBeenCalledWith(
             expect.objectContaining({
-                id: 77,
+                id: 78,
                 status: "sent",
                 aligoMid: "123",
                 errorMessage: null,
                 nextRetryAt: null,
             }),
         );
+        expect(log).toEqual(expect.objectContaining({
+            id: 77,
+            status: "failed",
+            attempts: 1,
+            errorMessage: "등록되지 않은 IP 입니다.",
+        }));
     });
 
-    it("schedules the original branch-owned log without sending concurrently with the retry worker", async () => {
-        const log = createSmsRetryLog();
-        logRepository.findByIdInBranch.mockResolvedValue(log);
-        logRepository.scheduleFailedForRetry.mockImplementation(async () => {
-            log.status = "pending";
-            log.nextRetryAt = new Date(0);
-            return log;
+    it("manually retries a branch-owned failure as a separate history item", async () => {
+        const sourceLog = createSmsRetryLog();
+        logRepository.findByIdInBranch.mockResolvedValue(sourceLog);
+        aligoService.sendSms.mockResolvedValue({
+            request: {
+                senderPhone: "0212345678",
+                receiver: "01012345678",
+                msgType: "LMS",
+                testModeYn: "N",
+            },
+            response: {
+                result_code: 1,
+                message: "성공적으로 전송요청 하였습니다.",
+                msg_id: 123,
+                success_cnt: 1,
+                error_cnt: 0,
+                msg_type: "LMS",
+            },
         });
 
         const result = await service.retryById(
@@ -128,15 +180,12 @@ describe("SmsRetryService", () => {
             "11111111-1111-1111-1111-111111111111",
             77,
         );
-        expect(logRepository.scheduleFailedForRetry).toHaveBeenCalledWith(
-            "11111111-1111-1111-1111-111111111111",
-            77,
-        );
-        expect(aligoService.sendSms).not.toHaveBeenCalled();
-        expect(result).toBe(log);
-        expect(result.templateKey).toBe("client_greeting_sms");
-        expect(result.status).toBe("pending");
-        expect(result.nextRetryAt).toEqual(new Date(0));
+        expect(result).toEqual(expect.objectContaining({ id: 78, status: "sent" }));
+        expect(sourceLog).toEqual(expect.objectContaining({
+            id: 77,
+            status: "failed",
+            errorMessage: "등록되지 않은 IP 입니다.",
+        }));
     });
 
     it("does not reveal or retry a log owned by another branch", async () => {
@@ -144,14 +193,14 @@ describe("SmsRetryService", () => {
 
         await expect(service.retryById("branch-2", 77)).rejects.toThrow(NotFoundException);
 
-        expect(logRepository.scheduleFailedForRetry).not.toHaveBeenCalled();
+        expect(logRepository.startRetryAttempt).not.toHaveBeenCalled();
         expect(aligoService.sendSms).not.toHaveBeenCalled();
     });
 
     it("rejects a duplicate manual retry when another request already claimed the log", async () => {
-        const log = createSmsRetryLog();
-        logRepository.findByIdInBranch.mockResolvedValue(log);
-        logRepository.scheduleFailedForRetry.mockResolvedValue(null);
+        const sourceLog = createSmsRetryLog();
+        logRepository.findByIdInBranch.mockResolvedValue(sourceLog);
+        logRepository.startRetryAttempt.mockResolvedValue(null);
 
         await expect(
             service.retryById("11111111-1111-1111-1111-111111111111", 77),
@@ -171,7 +220,7 @@ describe("SmsRetryService", () => {
 
         expect(logRepository.update).toHaveBeenCalledWith(
             expect.objectContaining({
-                id: 77,
+                id: 78,
                 status: "failed",
                 attempts: 2,
                 errorMessage: "Aligo SMS API error (403): 등록되지 않은 IP 입니다.",
@@ -218,7 +267,7 @@ describe("SmsRetryService", () => {
         );
         expect(logRepository.update).toHaveBeenCalledWith(
             expect.objectContaining({
-                id: 77,
+                id: 78,
                 status: "pending",
                 aligoMid: "124",
                 nextRetryAt: null,
@@ -241,7 +290,7 @@ describe("SmsRetryService", () => {
         await service.retry(log);
 
         expect(logRepository.update).toHaveBeenCalledWith(
-            expect.objectContaining({ id: 77, status: "pending", nextRetryAt: null }),
+            expect.objectContaining({ id: 78, status: "pending", nextRetryAt: null }),
         );
     });
 
@@ -266,7 +315,7 @@ describe("SmsRetryService", () => {
         expect(sendSmsCall).not.toHaveProperty("scheduledDate");
         expect(sendSmsCall).not.toHaveProperty("scheduledTime");
         expect(logRepository.update).toHaveBeenCalledWith(
-            expect.objectContaining({ id: 77, status: "sent", nextRetryAt: null }),
+            expect.objectContaining({ id: 78, status: "sent", nextRetryAt: null }),
         );
     });
 
@@ -281,7 +330,7 @@ describe("SmsRetryService", () => {
         expect(aligoService.sendSms).not.toHaveBeenCalled();
         expect(logRepository.update).toHaveBeenCalledWith(
             expect.objectContaining({
-                id: 77,
+                id: 78,
                 status: "failed",
                 nextRetryAt: null,
             }),

--- a/mobile/src/components/app/clients/__tests__/client-detail.test.tsx
+++ b/mobile/src/components/app/clients/__tests__/client-detail.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 
-import { ClientDetailContent } from "../client-detail";
+import {
+  ClientDetailContent,
+  type ClientNotificationLogRecord,
+} from "../client-detail";
 import type { Client } from "@/lib/client/types";
 import type { EformsignDocument } from "@/lib/eformsign/types";
 
@@ -173,5 +176,52 @@ describe("ClientDetailContent", () => {
     expect(screen.getByText("서비스 기간").closest("div")).toHaveTextContent("10일");
     expect(screen.queryByText("계약 서명일")).not.toBeInTheDocument();
     expect(screen.queryByText("본인부담금 수령일")).not.toBeInTheDocument();
+  });
+
+  it("shows an original failure and its successful retry as separate history items", () => {
+    const baseLog: ClientNotificationLogRecord = {
+      id: 49,
+      provider: "aligo_sms",
+      templateKey: "service_record_link_sms",
+      receiver: "01012345678",
+      recipientPhone: "01012345678",
+      recipientName: "관리사",
+      clientId: client.id,
+      status: "failed",
+      messageBody: "제공기록지 작성 링크",
+      errorMessage: "등록/인증되지 않은 발신번호입니다.",
+      createdAt: "2026-07-22T17:13:11.811Z",
+      ruleName: "제공기록지 작성 링크",
+      variables: {},
+    };
+
+    render(
+      <ClientDetailContent
+        client={client}
+        contractDocument={null}
+        activeTab="message"
+        notificationLogs={[
+          {
+            ...baseLog,
+            id: 50,
+            status: "sent",
+            errorMessage: null,
+            createdAt: "2026-07-22T17:30:00.850Z",
+            variables: { retryOfLogId: "49", retryAttempt: "2" },
+          },
+          baseLog,
+        ]}
+        onTabChange={jest.fn()}
+        onMessage={jest.fn()}
+        onIssueContract={jest.fn()}
+        onEdit={jest.fn()}
+        onDelete={jest.fn()}
+        onClientUpdated={jest.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText("메시지 · 제공기록지 작성 링크")).toHaveLength(2);
+    expect(screen.getByText("발송 실패")).toBeInTheDocument();
+    expect(screen.getByText("발송 성공")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 변경 사항

- Preview에서 기존 실패 로그를 그대로 보존합니다.
- 자동·수동 재시도는 새 메시지 이력 행으로 생성합니다.
- 새 행만 성공/실패 상태로 갱신하며 중복 재시도를 원자적으로 차단합니다.
- 모바일 고객 상세에서 최초 실패와 새 성공 기록을 각각 표시합니다.

## 검증

- Preview-base backend regression: 18 passed
- Preview-base mobile regression: 6 passed
- Backend/mobile type-check passed
- Same change passed full backend/frontend/mobile suites and builds in PR #355
- No schema, dependency, or environment changes

Promotes the corrected behavior from dev PR #355 and replaces the in-place mutation behavior introduced by #358.