### PR TITLE
release: 제공기록지 용어 통일 + PR e2e 조용한 건너뜀 수정

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -146,7 +146,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # changed-spec selection diffs against the PR base branch
+          # Full history; the changed-spec selection below no longer depends on it
+          # (it asks the API instead), but keep it so any future git-based step works.
           fetch-depth: 0
 
       - name: Setup pnpm
@@ -202,16 +203,39 @@ jobs:
         run: pnpm --filter ./mobile exec playwright install --with-deps chromium
 
       - name: Playwright tests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           # PR runs are advisory: execute only specs the PR itself touched —
           # the full suite runs on every push to dev (post-merge) instead.
+          #
+          # The file list comes from the API rather than a local `git diff` against
+          # the base ref. A PR that changed four specs was once reported as "no spec
+          # files changed" and passed green without running anything, so the job
+          # certified nothing. The API answer does not depend on which refs the
+          # runner happens to have fetched, and an API failure is fatal below
+          # instead of collapsing into an empty list.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            CHANGED_SPECS=$(git diff --name-only --diff-filter=d "origin/${{ github.base_ref }}...HEAD" -- 'mobile/tests/*.spec.ts' 'mobile/tests/**/*.spec.ts' | sed 's|^mobile/||' | tr '\n' ' ')
+            if ! PR_FILES=$(gh api --paginate \
+              "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+              --jq '.[] | select(.status != "removed") | .filename'); then
+              echo "::error::Could not list the files this PR changes; refusing to report a green run that tested nothing."
+              exit 1
+            fi
+            if [ -z "$PR_FILES" ]; then
+              echo "::error::The API reported no files for this PR, which cannot be right."
+              exit 1
+            fi
+            CHANGED_SPECS=$(printf '%s\n' "$PR_FILES" \
+              | { grep -E '^mobile/tests/.+\.spec\.ts$' || true; } \
+              | sed 's|^mobile/||' | tr '\n' ' ')
             if [ -n "$CHANGED_SPECS" ]; then
               echo "PR mode — running changed specs only: $CHANGED_SPECS"
               pnpm --filter ./mobile exec playwright test $CHANGED_SPECS
             else
-              echo "PR mode — no spec files changed; skipping (full suite runs on dev push)"
+              echo "PR mode — this PR changes no spec files, so nothing runs here."
+              echo "The full suite runs on the push to dev after merge."
             fi
           else
             pnpm --filter ./mobile run test:e2e

--- a/backend/application/services/admin-service-record.service.ts
+++ b/backend/application/services/admin-service-record.service.ts
@@ -374,7 +374,7 @@ export class AdminServiceRecordService {
             }
 
             this.logger.warn(
-                "Skipping service feedback signature docs because eformsign_doc feedback columns are not migrated yet.",
+                "Skipping service-record signature docs because eformsign_doc service-record columns are not migrated yet.",
             );
             return [];
         }

--- a/backend/application/services/client.service.ts
+++ b/backend/application/services/client.service.ts
@@ -540,7 +540,7 @@ export class ClientService {
                         this.serviceRecordLinkService
                             ?.scheduleForServiceStart(assignment.createdScheduleId)
                             ?.catch((error) => {
-                                this.logger.error(`Failed to schedule feedback link SMS: ${error}`);
+                                this.logger.error(`Failed to schedule service-record link SMS: ${error}`);
                             });
                     }
                 }
@@ -622,7 +622,7 @@ export class ClientService {
             this.serviceRecordLinkService
                 ?.scheduleForServiceStart(createdScheduleId)
                 ?.catch((error) => {
-                    this.logger.error(`Failed to schedule feedback link SMS: ${error}`);
+                    this.logger.error(`Failed to schedule service-record link SMS: ${error}`);
                 });
         }
 
@@ -1080,7 +1080,7 @@ export class ClientService {
             this.serviceRecordLinkService
                 ?.scheduleForServiceStart(createdScheduleId)
                 ?.catch((error) => {
-                    this.logger.error(`Failed to schedule feedback link SMS: ${error}`);
+                    this.logger.error(`Failed to schedule service-record link SMS: ${error}`);
                 });
         }
         return updatedClient;
@@ -1128,7 +1128,7 @@ export class ClientService {
             data: { endDate: new Date() },
         });
 
-        // Revoke any outstanding feedback links for this client's active assignments
+        // Revoke any outstanding service-record links for this client's active assignments
         const activeSchedules = await this.prismaService.employee_schedule.findMany({
             where: { clientId: clientId, replaced: false },
             select: { id: true },
@@ -1220,7 +1220,7 @@ export class ClientService {
         this.serviceRecordLinkService
             ?.scheduleForServiceStart(replacementSchedule.id)
             ?.catch((error) => {
-                this.logger.error(`Failed to schedule replacement feedback link SMS: ${error}`);
+                this.logger.error(`Failed to schedule replacement service-record link SMS: ${error}`);
             });
 
         const updatedClient = await this.findClientByIdUsecase.execute(branchid, clientId);

--- a/backend/application/services/eformsign-webhook.service.ts
+++ b/backend/application/services/eformsign-webhook.service.ts
@@ -121,23 +121,23 @@ export class EformsignWebhookService {
     ) {}
 
     /**
-     * BJJ-247 gate: is this document the daily-feedback snapshot template?
-     * A feedback document's completion must NOT trigger contract-completion side
+     * BJJ-247 gate: is this document the service-record snapshot template?
+     * A service-record document's completion must NOT trigger contract-completion side
      * effects (link eDocId / sync endDate). Checks all configured 제공기록지 tiers
      * (BJJ-multi-tier: base 5회 + optional 10/15/20회), not just the base template —
      * no-op (returns false) when none of the 4 env vars are set, preserving existing behavior.
      */
     private isServiceRecordTemplate(templateId?: string): boolean {
         if (!templateId) return false;
-        const feedbackTemplateIds = new Set(
+        const serviceRecordTemplateIds = new Set(
             [
-                process.env["EFORMSIGN_FEEDBACK_TEMPLATE_ID"],
-                process.env["EFORMSIGN_FEEDBACK_TEMPLATE_ID_10"],
-                process.env["EFORMSIGN_FEEDBACK_TEMPLATE_ID_15"],
-                process.env["EFORMSIGN_FEEDBACK_TEMPLATE_ID_20"],
+                process.env["EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID"],
+                process.env["EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID_10"],
+                process.env["EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID_15"],
+                process.env["EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID_20"],
             ].filter((id): id is string => Boolean(id)),
         );
-        return feedbackTemplateIds.has(templateId);
+        return serviceRecordTemplateIds.has(templateId);
     }
 
     async processWebhook(payload: EformsignWebhookPayloadDto): Promise<void> {
@@ -207,7 +207,7 @@ export class EformsignWebhookService {
 
             if (this.isServiceRecordTemplate(template_id)) {
                 this.logger.log(
-                    `Document ${documentId} is a feedback snapshot (template ${template_id}); skipping contract-completion side effects (BJJ-247 gate).`
+                    `Document ${documentId} is a service-record snapshot (template ${template_id}); skipping contract-completion side effects (BJJ-247 gate).`
                 );
                 await this.handleServiceRecordSnapshotCompleted(branchid, documentId);
             } else {
@@ -332,7 +332,7 @@ export class EformsignWebhookService {
         if (status === DOCUMENT_STATUS.DOC_COMPLETE) {
             if (this.isServiceRecordTemplate(template_id)) {
                 this.logger.log(
-                    `Document ${documentId} is a feedback snapshot (template ${template_id}); skipping contract-completion side effects (BJJ-247 gate).`
+                    `Document ${documentId} is a service-record snapshot (template ${template_id}); skipping contract-completion side effects (BJJ-247 gate).`
                 );
                 await this.handleServiceRecordSnapshotCompleted(branchid, documentId);
             } else {
@@ -412,7 +412,7 @@ export class EformsignWebhookService {
         const doc = await this.eformsignDocRepository.findByDocumentId(branchid, documentId);
         if (doc?.documentKind === EFORMSIGN_DOCUMENT_KIND.SERVICE_RECORD_SNAPSHOT) {
             this.logger.log(
-                `Document ${documentId} is a feedback snapshot row; skipping contract-completion side effects (${source}).`,
+                `Document ${documentId} is a service-record snapshot row; skipping contract-completion side effects (${source}).`,
             );
             await this.handleServiceRecordSnapshotCompleted(branchid, documentId);
             return;

--- a/backend/application/services/service-record-entry.service.ts
+++ b/backend/application/services/service-record-entry.service.ts
@@ -295,7 +295,7 @@ export class ServiceRecordEntryService {
             return row;
         });
         if (lock) {
-            this.logger.log(`Service feedback session ${sessionIndex} submitted + locked for case ${aggregate.id}`);
+            this.logger.log(`Service-record session ${sessionIndex} submitted + locked for case ${aggregate.id}`);
         }
         return { ...saved, sessionIndex: saved.caseSessionIndex ?? saved.sessionIndex };
     }

--- a/backend/application/services/service-record-link.service.ts
+++ b/backend/application/services/service-record-link.service.ts
@@ -78,7 +78,7 @@ export class ServiceRecordLinkService {
                 handled: true,
                 scheduleId,
             });
-            this.logger.error(`Failed to schedule feedback link for schedule ${scheduleId}: ${error}`);
+            this.logger.error(`Failed to schedule service-record link for schedule ${scheduleId}: ${error}`);
         }
     }
 
@@ -189,14 +189,14 @@ export class ServiceRecordLinkService {
         };
     }
 
-    /** Revoke an assignment's feedback access (replacement / termination). */
+    /** Revoke an assignment's service-record access (replacement / termination). */
     async revoke(scheduleId: number): Promise<void> {
         try {
             await this.tokenService.revokeForSchedule(scheduleId);
             await this.cancelPendingServiceRecordJobs(scheduleId, "Service record access revoked");
             this.logger.log(`Service record access revoked for schedule ${scheduleId}`);
         } catch (error) {
-            this.logger.error(`Failed to revoke feedback link for schedule ${scheduleId}: ${error}`);
+            this.logger.error(`Failed to revoke service-record link for schedule ${scheduleId}: ${error}`);
             throw error;
         }
     }
@@ -211,7 +211,7 @@ export class ServiceRecordLinkService {
                 await this.tokenService.extendExpiryForSchedule(scheduleId, expiresAt);
             }
         } catch (error) {
-            this.logger.error(`Failed to extend feedback token expiry for schedule ${scheduleId}: ${error}`);
+            this.logger.error(`Failed to extend service-record token expiry for schedule ${scheduleId}: ${error}`);
             throw error;
         }
     }
@@ -297,7 +297,7 @@ export class ServiceRecordLinkService {
             }
 
             this.logger.warn(
-                `Schedule ${scheduleId}: provider ${employee.id} has no phone on file; feedback link NOT sent. Set the employee's phone first.`
+                `Schedule ${scheduleId}: provider ${employee.id} has no phone on file; service-record link NOT sent. Set the employee's phone first.`
             );
             await this.recordPermanentFailure({
                 branchId: schedule.branchId,

--- a/backend/application/services/service-record-token.service.ts
+++ b/backend/application/services/service-record-token.service.ts
@@ -27,11 +27,11 @@ interface ServiceRecordLinkTokenParams {
 }
 
 /**
- * No-login per-assignment feedback access (BJJ-247).
+ * No-login per-assignment service-record access (BJJ-247).
  * Two secrets per token row:
  *   - link token: carried in the SMS URL (possession). Stored plaintext so the issued
  *     form URL can be recovered from the database when needed; only reaches the phone challenge.
- *   - access token: minted after a correct phone number (knowledge). Grants the feedback endpoints
+ *   - access token: minted after a correct phone number (knowledge). Grants the service-record endpoints
  *     until expiresAt (= schedule.endDate + grace buffer).
  * The access token and expected phone remain sha256 hashes. `linkTokenHash` retains its
  * legacy Prisma/database name even though newly issued form-link values are plaintext.

--- a/backend/application/usecases/eformsign-doc/create-and-send-service-record-snapshot.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/create-and-send-service-record-snapshot.usecase.ts
@@ -20,8 +20,8 @@ import {
     type ServiceRecordDayInput,
 } from "./service-record-field-mapper";
 import {
-    FEEDBACK_TEMPLATE_SESSIONS_PER_DOCUMENT,
-    FEEDBACK_TEMPLATE_TIER_ENV_KEYS,
+    SERVICE_RECORD_TEMPLATE_SESSIONS_PER_DOCUMENT,
+    SERVICE_RECORD_TEMPLATE_TIER_ENV_KEYS,
 } from "./service-record-field-ids";
 
 const CASE_SNAPSHOT_INCLUDE = {
@@ -100,7 +100,7 @@ const MAX_RECONCILIATION_ATTEMPTS = 12;
  * segments longer than the max tier are cut at max-tier size with the remainder re-tiered.
  * Each document's fields are prefilled from `service_record` + `service_record_day`
  * by the pure mapper. Persisted with linkToClient:false — the client's eDocId is NEVER touched —
- * and the webhook template_id gate (all EFORMSIGN_FEEDBACK_TEMPLATE_ID* tiers) keeps completion
+ * and the webhook template_id gate (all EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID* tiers) keeps completion
  * from marking the contract done.
  *
  * Retry-safe: durable `service_record_snapshot_chunk` rows let a re-run skip documents already created.
@@ -124,12 +124,12 @@ export class CreateAndSendServiceRecordSnapshotUsecase {
      * when even the base tier is missing, preserving the existing "not configured" contract.
      */
     private getConfiguredTiers(): Array<{ tier: number; templateId: string }> {
-        const tiers = FEEDBACK_TEMPLATE_TIER_ENV_KEYS
+        const tiers = SERVICE_RECORD_TEMPLATE_TIER_ENV_KEYS
             .map(({ tier, envKey }) => ({ tier, templateId: this.configService.get<string>(envKey)?.trim() ?? "" }))
             .filter((entry) => entry.templateId !== "");
-        const hasBase = tiers.some((entry) => entry.tier === FEEDBACK_TEMPLATE_SESSIONS_PER_DOCUMENT);
+        const hasBase = tiers.some((entry) => entry.tier === SERVICE_RECORD_TEMPLATE_SESSIONS_PER_DOCUMENT);
         if (!hasBase) {
-            throw new BadRequestException("EFORMSIGN_FEEDBACK_TEMPLATE_ID is not configured.");
+            throw new BadRequestException("EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID is not configured.");
         }
         return tiers;
     }

--- a/backend/application/usecases/eformsign-doc/link-document-to-client.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/link-document-to-client.usecase.ts
@@ -26,7 +26,7 @@ export class LinkDocumentToClientUsecase {
         }
 
         if (doc.documentKind === EFORMSIGN_DOCUMENT_KIND.SERVICE_RECORD_SNAPSHOT) {
-            this.logger.debug(`Skipping client contract link for feedback document ${documentId}`);
+            this.logger.debug(`Skipping client contract link for service-record document ${documentId}`);
             return;
         }
 

--- a/backend/application/usecases/eformsign-doc/service-record-field-ids.ts
+++ b/backend/application/usecases/eformsign-doc/service-record-field-ids.ts
@@ -13,26 +13,26 @@
  */
 
 /** Fixed number of session columns in the template; drives chunking. */
-export const FEEDBACK_TEMPLATE_SESSIONS_PER_DOCUMENT = 5;
+export const SERVICE_RECORD_TEMPLATE_SESSIONS_PER_DOCUMENT = 5;
 
 /**
  * Multi-tier 제공기록지 templates (BJJ-multi-tier): each tier is a fixed N-session grid sharing
- * the same header + `feedbackDayFieldIds(n)` field-naming scheme, just with more slots. Only
+ * the same header + `serviceRecordDayFieldIds(n)` field-naming scheme, just with more slots. Only
  * tiers whose env var is actually set are usable — an unset env key means that tier's template
  * has not been deployed to this environment, so chunking must fall back to the tiers that are.
  * The 5-session tier is the base tier and its env key must stay backward-compatible.
  */
-export const FEEDBACK_TEMPLATE_TIER_ENV_KEYS: ReadonlyArray<{ tier: number; envKey: string }> = [
-    { tier: 5, envKey: "EFORMSIGN_FEEDBACK_TEMPLATE_ID" },
-    { tier: 10, envKey: "EFORMSIGN_FEEDBACK_TEMPLATE_ID_10" },
-    { tier: 15, envKey: "EFORMSIGN_FEEDBACK_TEMPLATE_ID_15" },
-    { tier: 20, envKey: "EFORMSIGN_FEEDBACK_TEMPLATE_ID_20" },
+export const SERVICE_RECORD_TEMPLATE_TIER_ENV_KEYS: ReadonlyArray<{ tier: number; envKey: string }> = [
+    { tier: 5, envKey: "EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID" },
+    { tier: 10, envKey: "EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID_10" },
+    { tier: 15, envKey: "EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID_15" },
+    { tier: 20, envKey: "EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID_20" },
 ];
 
 /**
  * Value that marks a selection field (결제 확인, and the ①–⑪ selection marks) as "selected".
  * 산모확인서명 N is NOT a checkbox mark — it is a binary(서명) field filled with a raw
- * `data:image/png;base64,...` dataURI by the mapper (see `feedbackDayFieldIds` below); this
+ * `data:image/png;base64,...` dataURI by the mapper (see `serviceRecordDayFieldIds` below); this
  * constant does not apply to it.
  *
  * Per the eformsign API spec, 체크/라디오/콤보/토글 fields are filled by sending the ITEM's
@@ -55,10 +55,10 @@ export const CHECKBOX_UNCHECKED_VALUE = "false";
  * (see CHECKBOX_*_VALUE); 산모확인서명 is a binary(서명) field — an empty string "" satisfies the
  * required check while leaving the signature blank (verified live 2026-07-15).
  */
-export const FEEDBACK_REQUIRED_SLOT_FIELD_BASES = ["결제 확인", "산모확인서명"] as const;
+export const SERVICE_RECORD_REQUIRED_SLOT_FIELD_BASES = ["결제 확인", "산모확인서명"] as const;
 
 /** Header fields (filled once per document, no slot suffix). */
-export const FEEDBACK_HEADER_FIELD_IDS = {
+export const SERVICE_RECORD_HEADER_FIELD_IDS = {
     momName: "산모 이름",
     momBirth: "산모 생년월일", // date_yyyy-MM-dd
     deliveryNatural: "자연분만", // checkbox mark
@@ -74,7 +74,7 @@ export const FEEDBACK_HEADER_FIELD_IDS = {
  * NOT the global session index. Selection groups are keyed by the form-layout option strings
  * (e.g. "잘 잠" with a space) so the mapper can look them up directly from `answers`.
  */
-export function feedbackDayFieldIds(n: number) {
+export function serviceRecordDayFieldIds(n: number) {
     return {
         month: `월 ${n}`, // date_MM  → "07"
         day: `일 ${n}`, // date_DD → "09"

--- a/backend/application/usecases/eformsign-doc/service-record-field-mapper.ts
+++ b/backend/application/usecases/eformsign-doc/service-record-field-mapper.ts
@@ -8,9 +8,9 @@
 import {
     CHECKBOX_CHECKED_VALUE,
     CHECKBOX_UNCHECKED_VALUE,
-    FEEDBACK_HEADER_FIELD_IDS,
-    FEEDBACK_TEMPLATE_SESSIONS_PER_DOCUMENT,
-    feedbackDayFieldIds,
+    SERVICE_RECORD_HEADER_FIELD_IDS,
+    SERVICE_RECORD_TEMPLATE_SESSIONS_PER_DOCUMENT,
+    serviceRecordDayFieldIds,
 } from "./service-record-field-ids";
 
 export interface ServiceRecordHeaderInput {
@@ -64,7 +64,7 @@ function utcDay(date: Date): string {
 }
 
 /** Split sessions into fixed-size chunks (one eformsign document per chunk). */
-export function chunkSessions<T>(days: T[], size: number = FEEDBACK_TEMPLATE_SESSIONS_PER_DOCUMENT): T[][] {
+export function chunkSessions<T>(days: T[], size: number = SERVICE_RECORD_TEMPLATE_SESSIONS_PER_DOCUMENT): T[][] {
     if (size < 1) throw new Error("chunk size must be >= 1");
     const chunks: T[][] = [];
     for (let i = 0; i < days.length; i += size) {
@@ -126,7 +126,7 @@ export function buildServiceRecordDocumentFields(input: {
     days: ServiceRecordDayInput[];
     slotCount?: number;
 }): EformsignField[] {
-    const { header, employeeName, days, slotCount = FEEDBACK_TEMPLATE_SESSIONS_PER_DOCUMENT } = input;
+    const { header, employeeName, days, slotCount = SERVICE_RECORD_TEMPLATE_SESSIONS_PER_DOCUMENT } = input;
     if (days.length > slotCount) {
         throw new Error(`buildServiceRecordDocumentFields: ${days.length} days exceed slotCount ${slotCount}`);
     }
@@ -146,19 +146,19 @@ export function buildServiceRecordDocumentFields(input: {
     };
 
     // ── Header (once per document) — every header field is required at creation ──
-    pushRequired(FEEDBACK_HEADER_FIELD_IDS.employeeName, employeeName);
-    pushRequired(FEEDBACK_HEADER_FIELD_IDS.momName, header?.momName);
-    pushRequired(FEEDBACK_HEADER_FIELD_IDS.momBirth, yymmddToIso(header?.momBirth));
-    pushRequired(FEEDBACK_HEADER_FIELD_IDS.babyName, header?.babyName);
-    pushRequired(FEEDBACK_HEADER_FIELD_IDS.babyBirth, yymmddToIso(header?.babyBirth));
-    pushRequired(FEEDBACK_HEADER_FIELD_IDS.babyWeight, header?.babyWeight);
+    pushRequired(SERVICE_RECORD_HEADER_FIELD_IDS.employeeName, employeeName);
+    pushRequired(SERVICE_RECORD_HEADER_FIELD_IDS.momName, header?.momName);
+    pushRequired(SERVICE_RECORD_HEADER_FIELD_IDS.momBirth, yymmddToIso(header?.momBirth));
+    pushRequired(SERVICE_RECORD_HEADER_FIELD_IDS.babyName, header?.babyName);
+    pushRequired(SERVICE_RECORD_HEADER_FIELD_IDS.babyBirth, yymmddToIso(header?.babyBirth));
+    pushRequired(SERVICE_RECORD_HEADER_FIELD_IDS.babyWeight, header?.babyWeight);
     // Both delivery-type marks are required — send the pair, checked per deliveryType.
-    pushCheck(FEEDBACK_HEADER_FIELD_IDS.deliveryNatural, header?.deliveryType === "자연분만");
-    pushCheck(FEEDBACK_HEADER_FIELD_IDS.deliveryCSection, header?.deliveryType === "제왕절개");
+    pushCheck(SERVICE_RECORD_HEADER_FIELD_IDS.deliveryNatural, header?.deliveryType === "자연분만");
+    pushCheck(SERVICE_RECORD_HEADER_FIELD_IDS.deliveryCSection, header?.deliveryType === "제왕절개");
 
     // ── Session slots 1..slotCount ──
     for (let slot = 1; slot <= slotCount; slot++) {
-        const ids = feedbackDayFieldIds(slot);
+        const ids = serviceRecordDayFieldIds(slot);
         const day = days[slot - 1];
 
         if (!day) {

--- a/backend/domain/entities/eformsign-doc.entity.ts
+++ b/backend/domain/entities/eformsign-doc.entity.ts
@@ -37,7 +37,7 @@ interface EformsignDocProps {
     clientId: number | null;
     // document classification. null means an older/unclassified row.
     documentKind?: EformsignDocumentKind | null;
-    // FK to employee_schedule for service feedback snapshots.
+    // FK to employee_schedule for service-record snapshots.
     employeeScheduleId?: number | null;
     // Source eformsign template identifier.
     templateId?: string | null;

--- a/backend/domain/repositories/eformsign.client.interface.ts
+++ b/backend/domain/repositories/eformsign.client.interface.ts
@@ -87,7 +87,7 @@ export interface CreateDocumentPayload {
     };
     /**
      * Dispatch to a reviewer step whose recipient is pre-specified in the template
-     * (feedback flow). The member info must MIRROR the template's step settings exactly —
+     * (service record flow). The member info must MIRROR the template's step settings exactly —
      * eformsign rejects mismatches with 4000012 — so obtain it via getTemplateReviewer().
      */
     reviewer?: EformsignReviewerMember;

--- a/backend/env.example
+++ b/backend/env.example
@@ -10,7 +10,7 @@ PRODUCTION_FRONTEND_URL="https://admin.babyjamjam.com"
 PRODUCTION_MOBILE_FRONTEND_URL="https://m.admin.babyjamjam.com"
 PREVIEW_FRONTEND_URL="https://admin.babyjamjam.com"
 PREVIEW_MOBILE_FRONTEND_URL="https://m.admin.babyjamjam.com"
-# Base URL for the no-login 제공기록지 SMS link (/feedback/<token>). Defaults to
+# Base URL for the no-login 제공기록지 SMS link (/service-record/<token>). Defaults to
 # https://m.admin.babyjamjam.com in code; set explicitly per environment.
 # Deployed (production/preview/dev on Railway): "https://m.admin.babyjamjam.com"
 # Local development: "http://localhost:3000" (the locally running mobile app)
@@ -28,10 +28,10 @@ SENTRY_AUTH_TOKEN=""
 EFORMSIGN_COMPANY_ID="replace-me"
 EFORMSIGN_WEBHOOK_ALLOWED_COMPANY_IDS=""
 EFORMSIGN_WEBHOOK_SECRET="replace-me"
-EFORMSIGN_FEEDBACK_TEMPLATE_ID="replace-me"
-EFORMSIGN_FEEDBACK_TEMPLATE_ID_10="replace-me"
-EFORMSIGN_FEEDBACK_TEMPLATE_ID_15="replace-me"
-EFORMSIGN_FEEDBACK_TEMPLATE_ID_20="replace-me"
+EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID="replace-me"
+EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID_10="replace-me"
+EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID_15="replace-me"
+EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID_20="replace-me"
 
 # Railway Static Outbound IP registered in the Aligo console for this environment.
 ALIGO_STATIC_OUTBOUND_IP="replace-me"

--- a/backend/infrastructure/auth/service-record.guard.ts
+++ b/backend/infrastructure/auth/service-record.guard.ts
@@ -12,7 +12,7 @@ import {
 } from "application/services/service-record-token.service";
 
 /**
- * DB-backed bearer guard for the no-login feedback data endpoints (BJJ-247).
+ * DB-backed bearer guard for the no-login service-record data endpoints (BJJ-247).
  * Expects the minted ACCESS token (post-DOB) as `Authorization: Bearer <token>`;
  * attaches the resolved assignment context to request.serviceRecordContext.
  * The DOB-challenge endpoint itself is NOT guarded by this — it takes the link token in the body.

--- a/backend/interface/controllers/eformsign-doc.controller.ts
+++ b/backend/interface/controllers/eformsign-doc.controller.ts
@@ -9,7 +9,7 @@ import { DispatchDocumentHeadlessUsecase } from "application/usecases/eformsign-
 import { FinalizeDocumentHeadlessUsecase } from "application/usecases/eformsign-doc/finalize-document-headless.usecase";
 import { AdoptEformsignDocUsecase } from "application/usecases/eformsign-doc/adopt-eformsign-doc.usecase";
 import type { CreateEformsignDocResult } from "application/usecases/eformsign-doc/create-eformsign-doc.usecase";
-import { FEEDBACK_TEMPLATE_TIER_ENV_KEYS } from "application/usecases/eformsign-doc/service-record-field-ids";
+import { SERVICE_RECORD_TEMPLATE_TIER_ENV_KEYS } from "application/usecases/eformsign-doc/service-record-field-ids";
 import {
     GetAccessTokenDto,
     RefreshAccessTokenDto,
@@ -45,16 +45,16 @@ export class EformsignDocController {
 
     /**
      * GET /eformsign-docs/feedback-template-id
-     * Exposes the 제공기록지 template id(s) so the UI can split feedback documents
+     * Exposes the 제공기록지 template id(s) so the UI can split service-record documents
      * from contract documents by template — never by (renamable) template name.
      * `templateId` stays the base (5회) id for backward compatibility; `templateIds`
      * lists every configured tier (base, then 10/15/20회 in that order) so the UI can
      * match documents created on any tier's template (BJJ-multi-tier).
      */
     @Get("feedback-template-id")
-    getFeedbackTemplateId(): { templateId: string | null; templateIds: string[] } {
-        const templateId = this.configService.get<string>("EFORMSIGN_FEEDBACK_TEMPLATE_ID")?.trim();
-        const templateIds = FEEDBACK_TEMPLATE_TIER_ENV_KEYS
+    getServiceRecordTemplateId(): { templateId: string | null; templateIds: string[] } {
+        const templateId = this.configService.get<string>("EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID")?.trim();
+        const templateIds = SERVICE_RECORD_TEMPLATE_TIER_ENV_KEYS
             .map(({ envKey }) => this.configService.get<string>(envKey)?.trim())
             .filter((id): id is string => Boolean(id));
         return { templateId: templateId || null, templateIds };

--- a/backend/module/service-record-entry.module.ts
+++ b/backend/module/service-record-entry.module.ts
@@ -17,7 +17,7 @@ import { ServiceRecordFinalizationService } from "application/services/service-r
 import { ServiceRecordFinalizationSchedulerService } from "application/services/service-record-finalization-scheduler.service";
 
 /**
- * No-login daily service feedback capture (BJJ-247).
+ * No-login daily service-record capture (BJJ-247).
  * Exports the token + link services so the assignment / replacement / termination
  * hooks (employee-schedule + client modules) can issue and revoke links.
  */

--- a/backend/scripts/run-full-flow-e2e.mjs
+++ b/backend/scripts/run-full-flow-e2e.mjs
@@ -8,7 +8,7 @@ const env = {
     DIRECT_URL: databaseUrl,
     NODE_ENV: "test",
     E2E_VENDOR_STUBS: "1",
-    EFORMSIGN_FEEDBACK_TEMPLATE_ID: "tpl-test",
+    EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID: "tpl-test",
 };
 
 function run(command, args, options = {}) {

--- a/backend/test/e2e/bjj249-service-record-snapshot.live.e2e.spec.ts
+++ b/backend/test/e2e/bjj249-service-record-snapshot.live.e2e.spec.ts
@@ -41,12 +41,12 @@ const TEST_CLIENT_SIGNATURE =
 
 const d = (iso: string) => new Date(`${iso}T00:00:00.000Z`);
 
-(LIVE ? describe : describe.skip)("BJJ-249 live E2E — case-based feedback snapshot pipeline", () => {
+(LIVE ? describe : describe.skip)("BJJ-249 live E2E — case-based service-record snapshot pipeline", () => {
     jest.setTimeout(180_000);
 
     let moduleRef: Awaited<ReturnType<ReturnType<typeof Test.createTestingModule>["compile"]>>;
     let prisma: PrismaService;
-    let feedbackService: ServiceRecordEntryService;
+    let serviceRecordService: ServiceRecordEntryService;
     let lifecycleService: ServiceRecordLifecycleService;
     let finalizationService: ServiceRecordFinalizationService;
     let webhookService: EformsignWebhookService;
@@ -70,7 +70,7 @@ const d = (iso: string) => new Date(`${iso}T00:00:00.000Z`);
         }).compile();
 
         prisma = moduleRef.get(PrismaService, { strict: false });
-        feedbackService = moduleRef.get(ServiceRecordEntryService, { strict: false });
+        serviceRecordService = moduleRef.get(ServiceRecordEntryService, { strict: false });
         lifecycleService = moduleRef.get(ServiceRecordLifecycleService, { strict: false });
         finalizationService = moduleRef.get(ServiceRecordFinalizationService, { strict: false });
         webhookService = moduleRef.get(EformsignWebhookService, { strict: false });
@@ -164,7 +164,7 @@ const d = (iso: string) => new Date(`${iso}T00:00:00.000Z`);
     });
 
     it("wizard path: header + 7 approved sessions drive the case to READY_TO_FINALIZE", async () => {
-        await feedbackService.saveHeader(ctx, {
+        await serviceRecordService.saveHeader(ctx, {
             momName: "김산모",
             momBirth: "900101",
             babyName: "김아기",
@@ -192,7 +192,7 @@ const d = (iso: string) => new Date(`${iso}T00:00:00.000Z`);
         const lightAnswers = { sitzBath: "미실시", sleep: "잘 못 잠", stool: "정상변" };
 
         for (let i = 1; i <= SESSION_COUNT; i++) {
-            await feedbackService.upsertSession(
+            await serviceRecordService.upsertSession(
                 ctx,
                 i,
                 {
@@ -317,7 +317,7 @@ const d = (iso: string) => new Date(`${iso}T00:00:00.000Z`);
                 id: documentId,
                 status: "doc_complete",
                 document_title: `서비스 제공기록지 - 테스트고객-${TEST_TAG} (${index + 1}/2)`,
-                template_id: process.env["EFORMSIGN_FEEDBACK_TEMPLATE_ID"],
+                template_id: process.env["EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID"],
                 workflow_seq: 1,
                 workflow_name: "wf",
             });
@@ -328,7 +328,7 @@ const d = (iso: string) => new Date(`${iso}T00:00:00.000Z`);
         expect(record?.documentsCompletedAt).not.toBeNull();
 
         const after = await prisma.client.findUnique({ where: { id: clientId } });
-        expect(after?.eDocId).toBeNull(); // BJJ-247 invariant: feedback docs never link eDocId
+        expect(after?.eDocId).toBeNull(); // BJJ-247 invariant: service-record docs never link eDocId
         expect(after?.endDate).toEqual(before?.endDate ?? null);
     });
 });

--- a/backend/test/integration/service-record.schedule-change.integration.spec.ts
+++ b/backend/test/integration/service-record.schedule-change.integration.spec.ts
@@ -78,7 +78,7 @@ describe("ServiceRecordEntryController schedule-change endpoints (Integration)",
     });
 
     describe("GET /service-record/schedule-change/preview", () => {
-        it("should expose the preview route and call the schedule-change service with feedback context", async () => {
+        it("should expose the preview route and call the schedule-change service with service-record context", async () => {
             scheduleChangeService.preview.mockResolvedValue({
                 sessionIndex: 3,
                 fromDate: "2026-07-03",
@@ -103,7 +103,7 @@ describe("ServiceRecordEntryController schedule-change endpoints (Integration)",
     });
 
     describe("POST /service-record/schedule-change", () => {
-        it("should expose the create route and call the schedule-change service with feedback context", async () => {
+        it("should expose the create route and call the schedule-change service with service-record context", async () => {
             scheduleChangeService.createRequest.mockResolvedValue({
                 id: "request-1",
                 sessionIndex: 3,

--- a/backend/test/services/admin-service-record.service.spec.ts
+++ b/backend/test/services/admin-service-record.service.spec.ts
@@ -140,7 +140,7 @@ describe("AdminServiceRecordService", () => {
         prisma.eformsign_doc.findMany.mockResolvedValue([
             {
                 employeeScheduleId: 3,
-                documentId: "feedback-doc-3",
+                documentId: "service-record-doc-3",
                 statusDetail: "완료",
                 stepName: "제공기록지 서명",
                 createdDate: new Date("2026-07-02T07:00:00.000Z"),
@@ -150,7 +150,7 @@ describe("AdminServiceRecordService", () => {
             },
             {
                 employeeScheduleId: 3,
-                documentId: "feedback-doc-3-old",
+                documentId: "service-record-doc-3-old",
                 statusDetail: "대기",
                 stepName: "제공기록지 서명",
                 createdDate: new Date("2026-07-01T07:00:00.000Z"),
@@ -198,7 +198,7 @@ describe("AdminServiceRecordService", () => {
         }));
         expect(overview.assignments.find((assignment) => assignment.scheduleId === 1)?.signatureDoc).toBeNull();
         expect(overview.assignments.find((assignment) => assignment.scheduleId === 3)?.signatureDoc).toEqual({
-            documentId: "feedback-doc-3",
+            documentId: "service-record-doc-3",
             statusDetail: "완료",
             stepName: "제공기록지 서명",
             createdDate: new Date("2026-07-02T07:00:00.000Z"),
@@ -245,7 +245,7 @@ describe("AdminServiceRecordService", () => {
         expect(statuses.get(2)).toBe("none");
     });
 
-    it("keeps overview available when feedback signature doc columns are not migrated yet", async () => {
+    it("keeps overview available when service-record signature doc columns are not migrated yet", async () => {
         const prisma = createPrisma();
         const service = new AdminServiceRecordService(
             prisma as unknown as PrismaService,

--- a/backend/test/services/client.service.spec.ts
+++ b/backend/test/services/client.service.spec.ts
@@ -977,7 +977,7 @@ describe("ClientService", () => {
                 expect(serviceRecordLinkService.scheduleForServiceStart).toHaveBeenCalledWith(20);
             });
 
-            it("keeps feedback access for the old assignment when replacement creation fails", async () => {
+            it("keeps service-record access for the old assignment when replacement creation fails", async () => {
                 const existingClient = createClientEntity();
                 findClientByIdUsecase.execute.mockResolvedValue(existingClient);
                 prismaService.employee_schedule.findFirst.mockResolvedValue({

--- a/backend/test/services/eformsign-webhook-service-record-gate.spec.ts
+++ b/backend/test/services/eformsign-webhook-service-record-gate.spec.ts
@@ -1,14 +1,14 @@
 import { EformsignWebhookService } from "../../application/services/eformsign-webhook.service";
 
 /**
- * BJJ-247 contract-isolation guarantee: completing a FEEDBACK snapshot document must NOT run
+ * BJJ-247 contract-isolation guarantee: completing a SERVICE_RECORD snapshot document must NOT run
  * the contract-completion side effects (link eDocId / sync endDate), which
  * all funnel through handleCompletedDocument(). The gate keys on the document's template_id.
  */
-const FEEDBACK_TPL = "tpl_feedback_123";
-const FEEDBACK_TPL_10 = "tpl_feedback_10";
-const FEEDBACK_TPL_15 = "tpl_feedback_15";
-const FEEDBACK_TPL_20 = "tpl_feedback_20";
+const SERVICE_RECORD_TPL = "tpl_service_record_123";
+const SERVICE_RECORD_TPL_10 = "tpl_service_record_10";
+const SERVICE_RECORD_TPL_15 = "tpl_service_record_15";
+const SERVICE_RECORD_TPL_20 = "tpl_service_record_20";
 const CONTRACT_TPL = "tpl_contract_999";
 
 function makeService() {
@@ -53,13 +53,13 @@ const pdfEvent = (template_id: string) => ({
     document_id: "doc1", document_status: "doc_complete", template_id, workflow_seq: 1, workflow_name: "wf",
 });
 
-describe("EformsignWebhookService — feedback template_id gate", () => {
+describe("EformsignWebhookService — service-record template_id gate", () => {
     // BJJ-multi-tier: the gate must match documents created on ANY configured tier's template.
     const TIER_ENV = {
-        EFORMSIGN_FEEDBACK_TEMPLATE_ID: FEEDBACK_TPL,
-        EFORMSIGN_FEEDBACK_TEMPLATE_ID_10: FEEDBACK_TPL_10,
-        EFORMSIGN_FEEDBACK_TEMPLATE_ID_15: FEEDBACK_TPL_15,
-        EFORMSIGN_FEEDBACK_TEMPLATE_ID_20: FEEDBACK_TPL_20,
+        EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID: SERVICE_RECORD_TPL,
+        EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID_10: SERVICE_RECORD_TPL_10,
+        EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID_15: SERVICE_RECORD_TPL_15,
+        EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID_20: SERVICE_RECORD_TPL_20,
     } as const;
     const OLD: Record<string, string | undefined> = {};
     beforeAll(() => {
@@ -81,9 +81,9 @@ describe("EformsignWebhookService — feedback template_id gate", () => {
         expect(handleCompleted).toHaveBeenCalledTimes(1);
     });
 
-    it("document event + feedback template → SKIPS contract-completion side effects", async () => {
+    it("document event + service-record template → SKIPS contract-completion side effects", async () => {
         const { service, handleCompleted } = makeService();
-        await (service as any).handleDocumentEvent("branch1", docEvent(FEEDBACK_TPL));
+        await (service as any).handleDocumentEvent("branch1", docEvent(SERVICE_RECORD_TPL));
         expect(handleCompleted).not.toHaveBeenCalled();
     });
 
@@ -93,16 +93,16 @@ describe("EformsignWebhookService — feedback template_id gate", () => {
         expect(handleCompleted).toHaveBeenCalledTimes(1);
     });
 
-    it("ready_document_pdf + feedback template → SKIPS contract-completion side effects", async () => {
+    it("ready_document_pdf + service-record template → SKIPS contract-completion side effects", async () => {
         const { service, handleCompleted } = makeService();
-        await (service as any).handleReadyDocumentPdfEvent("branch1", pdfEvent(FEEDBACK_TPL));
+        await (service as any).handleReadyDocumentPdfEvent("branch1", pdfEvent(SERVICE_RECORD_TPL));
         expect(handleCompleted).not.toHaveBeenCalled();
     });
 
     it.each([
-        ["10회", FEEDBACK_TPL_10],
-        ["15회", FEEDBACK_TPL_15],
-        ["20회", FEEDBACK_TPL_20],
+        ["10회", SERVICE_RECORD_TPL_10],
+        ["15회", SERVICE_RECORD_TPL_15],
+        ["20회", SERVICE_RECORD_TPL_20],
     ])("document event + %s tier template → SKIPS contract-completion side effects", async (_tier, templateId) => {
         const { service, handleCompleted } = makeService();
         await (service as any).handleDocumentEvent("branch1", docEvent(templateId));
@@ -110,9 +110,9 @@ describe("EformsignWebhookService — feedback template_id gate", () => {
     });
 
     it.each([
-        ["10회", FEEDBACK_TPL_10],
-        ["15회", FEEDBACK_TPL_15],
-        ["20회", FEEDBACK_TPL_20],
+        ["10회", SERVICE_RECORD_TPL_10],
+        ["15회", SERVICE_RECORD_TPL_15],
+        ["20회", SERVICE_RECORD_TPL_20],
     ])("ready_document_pdf + %s tier template → SKIPS contract-completion side effects", async (_tier, templateId) => {
         const { service, handleCompleted } = makeService();
         await (service as any).handleReadyDocumentPdfEvent("branch1", pdfEvent(templateId));

--- a/backend/test/services/employee-schedule.service.spec.ts
+++ b/backend/test/services/employee-schedule.service.spec.ts
@@ -11,7 +11,7 @@ describe("EmployeeScheduleService", () => {
         const updateUsecase = { execute: jest.fn() };
         const deleteUsecase = { execute: jest.fn() };
         const triggerService = { syncEmployeeAssignmentRulesForSchedule: jest.fn() };
-        const feedbackLinkService = {
+        const serviceRecordLinkService = {
             scheduleForServiceStart: jest.fn().mockResolvedValue(undefined),
             extendExpiryForEndDate: jest.fn().mockResolvedValue(undefined),
         };
@@ -26,16 +26,16 @@ describe("EmployeeScheduleService", () => {
                 updateUsecase as never,
                 deleteUsecase as never,
                 triggerService as never,
-                feedbackLinkService as never,
+                serviceRecordLinkService as never,
             ),
             createUsecase,
             updateUsecase,
-            feedbackLinkService,
+            serviceRecordLinkService,
         };
     };
 
-    it("schedules the feedback link SMS when a service schedule is created", async () => {
-        const { service, createUsecase, feedbackLinkService } = createService();
+    it("schedules the service-record link SMS when a service schedule is created", async () => {
+        const { service, createUsecase, serviceRecordLinkService } = createService();
         createUsecase.execute.mockResolvedValue({ id: 10 } as EmployeeScheduleEntity);
 
         await service.create("branch-1", {
@@ -47,11 +47,11 @@ describe("EmployeeScheduleService", () => {
             endDate: "2026-07-12",
         });
 
-        expect(feedbackLinkService.scheduleForServiceStart).toHaveBeenCalledWith(10);
+        expect(serviceRecordLinkService.scheduleForServiceStart).toHaveBeenCalledWith(10);
     });
 
-    it("extends feedback token expiry when a service schedule end date changes", async () => {
-        const { service, updateUsecase, feedbackLinkService } = createService();
+    it("extends service-record token expiry when a service schedule end date changes", async () => {
+        const { service, updateUsecase, serviceRecordLinkService } = createService();
         const endDate = new Date("2026-07-20T00:00:00.000Z");
         updateUsecase.execute.mockResolvedValue({
             id: 10,
@@ -62,17 +62,17 @@ describe("EmployeeScheduleService", () => {
             endDate: "2026-07-20",
         });
 
-        expect(feedbackLinkService.extendExpiryForEndDate).toHaveBeenCalledWith(10, endDate);
+        expect(serviceRecordLinkService.extendExpiryForEndDate).toHaveBeenCalledWith(10, endDate);
     });
 
-    it("does not touch feedback token expiry when end date is unchanged", async () => {
-        const { service, updateUsecase, feedbackLinkService } = createService();
+    it("does not touch service-record token expiry when end date is unchanged", async () => {
+        const { service, updateUsecase, serviceRecordLinkService } = createService();
         updateUsecase.execute.mockResolvedValue({ id: 10 } as EmployeeScheduleEntity);
 
         await service.update("branch-1", 10, {
             workAddress: "서울",
         });
 
-        expect(feedbackLinkService.extendExpiryForEndDate).not.toHaveBeenCalled();
+        expect(serviceRecordLinkService.extendExpiryForEndDate).not.toHaveBeenCalled();
     });
 });

--- a/backend/test/services/service-record-link.service.spec.ts
+++ b/backend/test/services/service-record-link.service.spec.ts
@@ -328,7 +328,7 @@ describe("ServiceRecordLinkService", () => {
         expect(logRepository.update).not.toHaveBeenCalled();
     });
 
-    it("provisions the fixed system rule before issuing a feedback token", async () => {
+    it("provisions the fixed system rule before issuing a service-record token", async () => {
         const prisma = createPrisma();
         const tokenService = createTokenService();
         const service = new ServiceRecordLinkService(

--- a/backend/test/services/sms-trigger-delivery.service.spec.ts
+++ b/backend/test/services/sms-trigger-delivery.service.spec.ts
@@ -414,7 +414,7 @@ https://mobile.test/service-record/efl_token`;
 
     const createServiceRecordJob = () =>
         MessageTriggerJobEntity.reconstitute(
-            "job-feedback-link",
+            "job-service-record-link",
             "branch-1",
             "system:service_record_link",
             "pending",
@@ -448,7 +448,7 @@ https://mobile.test/service-record/efl_token`;
             new Date("2026-07-02T00:00:00.000Z"),
         );
 
-    it("renders the editable service feedback system template and records it in SMS history", async () => {
+    it("renders the editable service-record system template and records it in SMS history", async () => {
         const aligoService = {
             sendSms: jest.fn().mockResolvedValue({
                 request: { receiver: "01011112222", msgType: "LMS", testModeYn: "N" },
@@ -486,7 +486,7 @@ https://mobile.test/service-record/efl_token`;
         }));
     });
 
-    it("records a failed retryable SMS history row when Aligo rejects the feedback link message", async () => {
+    it("records a failed retryable SMS history row when Aligo rejects the service-record link message", async () => {
         const aligoService = {
             sendSms: jest.fn().mockResolvedValue({
                 request: { receiver: "01011112222", msgType: "LMS", testModeYn: "N" },
@@ -510,7 +510,7 @@ https://mobile.test/service-record/efl_token`;
         expect(savedLog.nextRetryAt).toBeInstanceOf(Date);
     });
 
-    it("uses the registry default when the editable feedback link template row is unavailable", async () => {
+    it("uses the registry default when the editable service-record link template row is unavailable", async () => {
         const aligoService = {
             sendSms: jest.fn().mockResolvedValue({
                 request: { receiver: "01011112222", msgType: "LMS", testModeYn: "N" },

--- a/backend/test/usecases/eformsign-doc/create-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/create-eformsign-doc.usecase.spec.ts
@@ -138,18 +138,18 @@ describe("CreateEformsignDocUsecase", () => {
         expect(clientRepository.update).toHaveBeenCalledWith(branchId, client);
     });
 
-    it("stores service feedback snapshot linkage without updating the client contract pointer", async () => {
+    it("stores service-record snapshot linkage without updating the client contract pointer", async () => {
         const result = await usecase.execute(branchId, createParams({
-            documentId: "feedback-doc-1",
+            documentId: "service-record-doc-1",
             linkToClient: false,
             documentKind: EFORMSIGN_DOCUMENT_KIND.SERVICE_RECORD_SNAPSHOT,
             employeeScheduleId: 33,
-            templateId: "feedback-template-1",
+            templateId: "service-record-template-1",
         }));
 
         expect(result.documentKind).toBe(EFORMSIGN_DOCUMENT_KIND.SERVICE_RECORD_SNAPSHOT);
         expect(result.employeeScheduleId).toBe(33);
-        expect(result.templateId).toBe("feedback-template-1");
+        expect(result.templateId).toBe("service-record-template-1");
         expect(clientRepository.update).not.toHaveBeenCalled();
     });
 });

--- a/backend/test/usecases/eformsign-doc/link-document-to-client.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/link-document-to-client.usecase.spec.ts
@@ -118,7 +118,7 @@ describe("LinkDocumentToClientUsecase", () => {
         expect(clientRepository.findById).not.toHaveBeenCalled();
     });
 
-    it("does not link service feedback snapshot documents to the client contract pointer", async () => {
+    it("does not link service-record snapshot documents to the client contract pointer", async () => {
         eformsignDocRepository.findByDocumentId.mockResolvedValue(createDoc({
             documentKind: EFORMSIGN_DOCUMENT_KIND.SERVICE_RECORD_SNAPSHOT,
         }));

--- a/backend/test/usecases/eformsign-doc/service-record-case-snapshot.spec.ts
+++ b/backend/test/usecases/eformsign-doc/service-record-case-snapshot.spec.ts
@@ -24,7 +24,7 @@ type PersistedChunkLayout = {
     employeeNameSnapshot: string;
 };
 
-/** base-only env (only EFORMSIGN_FEEDBACK_TEMPLATE_ID set) — preserves the pre-multi-tier 5-only chunking. */
+/** base-only env (only EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID set) — preserves the pre-multi-tier 5-only chunking. */
 const BASE_ONLY_TIERS = [5];
 const BASE_ONLY_TEMPLATE_BY_TIER = new Map([[5, "template-1"]]);
 
@@ -217,7 +217,7 @@ describe("client-owned service record snapshot", () => {
         );
         const reader = usecase as unknown as { getConfiguredTiers(): unknown };
 
-        expect(() => reader.getConfiguredTiers()).toThrow(/EFORMSIGN_FEEDBACK_TEMPLATE_ID/);
+        expect(() => reader.getConfiguredTiers()).toThrow(/EFORMSIGN_SERVICE_RECORD_TEMPLATE_ID/);
     });
 
     it("sizes each provider segment to the smallest fitting tier and carries that tier's templateId", () => {

--- a/docs/conventions/date-handling.md
+++ b/docs/conventions/date-handling.md
@@ -77,14 +77,14 @@ proper timezone-aware formatter, never through manual millisecond/hour arithmeti
 ## 3. Accepted trade-off: 제공기록지 link token is stored plaintext (P2-10)
 
 `backend/application/services/service-record-token.service.ts` issues two secrets per
-no-login feedback access token row (BJJ-247):
+no-login service-record access token row (BJJ-247):
 
 - **link token** (`efl_...`, carried in the SMS URL): stored **plaintext** in the database, by
   design, so the issued form URL can be recovered/re-sent from admin tooling when needed. It
-  only grants access to the phone-verification challenge, not to feedback data itself.
+  only grants access to the phone-verification challenge, not to service-record data itself.
 - **access token** (minted only after a correct phone number match): stored as a **sha256
   hash**, same as the expected phone number. This is the token that actually grants the
-  feedback/service-record endpoints, until `expiresAt` (= schedule `endDate` + grace buffer via
+  service-record endpoints, until `expiresAt` (= schedule `endDate` + grace buffer via
   `getServiceRecordTokenExpiresAt`).
 
 This is an **accepted design trade-off**, not an oversight: the phone-number check is the

--- a/frontend/src/app/(protected)/contracts/page.tsx
+++ b/frontend/src/app/(protected)/contracts/page.tsx
@@ -485,9 +485,9 @@ export default function ContractsPage() {
   useEformsignDocsLiveStream(isAuthenticated);
   const { toast } = useToast();
   const deleteDocument = useDeleteEformsignDocument();
-  const { data: feedbackTemplateConfig, isLoading: isFeedbackTemplateLoading } = useQuery({
-    queryKey: ["eformsign-docs", "feedback-template-id"],
-    queryFn: () => eformsignApi.getFeedbackTemplateId(),
+  const { data: serviceRecordTemplateConfig, isLoading: isServiceRecordTemplateLoading } = useQuery({
+    queryKey: ["eformsign-docs", "service-record-template-id"],
+    queryFn: () => eformsignApi.getServiceRecordTemplateId(),
     enabled: isAuthenticated,
     staleTime: 1000 * 60 * 60,
   });
@@ -512,26 +512,26 @@ export default function ContractsPage() {
   // BJJ-multi-tier: match documents created on ANY configured 제공기록지 tier's template, not
   // just the base 5회 one. Falls back to the single base id for older backend responses.
   // Memoized so the array identity is stable for the useMemo deps below.
-  const feedbackTemplateIds = useMemo(
-    () => feedbackTemplateConfig?.templateIds
-      ?? (feedbackTemplateConfig?.templateId ? [feedbackTemplateConfig.templateId] : []),
-    [feedbackTemplateConfig],
+  const serviceRecordTemplateIds = useMemo(
+    () => serviceRecordTemplateConfig?.templateIds
+      ?? (serviceRecordTemplateConfig?.templateId ? [serviceRecordTemplateConfig.templateId] : []),
+    [serviceRecordTemplateConfig],
   );
   const activeListTab = activeSection === "service-records" ? serviceRecordActiveTab : activeTab;
   const filterType: DocumentFilterType = activeListTab === "all" ? null : (activeListTab as DocumentFilterType);
   const templateFilter = useMemo(
-    () => feedbackTemplateIds.length > 0
+    () => serviceRecordTemplateIds.length > 0
       ? {
-          templateId: feedbackTemplateIds.join(","),
+          templateId: serviceRecordTemplateIds.join(","),
           templateMatch: activeSection === "service-records" ? "include" as const : "exclude" as const,
         }
       : undefined,
-    [activeSection, feedbackTemplateIds],
+    [activeSection, serviceRecordTemplateIds],
   );
   const canFetchDocuments =
     isAuthenticated &&
-    !isFeedbackTemplateLoading &&
-    (activeSection !== "service-records" || feedbackTemplateIds.length > 0);
+    !isServiceRecordTemplateLoading &&
+    (activeSection !== "service-records" || serviceRecordTemplateIds.length > 0);
 
   // Fetch filtered docs with infinite scroll for the current tab
   const {
@@ -557,7 +557,7 @@ export default function ContractsPage() {
   });
   const isBootstrappingAuth = isLoadingAuth && !isAuthenticated;
   // Initial loading: first auth bootstrap or first "all" data fetch
-  const isInitialLoading = isBootstrappingAuth || isFeedbackTemplateLoading || isLoadingInfinite;
+  const isInitialLoading = isBootstrappingAuth || isServiceRecordTemplateLoading || isLoadingInfinite;
   // Content loading: fetching filtered data after initial load is complete
   const isContentLoading = !isInitialLoading && isLoadingInfinite;
   // Stats are derived from the "전체" tab's data and are independent of which
@@ -575,14 +575,14 @@ export default function ContractsPage() {
   );
 
   const serviceRecordDocuments = useMemo(() => {
-    if (feedbackTemplateIds.length === 0) return [];
+    if (serviceRecordTemplateIds.length === 0) return [];
     return infiniteDocuments.filter(
       (doc) =>
         matchesDocumentStatusTab(doc, serviceRecordActiveTab) &&
         matchesDocumentSearch(doc, serviceRecordSearchQuery, resolveCustomerName(doc)),
     );
   }, [
-    feedbackTemplateIds,
+    serviceRecordTemplateIds,
     infiniteDocuments,
     resolveCustomerName,
     serviceRecordActiveTab,

--- a/frontend/src/app/api/admin/service-records/schedules/[scheduleId]/send-link/route.ts
+++ b/frontend/src/app/api/admin/service-records/schedules/[scheduleId]/send-link/route.ts
@@ -33,7 +33,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         preparedLinkToken !== undefined
         && (typeof preparedLinkToken !== "string" || !PREPARED_LINK_TOKEN_PATTERN.test(preparedLinkToken))
     ) {
-        return NextResponse.json({ error: "Invalid prepared feedback link" }, { status: 400 });
+        return NextResponse.json({ error: "Invalid prepared service-record link" }, { status: 400 });
     }
     if (
         recipientPhone !== undefined

--- a/frontend/src/app/api/admin/service-records/schedules/__tests__/link-routes.test.ts
+++ b/frontend/src/app/api/admin/service-records/schedules/__tests__/link-routes.test.ts
@@ -29,12 +29,12 @@ function createRequest(path: string, body?: object, authenticated = true): NextR
     });
 }
 
-describe("service-record feedback link proxy routes", () => {
+describe("service-record link proxy routes", () => {
     beforeEach(() => {
         mockPost.mockReset();
     });
 
-    it("prepares an exact feedback URL for the manually entered recipient phone", async () => {
+    it("prepares an exact service-record URL for the manually entered recipient phone", async () => {
         mockPost.mockResolvedValue({
             status: 201,
             data: {

--- a/frontend/src/app/api/eformsign-docs/feedback-template-id/__tests__/route.test.ts
+++ b/frontend/src/app/api/eformsign-docs/feedback-template-id/__tests__/route.test.ts
@@ -25,7 +25,7 @@ describe("GET /api/eformsign-docs/feedback-template-id", () => {
     mockServerGet.mockReset();
   });
 
-  it("returns the configured feedback template id", async () => {
+  it("returns the configured service-record template id", async () => {
     mockServerGet.mockResolvedValue({
       status: 200,
       data: { templateId: "f091d768fb2c4a74b429525b428337f7" },

--- a/frontend/src/app/api/eformsign-docs/feedback-template-id/route.ts
+++ b/frontend/src/app/api/eformsign-docs/feedback-template-id/route.ts
@@ -25,6 +25,6 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(response.data);
   } catch (error) {
-    return errorResponse(error, "get feedback template id");
+    return errorResponse(error, "get service record template id");
   }
 }

--- a/frontend/src/components/app/messages/forms/ServiceRecordLinkMessageForm.tsx
+++ b/frontend/src/components/app/messages/forms/ServiceRecordLinkMessageForm.tsx
@@ -34,7 +34,7 @@ interface ServiceRecordLinkMessageFormProps {
 const ALIGNED_AUTOCOMPLETE_CLASS_NAME =
   "grid gap-[calc(7px*var(--glint-ui-scale,1))] space-y-0";
 
-interface PreparedFeedbackLink extends ServiceRecordLinkPreparation {
+interface PreparedServiceRecordLink extends ServiceRecordLinkPreparation {
   selectionKey: string;
 }
 
@@ -58,31 +58,31 @@ export const ServiceRecordLinkMessageForm = ({
     resetEmployeeFields,
   } = useFormStore();
   const { data: systemTemplate } = useSystemTemplate("SERVICE_RECORD_LINK");
-  const [preparedFeedbackLink, setPreparedFeedbackLink] = useState<PreparedFeedbackLink | null>(null);
+  const [preparedServiceRecordLink, setPreparedServiceRecordLink] = useState<PreparedServiceRecordLink | null>(null);
   const [preparationErrorKey, setPreparationErrorKey] = useState<string | null>(null);
   const inFlightPreparationRef = useRef<{
     selectionKey: string;
-    promise: Promise<PreparedFeedbackLink>;
+    promise: Promise<PreparedServiceRecordLink>;
   } | null>(null);
 
   const normalizedEmployeePhone = normalizeKoreanPhoneLookupKey(employeePhone);
-  const canPrepareFeedbackLink = clientId !== null
+  const canPrepareServiceRecordLink = clientId !== null
     && Boolean(clientName.trim())
     && employeeId !== null
     && Boolean(employeeName.trim())
     && isValidKoreanPhoneNumber(normalizedEmployeePhone);
-  const selectionKey = canPrepareFeedbackLink
+  const selectionKey = canPrepareServiceRecordLink
     ? `${clientId}:${employeeId}:${normalizedEmployeePhone}`
     : null;
-  const currentPreparation = preparedFeedbackLink?.selectionKey === selectionKey
-    ? preparedFeedbackLink
+  const currentPreparation = preparedServiceRecordLink?.selectionKey === selectionKey
+    ? preparedServiceRecordLink
     : null;
 
   useEffect(() => {
     if (selectionKey === null || clientId === null || employeeId === null) {
       return;
     }
-    if (preparedFeedbackLink?.selectionKey === selectionKey) {
+    if (preparedServiceRecordLink?.selectionKey === selectionKey) {
       return;
     }
 
@@ -91,7 +91,7 @@ export const ServiceRecordLinkMessageForm = ({
     const existingRequest = inFlightPreparationRef.current;
     const promise = existingRequest?.selectionKey === selectionKey
       ? existingRequest.promise
-      : (async (): Promise<PreparedFeedbackLink> => {
+      : (async (): Promise<PreparedServiceRecordLink> => {
           const overviewResponse = await serviceRecordsApi.getClientOverview(clientId);
           const assignment = overviewResponse.data.assignments.find(
             (item) => !item.replaced && item.employee.id === employeeId,
@@ -115,7 +115,7 @@ export const ServiceRecordLinkMessageForm = ({
     void promise
       .then((prepared) => {
         if (!cancelled) {
-          setPreparedFeedbackLink(prepared);
+          setPreparedServiceRecordLink(prepared);
         }
       })
       .catch(() => {
@@ -136,14 +136,14 @@ export const ServiceRecordLinkMessageForm = ({
     clientId,
     employeeId,
     normalizedEmployeePhone,
-    preparedFeedbackLink?.selectionKey,
+    preparedServiceRecordLink?.selectionKey,
     selectionKey,
   ]);
 
   const resolvedEmployeeName = employeeName.trim() || "{{employeeName}}";
   const resolvedClientName = clientName.trim() || "{{clientName}}";
   const resolvedServiceRecordUrl = currentPreparation?.serviceRecordUrl ?? "{{serviceRecordUrl}}";
-  const feedbackLinkDisplayValue = currentPreparation?.serviceRecordUrl
+  const serviceRecordLinkDisplayValue = currentPreparation?.serviceRecordUrl
     ?? (selectionKey === null
       ? "필수 정보 입력 후 생성"
       : preparationErrorKey === selectionKey
@@ -177,8 +177,8 @@ ${resolvedServiceRecordUrl}`;
     return navigator.clipboard.writeText(generatedMessage);
   };
 
-  const invalidatePreparedFeedbackLink = () => {
-    setPreparedFeedbackLink(null);
+  const invalidatePreparedServiceRecordLink = () => {
+    setPreparedServiceRecordLink(null);
     setPreparationErrorKey(null);
   };
 
@@ -186,7 +186,7 @@ ${resolvedServiceRecordUrl}`;
     nextEmployeeId: number | null,
     employee: Employee | null,
   ) => {
-    invalidatePreparedFeedbackLink();
+    invalidatePreparedServiceRecordLink();
     if (!employee || nextEmployeeId === null) {
       resetEmployeeFields();
       return;
@@ -197,7 +197,7 @@ ${resolvedServiceRecordUrl}`;
   };
 
   const handleEmployeeManualNameChange = (value: string) => {
-    invalidatePreparedFeedbackLink();
+    invalidatePreparedServiceRecordLink();
     const nextName = value.trimStart();
     if (!nextName.trim()) {
       resetEmployeeFields();
@@ -212,7 +212,7 @@ ${resolvedServiceRecordUrl}`;
     nextClientId: number | null,
     client: Client | null,
   ) => {
-    invalidatePreparedFeedbackLink();
+    invalidatePreparedServiceRecordLink();
     if (!client || nextClientId === null) {
       setClientId(null);
       return;
@@ -223,13 +223,13 @@ ${resolvedServiceRecordUrl}`;
   };
 
   const handleClientManualNameChange = (value: string) => {
-    invalidatePreparedFeedbackLink();
+    invalidatePreparedServiceRecordLink();
     setClientId(null);
     setClientName(value);
   };
 
   const handleEmployeePhoneChange = (value: string) => {
-    invalidatePreparedFeedbackLink();
+    invalidatePreparedServiceRecordLink();
     setEmployeePhone(value);
   };
 
@@ -287,12 +287,12 @@ ${resolvedServiceRecordUrl}`;
         { label: "관리사님 성함", value: employeeName.trim() || "-" },
         { label: "관리사님 전화번호", value: employeePhone.trim() || "-" },
         { label: "산모님 성함", value: clientName.trim() || "-" },
-        { label: "제공기록지 링크", value: feedbackLinkDisplayValue },
+        { label: "제공기록지 링크", value: serviceRecordLinkDisplayValue },
       ]}
       variableItems={[
         { token: "{{employeeName}}", label: "관리사님 성함", value: employeeName.trim() || "-" },
         { token: "{{clientName}}", label: "산모님 성함", value: clientName.trim() || "-" },
-        { token: "{{serviceRecordUrl}}", label: "제공기록지 링크", value: feedbackLinkDisplayValue },
+        { token: "{{serviceRecordUrl}}", label: "제공기록지 링크", value: serviceRecordLinkDisplayValue },
       ]}
       handleCopy={handleCopy}
       showSide={showMessageSide}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -25,7 +25,7 @@ import type {
 const DEFAULT_EFORMSIGN_LIMIT = 100;
 const DEFAULT_EFORMSIGN_SKIP = 0;
 
-export interface FeedbackTemplateIdResponse {
+export interface ServiceRecordTemplateIdResponse {
     templateId: string | null;
     templateIds?: string[];
 }
@@ -295,7 +295,7 @@ export const eformsignApi = {
         const { data } = await api.get('/eformsign-docs/client-names');
         return data;
     },
-    getFeedbackTemplateId: async (): Promise<FeedbackTemplateIdResponse> => {
+    getServiceRecordTemplateId: async (): Promise<ServiceRecordTemplateIdResponse> => {
         const { data } = await api.get('/eformsign-docs/feedback-template-id');
         return data;
     },

--- a/mobile/src/app/(shell)/contracts/page.tsx
+++ b/mobile/src/app/(shell)/contracts/page.tsx
@@ -1861,11 +1861,11 @@ export default function ContractsPage() {
   });
 
   const {
-    data: feedbackTemplateData,
-    isError: isFeedbackTemplateError,
+    data: serviceRecordTemplateData,
+    isError: isServiceRecordTemplateError,
   } = useQuery({
-    queryKey: ["eformsign-docs", "feedback-template-id"],
-    queryFn: eformsignApi.getFeedbackTemplateId,
+    queryKey: ["eformsign-docs", "service-record-template-id"],
+    queryFn: eformsignApi.getServiceRecordTemplateId,
     enabled: isAuthenticated,
     staleTime: 1000 * 60 * 5,
   });
@@ -1874,9 +1874,9 @@ export default function ContractsPage() {
   // template id가 미설정(null)인 설치에서는 모든 문서를 산모 계약서로 취급한다 —
   // 산모 섹션은 템플릿 필터 없이 조회하고, 제공기록지 섹션만 비활성(빈 목록)으로 남긴다.
   const serviceRecordTemplateIds = useMemo(
-    () => feedbackTemplateData?.templateIds
-      ?? (feedbackTemplateData?.templateId ? [feedbackTemplateData.templateId] : []),
-    [feedbackTemplateData],
+    () => serviceRecordTemplateData?.templateIds
+      ?? (serviceRecordTemplateData?.templateId ? [serviceRecordTemplateData.templateId] : []),
+    [serviceRecordTemplateData],
   );
   const serviceRecordTemplateId = useMemo(
     () => serviceRecordTemplateIds.length > 0
@@ -1884,11 +1884,11 @@ export default function ContractsPage() {
       : null,
     [serviceRecordTemplateIds],
   );
-  const isFeedbackTemplateResolved =
-    feedbackTemplateData !== undefined || isFeedbackTemplateError;
+  const isServiceRecordTemplateResolved =
+    serviceRecordTemplateData !== undefined || isServiceRecordTemplateError;
   const sectionTemplateMatch = activeSection === "service-records" ? "include" : "exclude";
   const sectionFilterReady =
-    isFeedbackTemplateResolved
+    isServiceRecordTemplateResolved
     && (activeSection === "maternal-contracts" || serviceRecordTemplateIds.length > 0);
   const debouncedSearchQuery = useDebouncedValue(searchQuery.trim(), 300);
   const statusCategoryParam = FILTER_TO_STATUS_CATEGORY[activeFilter];
@@ -1943,7 +1943,7 @@ export default function ContractsPage() {
 
   const isContractsLoading =
     isAuthLoading ||
-    (isAuthenticated && !isFeedbackTemplateResolved) ||
+    (isAuthenticated && !isServiceRecordTemplateResolved) ||
     (
       isAuthenticated
       && sectionFilterReady

--- a/mobile/src/app/api/eformsign-docs/feedback-template-id/__tests__/route.test.ts
+++ b/mobile/src/app/api/eformsign-docs/feedback-template-id/__tests__/route.test.ts
@@ -26,7 +26,7 @@ describe("GET /api/eformsign-docs/feedback-template-id", () => {
     mockServerGet.mockReset();
   });
 
-  it("returns the configured feedback template id", async () => {
+  it("returns the configured service-record template id", async () => {
     mockServerGet.mockResolvedValue({
       status: 200,
       data: { templateId: "service-record-template" },

--- a/mobile/src/app/api/eformsign-docs/feedback-template-id/route.ts
+++ b/mobile/src/app/api/eformsign-docs/feedback-template-id/route.ts
@@ -25,6 +25,6 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(response.data);
   } catch (error) {
-    return errorResponse(error, "get feedback template id");
+    return errorResponse(error, "get service record template id");
   }
 }

--- a/mobile/src/components/app/root/contracts-prefetch-coordinator.tsx
+++ b/mobile/src/components/app/root/contracts-prefetch-coordinator.tsx
@@ -55,13 +55,13 @@ export function ContractsPrefetchCoordinator(): null {
         // 계약 페이지의 기본 뷰(산모 계약서 섹션)와 완전히 같은 쿼리 키로 프리페치해야
         // 캐시가 재사용된다: 섹션은 제공기록지 template id의 exclude 필터로 표현되므로
         // template id를 먼저 확보한다(페이지와 동일한 쿼리 키 — 이 조회도 함께 워밍됨).
-        const feedbackTemplate = await queryClient.fetchQuery({
-          queryKey: ["eformsign-docs", "feedback-template-id"],
-          queryFn: eformsignApi.getFeedbackTemplateId,
+        const serviceRecordTemplate = await queryClient.fetchQuery({
+          queryKey: ["eformsign-docs", "service-record-template-id"],
+          queryFn: eformsignApi.getServiceRecordTemplateId,
           staleTime: 1000 * 60 * 5,
         });
-        const serviceRecordTemplateIds = feedbackTemplate?.templateIds
-          ?? (feedbackTemplate?.templateId ? [feedbackTemplate.templateId] : []);
+        const serviceRecordTemplateIds = serviceRecordTemplate?.templateIds
+          ?? (serviceRecordTemplate?.templateId ? [serviceRecordTemplate.templateId] : []);
         if (cancelled || serviceRecordTemplateIds.length === 0) return;
         const serviceRecordTemplateId = serviceRecordTemplateIds.join(",");
 

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -46,7 +46,7 @@ export interface ContractDataDto {
   actualPrice: string;
 }
 
-export interface FeedbackTemplateIdResponse {
+export interface ServiceRecordTemplateIdResponse {
     templateId: string | null;
     templateIds?: string[];
 }
@@ -390,7 +390,7 @@ export const eformsignApi = {
         const { data } = await api.get('/eformsign-docs/client-names');
         return data;
     },
-    getFeedbackTemplateId: async (): Promise<FeedbackTemplateIdResponse> => {
+    getServiceRecordTemplateId: async (): Promise<ServiceRecordTemplateIdResponse> => {
         const { data } = await api.get('/eformsign-docs/feedback-template-id');
         return data;
     },

--- a/mobile/tests/contracts-skeleton-loading.spec.ts
+++ b/mobile/tests/contracts-skeleton-loading.spec.ts
@@ -228,7 +228,7 @@ test.describe('Contracts Page Skeleton Loading', () => {
     await expect(page.locator('[data-component="mobile_contracts_detail-sheet_stack_list-page_content_list-card_body_loading-row"]')).toHaveCount(0);
   });
 
-  test('falls back to the maternal contract filter when feedback template lookup fails', async ({ page }) => {
+  test('falls back to the maternal contract filter when service-record template lookup fails', async ({ page }) => {
     await page.route('**/api/access-token', async (route) => {
       await route.fulfill({
         status: 200,
@@ -238,7 +238,7 @@ test.describe('Contracts Page Skeleton Loading', () => {
     });
     await routeContractsApi(page, {
       getDocuments: () => MOCK_DOCUMENTS.documents,
-      feedbackTemplateStatus: 500,
+      serviceRecordTemplateStatus: 500,
     });
     await routeSharedContractDependencies(page);
 

--- a/mobile/tests/contracts-template-filter.spec.ts
+++ b/mobile/tests/contracts-template-filter.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
 import {
-  DEFAULT_FEEDBACK_TEMPLATE_IDS,
+  DEFAULT_SERVICE_RECORD_TEMPLATE_IDS,
   routeContractsApi,
   type ContractListRequest,
   type ContractMockDocument,
@@ -25,7 +25,7 @@ const TIER_SERVICE_RECORD_DOCUMENT: ContractMockDocument = {
   document_number: "RECORD-010",
   document_name: "김산모 10회차 기록",
   template: {
-    id: DEFAULT_FEEDBACK_TEMPLATE_IDS[1],
+    id: DEFAULT_SERVICE_RECORD_TEMPLATE_IDS[1],
     name: "산모신생아 건강관리 10회차",
   },
   created_date: Date.now() - 1_000,
@@ -111,7 +111,7 @@ test.describe("contracts service-record template filters", () => {
 
     await page.goto("/contracts");
 
-    const joinedTemplateIds = DEFAULT_FEEDBACK_TEMPLATE_IDS.join(",");
+    const joinedTemplateIds = DEFAULT_SERVICE_RECORD_TEMPLATE_IDS.join(",");
     await expect.poll(() =>
       listRequests.some(
         (request) =>
@@ -157,14 +157,14 @@ test.describe("contracts service-record template filters", () => {
     await expect.poll(() =>
       listRequests.some(
         (request) =>
-          request.templateId === DEFAULT_FEEDBACK_TEMPLATE_IDS[0]
+          request.templateId === DEFAULT_SERVICE_RECORD_TEMPLATE_IDS[0]
           && request.templateMatch === "exclude",
       ),
     ).toBe(true);
     await expect.poll(() =>
       statusCountsRequests.some(
         (request) =>
-          request.templateId === DEFAULT_FEEDBACK_TEMPLATE_IDS[0]
+          request.templateId === DEFAULT_SERVICE_RECORD_TEMPLATE_IDS[0]
           && request.templateMatch === "exclude",
       ),
     ).toBe(true);

--- a/mobile/tests/helpers/contracts-api-mock.ts
+++ b/mobile/tests/helpers/contracts-api-mock.ts
@@ -6,20 +6,20 @@ import {
   isProviderReviewWorkflowStep,
 } from "../../src/lib/eformsign/status-codes";
 
-export const DEFAULT_FEEDBACK_TEMPLATE_IDS = [
+export const DEFAULT_SERVICE_RECORD_TEMPLATE_IDS = [
   "service-record-template",
   "service-record-template-10",
   "service-record-template-15",
   "service-record-template-20",
 ] as const;
-const DEFAULT_FEEDBACK_TEMPLATE_ID = DEFAULT_FEEDBACK_TEMPLATE_IDS[0];
+const DEFAULT_SERVICE_RECORD_TEMPLATE_ID = DEFAULT_SERVICE_RECORD_TEMPLATE_IDS[0];
 const DEFAULT_FIRST_PAGE_LIMIT = 9;
 const DEFAULT_SKIP = 0;
 const SNAPSHOT_VERSION = "e2e-contracts-snapshot";
 
 const LIST_ROUTE = /\/api\/eformsign\/documents(?:\?.*)?$/;
 const STATUS_COUNTS_ROUTE = /\/api\/eformsign\/documents\/status-counts(?:\?.*)?$/;
-const FEEDBACK_TEMPLATE_ROUTE = /\/api\/eformsign-docs\/feedback-template-id(?:\?.*)?$/;
+const SERVICE_RECORD_TEMPLATE_ROUTE = /\/api\/eformsign-docs\/feedback-template-id(?:\?.*)?$/;
 const CHOSUNG = [
   "ㄱ",
   "ㄲ",
@@ -105,7 +105,7 @@ export interface RouteContractsApiOptions {
   templateId?: string;
   templateIds?: readonly string[];
   omitTemplateIds?: boolean;
-  feedbackTemplateStatus?: number;
+  serviceRecordTemplateStatus?: number;
   listStatus?: number;
   statusCountsStatus?: number;
   beforeListResponse?: (request: ContractListRequest) => Promise<void> | void;
@@ -329,14 +329,14 @@ export async function routeContractsApi(
   page: Page,
   {
     getDocuments,
-    templateId = DEFAULT_FEEDBACK_TEMPLATE_ID,
+    templateId = DEFAULT_SERVICE_RECORD_TEMPLATE_ID,
     // 앱은 templateIds를 우선하므로 templateId만 오버라이드한 스펙에서
     // 기본 4개 목록이 남아 오버라이드가 무시되는 일이 없도록 파생시킨다.
-    templateIds = templateId === DEFAULT_FEEDBACK_TEMPLATE_ID
-      ? DEFAULT_FEEDBACK_TEMPLATE_IDS
+    templateIds = templateId === DEFAULT_SERVICE_RECORD_TEMPLATE_ID
+      ? DEFAULT_SERVICE_RECORD_TEMPLATE_IDS
       : [templateId],
     omitTemplateIds = false,
-    feedbackTemplateStatus = 200,
+    serviceRecordTemplateStatus = 200,
     listStatus = 200,
     statusCountsStatus = 200,
     beforeListResponse,
@@ -344,17 +344,17 @@ export async function routeContractsApi(
     onStatusCountsRequest,
   }: RouteContractsApiOptions,
 ): Promise<void> {
-  await page.route(FEEDBACK_TEMPLATE_ROUTE, async (route) => {
+  await page.route(SERVICE_RECORD_TEMPLATE_ROUTE, async (route) => {
     await route.fulfill({
-      status: feedbackTemplateStatus,
+      status: serviceRecordTemplateStatus,
       contentType: "application/json",
       body: JSON.stringify(
-        feedbackTemplateStatus === 200
+        serviceRecordTemplateStatus === 200
           ? {
               templateId,
               ...(!omitTemplateIds && { templateIds }),
             }
-          : { error: "feedback template unavailable" },
+          : { error: "service-record template unavailable" },
       ),
     });
   });


### PR DESCRIPTION
dev → preview 승격. 두 덩어리.

## 1. 제공기록지 도메인 용어 통일 (`feedback` → `service_record`, 43파일)

식별자·캐시 키·환경변수 4개·주석을 통일했습니다. Opus 리뷰 APPROVE.

**환경변수는 폴백 없이 새 이름만 읽습니다.** 새 이름 4개는 이미 Railway 세 환경에 동일 값으로 등록돼 있고, dev 배포에서 백엔드 정상 기동이 확인됐습니다.

의도적 제외: HTTP 경로(`/eformsign-docs/feedback-template-id` — 백엔드·프론트 독립 배포로 인한 404 창 방지), `"service-feedback-link"` 정책 ID(wire 계약), 채팅 피드백 계열, 과거 마이그레이션.

## 2. PR e2e가 조용히 건너뛰고 초록불이 되던 문제

스펙 4개를 바꾼 PR이 "변경된 스펙 없음"으로 판정돼 아무 테스트도 돌리지 않고 통과한 사례가 있었습니다. 같은 명령이 로컬에서는 정상 동작해 러너에서만 빈 결과가 나온 이유는 특정하지 못했고, 그래서 그 방식에 의존하지 않도록 변경 파일 목록을 API에서 직접 가져옵니다. **API 실패와 빈 목록을 모두 치명적 오류로 처리**해, 같은 일이 재발하면 초록불이 아니라 빨간불이 납니다.

## 검증
dev에서 전 CI 통과.

Railway 백엔드 배포 검사가 PR #404에서 한 차례 실패했으나 원인은 DB 연결 슬롯 고갈(`EMAXCONNSESSION`, 동시 배포로 15개 풀 소진)이며 빌드는 성공했습니다. 해당 PR은 워크플로 파일 한 개만 변경합니다.

## 배포 후 확인
용어 통일이 포함되므로 preview 백엔드 기동과 제공기록지 목록 정상 여부를 확인합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG