### PR TITLE
fix(contracts): show that the list is loading more, instead of nothing

### DIFF
--- a/frontend/src/app/(protected)/contracts/page.tsx
+++ b/frontend/src/app/(protected)/contracts/page.tsx
@@ -788,6 +788,7 @@ export default function ContractsPage() {
                 hasMore={hasNextPage}
                 onLoadMore={() => fetchNextPage()}
                 isFetchingMore={isFetchingNextPage}
+                fetchingMoreCount={3}
                 render={({ item: doc, isLoading }) => {
                   const customerName = resolveCustomerName(doc);
 
@@ -915,6 +916,7 @@ export default function ContractsPage() {
                     hasMore={hasNextPage}
                     onLoadMore={() => fetchNextPage()}
                     isFetchingMore={isFetchingNextPage}
+                    fetchingMoreCount={3}
                     render={({ item: doc, isLoading }) => (
                       <ContractsListItem
                         data-component="desktop_contracts_sections_section-content_service-records-section_split-layout_list-panel_item"

--- a/mobile/src/app/(shell)/contracts/page.tsx
+++ b/mobile/src/app/(shell)/contracts/page.tsx
@@ -2181,6 +2181,7 @@ export default function ContractsPage() {
               ) : isInitialLoad && hasMore ? (
                 <ListLoadMoreButton
                   onLoadMore={loadMore}
+                  isLoading={isFetchingNextPage}
                   data-component="mobile_contracts_detail-sheet_stack_list-page_content_list-card_load-more_button"
                 />
               ) : null
@@ -2309,6 +2310,7 @@ export default function ContractsPage() {
                 {!isInitialLoad && hasMore && (
                   <ListLoadMoreSentinel
                     sentinelRef={sentinelRef}
+                    isLoading={isFetchingNextPage}
                     data-component="mobile_contracts_detail-sheet_stack_list-page_content_list-card_body_load-sentinel"
                   />
                 )}

--- a/mobile/src/components/app/mobile-redesign/__tests__/list-load-more.test.tsx
+++ b/mobile/src/components/app/mobile-redesign/__tests__/list-load-more.test.tsx
@@ -1,0 +1,84 @@
+import { createRef } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ListLoadMoreButton, ListLoadMoreSentinel } from "../primitives";
+
+const BUTTON_DATA_COMPONENT = "mobile_test_load-more_button";
+const SENTINEL_DATA_COMPONENT = "mobile_test_load-sentinel";
+
+describe("ListLoadMoreButton", () => {
+    it("offers the tap affordance and loads more when idle", async () => {
+        const onLoadMore = jest.fn();
+        render(
+            <ListLoadMoreButton data-component={BUTTON_DATA_COMPONENT} onLoadMore={onLoadMore} />,
+        );
+
+        const button = screen.getByRole("button", { name: "더 많은 항목 불러오기" });
+        expect(button).toHaveTextContent("탭하여 더보기");
+        expect(button.querySelector('[data-slot="spinner"]')).toBeNull();
+
+        await userEvent.click(button);
+        expect(onLoadMore).toHaveBeenCalledTimes(1);
+    });
+
+    it("swaps in a spinner and stops accepting taps while the next page loads", async () => {
+        const onLoadMore = jest.fn();
+        render(
+            <ListLoadMoreButton
+                data-component={BUTTON_DATA_COMPONENT}
+                onLoadMore={onLoadMore}
+                isLoading
+            />,
+        );
+
+        const button = screen.getByRole("button", { name: "더 많은 항목 불러오기" });
+        expect(button).toBeDisabled();
+        expect(button).toHaveAttribute("aria-busy", "true");
+        expect(button).not.toHaveTextContent("탭하여 더보기");
+        expect(button.querySelector('[data-slot="spinner"]')).not.toBeNull();
+
+        // A disabled button swallows the click, so the page cannot be fetched twice.
+        await userEvent.click(button);
+        expect(onLoadMore).not.toHaveBeenCalled();
+    });
+});
+
+describe("ListLoadMoreSentinel", () => {
+    it("stays invisible while idle so it only acts as a scroll trigger", () => {
+        const ref = createRef<HTMLDivElement>();
+        const { container } = render(
+            <ListLoadMoreSentinel data-component={SENTINEL_DATA_COMPONENT} sentinelRef={ref} />,
+        );
+
+        expect(screen.queryByRole("status")).toBeNull();
+        expect(container.querySelector('[data-slot="spinner"]')).toBeNull();
+        expect(ref.current).not.toBeNull();
+    });
+
+    it("announces the fetch and keeps the same node, so the observer stays attached", () => {
+        const ref = createRef<HTMLDivElement>();
+        const { rerender } = render(
+            <ListLoadMoreSentinel data-component={SENTINEL_DATA_COMPONENT} sentinelRef={ref} />,
+        );
+        const idleNode = ref.current;
+
+        rerender(
+            <ListLoadMoreSentinel
+                data-component={SENTINEL_DATA_COMPONENT}
+                sentinelRef={ref}
+                isLoading
+            />,
+        );
+
+        const status = screen.getByRole("status", { name: "더 많은 항목 불러오는 중" });
+        expect(status.querySelector('[data-slot="spinner"]')).not.toBeNull();
+
+        // useListInfiniteScroll does not list isFetchingNextPage among its effect
+        // dependencies, so it never re-observes. If React swapped the DOM node here the
+        // IntersectionObserver would be left watching a detached element and infinite
+        // scroll would stop working entirely after the first auto-load.
+        expect(ref.current).toBe(idleNode);
+        expect(status).toBe(idleNode);
+    });
+});

--- a/mobile/src/components/app/mobile-redesign/primitives.tsx
+++ b/mobile/src/components/app/mobile-redesign/primitives.tsx
@@ -7,6 +7,8 @@ import { ChevronDown, ChevronRight, FileCheck2, type LucideIcon } from "lucide-r
 
 import { StatusPill } from "@/components/app/ui/status-badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
 import { ListCardBody } from "./ListCardBody";
 import { ListCardHeader } from "./ListCardHeader";
 import { ListCardLoadMore } from "./ListCardLoadMore";
@@ -25,21 +27,35 @@ const CONTRACT_LIST_SOURCE_COMPONENT = "ContractList";
 export function ListLoadMoreButton({
   "data-component": dataComponent,
   onLoadMore,
+  isLoading = false,
 }: {
   "data-component": string;
   onLoadMore: () => void;
+  /** True while the next page is being fetched. Disables the button and swaps the affordance for a spinner. */
+  isLoading?: boolean;
 }) {
   return (
     <button
       type="button"
       onClick={onLoadMore}
-      className="peek-bounce flex min-h-[44px] min-w-[44px] flex-col items-center justify-center gap-0.5 text-v3-primary"
+      disabled={isLoading}
+      aria-busy={isLoading}
+      className={cn(
+        "flex min-h-[44px] min-w-[44px] flex-col items-center justify-center gap-0.5 text-v3-primary",
+        isLoading ? "cursor-default" : "peek-bounce"
+      )}
       data-component={dataComponent}
       data-source-component={LIST_LOAD_MORE_BUTTON_SOURCE_COMPONENT}
       aria-label="더 많은 항목 불러오기"
     >
-      <span className="text-[0.78rem] font-bold">탭하여 더보기</span>
-      <ChevronDown size={20} strokeWidth={2.5} />
+      {isLoading ? (
+        <Spinner size="sm" data-component={`${dataComponent}_spinner`} />
+      ) : (
+        <>
+          <span className="text-[0.78rem] font-bold">탭하여 더보기</span>
+          <ChevronDown size={20} strokeWidth={2.5} />
+        </>
+      )}
     </button>
   );
 }
@@ -47,10 +63,28 @@ export function ListLoadMoreButton({
 export function ListLoadMoreSentinel({
   "data-component": dataComponent,
   sentinelRef,
+  isLoading = false,
 }: {
   "data-component": string;
   sentinelRef: RefObject<HTMLDivElement | null>;
+  /** True while the next page is being fetched. Renders a visible spinner instead of the invisible trigger div. */
+  isLoading?: boolean;
 }) {
+  if (isLoading) {
+    return (
+      <div
+        ref={sentinelRef}
+        role="status"
+        aria-label="더 많은 항목 불러오는 중"
+        className="flex min-h-[44px] items-center justify-center py-2 text-v3-primary"
+        data-component={dataComponent}
+        data-source-component={LIST_LOAD_MORE_SENTINEL_SOURCE_COMPONENT}
+      >
+        <Spinner size="sm" data-component={`${dataComponent}_spinner`} />
+      </div>
+    );
+  }
+
   return (
     <div
       ref={sentinelRef}


### PR DESCRIPTION
## 문제

계약서 목록을 스크롤해 다음 페이지를 불러오는 동안 **아무 표시가 없어** 멈춘 것처럼 보인다는 사용자 보고.

**백엔드 지연이 원인이 아닙니다.** 스냅샷 캐시 키(`eformsign-document-snapshot.service.ts:463-466`)에 `limit`/`skip` 이 들어가지 않아 모든 페이지가 같은 캐시 항목을 공유합니다 — 첫 조회 이후 페이지들은 이미 캐시에서 빠르게 나옵니다. 그냥 **아무것도 그려지지 않고 있었던 것**입니다.

## 데스크톱 — 기능은 이미 있었고 켜지지 않았을 뿐

`AnimatedSlotList` 는 목록 끝에 로딩 스켈레톤을 덧붙이는 로직을 이미 갖고 있습니다(`:119` `isAppendLoadingSlot`, 스태거 애니메이션까지). 그런데 슬롯 개수를 늘리는 값이 `fetchingMoreCount` 인데 계약서 페이지가 이걸 안 넘겨서 기본값 0 → **스켈레톤이 한 줄도 렌더되지 않았습니다.** 저장소 전체에서 이 prop 을 넘기는 호출자가 하나도 없었습니다.

`3` 을 넘깁니다. 실제 페이지 크기는 20(`useInfiniteContracts.ts:11`)이지만 20줄을 덧그리면 화면을 뒤덮어 오히려 나빠지고, 같은 두 호출부가 초기 로딩에 이미 `loadingCount={3}` 을 쓰고 있어 그 관례를 따랐습니다. 마지막 페이지에서 과하게 그려도 fetch 가 끝나면 `slotCount` 가 실제 개수로 다시 계산되므로 남지 않습니다.

`AnimatedSlotList.tsx` 자체는 손대지 않았습니다.

## 모바일 — 상태가 UI에 연결돼 있지 않았음

모바일 무한 스크롤은 서버 페이지네이션이 아니라 **이미 받아온 데이터를 6개씩 잘라 보여주는 방식**이라 대부분의 탭은 즉시 처리되고 표시가 필요 없습니다. `isFetchingNextPage` 는 로컬 슬라이스가 바닥나 **실제 서버 요청이 나갈 때만** 켜지는데, 그 순간이 정확히 사용자가 멈췄다고 느끼는 지점입니다. 그런데 이 값은 중복 요청 가드(`contracts/page.tsx:2120`)로만 쓰이고 렌더된 적이 없었습니다.

- `ListLoadMoreButton`: 로딩 중 스피너로 교체, `disabled` + `aria-busy`, `peek-bounce` 애니메이션 해제
- `ListLoadMoreSentinel`: 자동 스크롤 단계로 넘어간 뒤에는 버튼이 사라지므로(둘은 상호배타적으로 렌더됨) sentinel 자리에 `role="status"` 스피너 표시

두 prop 모두 **옵셔널**이라 같은 컴포넌트를 쓰는 다른 5개 페이지(clients, consultations, files, employees, messages/templates)는 영향 없습니다.

## 검토한 위험 하나

`useListInfiniteScroll` 의 IntersectionObserver 는 의존성이 `[hasMore, isInitialLoad, loadMore]` 뿐이라 `isFetchingNextPage` 로 sentinel 이 바뀔 때 **재등록되지 않습니다.** DOM 노드가 교체되면 observer 가 떨어져 나간 노드를 감시하게 되어 무한 스크롤이 아예 죽습니다. 두 분기 모두 루트가 같은 위치의 `div` 라 React 가 노드를 재사용해 ref 와 observer 가 유지되는 것을 확인했습니다.

## 하지 않은 것

- `rootMargin` 등 트리거 조건, 프리페치 전략, 페이지 크기, 쿼리 키 — 전부 그대로
- 백엔드/캐시/스냅샷 서비스 무변경
- `data-component`/`data-slot`/`data-source-component` 기존 값 무변경 (새 스피너에만 기존 접미사 관례를 따른 새 값 부여)

## 검증

- `frontend` `npx tsc --noEmit` exit 0
- `mobile` `npx tsc --noEmit` exit 0
- `mobile` Jest 144 suites / 830 tests 전체 통과
- 변경 파일 ESLint 신규 에러 0

Playwright e2e 는 실제 백엔드가 필요해 로컬에서 돌리지 않았습니다 — CI 에서 확인합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG