### PR TITLE
fix: Sentry 제공기록지 경로 식별자 제거

### DIFF
--- a/backend/infrastructure/observability/service-record-sentry.spec.ts
+++ b/backend/infrastructure/observability/service-record-sentry.spec.ts
@@ -102,6 +102,32 @@ describe("service-record backend Sentry contract", () => {
         ).toBe("/admin/service-records/client/[Filtered]");
     });
 
+    it("redacts service-record resource identifiers and transaction paths", () => {
+        expect(sanitizeSentryUrl("/admin/service-records/client/77")).toBe(
+            "/admin/service-records/client/[Filtered]",
+        );
+        expect(sanitizeSentryUrl("/admin/service-records/schedules/431/finalize")).toBe(
+            "/admin/service-records/schedules/[Filtered]/finalize",
+        );
+        expect(
+            sanitizeSentryUrl("/schedule-change-requests/schedules/431/preview"),
+        ).toBe("/schedule-change-requests/schedules/[Filtered]/preview");
+        expect(sanitizeSentryUrl("/service-record/link/efl_secret")).toBe(
+            "/service-record/link/[Filtered]",
+        );
+        expect(sanitizeSentryUrl("/service-record/sessions/9/submit")).toBe(
+            "/service-record/sessions/[Filtered]/submit",
+        );
+
+        expect(filterAndSanitizeSentryEvent({
+            type: undefined,
+            tags: { feature: "service-records" },
+            transaction: "GET /admin/service-records/client/77?expand=schedules",
+        })).toMatchObject({
+            transaction: "GET /admin/service-records/client/[Filtered]",
+        });
+    });
+
     it("captures a handled background failure once with bounded tags and context", () => {
         const error = new Error("snapshot failed");
         captureServiceRecordError(error, {

--- a/backend/infrastructure/observability/service-record-sentry.ts
+++ b/backend/infrastructure/observability/service-record-sentry.ts
@@ -44,6 +44,10 @@ const PHONE_PATTERN = /(?:\+?82[-\s]?)?0?1[016789][-.\s]?\d{3,4}[-.\s]?\d{4}/g;
 const BEARER_PATTERN = /(bearer\s+)[^\s,;]+/gi;
 const SERVICE_RECORD_TOKEN_PATTERN =
     /(\/(?:api\/)?service-record\/link\/)[^/?#\s]+/gi;
+const SERVICE_RECORD_RESOURCE_ID_PATTERN =
+    /(\/(?:api\/)?(?:admin\/service-records\/(?:client|schedules)|schedule-change-requests\/schedules)\/)[^/?#\s]+/gi;
+const SERVICE_RECORD_SESSION_ID_PATTERN =
+    /(\/(?:api\/)?service-record\/sessions\/)[^/?#\s]+/gi;
 const UUID_PATH_SEGMENT_PATTERN =
     /\/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}(?=\/|$)/gi;
 const SERVICE_RECORD_SIGNAL_PATTERN =
@@ -57,6 +61,8 @@ function sanitizeText(value: string): string {
         .replace(EMAIL_PATTERN, "[Email]")
         .replace(PHONE_PATTERN, "[Phone]")
         .replace(SERVICE_RECORD_TOKEN_PATTERN, `$1${FILTERED_VALUE}`)
+        .replace(SERVICE_RECORD_RESOURCE_ID_PATTERN, `$1${FILTERED_VALUE}`)
+        .replace(SERVICE_RECORD_SESSION_ID_PATTERN, `$1${FILTERED_VALUE}`)
         .replace(UUID_PATH_SEGMENT_PATTERN, `/${FILTERED_VALUE}`);
 }
 
@@ -105,6 +111,9 @@ export function sanitizeSentryEvent(event: Event): Event {
     return {
         ...event,
         message: event.message ? "Service-record backend failure" : event.message,
+        transaction: event.transaction
+            ? sanitizeText(event.transaction.replace(/[?#].*$/, ""))
+            : event.transaction,
         user: undefined,
         request: event.request
             ? {

--- a/frontend/src/lib/observability/capture-api-error.test.ts
+++ b/frontend/src/lib/observability/capture-api-error.test.ts
@@ -78,7 +78,7 @@ describe("captureApiError", () => {
     expect(mockScope.setTag).toHaveBeenCalledWith("feature", "service-records");
     expect(mockScope.setContext).toHaveBeenCalledWith("api", {
       method: "POST",
-      path: "/admin/service-records/schedules/51/send-link",
+      path: "/admin/service-records/schedules/[Filtered]/send-link",
       operation: "public-link",
       status: 503,
       code: null,
@@ -90,7 +90,7 @@ describe("captureApiError", () => {
     expect(mockScope.setFingerprint).toHaveBeenCalledWith([
       "api-error",
       "POST",
-      "/admin/service-records/schedules/51/send-link",
+      "/admin/service-records/schedules/[Filtered]/send-link",
       "503",
     ]);
   });

--- a/frontend/src/lib/observability/sentry-config.test.ts
+++ b/frontend/src/lib/observability/sentry-config.test.ts
@@ -29,8 +29,26 @@ describe("Sentry privacy filters", () => {
     expect(sanitizeSentryUrl("https://mobile.example.com/service-record/efl_secret")).toBe(
       "https://mobile.example.com/service-record/[Filtered]",
     );
+    expect(sanitizeSentryUrl("/service-record/link/efl_secret/context")).toBe(
+      "/service-record/link/[Filtered]/context",
+    );
     expect(sanitizeSentryUrl("/api/service-record/efl_secret/context")).toBe(
       "/api/service-record/[Filtered]/context",
+    );
+  });
+
+  it("redacts service-record resource identifiers from URLs", () => {
+    expect(sanitizeSentryUrl("/api/admin/service-records/client/77")).toBe(
+      "/api/admin/service-records/client/[Filtered]",
+    );
+    expect(sanitizeSentryUrl("/admin/service-records/schedules/431/finalize")).toBe(
+      "/admin/service-records/schedules/[Filtered]/finalize",
+    );
+    expect(
+      sanitizeSentryUrl("/api/schedule-change-requests/schedules/431/preview"),
+    ).toBe("/api/schedule-change-requests/schedules/[Filtered]/preview");
+    expect(sanitizeSentryUrl("/api/service-record/efl_secret/sessions/9/submit")).toBe(
+      "/api/service-record/[Filtered]/sessions/[Filtered]/submit",
     );
   });
 
@@ -151,7 +169,11 @@ describe("service-record Sentry scope", () => {
           url: "https://admin.example.com/api/admin/service-records/client/7",
         },
       }),
-    ).not.toBeNull();
+    ).toMatchObject({
+      request: {
+        url: "https://admin.example.com/api/admin/service-records/client/[Filtered]",
+      },
+    });
     expect(
       options.beforeSendTransaction({
         type: "transaction",

--- a/frontend/src/lib/observability/sentry-config.ts
+++ b/frontend/src/lib/observability/sentry-config.ts
@@ -19,7 +19,11 @@ const BEARER_PATTERN = /(bearer\s+)[^\s,;]+/gi;
 const SECRET_ASSIGNMENT_PATTERN =
   /((?:password|token|secret|api[_-]?key|authorization)\s*[:=]\s*)[^\s,;]+/gi;
 const SERVICE_RECORD_ACCESS_TOKEN_PATTERN =
-  /(\/(?:api\/)?service-record\/)[^/?#\s]+/gi;
+  /(\/(?:api\/)?service-record\/(?:link\/)?)[^/?#\s]+/gi;
+const SERVICE_RECORD_RESOURCE_ID_PATTERN =
+  /(\/(?:api\/)?(?:admin\/service-records\/(?:client|schedules)|schedule-change-requests\/schedules)\/)[^/?#\s]+/gi;
+const SERVICE_RECORD_SESSION_ID_PATTERN =
+  /(\/(?:api\/)?service-record\/[^/?#\s]+\/sessions\/)[^/?#\s]+/gi;
 const UUID_PATH_SEGMENT_PATTERN =
   /\/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}(?=\/|$)/gi;
 const SERVICE_RECORD_SIGNAL_PATTERN =
@@ -52,6 +56,8 @@ export function sanitizeSentryText(value: string): string {
     .replace(EMAIL_PATTERN, "[Email]")
     .replace(PHONE_PATTERN, "[Phone]")
     .replace(SERVICE_RECORD_ACCESS_TOKEN_PATTERN, `$1${FILTERED_VALUE}`)
+    .replace(SERVICE_RECORD_RESOURCE_ID_PATTERN, `$1${FILTERED_VALUE}`)
+    .replace(SERVICE_RECORD_SESSION_ID_PATTERN, `$1${FILTERED_VALUE}`)
     .replace(UUID_PATH_SEGMENT_PATTERN, `/${FILTERED_VALUE}`);
 }
 

--- a/mobile/src/lib/observability/capture-service-record-error.test.ts
+++ b/mobile/src/lib/observability/capture-service-record-error.test.ts
@@ -68,7 +68,7 @@ describe("captureServiceRecordError", () => {
     expect(mockScope.setContext).toHaveBeenCalledWith("serviceRecord", {
       operation: "submit-session",
       method: "POST",
-      path: "/service-record/[Filtered]/sessions/1/submit",
+      path: "/service-record/[Filtered]/sessions/[Filtered]/submit",
       status: 503,
       code: null,
       runtime: "browser",

--- a/mobile/src/lib/observability/sentry-config.test.ts
+++ b/mobile/src/lib/observability/sentry-config.test.ts
@@ -8,9 +8,24 @@ describe("mobile service-record Sentry scope", () => {
     expect(sanitizeSentryUrl("https://mobile.example.com/service-record/efl_secret")).toBe(
       "https://mobile.example.com/service-record/[Filtered]",
     );
-    expect(sanitizeSentryUrl("/api/service-record/efl_secret/sessions/1/submit")).toBe(
-      "/api/service-record/[Filtered]/sessions/1/submit",
+    expect(sanitizeSentryUrl("/service-record/link/efl_secret/context")).toBe(
+      "/service-record/link/[Filtered]/context",
     );
+    expect(sanitizeSentryUrl("/api/service-record/efl_secret/sessions/1/submit")).toBe(
+      "/api/service-record/[Filtered]/sessions/[Filtered]/submit",
+    );
+  });
+
+  it("redacts service-record resource identifiers from URLs", () => {
+    expect(sanitizeSentryUrl("/api/admin/service-records/client/77")).toBe(
+      "/api/admin/service-records/client/[Filtered]",
+    );
+    expect(sanitizeSentryUrl("/admin/service-records/schedules/431/finalize")).toBe(
+      "/admin/service-records/schedules/[Filtered]/finalize",
+    );
+    expect(
+      sanitizeSentryUrl("/api/schedule-change-requests/schedules/431/apply"),
+    ).toBe("/api/schedule-change-requests/schedules/[Filtered]/apply");
   });
 
   it("redacts UUID path segments from URLs", () => {

--- a/mobile/src/lib/observability/sentry-config.ts
+++ b/mobile/src/lib/observability/sentry-config.ts
@@ -19,7 +19,11 @@ const BEARER_PATTERN = /(bearer\s+)[^\s,;]+/gi;
 const SECRET_ASSIGNMENT_PATTERN =
   /((?:password|token|secret|api[_-]?key|authorization)\s*[:=]\s*)[^\s,;]+/gi;
 const SERVICE_RECORD_ACCESS_TOKEN_PATTERN =
-  /(\/(?:api\/)?service-record\/)[^/?#\s]+/gi;
+  /(\/(?:api\/)?service-record\/(?:link\/)?)[^/?#\s]+/gi;
+const SERVICE_RECORD_RESOURCE_ID_PATTERN =
+  /(\/(?:api\/)?(?:admin\/service-records\/(?:client|schedules)|schedule-change-requests\/schedules)\/)[^/?#\s]+/gi;
+const SERVICE_RECORD_SESSION_ID_PATTERN =
+  /(\/(?:api\/)?service-record\/[^/?#\s]+\/sessions\/)[^/?#\s]+/gi;
 const UUID_PATH_SEGMENT_PATTERN =
   /\/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}(?=\/|$)/gi;
 const SERVICE_RECORD_SIGNAL_PATTERN =
@@ -50,6 +54,8 @@ export function sanitizeSentryText(value: string): string {
     .replace(EMAIL_PATTERN, "[Email]")
     .replace(PHONE_PATTERN, "[Phone]")
     .replace(SERVICE_RECORD_ACCESS_TOKEN_PATTERN, `$1${FILTERED_VALUE}`)
+    .replace(SERVICE_RECORD_RESOURCE_ID_PATTERN, `$1${FILTERED_VALUE}`)
+    .replace(SERVICE_RECORD_SESSION_ID_PATTERN, `$1${FILTERED_VALUE}`)
     .replace(UUID_PATH_SEGMENT_PATTERN, `/${FILTERED_VALUE}`);
 }
 


### PR DESCRIPTION
## 요약
- 관리자 제공기록지 client/schedule ID를 Sentry URL, context, fingerprint에서 `[Filtered]`로 정규화합니다.
- 모바일 공개 제공기록지의 access token/session ID와 백엔드 transaction 경로도 동일하게 정규화합니다.
- 고객용 API 응답과 제공기록지 동작은 변경하지 않습니다.

## 검증
- frontend observability tests: 19 passed
- mobile observability tests: 11 passed
- backend observability tests: 7 passed
- frontend/mobile/backend typecheck passed
- changed-file ESLint passed

## 배경
Preview 실제 Sentry 이벤트 검증 중 숫자형 client ID가 context path에 남는 것을 확인해 Production 승격을 중지하고 보완했습니다.