### PR TITLE
[fix] 모바일 관리자 제공기록지 API 오류 수집

### DIFF
--- a/mobile/src/lib/api/__tests__/client.test.ts
+++ b/mobile/src/lib/api/__tests__/client.test.ts
@@ -1,9 +1,18 @@
 import { AxiosError } from "axios";
 
+import { captureServiceRecordError } from "@/lib/observability/capture-service-record-error";
+
 import {
+    api,
     isConcurrentAuthRefreshError,
     isEformsignTokenEndpoint,
 } from "../client";
+
+jest.mock("@/lib/observability/capture-service-record-error", () => ({
+    captureServiceRecordError: jest.fn(),
+}));
+
+const mockCaptureServiceRecordError = jest.mocked(captureServiceRecordError);
 
 describe("isEformsignTokenEndpoint", () => {
     it.each([
@@ -52,5 +61,63 @@ describe("isConcurrentAuthRefreshError", () => {
         );
 
         expect(isConcurrentAuthRefreshError(error)).toBe(true);
+    });
+});
+
+describe("service-record API error monitoring", () => {
+    const originalAdapter = api.defaults.adapter;
+
+    afterEach(() => {
+        api.defaults.adapter = originalAdapter;
+        mockCaptureServiceRecordError.mockReset();
+    });
+
+    it("captures a service-record network failure once after the retry is exhausted", async () => {
+        const adapter = jest.fn(async (config) => {
+            throw new AxiosError("Network Error", "ERR_NETWORK", config);
+        });
+        api.defaults.adapter = adapter;
+
+        await expect(api.get("/admin/service-records/client/42")).rejects.toMatchObject({
+            code: "ERR_NETWORK",
+        });
+
+        expect(adapter).toHaveBeenCalledTimes(2);
+        expect(mockCaptureServiceRecordError).toHaveBeenCalledTimes(1);
+        expect(mockCaptureServiceRecordError).toHaveBeenCalledWith(
+            expect.objectContaining({
+                code: "ERR_NETWORK",
+                config: expect.objectContaining({
+                    method: "get",
+                    url: "/admin/service-records/client/42",
+                }),
+            }),
+        );
+    });
+
+    it("captures a resolved service-record 5xx failure without retrying", async () => {
+        const adapter = jest.fn(async (config) => {
+            throw new AxiosError(
+                "Request failed with status code 503",
+                "ERR_BAD_RESPONSE",
+                config,
+                undefined,
+                {
+                    status: 503,
+                    statusText: "Service Unavailable",
+                    headers: {},
+                    config,
+                    data: {},
+                },
+            );
+        });
+        api.defaults.adapter = adapter;
+
+        await expect(api.get("/admin/service-records/client/42")).rejects.toMatchObject({
+            response: expect.objectContaining({ status: 503 }),
+        });
+
+        expect(adapter).toHaveBeenCalledTimes(1);
+        expect(mockCaptureServiceRecordError).toHaveBeenCalledTimes(1);
     });
 });

--- a/mobile/src/lib/api/client.ts
+++ b/mobile/src/lib/api/client.ts
@@ -3,6 +3,7 @@ import { parse } from "cookie";
 
 import { isPublicAuthPath } from "@/lib/auth/routes";
 import { getServerRuntimeConfig } from "@/lib/env";
+import { captureServiceRecordError } from "@/lib/observability/capture-service-record-error";
 import { safeStorageRemoveItem, safeStorageSetItem } from "@/lib/safe-storage";
 
 const API_BASE_URL = typeof window === 'undefined'
@@ -87,7 +88,7 @@ api.interceptors.response.use(
         // Network error - single retry
         if (err.message === "Network Error" && originalRequest && !originalRequest._retry) {
             originalRequest._retry = true;
-            return axios(originalRequest);
+            return api(originalRequest);
         }
 
         // 401 Unauthorized
@@ -181,6 +182,7 @@ api.interceptors.response.use(
             }
         }
 
+        captureServiceRecordError(err);
         return Promise.reject(err);
     }
 );


### PR DESCRIPTION
## Summary
- 모바일 관리자 제공기록지의 Axios 네트워크/5xx 실패를 Sentry helper로 전달합니다.
- 네트워크 오류는 기존 1회 재시도를 유지하고, 재시도까지 실패한 경우에만 한 번 수집합니다.

## Changes
- 모바일 API 응답 인터셉터에서 제공기록지 오류 capture 호출
- 재시도도 동일 Axios 인스턴스를 사용해 최종 실패가 인터셉터를 다시 통과하도록 수정
- 네트워크 실패 1회 수집 및 5xx 무재시도 수집 테스트 추가

## Test Plan
- mobile focused tests: 26 passed
- mobile full tests: 140 suites, 789 tests passed
- mobile lint: 0 errors (existing warnings only)
- mobile type-check: passed
- mobile production build: passed with required build-time env placeholders

## Related
- #372
- #375