### PR TITLE
fix(release): address PR #363 review findings

### DIFF
--- a/.github/workflows/database-patches.yml
+++ b/.github/workflows/database-patches.yml
@@ -135,6 +135,14 @@ jobs:
         working-directory: backend
         run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260721090000_make_branch_owner_nullable/migration.sql
 
+      - name: Apply out-of-pocket price info patch
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260722123000_add_out_of_pocket_price_info/migration.sql
+
+      - name: Verify out-of-pocket price info patch
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-out-of-pocket-price-info.sql
+
       - name: Preserve electronic documents on client deletion
         working-directory: backend
         run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260723090000_preserve_electronic_documents_on_client_delete/migration.sql
@@ -378,6 +386,14 @@ jobs:
       - name: Apply branch owner nullable patch
         working-directory: backend
         run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260721090000_make_branch_owner_nullable/migration.sql
+
+      - name: Apply out-of-pocket price info patch
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260722123000_add_out_of_pocket_price_info/migration.sql
+
+      - name: Verify out-of-pocket price info patch
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-out-of-pocket-price-info.sql
 
       - name: Preserve electronic documents on client deletion
         working-directory: backend
@@ -626,6 +642,14 @@ jobs:
       - name: Apply branch owner nullable patch
         working-directory: backend
         run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260721090000_make_branch_owner_nullable/migration.sql
+
+      - name: Apply out-of-pocket price info patch
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260722123000_add_out_of_pocket_price_info/migration.sql
+
+      - name: Verify out-of-pocket price info patch
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-out-of-pocket-price-info.sql
 
       - name: Preserve electronic documents on client deletion
         working-directory: backend

--- a/backend/interface/controllers/out-of-pocket-price-info.controller.ts
+++ b/backend/interface/controllers/out-of-pocket-price-info.controller.ts
@@ -2,14 +2,14 @@ import { Controller, Get, UseGuards } from "@nestjs/common";
 
 import { ListOutOfPocketPriceInfoUsecase } from "application/usecases/out-of-pocket-price-info/list-out-of-pocket-price-info.usecase";
 import { JwtGuard } from "infrastructure/auth/jwt.guard";
-import { OwnerOrAdminGuard } from "infrastructure/auth/owner-or-admin.guard";
+import { TenantGuard } from "infrastructure/tenant";
 
 @Controller("out-of-pocket-price-infos")
 export class OutOfPocketPriceInfoController {
     constructor(private readonly listOutOfPocketPriceInfo: ListOutOfPocketPriceInfoUsecase) {}
 
     @Get()
-    @UseGuards(JwtGuard, OwnerOrAdminGuard)
+    @UseGuards(JwtGuard, TenantGuard)
     list() {
         return this.listOutOfPocketPriceInfo.execute();
     }

--- a/backend/prisma/migrations/20260722123000_add_out_of_pocket_price_info/migration.sql
+++ b/backend/prisma/migrations/20260722123000_add_out_of_pocket_price_info/migration.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-CREATE TABLE "out_of_pocket_price_info" (
+CREATE TABLE IF NOT EXISTS "out_of_pocket_price_info" (
     "id" SMALLSERIAL NOT NULL,
     "duration" SMALLINT NOT NULL,
     "full_price" BIGINT NOT NULL,
@@ -14,7 +14,7 @@ CREATE TABLE "out_of_pocket_price_info" (
         CHECK ("full_price" >= 0)
 );
 
-CREATE UNIQUE INDEX "out_of_pocket_price_info_duration_key"
+CREATE UNIQUE INDEX IF NOT EXISTS "out_of_pocket_price_info_duration_key"
     ON "out_of_pocket_price_info"("duration");
 
 INSERT INTO "out_of_pocket_price_info" (
@@ -27,6 +27,7 @@ VALUES
     (5, 815000, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
     (10, 1620000, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
     (15, 2425000, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-    (20, 3240000, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+    (20, 3240000, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+ON CONFLICT ("duration") DO NOTHING;
 
 COMMIT;

--- a/backend/prisma/scripts/verify-out-of-pocket-price-info.sql
+++ b/backend/prisma/scripts/verify-out-of-pocket-price-info.sql
@@ -1,0 +1,37 @@
+DO $$
+BEGIN
+    IF to_regclass('public.out_of_pocket_price_info') IS NULL THEN
+        RAISE EXCEPTION 'out_of_pocket_price_info table is missing';
+    END IF;
+
+    IF to_regclass('public.out_of_pocket_price_info_duration_key') IS NULL THEN
+        RAISE EXCEPTION 'out_of_pocket_price_info duration index is missing';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'out_of_pocket_price_info_duration_check'
+          AND conrelid = 'public.out_of_pocket_price_info'::regclass
+    ) THEN
+        RAISE EXCEPTION 'out_of_pocket_price_info duration constraint is missing';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'out_of_pocket_price_info_full_price_check'
+          AND conrelid = 'public.out_of_pocket_price_info'::regclass
+    ) THEN
+        RAISE EXCEPTION 'out_of_pocket_price_info price constraint is missing';
+    END IF;
+
+    IF (
+        SELECT COUNT(*)
+        FROM "out_of_pocket_price_info"
+        WHERE "duration" IN (5, 10, 15, 20)
+    ) <> 4 THEN
+        RAISE EXCEPTION 'out_of_pocket_price_info seed rows are incomplete';
+    END IF;
+END
+$$;

--- a/backend/test/integration/out-of-pocket-price-info.controller.integration.spec.ts
+++ b/backend/test/integration/out-of-pocket-price-info.controller.integration.spec.ts
@@ -2,18 +2,18 @@ import { GUARDS_METADATA } from "@nestjs/common/constants";
 
 import { ListOutOfPocketPriceInfoUsecase } from "application/usecases/out-of-pocket-price-info/list-out-of-pocket-price-info.usecase";
 import { JwtGuard } from "infrastructure/auth/jwt.guard";
-import { OwnerOrAdminGuard } from "infrastructure/auth/owner-or-admin.guard";
+import { TenantGuard } from "infrastructure/tenant";
 import { OutOfPocketPriceInfoController } from "interface/controllers/out-of-pocket-price-info.controller";
 
 describe("OutOfPocketPriceInfoController", () => {
-    it("should protect the price list with owner/admin guards", () => {
+    it("should protect the price list with authenticated tenant guards", () => {
         const guards = Reflect.getMetadata(
             GUARDS_METADATA,
             OutOfPocketPriceInfoController.prototype.list,
         ) ?? [];
 
         expect(guards).toContain(JwtGuard);
-        expect(guards).toContain(OwnerOrAdminGuard);
+        expect(guards).toContain(TenantGuard);
     });
 
     it("should return JSON-safe price rows", async () => {


### PR DESCRIPTION
## What changed

- allow authenticated active tenant members to read out-of-pocket price rows used by client registration
- add the out-of-pocket price migration and verification to dev, preview, and production database patch jobs
- make the migration safe to rerun and verify the table, index, constraints, and seed durations

## Why

PR #363 review found that manager/staff client registration could receive a 403 when loading self-pay prices, and that deployed databases could miss the new price table because the explicit patch workflow omitted its migration.

## Verification

- backend targeted tests: 3 passed
- backend full tests: 1,621 passed, 8 skipped
- backend type-check: passed
- backend build: passed
- backend lint: 0 errors (75 existing warnings)
- database-patches.yml YAML parse: passed
- migration executed twice against an isolated local PostgreSQL cluster: passed
- verification SQL against the isolated cluster: passed
- changed-file secret and dangerous API scan: clean

## Security note

The existing repository audit still reports 4 high-severity Next.js 16.2.6 advisories requiring >=16.2.11. This PR does not change dependencies.