### PR TITLE
fix(mobile): PDF 미리보기 마무리 — 스피너 정중앙, 시트 배경색 정합, 새 탭 버튼 제거

### DIFF
--- a/mobile/next.config.ts
+++ b/mobile/next.config.ts
@@ -12,6 +12,13 @@ const nextConfig: NextConfig = {
     },
     // Workspace package ships TS source; Next transpiles it in-app.
     transpilePackages: ["@babyjamjam/shared"],
+    // Testing on a real phone means loading the dev server over the LAN, and Next
+    // blocks dev resources from any origin it was not told about — the page renders
+    // but never hydrates. Set NEXT_DEV_ALLOWED_ORIGINS to the machine's LAN IP.
+    allowedDevOrigins: (process.env.NEXT_DEV_ALLOWED_ORIGINS ?? "")
+        .split(",")
+        .map((origin) => origin.trim())
+        .filter(Boolean),
     turbopack: {
         root: path.resolve(__dirname, ".."),
     },

--- a/mobile/src/app/(shell)/contracts/page.tsx
+++ b/mobile/src/app/(shell)/contracts/page.tsx
@@ -11,7 +11,6 @@ import {
   ClipboardList,
   Download,
   Eye,
-  ExternalLink,
   FileCheck2,
   FileSignature,
   FileText,
@@ -1444,17 +1443,6 @@ function ContractDetailContent({
               >
                 <Download size={16} strokeWidth={2.5} />
                 <span>다운로드</span>
-              </a>
-              <a
-                className="contract-preview-open"
-                data-component="mobile_contracts_detail-sheet_stack_detail-page_content_pdf-preview_header_open"
-                href={downloadUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={`${name} PDF 새 탭에서 열기`}
-              >
-                <ExternalLink size={16} strokeWidth={2.5} />
-                <span>새 탭</span>
               </a>
             </div>
           </div>

--- a/mobile/src/components/app/contracts/__tests__/contract-pdf-viewer.test.tsx
+++ b/mobile/src/components/app/contracts/__tests__/contract-pdf-viewer.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import {
   calculateRenderDpr,
@@ -116,6 +116,7 @@ jest.mock("react-pdf", () => {
           data-loading-copy={typeof loading === "string" ? loading : undefined}
           data-error-copy={typeof error === "string" ? error : undefined}
         >
+          {loading}
           Page {pageNumber}
         </div>
       );
@@ -676,15 +677,15 @@ describe("ContractPdfViewer", () => {
     });
   });
 
-  it("sets Korean loading and error copy on every PDF page", async () => {
+  it("shows a labelled spinner while each PDF page renders, with Korean error copy", async () => {
     renderViewer();
 
     const pages = await screen.findAllByTestId(/^pdf-page-/);
     for (const page of pages) {
-      expect(page).toHaveAttribute(
-        "data-loading-copy",
-        "PDF 페이지를 불러오는 중입니다"
-      );
+      const status = within(page).getByRole("status", {
+        name: "PDF 페이지를 불러오는 중입니다",
+      });
+      expect(status.querySelector('[data-slot="spinner"]')).not.toBeNull();
       expect(page).toHaveAttribute(
         "data-error-copy",
         "PDF 페이지를 불러오지 못했습니다."

--- a/mobile/src/components/app/contracts/contract-pdf-viewer.tsx
+++ b/mobile/src/components/app/contracts/contract-pdf-viewer.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Document as PdfDocument, Page } from "react-pdf";
 
+import { Spinner } from "@/components/ui/spinner";
+
 import "@/lib/pdf-config";
 import { cn } from "@/lib/utils";
 
@@ -502,8 +504,9 @@ export function ContractPdfViewer({
               className="contract-pdf-status"
               data-slot="contract-pdf-status"
               role="status"
+              aria-label="PDF를 불러오는 중입니다"
             >
-              PDF를 불러오는 중입니다
+              <Spinner size="lg" className="contract-pdf-spinner" />
             </div>
           }
           error={
@@ -548,7 +551,16 @@ export function ContractPdfViewer({
                         pageNumber={index + 1}
                         width={baseWidth}
                         devicePixelRatio={renderDpr}
-                        loading="PDF 페이지를 불러오는 중입니다"
+                        loading={
+                          <div
+                            className="contract-pdf-status"
+                            data-slot="contract-pdf-status"
+                            role="status"
+                            aria-label="PDF 페이지를 불러오는 중입니다"
+                          >
+                            <Spinner size="lg" className="contract-pdf-spinner" />
+                          </div>
+                        }
                         error="PDF 페이지를 불러오지 못했습니다."
                         renderTextLayer={false}
                         renderAnnotationLayer={false}

--- a/mobile/src/components/app/mobile-redesign/redesign.css
+++ b/mobile/src/components/app/mobile-redesign/redesign.css
@@ -1702,7 +1702,9 @@ body.mobile-all-route .menu-row {
   flex-shrink: 0;
   position: relative;
   z-index: 3;
-  background: white;
+  /* Opaque so scrolled content cannot bleed through, but it has to be the
+     sheet's own colour — hardcoding white left a seam against the sheet. */
+  background: hsl(var(--v3-dim-white));
 }
 .sheet-title {
   min-width: 0;
@@ -1983,7 +1985,8 @@ body.mobile-all-route .menu-row {
   position: relative;
   padding: 0;
   border-bottom: 1px solid hsl(var(--v3-border));
-  background: white;
+  /* Matches .sheet-header: opaque for the sticky case, in the sheet's colour. */
+  background: hsl(var(--v3-dim-white));
 }
 body.mobile-clients-route .detail-tabs {
   position: sticky;
@@ -4469,8 +4472,7 @@ body.mobile-contracts-route .contract-preview-header-actions {
 
 body.mobile-contracts-route .contract-preview-back,
 body.mobile-contracts-route .contract-preview-receipt,
-body.mobile-contracts-route .contract-preview-download,
-body.mobile-contracts-route .contract-preview-open {
+body.mobile-contracts-route .contract-preview-download {
   display: inline-flex;
   min-width: 0;
   height: 32px;
@@ -4497,15 +4499,13 @@ body.mobile-contracts-route .contract-preview-open {
 
 body.mobile-contracts-route .contract-preview-back svg,
 body.mobile-contracts-route .contract-preview-receipt svg,
-body.mobile-contracts-route .contract-preview-download svg,
-body.mobile-contracts-route .contract-preview-open svg {
+body.mobile-contracts-route .contract-preview-download svg {
   transition: transform 160ms var(--ease-spatial);
 }
 
 body.mobile-contracts-route .contract-preview-back:active,
 body.mobile-contracts-route .contract-preview-receipt:active,
-body.mobile-contracts-route .contract-preview-download:active,
-body.mobile-contracts-route .contract-preview-open:active {
+body.mobile-contracts-route .contract-preview-download:active {
   opacity: 0.72;
   transform: translateX(-1px) scale(0.98);
 }
@@ -4568,19 +4568,27 @@ body.mobile-contracts-route .contract-pdf-page {
   box-shadow: 0 10px 28px rgb(15 23 42 / 10%);
 }
 
+/* react-pdf wraps loading/error content in its own unstyled `.react-pdf__message`
+   div, which shrinks to its content — centring inside that box parks the spinner
+   in the top-left corner of the frame. Take the status out of flow instead and
+   centre it over the viewer, which is `position: relative` above. */
 body.mobile-contracts-route .contract-pdf-status {
+  position: absolute;
+  z-index: 2;
   display: flex;
-  min-width: 100%;
-  min-height: 0;
   align-items: center;
-  flex: 1 0 auto;
   justify-content: center;
   gap: 10px;
   padding: 24px;
+  inset: 0;
   color: hsl(var(--v3-text));
   font-size: 0.86rem;
   font-weight: 700;
   text-align: center;
+}
+
+body.mobile-contracts-route .contract-pdf-spinner {
+  color: hsl(var(--v3-primary));
 }
 
 body.mobile-contracts-route .contract-pdf-status-error {


### PR DESCRIPTION
실기기(iOS·안드로이드) 확인 후 나온 수정 3건 + 로컬 테스트 편의 1건.

## 1. 로딩 표시를 스피너로, 정중앙에
텍스트로 나오던 로딩 안내를 디자인 시스템 스피너(프라이머리 색)로 교체했습니다.

처음엔 좌측 상단에 붙어 나왔는데, react-pdf가 로딩 요소를 **자체 `.react-pdf__message` div로 한 번 더 감싸고** 그 박스에 스타일이 없어 내용 크기만큼만 차지하기 때문이었습니다. 가운데 정렬은 그 좁은 박스 안에서만 동작하고 있었습니다. 상태 표시를 일반 흐름에서 빼내 뷰어 영역 전체를 덮도록 바꿔 해결했고, 같은 방식으로 오류 카드도 정중앙에 옵니다.

## 2. 시트 헤더·탭 배경색 회귀
스윕에서 헤더와 탭을 고정시키며 내용이 비치지 않도록 배경을 넣을 때 **순백색을 하드코딩**했는데, 시트 배경은 그보다 톤이 낮아 경계가 보였습니다. 원래는 둘 다 배경 지정이 없어 시트 색을 그대로 비쳤습니다. 시트 배경 변수를 쓰도록 되돌렸고 불투명도는 유지되어 고정 동작에는 영향이 없습니다.

## 3. 상시 "새 탭" 버튼 제거
사용자 요청. 로드 실패 상태의 동일 링크는 **유지**했습니다 — 그 상황에서 문서에 접근할 유일한 경로입니다.

> 참고: 뷰어가 PDF를 캔버스로 그리므로 텍스트 선택·검색·화면낭독기 접근은 되지 않습니다. 상시 링크 제거로 대체 경로가 줄었다는 점만 기록해 둡니다(현재 조치 불요).

## 4. LAN 개발 서버 접속 (`next.config.ts`)
실기기 테스트는 개발 서버를 LAN으로 열어야 하는데, Next가 모르는 출처의 개발 리소스를 차단해 **페이지는 뜨지만 하이드레이션이 안 되고 로그인 버튼이 무반응**이 됩니다. `NEXT_DEV_ALLOWED_ORIGINS` 환경변수로 허용 출처를 받도록 했습니다. 기본값은 비어 있어 배포에는 영향 없습니다.

## 검증
mobile type-check exit 0, Jest 144 suites / 830 tests 통과, ESLint 신규 오류 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG