### PR TITLE
fix(shared): duplicate query params broke paginated contracts endpoints behind the proxy

### DIFF
--- a/packages/shared/src/api/route-utils.ts
+++ b/packages/shared/src/api/route-utils.ts
@@ -150,10 +150,22 @@ export function getAuthHeaders(token: string | null): Record<string, string> {
     return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
-function getProxyGetParams(request: NextRequest, accessToken: string): Record<string, string> {
-    const { searchParams } = new URL(request.url);
+function getProxyGetParams(
+    request: NextRequest,
+    accessToken: string,
+    backendPathHasQuery: boolean,
+): Record<string, string> {
     const params: Record<string, string> = { accessToken };
 
+    // When the route handler pre-encoded its own query string into backendPath,
+    // forwarding the incoming request's params again would duplicate keys —
+    // the upstream then parses them as arrays and rejects them (e.g.
+    // "limit must be an integer").
+    if (backendPathHasQuery) {
+        return params;
+    }
+
+    const { searchParams } = new URL(request.url);
     for (const [key, value] of searchParams.entries()) {
         if (key === "accessToken") {
             continue;
@@ -368,7 +380,7 @@ export function createRouteUtils({
 
         try {
             const response = await serverAPIClient.get(backendPath, {
-                params: getProxyGetParams(request, accessToken),
+                params: getProxyGetParams(request, accessToken, backendPath.includes("?")),
                 headers: getAuthHeaders(authToken),
             });
 


### PR DESCRIPTION
## Root cause
`proxyGetRequest` forwards the incoming request's searchParams as axios `params` — but the Part 1 mobile routes (`/api/eformsign/documents`, `/status-counts`) pre-encode their own validated query into `backendPath`. Axios appends both, so the upstream URL carries duplicate keys (`limit=9&…&limit=9`); Nest parses them as arrays and the controller's integer validation rejects with 400 `limit must be an integer`.

Effect: contracts list + status counts returned 400 on every real-proxy environment (preview since #388, local dev) for all branches. Never caught in CI because mock-based specs intercept at the browser layer, before the proxy→backend hop.

## Fix
When `backendPath` already contains `?`, forward only `accessToken` — the route handler owns its query. Bare-path callers keep the existing auto-forward behavior (all other 10+ GET proxy routes).

## Verification
- Direct backend call (dup keys) reproduces 400; single keys return 200 with `has_more`/`snapshot_version`
- Fixed dev server on :3402 against the real backend: both endpoints 200, status pills render
- tsc clean both apps · mobile 799/799 · frontend 580/580

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVSSsorkBMCt1BvYrRgDns