### PR TITLE
ci(mobile): PR e2e가 조용히 건너뛰고 초록불이 되던 문제

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -146,7 +146,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # changed-spec selection diffs against the PR base branch
+          # Full history; the changed-spec selection below no longer depends on it
+          # (it asks the API instead), but keep it so any future git-based step works.
           fetch-depth: 0
 
       - name: Setup pnpm
@@ -202,16 +203,39 @@ jobs:
         run: pnpm --filter ./mobile exec playwright install --with-deps chromium
 
       - name: Playwright tests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           # PR runs are advisory: execute only specs the PR itself touched —
           # the full suite runs on every push to dev (post-merge) instead.
+          #
+          # The file list comes from the API rather than a local `git diff` against
+          # the base ref. A PR that changed four specs was once reported as "no spec
+          # files changed" and passed green without running anything, so the job
+          # certified nothing. The API answer does not depend on which refs the
+          # runner happens to have fetched, and an API failure is fatal below
+          # instead of collapsing into an empty list.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            CHANGED_SPECS=$(git diff --name-only --diff-filter=d "origin/${{ github.base_ref }}...HEAD" -- 'mobile/tests/*.spec.ts' 'mobile/tests/**/*.spec.ts' | sed 's|^mobile/||' | tr '\n' ' ')
+            if ! PR_FILES=$(gh api --paginate \
+              "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+              --jq '.[] | select(.status != "removed") | .filename'); then
+              echo "::error::Could not list the files this PR changes; refusing to report a green run that tested nothing."
+              exit 1
+            fi
+            if [ -z "$PR_FILES" ]; then
+              echo "::error::The API reported no files for this PR, which cannot be right."
+              exit 1
+            fi
+            CHANGED_SPECS=$(printf '%s\n' "$PR_FILES" \
+              | { grep -E '^mobile/tests/.+\.spec\.ts$' || true; } \
+              | sed 's|^mobile/||' | tr '\n' ' ')
             if [ -n "$CHANGED_SPECS" ]; then
               echo "PR mode — running changed specs only: $CHANGED_SPECS"
               pnpm --filter ./mobile exec playwright test $CHANGED_SPECS
             else
-              echo "PR mode — no spec files changed; skipping (full suite runs on dev push)"
+              echo "PR mode — this PR changes no spec files, so nothing runs here."
+              echo "The full suite runs on the push to dev after merge."
             fi
           else
             pnpm --filter ./mobile run test:e2e


### PR DESCRIPTION
## 문제

PR #397은 Playwright 스펙 **4개**를 변경했는데, e2e 작업이 `PR mode — no spec files changed; skipping` 을 출력하고 **아무 테스트도 돌리지 않은 채 통과**했습니다. 검증한 것이 없는데 검증한 것처럼 보였고, 실제 문제는 dev 병합 후 전체 스위트가 돌 때까지 드러나지 않습니다.

증상이 아니라 원인을 찾으려 했으나, 같은 명령을 당시 두 커밋으로 로컬에서 재현하면 스펙 4개를 **정상적으로 반환**합니다:

```
git diff --name-only --diff-filter=d d4cfc40a...104ad3ca -- 'mobile/tests/*.spec.ts' 'mobile/tests/**/*.spec.ts'
→ contracts-mobile-list-row / contracts-search / contracts-skeleton-loading / contracts-template-filter
```

워크플로에는 `fetch-depth: 0` 도, 올바른 `github.base_ref` 도 이미 있었고 `working-directory` 설정도 없습니다. 즉 **러너에서만 빈 결과가 나온 이유는 남은 증거로 특정하지 못했습니다.** 그래서 그 방식에 계속 의존하지 않기로 했습니다.

## 수정

변경 파일 목록을 로컬 git diff 대신 **API에 직접 묻습니다.** 러너가 어떤 ref를 받아왔는지, PR 병합 ref가 어떻게 계산됐는지에 의존하지 않습니다.

그리고 **조용히 건너뛰는 경로를 없앴습니다.** API 호출 실패와 파일 목록이 비어 있는 경우를 모두 치명적 오류로 처리하므로, 앞으로 같은 일이 생기면 초록불이 아니라 빨간불이 납니다. 검증하지 않았는데 통과로 보이는 것보다 실패하는 편이 낫습니다.

스펙을 바꾸지 않은 PR에서 아무것도 실행하지 않는 것은 의도된 동작이며 그대로입니다(전체 스위트는 dev 푸시에서 실행).

## 검증
- YAML 파싱, 셸 문법(`bash -n`) 통과
- `set -euo pipefail` 하에서 grep 무매치 시 파이프라인이 죽지 않고 빈 값이 되는 것, 매치 시 경로가 올바르게 추출되는 것을 실제 실행으로 확인
- **이 PR 자체는 스펙을 바꾸지 않으므로 "아무것도 실행 안 함"이 정상 출력입니다.** 새 경로가 실제로 스펙을 골라내는지는 다음번 스펙 변경 PR에서 확인됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG