### PR TITLE
release: promote proxy duplicate-params fix to preview

### DIFF
--- a/packages/shared/src/api/route-utils.ts
+++ b/packages/shared/src/api/route-utils.ts
@@ -150,10 +150,22 @@ export function getAuthHeaders(token: string | null): Record<string, string> {
     return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
-function getProxyGetParams(request: NextRequest, accessToken: string): Record<string, string> {
-    const { searchParams } = new URL(request.url);
+function getProxyGetParams(
+    request: NextRequest,
+    accessToken: string,
+    backendPathHasQuery: boolean,
+): Record<string, string> {
     const params: Record<string, string> = { accessToken };
 
+    // When the route handler pre-encoded its own query string into backendPath,
+    // forwarding the incoming request's params again would duplicate keys —
+    // the upstream then parses them as arrays and rejects them (e.g.
+    // "limit must be an integer").
+    if (backendPathHasQuery) {
+        return params;
+    }
+
+    const { searchParams } = new URL(request.url);
     for (const [key, value] of searchParams.entries()) {
         if (key === "accessToken") {
             continue;
@@ -368,7 +380,7 @@ export function createRouteUtils({
 
         try {
             const response = await serverAPIClient.get(backendPath, {
-                params: getProxyGetParams(request, accessToken),
+                params: getProxyGetParams(request, accessToken, backendPath.includes("?")),
                 headers: getAuthHeaders(authToken),
             });
 


### PR DESCRIPTION
Promotes #395 — the shared proxy fix that restores the paginated contracts endpoints (400 → 200) on real-proxy environments. dev and preview were identical before this, so this release contains exactly the one fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVSSsorkBMCt1BvYrRgDns