### PR TITLE
[fix] 전화번호 기반 고객-전자계약서 양방향 연결

### DIFF
--- a/backend/application/services/client.service.ts
+++ b/backend/application/services/client.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, ConflictException, Injectable, Inject, Logger, NotFoundException, Optional } from "@nestjs/common";
-import { normalizePhone } from "application/utils/normalize-phone";
+import { extractPhoneCandidates, normalizePhone } from "application/utils/normalize-phone";
 import {
     CreateClientUsecase,
     DeleteClientUsecase,
@@ -33,6 +33,7 @@ const CREATED_DOCUMENT_STATUS_TYPES = new Set(["001", "002", "010", "043"]);
 const REQUESTED_DOCUMENT_STATUS_TYPES = new Set(["030", "060", "070"]);
 const CONTRACT_AUTO_REGISTRATION_SOURCE = "contract_auto_registration";
 const DEFAULT_SERVICE_PERIOD_MS = 365 * 24 * 60 * 60 * 1000;
+const PHONE_LOOKUP_SUFFIX_LENGTH = 4;
 
 // Document status type for eformsign documents
 // Maps to eformsign_doc.statusType values:
@@ -171,6 +172,88 @@ export class ClientService {
         if (!isServiceStatus(status)) {
             throw new BadRequestException(
                 `serviceStatus must be one of: ${SERVICE_STATUS_VALUES.join(", ")}`
+            );
+        }
+    }
+
+    private async linkContractDocumentsByPhone(
+        branchid: string,
+        client: ClientEntity,
+        normalizedPhone: string,
+    ): Promise<void> {
+        const phoneLookupSuffix = normalizedPhone.slice(-PHONE_LOOKUP_SUFFIX_LENGTH);
+
+        try {
+            const candidateDocs = await this.prismaService.eformsign_doc.findMany({
+                where: {
+                    branchId: branchid,
+                    serviceRecordCaseId: null,
+                    stepRecipientSms: { contains: phoneLookupSuffix },
+                    OR: [
+                        { documentKind: EFORMSIGN_DOCUMENT_KIND.CONTRACT },
+                        { documentKind: null },
+                    ],
+                },
+                orderBy: [
+                    { createdDate: "desc" },
+                    { id: "desc" },
+                ],
+                select: {
+                    id: true,
+                    documentId: true,
+                    clientId: true,
+                    stepRecipientSms: true,
+                },
+            });
+            const matchingDocs = candidateDocs.filter((doc) =>
+                extractPhoneCandidates(doc.stepRecipientSms).includes(normalizedPhone),
+            );
+            const documentIdsToReassign = matchingDocs
+                .filter((doc) => doc.clientId !== client.id)
+                .map((doc) => doc.id);
+            const latestContract = matchingDocs[0];
+            const shouldUpdateClientDocument = latestContract !== undefined
+                && client.eDocId !== latestContract.documentId;
+
+            if (documentIdsToReassign.length === 0 && !shouldUpdateClientDocument) {
+                return;
+            }
+
+            await this.prismaService.$transaction(async (transaction) => {
+                if (documentIdsToReassign.length > 0) {
+                    const reassigned = await transaction.eformsign_doc.updateMany({
+                        where: {
+                            branchId: branchid,
+                            id: { in: documentIdsToReassign },
+                        },
+                        data: { clientId: client.id },
+                    });
+                    if (reassigned.count !== documentIdsToReassign.length) {
+                        throw new Error("Contract document reassignment was incomplete");
+                    }
+                }
+
+                if (shouldUpdateClientDocument) {
+                    const updated = await transaction.client.updateMany({
+                        where: {
+                            id: client.id,
+                            branchId: branchid,
+                        },
+                        data: { eDocId: latestContract.documentId },
+                    });
+                    if (updated.count !== 1) {
+                        throw new Error("Client contract pointer update failed");
+                    }
+                }
+            });
+
+            if (shouldUpdateClientDocument) {
+                client.update({ eDocId: latestContract.documentId });
+            }
+        } catch (error) {
+            const errorType = error instanceof Error ? error.name : "UnknownError";
+            this.logger.error(
+                `[CLIENT_CONTRACT_PHONE_LINK_FAILED] 고객 ${client.id} 계약서 자동 연결 실패 (${errorType})`,
             );
         }
     }
@@ -461,6 +544,7 @@ export class ClientService {
                             });
                     }
                 }
+                await this.linkContractDocumentsByPhone(branchid, existing, normalizedPhone);
                 await this.serviceRecordLifecycleService?.ensureForClient(existing.id);
                 return existing;
             }
@@ -516,6 +600,9 @@ export class ClientService {
             client = await this.createClientUsecase.execute(branchid, createParams);
         }
 
+        if (normalizedPhone) {
+            await this.linkContractDocumentsByPhone(branchid, client, normalizedPhone);
+        }
         await this.serviceRecordLifecycleService?.ensureForClient(client.id);
 
         if (this.triggerService && applyMessageAutomation) {
@@ -973,6 +1060,10 @@ export class ClientService {
         const updatedClient = await this.findClientByIdUsecase.execute(branchid, id);
         if (!updatedClient) {
             throw new NotFoundException(`Client with id ${id} not found`);
+        }
+        const updatedPhone = normalizePhone(updatedClient.phone);
+        if (updatedPhone) {
+            await this.linkContractDocumentsByPhone(branchid, updatedClient, updatedPhone);
         }
         await this.serviceRecordLifecycleService?.ensureForClient(id);
         if (this.triggerService) {

--- a/backend/test/services/client.service.spec.ts
+++ b/backend/test/services/client.service.spec.ts
@@ -74,6 +74,7 @@ describe("ClientService", () => {
             },
             eformsign_doc: {
                 findMany: jest.fn().mockResolvedValue([]),
+                updateMany: jest.fn().mockResolvedValue({ count: 0 }),
             },
             schedule_change_request: {
                 findMany: jest.fn().mockResolvedValue([]),
@@ -353,6 +354,77 @@ describe("ClientService", () => {
             );
         });
 
+        it("links every matching contract by normalized phone after manual client creation", async () => {
+            const mockClient = createClientEntity();
+            createClientUsecase.execute.mockResolvedValue(mockClient);
+            prismaService.eformsign_doc.updateMany.mockResolvedValue({ count: 2 });
+            prismaService.eformsign_doc.findMany.mockResolvedValue([
+                {
+                    id: 11,
+                    documentId: "DOC-LATEST",
+                    clientId: null,
+                    stepRecipientSms: "고객 010-1234-5678",
+                },
+                {
+                    id: 10,
+                    documentId: "DOC-OLDER",
+                    clientId: 99,
+                    stepRecipientSms: "연락처 +82 10 1234 5678",
+                },
+                {
+                    id: 9,
+                    documentId: "DOC-OTHER",
+                    clientId: null,
+                    stepRecipientSms: "010-9999-5678",
+                },
+            ]);
+
+            await service.create(branchId, {
+                name: "New Client",
+                phone: "010-1234-5678",
+                careCenter: false,
+                voucherClient: true,
+                breastPump: false,
+            });
+
+            expect(prismaService.eformsign_doc.findMany).toHaveBeenCalledWith({
+                where: {
+                    branchId,
+                    serviceRecordCaseId: null,
+                    stepRecipientSms: { contains: "5678" },
+                    OR: [
+                        { documentKind: "contract" },
+                        { documentKind: null },
+                    ],
+                },
+                orderBy: [
+                    { createdDate: "desc" },
+                    { id: "desc" },
+                ],
+                select: {
+                    id: true,
+                    documentId: true,
+                    clientId: true,
+                    stepRecipientSms: true,
+                },
+            });
+            expect(prismaService.eformsign_doc.updateMany).toHaveBeenCalledWith({
+                where: {
+                    branchId,
+                    id: { in: [11, 10] },
+                },
+                data: { clientId: mockClient.id },
+            });
+            expect(prismaService.client.updateMany).toHaveBeenCalledWith({
+                where: {
+                    id: mockClient.id,
+                    branchId,
+                },
+                data: { eDocId: "DOC-LATEST" },
+            });
+            expect(mockClient.eDocId).toBe("DOC-LATEST");
+        });
+
         it("calls ensureDefaultRulesForBranch then syncClientRulesForClient with suppressGreeting=true when suppressGreetingSms is set", async () => {
             // Arrange
             const mockClient = createClientEntity();
@@ -597,6 +669,45 @@ describe("ClientService", () => {
                 expect(prismaService.employee_schedule.create).not.toHaveBeenCalled();
             });
 
+            it("links matching contracts when reusing an existing client by phone", async () => {
+                const existingClient = createClientEntity();
+                clientRepository.findByPhone.mockResolvedValue(existingClient);
+                prismaService.eformsign_doc.updateMany.mockResolvedValue({ count: 1 });
+                prismaService.eformsign_doc.findMany.mockResolvedValue([
+                    {
+                        id: 9,
+                        documentId: "DOC-0009",
+                        clientId: null,
+                        stepRecipientSms: "고객 010-1234-5678",
+                    },
+                ]);
+
+                await service.create(branchId, {
+                    name: "Existing",
+                    phone: "010-1234-5678",
+                    careCenter: false,
+                    voucherClient: true,
+                    breastPump: false,
+                    reuseExistingClient: true,
+                });
+
+                expect(prismaService.eformsign_doc.updateMany).toHaveBeenCalledWith({
+                    where: {
+                        branchId,
+                        id: { in: [9] },
+                    },
+                    data: { clientId: existingClient.id },
+                });
+                expect(prismaService.client.updateMany).toHaveBeenCalledWith({
+                    where: {
+                        id: existingClient.id,
+                        branchId,
+                    },
+                    data: { eDocId: "DOC-0009" },
+                });
+                expect(existingClient.eDocId).toBe("DOC-0009");
+            });
+
             it("creates the missing assignment when a duplicate client is reused with a selected employee", async () => {
                 const existingClient = createClientEntity();
                 clientRepository.findByPhone.mockResolvedValue(existingClient);
@@ -750,6 +861,49 @@ describe("ClientService", () => {
                     data: expect.objectContaining({ name: "New Name", address: "New Address" }),
                 }));
                 expect(result).toBe(existingClient);
+            });
+
+            it("links matching contracts by the effective phone after client information is updated", async () => {
+                const existingClient = createClientEntity();
+                findClientByIdUsecase.execute.mockResolvedValue(existingClient);
+                prismaService.eformsign_doc.updateMany.mockResolvedValue({ count: 1 });
+                prismaService.eformsign_doc.findMany.mockResolvedValue([
+                    {
+                        id: 12,
+                        documentId: "DOC-AFTER-UPDATE",
+                        clientId: null,
+                        stepRecipientSms: "이용자 010 1234 5678",
+                    },
+                ]);
+
+                const result = await service.update(branchId, existingClient.id, {
+                    name: "Updated Client",
+                });
+
+                expect(prismaService.eformsign_doc.findMany).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        where: expect.objectContaining({
+                            branchId,
+                            serviceRecordCaseId: null,
+                            stepRecipientSms: { contains: "5678" },
+                        }),
+                    }),
+                );
+                expect(prismaService.eformsign_doc.updateMany).toHaveBeenCalledWith({
+                    where: {
+                        branchId,
+                        id: { in: [12] },
+                    },
+                    data: { clientId: existingClient.id },
+                });
+                expect(prismaService.client.updateMany).toHaveBeenCalledWith({
+                    where: {
+                        id: existingClient.id,
+                        branchId,
+                    },
+                    data: { eDocId: "DOC-AFTER-UPDATE" },
+                });
+                expect(result.eDocId).toBe("DOC-AFTER-UPDATE");
             });
 
             it("does not resolve a service date update before scheduled jobs are recalculated", async () => {

--- a/backend/test/usecases/eformsign-doc/create-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/create-eformsign-doc.usecase.spec.ts
@@ -98,6 +98,23 @@ describe("CreateEformsignDocUsecase", () => {
         expect(clientRepository.findByPhone).not.toHaveBeenCalled();
     });
 
+    it("links by normalized recipient phone when the supplied client does not exist", async () => {
+        const phoneMatchedClient = createClient(12, "01012345678");
+        clientRepository.findById.mockResolvedValue(null);
+        clientRepository.findByPhone.mockResolvedValue(phoneMatchedClient);
+
+        const result = await usecase.execute(branchId, createParams());
+
+        expect(clientRepository.findByPhone).toHaveBeenCalledWith(branchId, "01012345678");
+        expect(result.clientId).toBe(12);
+        expect(eformsignDocRepository.upsertByDocumentId).toHaveBeenCalledWith(
+            branchId,
+            expect.objectContaining({ clientId: 12, documentId }),
+        );
+        expect(phoneMatchedClient.eDocId).toBe(documentId);
+        expect(clientRepository.update).toHaveBeenCalledWith(branchId, phoneMatchedClient);
+    });
+
     it("returns a warning while keeping the document when client linking fails", async () => {
         const client = createClient(7, "010-1234-5678");
         clientRepository.findById.mockResolvedValue(client);


### PR DESCRIPTION
## Summary

고객과 전자계약서가 생성되는 순서와 관계없이 동일한 전화번호를 기준으로 자동 연결합니다.
고객 정보 수정 시에도 저장된 최종 전화번호로 연결을 재시도합니다.

## Changes

- 고객 수동 생성 및 기존 고객 재사용 시 동일 전화번호의 계약서를 연결
- 고객 정보 수정 완료 후 최종 전화번호로 계약서 연결을 재조회
- 전자문서가 나중에 생성되는 기존 역방향 연결 동작에 대한 회귀 테스트 추가
- 같은 지점의 계약서만 대상으로 하고 제공기록지는 제외
- 후보는 전화번호 뒤 4자리로 조회한 뒤 정규화한 전체 전화번호가 일치할 때만 연결
- 일치하는 계약서는 모두 고객에게 연결하고 최신 계약서를 고객 대표 전자문서로 지정

## Test Plan

- `pnpm test --runInBand` — 160 suites, 1,638 passed, 8 skipped
- `pnpm type-check` — passed
- `pnpm lint` — 0 errors, existing 76 warnings
- `pnpm build` — passed
- `pnpm audit --prod --audit-level high` — no known vulnerabilities

## Related

- 고객 수동 추가/수정과 기존 전자계약서 간 전화번호 기반 자동 연결