### PR TITLE
fix(mobile): 인증 미들웨어가 pdf.js 워커를 막아 세션이 끊기는 문제

### DIFF
--- a/mobile/src/middleware.ts
+++ b/mobile/src/middleware.ts
@@ -189,6 +189,12 @@ const PUBLIC_ROUTES = [
   "/manifest.json",
   "/sw.js",
   "/service-record",
+  // The PDF preview loads this as a Web Worker. A redirect here would not just
+  // break the preview: this middleware clears the auth cookies on its way to
+  // /login, so one worker fetch landing in an expired-token window would log
+  // the user out mid-session. It is an unmodified pdf.js build — nothing to gate.
+  "/pdf.worker.min.mjs",
+  "/pdfjs-iframe-test.html",
 ];
 
 const PUBLIC_API_ROUTES = [


### PR DESCRIPTION
## 문제

preview 배포 후 실측: `/pdf.worker.min.mjs` 요청이 `307 → /login` 으로 리다이렉트되고, 응답에 `auth_token`·`refresh_token`·`auto_login` 쿠키 **삭제**가 함께 실립니다.

PDF 미리보기는 이 파일을 Web Worker로 불러옵니다. 로그인된 요청은 쿠키를 실어 보내므로 평소에는 통과하지만, 토큰이 만료된 짧은 구간에 워커 요청이 걸리면 미리보기가 실패하는 데 그치지 않고 **사용자가 문서를 보던 중 로그아웃됩니다.** 실패 양상이 원인에 비해 지나치게 큽니다.

## 수정

워커 경로를 공개 경로로 지정합니다. 수정 없는 pdf.js 빌드 산출물이라 보호할 내용이 없습니다. 미리보기 방식 결정을 위한 임시 진단 페이지도 함께 넣었고, 기기 확인이 끝나면 페이지와 함께 제거합니다.

## 검증
- mobile type-check exit 0, Jest 144 suites / 830 tests 통과
- 배포 후 `/pdf.worker.min.mjs` 가 200 으로 응답하는지 재확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG