### PR TITLE
[fix] Preview 브라우저 Sentry release SHA 연결

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -11,8 +11,12 @@ function readPositiveInt(value: string | undefined): number | undefined {
 const localBuildCpus = readPositiveInt(process.env.NEXT_BUILD_CPUS) ?? (process.env.CI ? undefined : 2);
 const localStaticGenerationMaxConcurrency =
     readPositiveInt(process.env.NEXT_STATIC_GENERATION_MAX_CONCURRENCY) ?? (process.env.CI ? undefined : 1);
+const sentryRelease = process.env.SENTRY_RELEASE ?? process.env.VERCEL_GIT_COMMIT_SHA;
 
 const nextConfig: NextConfig = {
+    env: {
+        NEXT_PUBLIC_SENTRY_RELEASE: sentryRelease,
+    },
     // Workspace package ships TS source; Next transpiles it in-app.
     transpilePackages: ["@babyjamjam/shared"],
     turbopack: {

--- a/mobile/next.config.ts
+++ b/mobile/next.config.ts
@@ -3,9 +3,12 @@ import { withSentryConfig } from "@sentry/nextjs";
 import type { NextConfig } from "next";
 import packageJson from "./package.json";
 
+const sentryRelease = process.env.SENTRY_RELEASE ?? process.env.VERCEL_GIT_COMMIT_SHA;
+
 const nextConfig: NextConfig = {
     env: {
         NEXT_PUBLIC_APP_VERSION: packageJson.version,
+        NEXT_PUBLIC_SENTRY_RELEASE: sentryRelease,
     },
     // Workspace package ships TS source; Next transpiles it in-app.
     transpilePackages: ["@babyjamjam/shared"],


### PR DESCRIPTION
## Summary
- frontend와 mobile 브라우저 Sentry release를 Vercel 배포 Git SHA에 연결합니다.
- 검증된 dev 변경 중 두 개의 Next.js 설정 파일만 preview로 승격합니다.

## Changes
- `SENTRY_RELEASE ?? VERCEL_GIT_COMMIT_SHA`를 `NEXT_PUBLIC_SENTRY_RELEASE`로 빌드 타임 주입
- 서버와 브라우저 이벤트가 동일 배포 SHA를 사용하도록 정렬

## Test Plan
- frontend typecheck 및 production build 통과
- mobile typecheck 및 production build 통과
- fake Vercel SHA가 client/server build 산출물에 포함되는지 확인
- CI 및 Vercel Preview 배포 확인

## Related
- #375