### PR TITLE
test(mobile): repair clients detail-label e2e selectors

### DIFF
--- a/mobile/tests/clients-mobile-detail-labels.spec.ts
+++ b/mobile/tests/clients-mobile-detail-labels.spec.ts
@@ -176,7 +176,7 @@ test.describe("Mobile clients detail labels", () => {
     await expect(notificationTabButton).toBeVisible();
     await notificationTabButton.dispatchEvent("click");
 
-    const messageTab = page.locator('[data-component="mobile-clients-message-tab"]');
+    const messageTab = page.locator('[data-component="mobile_clients_detail-sheet_stack_detail-page_content_tab-panel_message"]');
     await expect(messageTab).toBeVisible();
     await expect(messageTab.locator(".info-card-title")).toHaveText("발송 내역");
     await expect(messageTab).toContainText("메시지 · 수동 메시지");
@@ -261,7 +261,7 @@ test.describe("Mobile clients detail labels", () => {
     await page.locator('[data-component="mobile-clients-row"]', { hasText: CLIENT.name }).click();
     await page.locator('[data-component="mobile-redesign-detail-tabs"] [data-tab="message"]').click();
 
-    const messageTab = page.locator('[data-component="mobile-clients-message-tab"]');
+    const messageTab = page.locator('[data-component="mobile_clients_detail-sheet_stack_detail-page_content_tab-panel_message"]');
     await expect(messageTab).toContainText("발송 내역을 불러오지 못했습니다.");
     await expect(messageTab).not.toContainText("발송 내역이 없습니다.");
     await expect(messageTab.locator('[data-component="mobile-clients-message-retry"]')).toBeVisible();

--- a/mobile/tests/dashboard-client-message-history.spec.ts
+++ b/mobile/tests/dashboard-client-message-history.spec.ts
@@ -113,7 +113,7 @@ test("dashboard client detail uses the same message history as the clients page"
   await page.locator('[data-component="mobile-redesign-list-row"]', { hasText: CLIENT.name }).click();
   await page.locator('[data-component="mobile-redesign-detail-tabs"] [data-tab="message"]').click();
 
-  const messageTab = page.locator('[data-component="mobile-clients-message-tab"]');
+  const messageTab = page.locator('[data-component="mobile_dashboard_detail-sheet_stack_detail-page_content_tab-panel_message"]');
   await expect(messageTab).toContainText("메시지 · 메시지");
   await expect(messageTab).not.toContainText("발송 내역이 없습니다.");
 });


### PR DESCRIPTION
## Summary
dev→preview 릴리스(#388)의 advisory e2e에서 실패하던 `clients-mobile-detail-labels.spec.ts` 2건 수정. 두 건 모두 소스에 존재한 적 없는 셀렉터(`mobile-clients-message-tab`)를 참조하는 **스펙 드리프트**였고, DOM 스냅샷 기준 실제 UI 동작은 정상(제품 버그 아님).

- 실제 렌더 값인 `mobile_clients_detail-sheet_stack_detail-page_content_tab-panel_message`로 교체 (client-detail.tsx:1277의 호출자 prefix 규칙)
- 같은 stale 셀렉터를 쓰던 `dashboard-client-message-history.spec.ts:116`도 dashboard prefix로 선제 수정 (다음 실행 시 동일 실패 예정이었음)
- 검증: mobile tsc 클린, 단위 142 suites / 799 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVSSsorkBMCt1BvYrRgDns