### PR TITLE
fix(preview): tolerate saturated database session pool

### DIFF
--- a/.github/workflows/database-patches.yml
+++ b/.github/workflows/database-patches.yml
@@ -196,13 +196,13 @@ jobs:
       - name: Apply message schema compatibility patches
         working-directory: backend
         run: |
-          pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260713120000_repair_message_table_renames/migration.sql
-          pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260709000000_message_automation_hardening/migration.sql
+          ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260713120000_repair_message_table_renames/migration.sql
+          ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260709000000_message_automation_hardening/migration.sql
 
       - name: Apply idempotent database patches
         working-directory: backend
         run: |
-          pnpm exec prisma db execute --schema prisma/schema.prisma --stdin <<'SQL'
+          ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --stdin <<'SQL'
           ALTER TABLE "client" ALTER COLUMN "care_center" DROP NOT NULL;
           ALTER TABLE "client_draft" ADD COLUMN IF NOT EXISTS "confirming_started_at" TIMESTAMPTZ(6);
           ALTER TABLE "message_trigger_job"  ADD COLUMN IF NOT EXISTS "attempts" INTEGER NOT NULL DEFAULT 0;
@@ -234,7 +234,7 @@ jobs:
       - name: Verify database patches
         working-directory: backend
         run: |
-          pnpm exec prisma db execute --schema prisma/schema.prisma --stdin <<'SQL'
+          ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --stdin <<'SQL'
           DO $$
           BEGIN
             IF EXISTS (
@@ -326,82 +326,82 @@ jobs:
       - name: Apply eformsign document relation patches
         working-directory: backend
         run: |
-          pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260709100000_link_eformsign_and_message_relations/migration.sql
-          pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260709110000_add_message_log_recipient_snapshot/migration.sql
+          ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260709100000_link_eformsign_and_message_relations/migration.sql
+          ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260709110000_add_message_log_recipient_snapshot/migration.sql
 
       - name: Verify eformsign document relation patches
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-eformsign-document-relations.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/scripts/verify-eformsign-document-relations.sql
 
       - name: Apply client-owned service-record patch
         working-directory: backend
         run: |
-          pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260713000000_add_client_service_record_case/migration.sql
-          pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260713110000_align_service_record_case_schema/migration.sql
+          ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260713000000_add_client_service_record_case/migration.sql
+          ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260713110000_align_service_record_case_schema/migration.sql
 
       - name: Verify client-owned service-record patch
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-service-record-cases.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/scripts/verify-service-record-cases.sql
 
       - name: Apply user approval + token-version patch
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260713100000_add_user_approval_and_token_version/migration.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260713100000_add_user_approval_and_token_version/migration.sql
 
       - name: Verify user approval + token-version patch
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-user-approval.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/scripts/verify-user-approval.sql
 
       - name: Apply auth session + outbox patch
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260717090000_add_auth_sessions/migration.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260717090000_add_auth_sessions/migration.sql
 
       - name: Verify auth session + outbox patch
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-auth-sessions.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/scripts/verify-auth-sessions.sql
 
       - name: Apply service-record mom signature patch
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260715140000_add_client_signature_to_service_record_day/migration.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260715140000_add_client_signature_to_service_record_day/migration.sql
 
       - name: Apply feedback to service-record rename patch
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260716090000_rename_feedback_to_service_record/migration.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260716090000_rename_feedback_to_service_record/migration.sql
 
       - name: Apply employee/client hardening patch
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260717000000_employee_client_hardening/migration.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260717000000_employee_client_hardening/migration.sql
 
       - name: Verify employee/client hardening patch
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-employee-client-hardening.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/scripts/verify-employee-client-hardening.sql
 
       - name: Apply client pre-booking status patch
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260717120000_add_client_pre_booking_status/migration.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260717120000_add_client_pre_booking_status/migration.sql
 
       - name: Verify client pre-booking status patch
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-client-pre-booking-status.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/scripts/verify-client-pre-booking-status.sql
 
       - name: Apply branch owner nullable patch
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260721090000_make_branch_owner_nullable/migration.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260721090000_make_branch_owner_nullable/migration.sql
 
       - name: Apply out-of-pocket price info patch
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260722123000_add_out_of_pocket_price_info/migration.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260722123000_add_out_of_pocket_price_info/migration.sql
 
       - name: Verify out-of-pocket price info patch
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-out-of-pocket-price-info.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/scripts/verify-out-of-pocket-price-info.sql
 
       - name: Preserve electronic documents on client deletion
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260723090000_preserve_electronic_documents_on_client_delete/migration.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260723090000_preserve_electronic_documents_on_client_delete/migration.sql
 
       - name: Verify client deletion document preservation
         working-directory: backend
-        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-client-delete-document-preservation.sql
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/scripts/verify-client-delete-document-preservation.sql
 
   apply-production:
     name: apply production database patches

--- a/backend/scripts/run-prisma-db-execute.sh
+++ b/backend/scripts/run-prisma-db-execute.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+declare -a execute_args=()
+stdin_file=""
+
+cleanup() {
+  if [[ -n "$stdin_file" ]]; then
+    rm -f "$stdin_file"
+  fi
+}
+trap cleanup EXIT
+
+for arg in "$@"; do
+  if [[ "$arg" == "--stdin" ]]; then
+    stdin_file="$(mktemp)"
+    cat >"$stdin_file"
+    execute_args+=(--file "$stdin_file")
+  else
+    execute_args+=("$arg")
+  fi
+done
+
+last_output=""
+last_status=0
+
+execute_once() {
+  local connection_url="$1"
+
+  set +e
+  last_output="$(
+    DIRECT_URL="$connection_url" \
+      pnpm exec prisma db execute "${execute_args[@]}" 2>&1
+  )"
+  last_status=$?
+  set -e
+
+  printf '%s\n' "$last_output"
+  return "$last_status"
+}
+
+if execute_once "$DIRECT_URL"; then
+  exit 0
+fi
+
+if [[ "$last_output" != *"EMAXCONNSESSION"* ]]; then
+  exit "$last_status"
+fi
+
+echo "Session pool is full; retrying this database patch through DATABASE_URL."
+
+for attempt in 1 2 3; do
+  if execute_once "$DATABASE_URL"; then
+    exit 0
+  fi
+
+  if [[ "$last_output" != *"EMAXCONNSESSION"* ]] || (( attempt == 3 )); then
+    exit "$last_status"
+  fi
+
+  sleep $((attempt * 5))
+done


### PR DESCRIPTION
## Summary
- keep Preview DB patches on the configured direct/session connection by default
- on the specific Supabase EMAXCONNSESSION saturation error only, retry the same SQL through the existing pooled DATABASE_URL
- preserve stdin SQL in a temporary file so the exact patch can be replayed safely
- leave dev and production patch behavior unchanged

## Validation
- bash syntax and ShellCheck pass
- stdin execution succeeds against local PostgreSQL
- a normal SQL error exits without fallback
- live Preview patch attempts reproduced EMAXCONNSESSION before any SQL ran

This unblocks the Preview Database Patches check on #363.