### PR TITLE
fix(mobile): enable branch list scrolling

### DIFF
--- a/mobile/src/components/app/mobile-redesign/redesign.css
+++ b/mobile/src/components/app/mobile-redesign/redesign.css
@@ -4509,9 +4509,13 @@ main[data-component="main-content"]:has([data-component="select-branch"]) > [dat
 }
 .branch-list {
   display: flex;
+  flex: 1 1 auto;
   flex-direction: column;
   gap: 10px;
-  margin-bottom: auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+  -webkit-overflow-scrolling: touch;
 }
 .branch-card {
   background: white;
@@ -4526,6 +4530,7 @@ main[data-component="main-content"]:has([data-component="select-branch"]) > [dat
   width: 100%;
   font-family: inherit;
   text-align: left;
+  flex-shrink: 0;
 }
 .branch-card:disabled {
   cursor: not-allowed;


### PR DESCRIPTION
## What changed
- Make the Mobile `/select-branch` branch list own vertical scrolling.
- Keep branch cards from shrinking so lower branches remain reachable.
- Contain mobile overscroll and preserve iOS momentum scrolling.

## Root cause
The route shell fixes the viewport and hides overflow on its ancestors, while `.branch-list` had no scroll ownership. When the branch count exceeded the available height, lower cards were clipped and could not be selected.

## Impact
The header and bottom branch-selection actions remain fixed while only the branch list scrolls.

## Validation
- Mobile Jest: 137 suites / 775 tests passed
- Mobile type-check passed
- Mobile lint completed with 0 errors (170 pre-existing warnings)
- Mobile production build passed with `NEXT_PUBLIC_API_BASE_URL` supplied inline
- `git diff --check` passed
- Scoped security review found no auth, data, dependency, or secret-handling changes