### PR TITLE
release: pdf.js 워커 공개 경로 지정 (미리보기 중 로그아웃 방지)

### DIFF
--- a/mobile/src/middleware.ts
+++ b/mobile/src/middleware.ts
@@ -189,6 +189,12 @@ const PUBLIC_ROUTES = [
   "/manifest.json",
   "/sw.js",
   "/service-record",
+  // The PDF preview loads this as a Web Worker. A redirect here would not just
+  // break the preview: this middleware clears the auth cookies on its way to
+  // /login, so one worker fetch landing in an expired-token window would log
+  // the user out mid-session. It is an unmodified pdf.js build — nothing to gate.
+  "/pdf.worker.min.mjs",
+  "/pdfjs-iframe-test.html",
 ];
 
 const PUBLIC_API_ROUTES = [


### PR DESCRIPTION
직전 릴리스 배포 후 실측으로 발견한 문제의 후속 수정 1건.

`/pdf.worker.min.mjs` 요청이 `307 → /login` 으로 리다이렉트되면서 인증 쿠키 세 개를 함께 삭제하고 있었습니다. PDF 미리보기가 이 파일을 Web Worker로 부르기 때문에, 토큰 만료 구간에 요청이 걸리면 미리보기 실패에 그치지 않고 **문서를 보던 사용자가 로그아웃**됩니다. 수정 없는 pdf.js 빌드 산출물이라 보호할 내용이 없으므로 공개 경로로 지정했습니다. 임시 진단 페이지도 함께 포함되며 기기 확인 후 제거합니다.

## 검증
dev에서 전 CI 통과. 배포 후 `/pdf.worker.min.mjs` 200 응답을 재확인할 예정입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG