### PR TITLE
fix: Sentry 브라우저 release를 배포 SHA로 고정

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -11,8 +11,12 @@ function readPositiveInt(value: string | undefined): number | undefined {
 const localBuildCpus = readPositiveInt(process.env.NEXT_BUILD_CPUS) ?? (process.env.CI ? undefined : 2);
 const localStaticGenerationMaxConcurrency =
     readPositiveInt(process.env.NEXT_STATIC_GENERATION_MAX_CONCURRENCY) ?? (process.env.CI ? undefined : 1);
+const sentryRelease = process.env.SENTRY_RELEASE ?? process.env.VERCEL_GIT_COMMIT_SHA;
 
 const nextConfig: NextConfig = {
+    env: {
+        NEXT_PUBLIC_SENTRY_RELEASE: sentryRelease,
+    },
     // Workspace package ships TS source; Next transpiles it in-app.
     transpilePackages: ["@babyjamjam/shared"],
     turbopack: {

--- a/mobile/next.config.ts
+++ b/mobile/next.config.ts
@@ -3,9 +3,12 @@ import { withSentryConfig } from "@sentry/nextjs";
 import type { NextConfig } from "next";
 import packageJson from "./package.json";
 
+const sentryRelease = process.env.SENTRY_RELEASE ?? process.env.VERCEL_GIT_COMMIT_SHA;
+
 const nextConfig: NextConfig = {
     env: {
         NEXT_PUBLIC_APP_VERSION: packageJson.version,
+        NEXT_PUBLIC_SENTRY_RELEASE: sentryRelease,
     },
     // Workspace package ships TS source; Next transpiles it in-app.
     transpilePackages: ["@babyjamjam/shared"],


### PR DESCRIPTION
## 요약
- Next 빌드 시 `SENTRY_RELEASE` 또는 `VERCEL_GIT_COMMIT_SHA`를 `NEXT_PUBLIC_SENTRY_RELEASE`로 주입합니다.
- 관리자·모바일 Sentry 이벤트의 release가 실제 배포 Git SHA와 일치하도록 합니다.
- API 동작과 고객 데이터는 변경하지 않습니다.

## 검증
- frontend typecheck + production build passed
- mobile typecheck + production build passed
- 두 빌드의 client/server 산출물에서 주입한 검증 SHA를 확인했습니다.

## 배경
Preview 실제 이벤트에서 environment와 개인정보 정규화는 확인됐지만 release가 현재 배포 SHA로 표시되지 않아 보완합니다.