### PR TITLE
fix: consolidate required service-record and auth fixes

### DIFF
--- a/backend/application/services/service-record-entry.service.ts
+++ b/backend/application/services/service-record-entry.service.ts
@@ -6,13 +6,15 @@ import {
     ConflictException,
 } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
+import { SERVICE_RECORD_TEXT_LIMITS } from "domain/constants/service-record-text-limits";
 import { PrismaService } from "infrastructure/database/prisma.service";
+import { SaveServiceHeaderDto, UpsertSessionDto } from "interface/dto/service-record-entry.dto";
+
 import {
     ServiceRecordTokenService,
     ServiceRecordTokenContext,
     VerifyPhoneResult,
 } from "./service-record-token.service";
-import { SaveServiceHeaderDto, UpsertSessionDto } from "interface/dto/service-record-entry.dto";
 import {
     SERVICE_RECORD_CASE_STATUS,
     ServiceRecordLifecycleService,
@@ -248,8 +250,14 @@ export class ServiceRecordEntryService {
                 sessionIndex,
                 serviceDate,
                 answers: answers as Prisma.InputJsonValue,
-                etcService: this.trimNullable(dto.etcService, 1000),
-                notes: this.trimNullable(dto.notes, 2000),
+                etcService: this.trimNullable(
+                    dto.etcService,
+                    SERVICE_RECORD_TEXT_LIMITS.etcService,
+                ),
+                notes: this.trimNullable(
+                    dto.notes,
+                    SERVICE_RECORD_TEXT_LIMITS.notes,
+                ),
                 paymentConfirmed: dto.paymentConfirmed ?? false,
                 momApproval: dto.momApproval ?? null,
                 locked: Boolean(existing?.locked || lock),
@@ -399,12 +407,12 @@ export class ServiceRecordEntryService {
         return answers;
     }
 
-    private trimNullable(value: string | undefined, maxLength: number): string | null {
-        const normalized = value?.trim();
-        if (!normalized) return null;
-        if (normalized.length > maxLength) {
+    private trimNullable(value: string | null | undefined, maxLength: number): string | null {
+        if (value !== null && value !== undefined && value.length > maxLength) {
             throw new BadRequestException(`입력값은 ${maxLength}자를 넘을 수 없습니다.`);
         }
+        const normalized = value?.trim();
+        if (!normalized) return null;
         return normalized;
     }
 }

--- a/backend/domain/constants/service-record-text-limits.ts
+++ b/backend/domain/constants/service-record-text-limits.ts
@@ -1,0 +1,4 @@
+export const SERVICE_RECORD_TEXT_LIMITS = {
+    etcService: 40,
+    notes: 80,
+} as const;

--- a/backend/interface/dto/service-record-entry.dto.ts
+++ b/backend/interface/dto/service-record-entry.dto.ts
@@ -1,12 +1,15 @@
 import {
     IsBoolean,
     IsDateString,
+    MaxLength,
     IsObject,
     IsOptional,
     IsString,
     ValidateBy,
     ValidationOptions,
 } from "class-validator";
+
+import { SERVICE_RECORD_TEXT_LIMITS } from "domain/constants/service-record-text-limits";
 
 const PNG_DATA_URI_PREFIX = "data:image/png;base64,";
 const MAX_SIGNATURE_BYTES = 192 * 1024;
@@ -60,8 +63,11 @@ export class UpsertSessionDto {
     /** ①–⑪ structured answers, free-form per the form layout. */
     @IsOptional() @IsObject() answers?: Record<string, unknown>;
 
-    @IsOptional() @IsString() etcService?: string;
-    @IsOptional() @IsString() notes?: string;
+    @IsOptional() @IsString() @MaxLength(SERVICE_RECORD_TEXT_LIMITS.etcService)
+    etcService?: string;
+
+    @IsOptional() @IsString() @MaxLength(SERVICE_RECORD_TEXT_LIMITS.notes)
+    notes?: string;
     @IsOptional() @IsBoolean() paymentConfirmed?: boolean;
     /** 산모 확인 (data URL / storage ref). */
     @IsOptional() @IsString() momApproval?: string;

--- a/backend/test/services/service-record-entry.service.spec.ts
+++ b/backend/test/services/service-record-entry.service.spec.ts
@@ -163,6 +163,33 @@ describe("ServiceRecordEntryService.upsertSession", () => {
         }));
     });
 
+    it("accepts 기타서비스 40자와 특이사항 80자를 정확히 입력할 수 있다", async () => {
+        const { service, upsert } = createHarness();
+        const etcService = "기".repeat(40);
+        const notes = "특".repeat(80);
+
+        await service.upsertSession(context, 1, createDto({ etcService, notes }), true);
+
+        expect(upsert).toHaveBeenCalledWith(expect.objectContaining({
+            create: expect.objectContaining({ etcService, notes }),
+        }));
+    });
+
+    it.each([
+        ["기타서비스", { etcService: ` ${"기".repeat(40)}` }, 40],
+        ["특이사항", { notes: ` ${"특".repeat(80)}` }, 80],
+    ])("%s 길이 계산에 앞 공백을 포함한다", async (_label, fields, maxLength) => {
+        const { service, upsert } = createHarness();
+
+        await expect(service.upsertSession(
+            context,
+            1,
+            createDto(fields),
+            true,
+        )).rejects.toThrow(`입력값은 ${maxLength}자를 넘을 수 없습니다.`);
+        expect(upsert).not.toHaveBeenCalled();
+    });
+
     it.each([
         SERVICE_RECORD_CASE_STATUS.FINALIZING,
         SERVICE_RECORD_CASE_STATUS.FINALIZATION_FAILED,
@@ -332,5 +359,26 @@ describe("UpsertSessionDto.clientSignature", () => {
         }));
 
         await expect(validate(dto)).resolves.toHaveLength(0);
+    });
+});
+
+describe("UpsertSessionDto service-record text limits", () => {
+    it("accepts 기타서비스 40자와 특이사항 80자", async () => {
+        const dto = Object.assign(new UpsertSessionDto(), createDto({
+            etcService: "기".repeat(40),
+            notes: "특".repeat(80),
+        }));
+
+        await expect(validate(dto)).resolves.toHaveLength(0);
+    });
+
+    it.each([
+        ["etcService", { etcService: ` ${"기".repeat(40)}` }],
+        ["notes", { notes: ` ${"특".repeat(80)}` }],
+    ])("rejects %s when a leading space exceeds its limit", async (property, fields) => {
+        const dto = Object.assign(new UpsertSessionDto(), createDto(fields));
+        const errors = await validate(dto);
+
+        expect(errors.some((error) => error.property === property)).toBe(true);
     });
 });

--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -107,4 +107,100 @@ describe("admin gateway proxy", () => {
     expect(response.headers.get("set-cookie")).toContain("refresh_token=next-refresh");
     fetchMock.mockRestore();
   });
+
+  it("refreshes an expired session when navigating to login", async () => {
+    mockJwtDecode.mockImplementation((token: string) => token === "new-access"
+      ? {
+        sub: "user-1",
+        sid: "session-1",
+        role: "admin",
+        branchId: "branch-1",
+        type: "access",
+        exp: Math.floor(Date.now() / 1000) + 60,
+      }
+      : {
+        sub: "user-1",
+        sid: "session-1",
+        role: "admin",
+        type: "access",
+        exp: Math.floor(Date.now() / 1000) - 60,
+      });
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({
+        accessToken: "new-access",
+        refreshToken: "next-refresh",
+      }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const response = await proxy(new NextRequest("http://localhost/login", {
+      method: "GET",
+      headers: {
+        cookie: "auth_token=expired; refresh_token=current",
+      },
+    }));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("http://localhost/");
+    expect(response.headers.get("set-cookie")).toContain("auth_token=new-access");
+    fetchMock.mockRestore();
+  });
+
+  it("allows login Server Action posts through without refreshing the previous session", async () => {
+    mockJwtDecode.mockReturnValue({
+      sub: "user-1",
+      sid: "session-1",
+      role: "admin",
+      type: "access",
+      exp: Math.floor(Date.now() / 1000) - 60,
+    });
+    const fetchMock = jest.spyOn(global, "fetch");
+
+    const response = await proxy(new NextRequest("http://localhost/login", {
+      method: "POST",
+      headers: {
+        cookie: "auth_token=expired; refresh_token=current",
+        "next-action": "login-action",
+      },
+    }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+    fetchMock.mockRestore();
+  });
+
+  it("allows pending account onboarding navigation without an auth session", async () => {
+    const response = await proxy(new NextRequest("http://localhost/onboarding", {
+      method: "GET",
+      headers: {
+        cookie: "pending_account_onboarding=pending-token",
+      },
+    }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("allows pending account onboarding Server Action posts", async () => {
+    const response = await proxy(new NextRequest("http://localhost/onboarding", {
+      method: "POST",
+      headers: {
+        cookie: "pending_account_onboarding=pending-token",
+        "next-action": "complete-onboarding-action",
+      },
+    }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("keeps onboarding protected when the pending token is missing", async () => {
+    const response = await proxy(new NextRequest("http://localhost/onboarding"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("http://localhost/login");
+  });
 });

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -55,6 +55,8 @@ const AUTH_ONLY_ROUTES = [
   "/select-branch",
 ];
 
+const PENDING_ACCOUNT_ONBOARDING_COOKIE = "pending_account_onboarding";
+
 function isAccessTokenExpiredOrInvalid(token: string): boolean {
   try {
     const decoded = jwtDecode<TokenPayload>(token);
@@ -149,9 +151,22 @@ export async function proxy(request: NextRequest) {
 
   let authToken = request.cookies.get("auth_token")?.value;
 
+  if (
+    pathname === "/onboarding"
+    && request.cookies.has(PENDING_ACCOUNT_ONBOARDING_COOKIE)
+  ) {
+    return NextResponse.next();
+  }
+
   // Skip public routes ("/" needs exact match — startsWith would match every path)
   if (pathname === "/" || PUBLIC_ROUTES.some((route) => pathname.startsWith(route))) {
-    if (pathname.startsWith("/login") && authToken && isAccessTokenExpiredOrInvalid(authToken)) {
+    const isNavigationRequest = request.method === "GET" || request.method === "HEAD";
+    if (
+      pathname.startsWith("/login")
+      && isNavigationRequest
+      && authToken
+      && isAccessTokenExpiredOrInvalid(authToken)
+    ) {
       const loginRefreshToken = request.cookies.get("refresh_token")?.value;
       if (loginRefreshToken) {
         const refreshAttempt = await tryRefreshAuthSession(loginRefreshToken);

--- a/mobile/src/app/(public)/service-record/[token]/page.tsx
+++ b/mobile/src/app/(public)/service-record/[token]/page.tsx
@@ -19,7 +19,13 @@ interface DailyItem {
     type: ItemType;
     opts?: string[];
     counts?: { k: string; label: string; unit: string }[];
+    maxLength?: number;
 }
+
+const SERVICE_RECORD_TEXT_LIMITS = {
+    etcService: 40,
+    notes: 80,
+} as const;
 
 const DAILY_ITEMS: DailyItem[] = [
     { key: "perineum", label: "① 회음절개부위 (또는 수술부위)", type: "multi", opts: ["이상없음", "열상", "혈종", "불편감"] },
@@ -33,8 +39,18 @@ const DAILY_ITEMS: DailyItem[] = [
     { key: "formulaFeeding", label: "⑨ 분유수유", type: "counts", counts: [{ k: "count", label: "횟수", unit: "회" }, { k: "ml", label: "회당", unit: "ml" }] },
     { key: "stool", label: "⑩ 배변양상", type: "stool", opts: ["정상변", "이상변"] },
     { key: "bath", label: "⑪ 목욕·제대관리", type: "radio", opts: ["실시", "미실시"] },
-    { key: "etcService", label: "기타 서비스 (필요 시 기재)", type: "textarea" },
-    { key: "notes", label: "특이사항 (필요 시 기재)", type: "textarea" },
+    {
+        key: "etcService",
+        label: "기타 서비스 (필요 시 기재)",
+        type: "textarea",
+        maxLength: SERVICE_RECORD_TEXT_LIMITS.etcService,
+    },
+    {
+        key: "notes",
+        label: "특이사항 (필요 시 기재)",
+        type: "textarea",
+        maxLength: SERVICE_RECORD_TEXT_LIMITS.notes,
+    },
     { key: "paymentConfirmed", label: "결제 확인", type: "confirm" },
 ];
 interface DayPage {
@@ -686,7 +702,19 @@ export default function ServiceRecordPage() {
             const placeholder = it.key === "etcService"
                 ? "추가사항에 대한 기록 필요 시 기재"
                 : "서비스 제공 관련 특이사항 기록 필요 시 기재";
-            return <textarea className="ta" value={(v as string) ?? ""} onChange={(e) => setField(it.key, e.target.value)} placeholder={placeholder} />;
+            const dataComponent = it.key === "etcService"
+                ? "mobile_service-record_daily-form_etc-service"
+                : "mobile_service-record_daily-form_notes";
+            return (
+                <textarea
+                    data-component={dataComponent}
+                    className="ta"
+                    value={(v as string) ?? ""}
+                    onChange={(e) => setField(it.key, e.target.value)}
+                    placeholder={placeholder}
+                    maxLength={it.maxLength}
+                />
+            );
         }
         if (it.type === "confirm") {
             return (

--- a/mobile/src/app/(public)/service-record/__tests__/page.auth.test.tsx
+++ b/mobile/src/app/(public)/service-record/__tests__/page.auth.test.tsx
@@ -162,6 +162,44 @@ describe("ServiceRecordPage authentication restoration", () => {
         expect(screen.getByDisplayValue("작성 중인 기록")).toBeInTheDocument();
     });
 
+    it("limits 기타서비스 to 40 characters and 특이사항 to 80 characters", async () => {
+        const user = userEvent.setup();
+        window.sessionStorage.setItem("daily-service-record-draft:link-token", JSON.stringify({
+            header: { momName: "홍길동" },
+            day: 1,
+            pageIdx: 2,
+            draft: {
+                _date: isoDateInKorea(),
+                etcService: "",
+                notes: "",
+            },
+        }));
+        fetchMock
+            .mockResolvedValueOnce(jsonResponse({ valid: true }))
+            .mockResolvedValueOnce(jsonResponse({
+                ...serviceRecordContext,
+                totalSessions: 2,
+                header: { momName: "홍길동" },
+            }));
+
+        render(<ServiceRecordPage />);
+
+        expect(await screen.findByText("제공기록표")).toBeInTheDocument();
+        await user.click(screen.getByRole("button", { name: "기록 시작" }));
+
+        const etcService = screen.getByPlaceholderText("추가사항에 대한 기록 필요 시 기재");
+        const notes = screen.getByPlaceholderText("서비스 제공 관련 특이사항 기록 필요 시 기재");
+
+        expect(etcService).toHaveAttribute("maxlength", "40");
+        expect(notes).toHaveAttribute("maxlength", "80");
+
+        await user.type(etcService, ` ${"기".repeat(40)}`);
+        await user.type(notes, ` ${"특".repeat(80)}`);
+
+        expect(etcService).toHaveValue(` ${"기".repeat(39)}`);
+        expect(notes).toHaveValue(` ${"특".repeat(79)}`);
+    });
+
     it("allows entry for a different service date while showing a warning", async () => {
         const user = userEvent.setup();
         window.sessionStorage.setItem("daily-service-record-draft:link-token", JSON.stringify({


### PR DESCRIPTION
## Summary
- enforce service-record free-text limits in DTO, service layer, and mobile UI
- allow login Server Action POSTs without stale-session refresh interception
- allow pending account onboarding requests with the dedicated onboarding cookie

## Validation
- backend: 159 suites, 1,627 passed, 8 skipped
- frontend: 121 suites, 568 passed
- mobile: 137 suites, 775 passed
- lint, type-check, and production build passed for all three packages
- branch diff secret scan passed