### PR TITLE
fix(contracts): preserve auto-registration policy

### DIFF
--- a/mobile/src/hooks/contracts/useContractCreationFlow.ts
+++ b/mobile/src/hooks/contracts/useContractCreationFlow.ts
@@ -30,6 +30,7 @@ import {
   todayIsoDate,
   yymmddToIso,
 } from "@/lib/contracts/date-input";
+import { buildContractAutoRegistrationPayload } from "@/lib/contracts/contract-auto-registration";
 import { calcEndDateBusinessDays } from "@/lib/date/business-days";
 import { buildInitialSignRequestDocRecord } from "@/lib/eformsign/document-record";
 import { formatKoreanPhoneNumber, normalizeKoreanPhoneDigits } from "@/lib/phone";
@@ -833,18 +834,15 @@ export function useContractCreationFlow(): ContractCreationFlow {
     try {
       let finalClientId = clientId ?? storedClientByIdentity?.id ?? storedClientByPhone?.id ?? null;
       if (!finalClientId && isManualEntry && shouldRegisterMissingClient) {
-        const newClient = await createClientMutation.mutateAsync({
+        const newClient = await createClientMutation.mutateAsync(buildContractAutoRegistrationPayload({
           name,
           phone,
           birthday: birthday || undefined,
           address: address || undefined,
           dueDate: dueDate || startDate || undefined,
-          primaryEmployeeId: null,
-          careCenter: false,
-          voucherClient: true,
-          breastPump: false,
-          suppressGreetingSms: true,
-        });
+          primaryEmployeeId: employeeId,
+          secondaryEmployeeId: showEmployee2 ? employee2Id : null,
+        }));
         finalClientId = newClient.id;
         setClientId(newClient.id);
       }

--- a/mobile/src/hooks/contracts/useContractCreationFlow.ts
+++ b/mobile/src/hooks/contracts/useContractCreationFlow.ts
@@ -840,6 +840,8 @@ export function useContractCreationFlow(): ContractCreationFlow {
           birthday: birthday || undefined,
           address: address || undefined,
           dueDate: dueDate || startDate || undefined,
+          startDate,
+          endDate,
           primaryEmployeeId: employeeId,
           secondaryEmployeeId: showEmployee2 ? employee2Id : null,
         }));

--- a/mobile/src/lib/contracts/__tests__/contract-auto-registration.test.ts
+++ b/mobile/src/lib/contracts/__tests__/contract-auto-registration.test.ts
@@ -8,6 +8,8 @@ describe("buildContractAutoRegistrationPayload", () => {
       birthday: "900101",
       address: "인천시 남동구",
       dueDate: "2026-08-01",
+      startDate: "2026-08-03",
+      endDate: "2026-08-14",
       primaryEmployeeId: 17,
       secondaryEmployeeId: 23,
     });
@@ -18,6 +20,8 @@ describe("buildContractAutoRegistrationPayload", () => {
       birthday: "900101",
       address: "인천시 남동구",
       dueDate: "2026-08-01",
+      startDate: "2026-08-03",
+      endDate: "2026-08-14",
       primaryEmployeeId: 17,
       secondaryEmployeeId: 23,
       careCenter: false,

--- a/mobile/src/lib/contracts/__tests__/contract-auto-registration.test.ts
+++ b/mobile/src/lib/contracts/__tests__/contract-auto-registration.test.ts
@@ -1,0 +1,30 @@
+import { buildContractAutoRegistrationPayload } from "../contract-auto-registration";
+
+describe("buildContractAutoRegistrationPayload", () => {
+  it("preserves selected employees and delegates auto-registration policy to the backend", () => {
+    const payload = buildContractAutoRegistrationPayload({
+      name: "홍길동",
+      phone: "010-1234-5678",
+      birthday: "900101",
+      address: "인천시 남동구",
+      dueDate: "2026-08-01",
+      primaryEmployeeId: 17,
+      secondaryEmployeeId: 23,
+    });
+
+    expect(payload).toEqual({
+      name: "홍길동",
+      phone: "010-1234-5678",
+      birthday: "900101",
+      address: "인천시 남동구",
+      dueDate: "2026-08-01",
+      primaryEmployeeId: 17,
+      secondaryEmployeeId: 23,
+      careCenter: false,
+      voucherClient: true,
+      breastPump: false,
+      source: "contract_auto_registration",
+    });
+    expect(payload).not.toHaveProperty("suppressGreetingSms");
+  });
+});

--- a/mobile/src/lib/contracts/contract-auto-registration.ts
+++ b/mobile/src/lib/contracts/contract-auto-registration.ts
@@ -6,6 +6,8 @@ export interface ContractAutoRegistrationPayloadInput {
   birthday?: string;
   address?: string;
   dueDate?: string;
+  startDate: string;
+  endDate: string;
   primaryEmployeeId: number | null;
   secondaryEmployeeId: number | null;
 }
@@ -19,6 +21,8 @@ export function buildContractAutoRegistrationPayload(
     birthday: input.birthday,
     address: input.address,
     dueDate: input.dueDate,
+    startDate: input.startDate,
+    endDate: input.endDate,
     primaryEmployeeId: input.primaryEmployeeId,
     secondaryEmployeeId: input.secondaryEmployeeId,
     careCenter: false,

--- a/mobile/src/lib/contracts/contract-auto-registration.ts
+++ b/mobile/src/lib/contracts/contract-auto-registration.ts
@@ -1,0 +1,29 @@
+import type { CreateClientDto } from "@/features/clients/types";
+
+export interface ContractAutoRegistrationPayloadInput {
+  name: string;
+  phone: string;
+  birthday?: string;
+  address?: string;
+  dueDate?: string;
+  primaryEmployeeId: number | null;
+  secondaryEmployeeId: number | null;
+}
+
+export function buildContractAutoRegistrationPayload(
+  input: ContractAutoRegistrationPayloadInput,
+): CreateClientDto {
+  return {
+    name: input.name,
+    phone: input.phone,
+    birthday: input.birthday,
+    address: input.address,
+    dueDate: input.dueDate,
+    primaryEmployeeId: input.primaryEmployeeId,
+    secondaryEmployeeId: input.secondaryEmployeeId,
+    careCenter: false,
+    voucherClient: true,
+    breastPump: false,
+    source: "contract_auto_registration",
+  };
+}


### PR DESCRIPTION
## What changed

- Preserve the selected primary and secondary employee IDs when the mobile contract flow auto-registers a missing client.
- Send `source: "contract_auto_registration"` so the backend applies the tenant auto-registration policy.
- Stop forcing `suppressGreetingSms: true`; the backend now decides greeting delivery from tenant settings.
- Add a focused payload regression test.

## Root cause

The extracted contract creation hook rebuilt the client payload with `primaryEmployeeId: null` and unconditionally suppressed the greeting SMS. That differed from the established contract auto-registration contract and could drop the provider schedule assignment while bypassing tenant policy.

## Validation

- Mobile Jest: 141 suites, 790 tests passed
- Mobile type-check: passed
- Mobile lint: passed (0 errors; existing warnings only)
- Mobile production build: passed with `NEXT_PUBLIC_API_BASE_URL=http://localhost:3001` (expected local backend connection warnings during static data fetch)
- `pnpm audit --prod --audit-level high`: no known vulnerabilities
- `git diff --check`: passed

## Review follow-up

Addresses the actionable feedback on #380:

- https://github.com/jaino-song/babyjamjam-admin/pull/380#discussion_r3642753987
- https://github.com/jaino-song/babyjamjam-admin/pull/380#discussion_r3642753989