### PR TITLE
[fix] Preview 모바일 관리자 제공기록지 오류 수집

### DIFF
--- a/mobile/src/lib/api/__tests__/client.test.ts
+++ b/mobile/src/lib/api/__tests__/client.test.ts
@@ -1,9 +1,18 @@
 import { AxiosError } from "axios";
 
+import { captureServiceRecordError } from "@/lib/observability/capture-service-record-error";
+
 import {
+    api,
     isConcurrentAuthRefreshError,
     isEformsignTokenEndpoint,
 } from "../client";
+
+jest.mock("@/lib/observability/capture-service-record-error", () => ({
+    captureServiceRecordError: jest.fn(),
+}));
+
+const mockCaptureServiceRecordError = jest.mocked(captureServiceRecordError);
 
 describe("isEformsignTokenEndpoint", () => {
     it.each([
@@ -52,5 +61,63 @@ describe("isConcurrentAuthRefreshError", () => {
         );
 
         expect(isConcurrentAuthRefreshError(error)).toBe(true);
+    });
+});
+
+describe("service-record API error monitoring", () => {
+    const originalAdapter = api.defaults.adapter;
+
+    afterEach(() => {
+        api.defaults.adapter = originalAdapter;
+        mockCaptureServiceRecordError.mockReset();
+    });
+
+    it("captures a service-record network failure once after the retry is exhausted", async () => {
+        const adapter = jest.fn(async (config) => {
+            throw new AxiosError("Network Error", "ERR_NETWORK", config);
+        });
+        api.defaults.adapter = adapter;
+
+        await expect(api.get("/admin/service-records/client/42")).rejects.toMatchObject({
+            code: "ERR_NETWORK",
+        });
+
+        expect(adapter).toHaveBeenCalledTimes(2);
+        expect(mockCaptureServiceRecordError).toHaveBeenCalledTimes(1);
+        expect(mockCaptureServiceRecordError).toHaveBeenCalledWith(
+            expect.objectContaining({
+                code: "ERR_NETWORK",
+                config: expect.objectContaining({
+                    method: "get",
+                    url: "/admin/service-records/client/42",
+                }),
+            }),
+        );
+    });
+
+    it("captures a resolved service-record 5xx failure without retrying", async () => {
+        const adapter = jest.fn(async (config) => {
+            throw new AxiosError(
+                "Request failed with status code 503",
+                "ERR_BAD_RESPONSE",
+                config,
+                undefined,
+                {
+                    status: 503,
+                    statusText: "Service Unavailable",
+                    headers: {},
+                    config,
+                    data: {},
+                },
+            );
+        });
+        api.defaults.adapter = adapter;
+
+        await expect(api.get("/admin/service-records/client/42")).rejects.toMatchObject({
+            response: expect.objectContaining({ status: 503 }),
+        });
+
+        expect(adapter).toHaveBeenCalledTimes(1);
+        expect(mockCaptureServiceRecordError).toHaveBeenCalledTimes(1);
     });
 });

--- a/mobile/src/lib/api/client.ts
+++ b/mobile/src/lib/api/client.ts
@@ -3,6 +3,7 @@ import { parse } from "cookie";
 
 import { isPublicAuthPath } from "@/lib/auth/routes";
 import { getServerRuntimeConfig } from "@/lib/env";
+import { captureServiceRecordError } from "@/lib/observability/capture-service-record-error";
 import { safeStorageRemoveItem, safeStorageSetItem } from "@/lib/safe-storage";
 
 const API_BASE_URL = typeof window === 'undefined'
@@ -87,7 +88,7 @@ api.interceptors.response.use(
         // Network error - single retry
         if (err.message === "Network Error" && originalRequest && !originalRequest._retry) {
             originalRequest._retry = true;
-            return axios(originalRequest);
+            return api(originalRequest);
         }
 
         // 401 Unauthorized
@@ -181,6 +182,7 @@ api.interceptors.response.use(
             }
         }
 
+        captureServiceRecordError(err);
         return Promise.reject(err);
     }
 );


### PR DESCRIPTION
## Summary
- 실제 Preview 검증에서 발견한 모바일 관리자 제공기록지 Axios 수집 누락을 보완합니다.
- 검증된 dev 변경 두 파일만 preview로 선택 승격합니다.

## Changes
- 최종 네트워크 실패와 5xx를 제공기록지 Sentry helper로 전달
- 네트워크 오류 재시도 동작 유지 및 중복 수집 방지
- focused/full 테스트 추가 및 통과

## Test Plan
- mobile full tests: 140 suites, 789 tests passed
- lint: 0 errors
- type-check: passed
- production build: passed
- Preview 배포 후 실제 네트워크 오류 이벤트의 app/mobile, environment/preview, release SHA, redacted path 확인

## Related
- #377
- #376