### PR TITLE
feat(backend): mirror externally created eformsign documents from webhooks (BJJ-288 1b)

### DIFF
--- a/backend/application/services/eformsign-webhook.service.ts
+++ b/backend/application/services/eformsign-webhook.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger, Inject, Optional } from "@nestjs/common";
 import { UpdateEformsignDocStatusUsecase } from "application/usecases/eformsign-doc/update-eformsign-doc-status.usecase";
 import { LinkDocumentToClientUsecase } from "application/usecases/eformsign-doc/link-document-to-client.usecase";
+import { MirrorUnassignedEformsignDocUsecase } from "application/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase";
+import { TERMINAL_STATUS_CODES } from "application/usecases/eformsign-doc/eformsign-doc-status.constants";
 import {
     SyncClientEndDateUsecase,
     type SyncedClientEndDate,
@@ -14,10 +16,14 @@ import {
     type EformsignApiDocumentResponse,
     type IEformsignClientRepository,
 } from "domain/repositories/eformsign.client.interface";
-import { EFORMSIGN_DOC_REPOSITORY, IEformsignDocRepository } from "domain/repositories/eformsign-doc.repository.interface";
+import {
+    EFORMSIGN_DOC_REPOSITORY,
+    EformsignDocMappingError,
+    IEformsignDocRepository,
+} from "domain/repositories/eformsign-doc.repository.interface";
 import { EMPLOYEE_SCHEDULE_REPOSITORY, IEmployeeScheduleRepository } from "domain/repositories/employee-schedule.repository.interface";
 import { EMPLOYEE_REPOSITORY, IEmployeeRepository } from "domain/repositories/employee.repository.interface";
-import { EFORMSIGN_DOCUMENT_KIND } from "domain/entities/eformsign-doc.entity";
+import { EformsignDocEntity, EFORMSIGN_DOCUMENT_KIND } from "domain/entities/eformsign-doc.entity";
 import { PrismaService } from "infrastructure/database/prisma.service";
 import {
     SERVICE_RECORD_CASE_STATUS,
@@ -65,6 +71,10 @@ const EVENT_TYPES = {
 };
 
 const REVIEW_REQUIRED_NOTIFICATION_TYPE = "eformsign-review-required";
+
+type LocalDocumentLookupResult =
+    | { branchId: null; document: EformsignDocEntity }
+    | { branchId: string; document?: EformsignDocEntity };
 
 const STATUS_NAME_TO_CODE: Record<string, string> = {
     doc_complete: "003",
@@ -115,6 +125,7 @@ export class EformsignWebhookService {
         private readonly employeeScheduleRepository: IEmployeeScheduleRepository,
         @Inject(EMPLOYEE_REPOSITORY)
         private readonly employeeRepository: IEmployeeRepository,
+        private readonly mirrorUnassignedDocUsecase: MirrorUnassignedEformsignDocUsecase,
         @Optional() private readonly prisma?: PrismaService,
         @Optional() private readonly serviceRecordLifecycle?: ServiceRecordLifecycleService,
         @Optional() private readonly documentSnapshotService?: EformsignDocumentSnapshotService,
@@ -148,12 +159,37 @@ export class EformsignWebhookService {
             return;
         }
 
-        const resolvedBranchId = await this.resolveBranchIdForDocument(documentId);
-        if (!resolvedBranchId) {
-            this.logger.warn(`Ignoring webhook ${webhook_id}: no local branch mapping for document ${documentId}`);
+        const localDocument = await this.findLocalDocument(documentId);
+        if (localDocument === undefined) {
             return;
         }
 
+        if (localDocument === null) {
+            try {
+                await this.mirrorUnassignedDocUsecase.execute(documentId);
+                this.logger.log(
+                    `Mirrored external document ${documentId} from webhook ${webhook_id} as unassigned`,
+                );
+            } catch (error) {
+                this.logger.warn(
+                    `Failed to mirror external document ${documentId} from webhook ${webhook_id}: ${error}`,
+                );
+            }
+            return;
+        }
+
+        if (localDocument.branchId === null) {
+            try {
+                await this.updateUnassignedDocumentFromWebhook(payload, localDocument.document);
+            } catch (error) {
+                this.logger.warn(
+                    `Failed to update unassigned document ${documentId} from webhook ${webhook_id}: ${error}`,
+                );
+            }
+            return;
+        }
+
+        const resolvedBranchId = localDocument.branchId;
         this.logger.log(`Processing webhook ${webhook_id}: event_type=${event_type}`);
 
         // Handle document events (status changes)
@@ -540,13 +576,125 @@ export class EformsignWebhookService {
         return `${year}-${month}-${day}`;
     }
 
-    private async resolveBranchIdForDocument(documentId: string): Promise<string | null> {
+    private async findLocalDocument(
+        documentId: string,
+    ): Promise<LocalDocumentLookupResult | null | undefined> {
         try {
-            return await this.eformsignDocRepository.findBranchIdByDocumentId(documentId);
+            const localDocument = await this.eformsignDocRepository.findByDocumentIdUnscoped(documentId);
+            if (!localDocument) {
+                return localDocument;
+            }
+            if (localDocument.branchId === null) {
+                return {
+                    branchId: null,
+                    document: localDocument.document,
+                };
+            }
+            return {
+                branchId: localDocument.branchId,
+                document: localDocument.document,
+            };
         } catch (error) {
-            this.logger.warn(`Failed to resolve branch for document ${documentId}: ${error}`);
-            return null;
+            if (!(error instanceof EformsignDocMappingError)) {
+                this.logger.warn(`Failed to query local document ${documentId}: ${error}`);
+                return undefined;
+            }
+
+            this.logger.warn(
+                `Failed to map local document ${documentId}; falling back to branch-only lookup: ${error.originalError}`,
+            );
+            try {
+                const branchId = await this.eformsignDocRepository.findBranchIdByDocumentId(documentId);
+                if (!branchId) {
+                    this.logger.warn(
+                        `Cannot process unmapped unassigned document ${documentId} without a domain entity`,
+                    );
+                    return undefined;
+                }
+                return { branchId };
+            } catch (fallbackError) {
+                this.logger.warn(
+                    `Failed branch-only lookup for document ${documentId}: ${fallbackError}`,
+                );
+                return undefined;
+            }
         }
+    }
+
+    private async updateUnassignedDocumentFromWebhook(
+        payload: EformsignWebhookPayloadDto,
+        existing: EformsignDocEntity,
+    ): Promise<void> {
+        const { event_type, webhook_id, document, ready_document_pdf } = payload;
+        let statusType: string;
+        let statusDetail: string;
+        let stepType: string;
+        let stepIndex: string;
+        let stepName: string;
+        let updatedTimestamp: number;
+        let documentName: string | undefined;
+        let templateId: string | undefined;
+
+        if (event_type === EVENT_TYPES.DOCUMENT && document) {
+            ({ statusType, statusDetail } = this.mapStatus(document.status));
+            stepType = String(document.workflow_seq);
+            stepIndex = String(document.workflow_seq);
+            stepName = document.workflow_name;
+            updatedTimestamp = document.updated_date;
+            documentName = document.document_title?.trim() || undefined;
+            templateId = document.template_id?.trim() || undefined;
+        } else if (event_type === EVENT_TYPES.DOCUMENT_ACTION && document) {
+            const isOpenAction = document.action?.includes("open");
+            statusType = "020";
+            statusDetail = isOpenAction ? "서명 페이지 열림" : `액션: ${document.action}`;
+            stepType = String(document.workflow_seq || 0);
+            stepIndex = String(document.workflow_seq || 0);
+            stepName = document.workflow_name || "unknown";
+            updatedTimestamp = document.updated_date;
+            documentName = document.document_title?.trim() || undefined;
+            templateId = document.template_id?.trim() || undefined;
+        } else if (event_type === EVENT_TYPES.READY_DOCUMENT_PDF && ready_document_pdf) {
+            ({ statusType, statusDetail } = this.mapStatus(ready_document_pdf.document_status));
+            stepType = String(ready_document_pdf.workflow_seq);
+            stepIndex = String(ready_document_pdf.workflow_seq);
+            stepName = ready_document_pdf.workflow_name;
+            updatedTimestamp = Date.now();
+            documentName = ready_document_pdf.document_title?.trim() || undefined;
+            templateId = ready_document_pdf.template_id?.trim() || undefined;
+        } else {
+            this.logger.warn(
+                `Unknown webhook event type for unassigned document ${existing.documentId}: ${event_type}`,
+            );
+            return;
+        }
+
+        if (
+            TERMINAL_STATUS_CODES.has(existing.statusType)
+            && !TERMINAL_STATUS_CODES.has(statusType)
+        ) {
+            this.logger.log(`ignoring stale downgrade ${statusType} for ${existing.documentId}`);
+            return;
+        }
+
+        const updatedDate = new Date(
+            Math.max(updatedTimestamp, existing.createdDate.getTime()),
+        );
+        const updated = EformsignDocEntity.reconstitute({
+            ...existing.toJSON(),
+            documentName: documentName ?? null,
+            templateId: templateId ?? null,
+            updatedDate,
+            statusType,
+            statusDetail,
+            stepType,
+            stepIndex,
+            stepName,
+            expired: false,
+        });
+        await this.eformsignDocRepository.upsertUnassignedByDocumentId(updated);
+        this.logger.log(
+            `Updated unassigned document ${existing.documentId} from webhook ${webhook_id}: event_type=${event_type}`,
+        );
     }
 
     private normalizeStatusCode(statusType: string | null | undefined): string {

--- a/backend/application/usecases/eformsign-doc/eformsign-doc-status.constants.ts
+++ b/backend/application/usecases/eformsign-doc/eformsign-doc-status.constants.ts
@@ -1,0 +1,32 @@
+const COMPLETED_STATUS_CODES = new Set([
+    "003",
+    "012",
+    "022",
+    "032",
+    "050",
+    "062",
+    "072",
+    "092",
+]);
+
+const REJECTED_STATUS_CODES = new Set([
+    "011",
+    "021",
+    "031",
+    "040",
+    "042",
+    "045",
+    "047",
+    "049",
+    "061",
+    "071",
+    "080",
+]);
+
+// "090"(철회)·"099"(삭제됨)은 웹훅 상태 매핑이 합성해 영속화하는 종료 코드다.
+export const TERMINAL_STATUS_CODES = new Set([
+    ...COMPLETED_STATUS_CODES,
+    ...REJECTED_STATUS_CODES,
+    "090",
+    "099",
+]);

--- a/backend/application/usecases/eformsign-doc/index.ts
+++ b/backend/application/usecases/eformsign-doc/index.ts
@@ -9,6 +9,7 @@ export * from "./list-eformsign-doc-display-fields.usecase";
 // Local DB use cases - Write
 export * from "./create-eformsign-doc.usecase";
 export * from "./adopt-eformsign-doc.usecase";
+export * from "./mirror-unassigned-eformsign-doc.usecase";
 export * from "./update-eformsign-doc-status.usecase";
 export * from "./link-document-to-client.usecase";
 export * from "./list-client-names-by-branch.usecase";

--- a/backend/application/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.ts
@@ -1,0 +1,95 @@
+import { Inject, Injectable, Logger } from "@nestjs/common";
+
+import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
+import {
+    EFORMSIGN_DOC_REPOSITORY,
+    IEformsignDocRepository,
+} from "domain/repositories/eformsign-doc.repository.interface";
+
+import { FetchEformsignDocFromApiUsecase } from "./fetch-eformsign-doc-from-api.usecase";
+import { GetEformsignAccessTokenUsecase } from "./get-eformsign-access-token.usecase";
+
+const DEFAULT_DOCUMENT_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000;
+
+@Injectable()
+export class MirrorUnassignedEformsignDocUsecase {
+    private readonly logger = new Logger(MirrorUnassignedEformsignDocUsecase.name);
+
+    constructor(
+        private readonly getAccessTokenUsecase: GetEformsignAccessTokenUsecase,
+        private readonly fetchEformsignDocFromApiUsecase: FetchEformsignDocFromApiUsecase,
+        @Inject(EFORMSIGN_DOC_REPOSITORY)
+        private readonly eformsignDocRepository: IEformsignDocRepository,
+    ) {}
+
+    async execute(documentId: string): Promise<EformsignDocEntity> {
+        const now = Date.now();
+        const token = await this.getAccessTokenUsecase.execute(now);
+        const remote = await this.fetchEformsignDocFromApiUsecase.execute(
+            token.oauth_token.access_token,
+            documentId,
+        );
+        const recipient = remote.current_status.step_recipients?.[0];
+        const remoteUpdatedDate = new Date(remote.updated_date);
+        const updatedDate = Number.isNaN(remoteUpdatedDate.getTime())
+            ? new Date(now)
+            : remoteUpdatedDate;
+        if (Number.isNaN(remoteUpdatedDate.getTime())) {
+            this.logger.warn(
+                `Invalid remote updated_date for eformsign document ${remote.id || documentId}; using current time`,
+            );
+        }
+
+        const remoteCreatedDate = new Date(remote.created_date);
+        const createdDate = Number.isNaN(remoteCreatedDate.getTime())
+            ? new Date(updatedDate)
+            : remoteCreatedDate;
+        if (Number.isNaN(remoteCreatedDate.getTime())) {
+            this.logger.warn(
+                `Invalid remote created_date for eformsign document ${remote.id || documentId}; using updated_date`,
+            );
+        }
+
+        // The entity rejects updatedDate < createdDate, and a mirror failure is swallowed
+        // by the caller so nothing would retry it — a document eformsign reports with the
+        // two out of order would never make it into the mirror at all. The webhook path
+        // clamps the same way.
+        const clampedUpdatedDate = new Date(
+            Math.max(updatedDate.getTime(), createdDate.getTime()),
+        );
+        if (clampedUpdatedDate.getTime() !== updatedDate.getTime()) {
+            this.logger.warn(
+                `Remote updated_date precedes created_date for eformsign document ${remote.id || documentId}; clamping to created_date`,
+            );
+        }
+
+        const doc = EformsignDocEntity.create({
+            documentId: remote.id || documentId,
+            documentName: remote.document_name || null,
+            documentNumber: remote.document_number || null,
+            createdDate,
+            updatedDate: clampedUpdatedDate,
+            statusType: remote.current_status.status_type || "000",
+            statusDetail:
+                remote.current_status.status_doc_detail
+                || remote.current_status.step_name
+                || "진행중",
+            stepType: remote.current_status.step_type || "01",
+            stepIndex: remote.current_status.step_index || "1",
+            stepName: remote.current_status.step_name || "서명 요청",
+            stepRecipientType: recipient?.recipient_type || "01",
+            stepRecipientName: recipient?.name || remote.document_name || "수신자",
+            stepRecipientSms: recipient?.id || "미확인",
+            expiredDate: remote.current_status.expired_date
+                ? new Date(remote.current_status.expired_date)
+                : new Date(now + DEFAULT_DOCUMENT_EXPIRY_MS),
+            expired: remote.current_status._expired ?? false,
+            clientId: null,
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: remote.template?.id ?? null,
+        });
+
+        return this.eformsignDocRepository.upsertUnassignedByDocumentId(doc);
+    }
+}

--- a/backend/application/usecases/eformsign-doc/update-eformsign-doc-status.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/update-eformsign-doc-status.usecase.ts
@@ -2,6 +2,8 @@ import { Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
 import { EFORMSIGN_DOC_REPOSITORY, IEformsignDocRepository } from "domain/repositories/eformsign-doc.repository.interface";
 
+import { TERMINAL_STATUS_CODES } from "./eformsign-doc-status.constants";
+
 export interface UpdateEformsignDocStatusParams {
     documentId: string;
     statusType: string;
@@ -12,22 +14,6 @@ export interface UpdateEformsignDocStatusParams {
     expired?: boolean;
     documentName?: string;
 }
-
-/**
- * Terminal eformsign document status codes (completed + rejected/expired series).
- * Mirrors the identical sets already defined in
- * application/services/eformsign-webhook.service.ts,
- * application/services/eformsign-doc.service.ts, and
- * application/usecases/eformsign-doc/dispatch-document-headless.usecase.ts.
- * No shared exported constant exists for these today, and those files are out
- * of scope for this change (P1-11), so the values are mirrored here rather
- * than introducing new/different status codes.
- */
-const COMPLETED_STATUS_CODES = new Set(["003", "012", "022", "032", "050", "062", "072", "092"]);
-const REJECTED_STATUS_CODES = new Set(["011", "021", "031", "040", "042", "045", "047", "049", "061", "071", "080"]);
-// "090"(철회)·"099"(삭제됨)은 eformsign-webhook.service.ts mapStatus가 합성해
-// 영속화하는 종료 코드 — REJECTED 시리즈에는 없지만 다운그레이드 보호 대상이다.
-const TERMINAL_STATUS_CODES = new Set([...COMPLETED_STATUS_CODES, ...REJECTED_STATUS_CODES, "090", "099"]);
 
 @Injectable()
 export class UpdateEformsignDocStatusUsecase {

--- a/backend/domain/repositories/eformsign-doc.repository.interface.ts
+++ b/backend/domain/repositories/eformsign-doc.repository.interface.ts
@@ -13,6 +13,21 @@ export interface EformsignDocDisplayFields {
     customerName: string | null;
 }
 
+export interface EformsignDocUnscopedResult {
+    document: EformsignDocEntity;
+    branchId: string | null;
+}
+
+export class EformsignDocMappingError extends Error {
+    readonly originalError: unknown;
+
+    constructor(documentId: string, originalError: unknown) {
+        super(`Failed to map eformsign document ${documentId}`);
+        this.name = EformsignDocMappingError.name;
+        this.originalError = originalError;
+    }
+}
+
 export interface EformsignDocCompletionClaimParams {
     documentId: string;
     statusType: string;
@@ -29,6 +44,7 @@ export type EformsignDocCompletionClaimResult = "claimed" | "duplicate" | "missi
 export interface IEformsignDocRepository {
     findById(branchid: string, id: number): Promise<EformsignDocEntity | null>;
     findByDocumentId(branchid: string, documentId: string): Promise<EformsignDocEntity | null>;
+    findByDocumentIdUnscoped(documentId: string): Promise<EformsignDocUnscopedResult | null>;
     findBranchIdByDocumentId(documentId: string): Promise<string | null>;
     claimCompletionStatus(
         branchid: string,
@@ -45,6 +61,7 @@ export interface IEformsignDocRepository {
     create(branchid: string, doc: EformsignDocEntity): Promise<EformsignDocEntity>;
     update(branchid: string, doc: EformsignDocEntity): Promise<EformsignDocEntity>;
     upsertByDocumentId(branchid: string, doc: EformsignDocEntity): Promise<EformsignDocEntity>;
+    upsertUnassignedByDocumentId(doc: EformsignDocEntity): Promise<EformsignDocEntity>;
     delete(branchid: string, id: number): Promise<void>;
     deleteByDocumentId(branchid: string, documentId: string): Promise<void>;
 }

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -6,6 +6,8 @@ import {
     EformsignDocCompletionClaimResult,
     EformsignDocClientSummary,
     EformsignDocDisplayFields,
+    EformsignDocMappingError,
+    EformsignDocUnscopedResult,
     IEformsignDocRepository,
 } from "domain/repositories/eformsign-doc.repository.interface";
 import { PrismaService } from "infrastructure/database/prisma.service";
@@ -92,6 +94,20 @@ const omitPendingEformsignDocColumns = <T extends {
     return legacyData;
 };
 
+const toUnscopedResult = (
+    documentId: string,
+    row: Parameters<typeof EformsignDocMapper.toDomain>[0] & { branchId: string | null },
+): EformsignDocUnscopedResult => {
+    try {
+        return {
+            document: EformsignDocMapper.toDomain(row),
+            branchId: row.branchId,
+        };
+    } catch (error) {
+        throw new EformsignDocMappingError(documentId, error);
+    }
+};
+
 @Injectable()
 export class SbEformsignDocRepository implements IEformsignDocRepository {
     constructor(private readonly prismaService: PrismaService) {}
@@ -102,6 +118,36 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
 
     async findByDocumentId(branchid: string, documentId: string): Promise<EformsignDocEntity | null> {
         return this.findFirstDomain({ documentId: documentId, branchId: branchid });
+    }
+
+    async findByDocumentIdUnscoped(documentId: string): Promise<EformsignDocUnscopedResult | null> {
+        try {
+            const doc = await this.prismaService.eformsign_doc.findUnique({
+                where: { documentId },
+            });
+            return doc ? toUnscopedResult(documentId, doc) : null;
+        } catch (error) {
+            if (error instanceof EformsignDocMappingError) {
+                throw error;
+            }
+            if (!isPendingEformsignDocColumnError(error)) {
+                throw error;
+            }
+
+            const doc = await this.prismaService.eformsign_doc.findUnique({
+                where: { documentId },
+                select: {
+                    ...EFORMSIGN_DOC_COMPAT_READ_SELECT,
+                    branchId: true,
+                },
+            });
+            return doc
+                ? toUnscopedResult(documentId, {
+                    ...toCompatDomainRow(doc),
+                    branchId: doc.branchId,
+                })
+                : null;
+        }
     }
 
     async findBranchIdByDocumentId(documentId: string): Promise<string | null> {
@@ -348,60 +394,90 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
     }
 
     async upsertByDocumentId(branchid: string, doc: EformsignDocEntity): Promise<EformsignDocEntity> {
-        const createData = {
+        const existingOwner = await this.prismaService.eformsign_doc.findUnique({
+            where: { documentId: doc.documentId },
+            select: { branchId: true },
+        });
+        if (existingOwner?.branchId && existingOwner.branchId !== branchid) {
+            throw new Error(`Eformsign document ${doc.documentId} belongs to another branch`);
+        }
+
+        const create = {
             ...EformsignDocMapper.toPrismaCreate(doc),
             branchId: branchid,
         };
-        const existing = await this.prismaService.eformsign_doc.findFirst({
-            where: { documentId: doc.documentId, branchId: branchid },
-            select: { id: true },
-        });
-        if (existing) {
-            const updateData = {
-                ...EformsignDocMapper.toPrismaUpdate(doc),
-                branchId: branchid,
-            };
-            let result: Prisma.BatchPayload;
-
-            try {
-                result = await this.prismaService.eformsign_doc.updateMany({
-                    where: { id: existing.id, branchId: branchid },
-                    data: updateData,
-                });
-            } catch (error) {
-                if (!isPendingEformsignDocColumnError(error)) {
-                    throw error;
-                }
-
-                result = await this.prismaService.eformsign_doc.updateMany({
-                    where: { id: existing.id, branchId: branchid },
-                    data: omitPendingEformsignDocColumns(updateData),
-                });
-            }
-
-            if (result.count === 0) {
-                throw new Error("Eformsign doc not found for branch");
-            }
-            const updated = await this.findFirstDomain({ id: existing.id, branchId: branchid });
-            if (!updated) {
-                throw new Error("Eformsign doc not found after update");
-            }
-            return updated;
-        }
+        const update: Partial<ReturnType<typeof EformsignDocMapper.toPrismaUpdate>> & {
+            branchId: string;
+        } = {
+            ...EformsignDocMapper.toPrismaUpdate(doc),
+            branchId: branchid,
+        };
+        delete update.documentId;
 
         try {
-            const created = await this.prismaService.eformsign_doc.create({ data: createData });
-            return EformsignDocMapper.toDomain(created);
+            const upserted = await this.prismaService.eformsign_doc.upsert({
+                where: { documentId: doc.documentId },
+                create,
+                update,
+            });
+            return EformsignDocMapper.toDomain(upserted);
         } catch (error) {
             if (!isPendingEformsignDocColumnError(error)) {
                 throw error;
             }
 
-            const created = await this.prismaService.eformsign_doc.create({
-                data: omitPendingEformsignDocColumns(createData),
+            const upserted = await this.prismaService.eformsign_doc.upsert({
+                where: { documentId: doc.documentId },
+                create: omitPendingEformsignDocColumns(create),
+                update: omitPendingEformsignDocColumns(update),
                 select: EFORMSIGN_DOC_COMPAT_READ_SELECT,
             });
-            return EformsignDocMapper.toDomain(toCompatDomainRow(created));
+            return EformsignDocMapper.toDomain(toCompatDomainRow(upserted));
+        }
+    }
+
+    async upsertUnassignedByDocumentId(doc: EformsignDocEntity): Promise<EformsignDocEntity> {
+        const documentName = doc.documentName?.trim() || undefined;
+        const documentNumber = doc.documentNumber?.trim() || undefined;
+        const templateId = doc.templateId?.trim() || undefined;
+        const create = {
+            ...EformsignDocMapper.toPrismaCreate(doc),
+            documentName: documentName ?? null,
+            documentNumber: documentNumber ?? null,
+            templateId: templateId ?? null,
+            branchId: null,
+        };
+        const update = {
+            statusType: doc.statusType,
+            statusDetail: doc.statusDetail,
+            stepType: doc.stepType,
+            stepIndex: doc.stepIndex,
+            stepName: doc.stepName,
+            expired: doc.expired,
+            updatedDate: doc.updatedDate,
+            ...(documentName ? { documentName } : {}),
+            ...(templateId ? { templateId } : {}),
+        };
+
+        try {
+            const upserted = await this.prismaService.eformsign_doc.upsert({
+                where: { documentId: doc.documentId },
+                create,
+                update,
+            });
+            return EformsignDocMapper.toDomain(upserted);
+        } catch (error) {
+            if (!isPendingEformsignDocColumnError(error)) {
+                throw error;
+            }
+
+            const upserted = await this.prismaService.eformsign_doc.upsert({
+                where: { documentId: doc.documentId },
+                create: omitPendingEformsignDocColumns(create),
+                update: omitPendingEformsignDocColumns(update),
+                select: EFORMSIGN_DOC_COMPAT_READ_SELECT,
+            });
+            return EformsignDocMapper.toDomain(toCompatDomainRow(upserted));
         }
     }
 

--- a/backend/module/eformsign-doc.module.ts
+++ b/backend/module/eformsign-doc.module.ts
@@ -20,6 +20,7 @@ import {
     DispatchDocumentHeadlessUsecase,
     FinalizeDocumentHeadlessUsecase,
     AdoptEformsignDocUsecase,
+    MirrorUnassignedEformsignDocUsecase,
 } from "application/usecases/eformsign-doc";
 import { EFORMSIGN_DOC_REPOSITORY } from "domain/repositories/eformsign-doc.repository.interface";
 import { EFORMSIGN_CLIENT_REPOSITORY } from "domain/repositories/eformsign.client.interface";
@@ -68,6 +69,7 @@ import { EformsignDocumentSnapshotService } from "application/services/eformsign
         DispatchDocumentHeadlessUsecase,
         FinalizeDocumentHeadlessUsecase,
         AdoptEformsignDocUsecase,
+        MirrorUnassignedEformsignDocUsecase,
         // Services
         EformsignDocService,
         EformsignService,
@@ -100,6 +102,7 @@ import { EformsignDocumentSnapshotService } from "application/services/eformsign
         EFORMSIGN_DOC_REPOSITORY,
         CreateAndSendServiceRecordSnapshotUsecase,
         EformsignDocumentSnapshotService,
+        MirrorUnassignedEformsignDocUsecase,
     ],
 })
 export class EformsignDocModule {}

--- a/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
@@ -47,6 +47,7 @@ describe("SbEformsignDocRepository", () => {
         updateMany: jest.fn(),
         deleteMany: jest.fn(),
         findUnique: jest.fn(),
+        upsert: jest.fn(),
     });
 
     let eformsignDocModel: ReturnType<typeof createMockPrismaEformsignDoc>;
@@ -126,6 +127,28 @@ describe("SbEformsignDocRepository", () => {
         expect(result?.documentKind).toBe("service_record_snapshot");
     });
 
+    it("finds a document without adding branchId to the unique where clause", async () => {
+        eformsignDocModel.findUnique.mockResolvedValue({
+            ...legacyRow,
+            branchId: null,
+            clientId: null,
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: "template-1",
+            documentName: "외부 문서",
+            documentNumber: "DOC-001",
+        });
+
+        const result = await repository.findByDocumentIdUnscoped("doc-1");
+
+        expect(eformsignDocModel.findUnique).toHaveBeenCalledWith({
+            where: { documentId: "doc-1" },
+        });
+        expect(eformsignDocModel.findUnique.mock.calls[0][0].where).not.toHaveProperty("branchId");
+        expect(result?.branchId).toBeNull();
+        expect(result?.document.documentName).toBe("외부 문서");
+    });
+
     it("loads page display fields with one branch-scoped query", async () => {
         eformsignDocModel.findMany.mockResolvedValue([
             {
@@ -191,26 +214,210 @@ describe("SbEformsignDocRepository", () => {
         expect(result.statusType).toBe("050");
     });
 
-    it("preserves stored document metadata when upserting without documentName", async () => {
-        eformsignDocModel.findFirst
-            .mockResolvedValueOnce({ id: 1 })
-            .mockResolvedValueOnce({
-                ...legacyRow,
-                documentKind: null,
-                employeeScheduleId: null,
-                templateId: null,
-                documentName: "기존 문서명",
-                documentNumber: "DOC-001",
-            });
-        eformsignDocModel.updateMany.mockResolvedValue({ count: 1 });
+    it("adopts an unassigned row for the branch without creating a duplicate", async () => {
+        eformsignDocModel.findUnique.mockResolvedValue({ branchId: null });
+        eformsignDocModel.upsert.mockResolvedValue({
+            ...legacyRow,
+            branchId: "branch-1",
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: null,
+            documentName: "기존 문서명",
+            documentNumber: "DOC-001",
+        });
 
         const result = await repository.upsertByDocumentId("branch-1", createEntity());
 
-        const updateData = eformsignDocModel.updateMany.mock.calls[0][0].data;
+        expect(eformsignDocModel.upsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { documentId: "doc-1" },
+                update: expect.objectContaining({ branchId: "branch-1" }),
+            }),
+        );
+        expect(eformsignDocModel.create).not.toHaveBeenCalled();
+        expect(result.documentName).toBe("기존 문서명");
+    });
+
+    it("preserves stored document metadata when adopting without a name or number", async () => {
+        eformsignDocModel.findUnique.mockResolvedValue({ branchId: null });
+        eformsignDocModel.upsert.mockResolvedValue({
+            ...legacyRow,
+            branchId: "branch-1",
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: null,
+            documentName: "기존 문서명",
+            documentNumber: "DOC-001",
+        });
+
+        const result = await repository.upsertByDocumentId("branch-1", createEntity());
+
+        const updateData = eformsignDocModel.upsert.mock.calls[0][0].update;
+        expect(updateData).not.toHaveProperty("documentId");
         expect(updateData).not.toHaveProperty("documentName");
         expect(updateData).not.toHaveProperty("documentNumber");
         expect(result.documentName).toBe("기존 문서명");
         expect(result.documentNumber).toBe("DOC-001");
+    });
+
+    it("creates a branch-owned row through the documentId upsert when no local row exists", async () => {
+        eformsignDocModel.findUnique.mockResolvedValue(null);
+        eformsignDocModel.upsert.mockResolvedValue({
+            ...legacyRow,
+            branchId: "branch-1",
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: null,
+            documentName: null,
+            documentNumber: null,
+        });
+
+        await repository.upsertByDocumentId("branch-1", createEntity());
+
+        expect(eformsignDocModel.upsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { documentId: "doc-1" },
+                create: expect.objectContaining({
+                    documentId: "doc-1",
+                    branchId: "branch-1",
+                }),
+            }),
+        );
+        expect(eformsignDocModel.create).not.toHaveBeenCalled();
+    });
+
+    it("updates an existing row owned by the same branch through the documentId upsert", async () => {
+        eformsignDocModel.findUnique.mockResolvedValue({ branchId: "branch-1" });
+        eformsignDocModel.upsert.mockResolvedValue({
+            ...legacyRow,
+            branchId: "branch-1",
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: null,
+            documentName: null,
+            documentNumber: null,
+        });
+
+        await repository.upsertByDocumentId("branch-1", createEntity());
+
+        expect(eformsignDocModel.upsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { documentId: "doc-1" },
+                update: expect.objectContaining({
+                    branchId: "branch-1",
+                    statusType: "050",
+                }),
+            }),
+        );
+        expect(eformsignDocModel.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("retries the documentId upsert without pending columns", async () => {
+        eformsignDocModel.findUnique.mockResolvedValue({ branchId: null });
+        eformsignDocModel.upsert
+            .mockRejectedValueOnce(pendingColumnError)
+            .mockResolvedValueOnce(legacyRow);
+
+        await repository.upsertByDocumentId("branch-1", createEntity());
+
+        const retry = eformsignDocModel.upsert.mock.calls[1][0];
+        expect(retry).toEqual(expect.objectContaining({
+            where: { documentId: "doc-1" },
+            select: expect.objectContaining({ documentId: true }),
+        }));
+        expect(retry.create).not.toHaveProperty("documentKind");
+        expect(retry.create).not.toHaveProperty("employeeScheduleId");
+        expect(retry.update).not.toHaveProperty("documentId");
+        expect(retry.update).not.toHaveProperty("documentKind");
+        expect(retry.update).not.toHaveProperty("employeeScheduleId");
+    });
+
+    it("does not transfer a document already owned by another branch", async () => {
+        eformsignDocModel.findUnique.mockResolvedValue({ branchId: "branch-2" });
+
+        await expect(
+            repository.upsertByDocumentId("branch-1", createEntity()),
+        ).rejects.toThrow("belongs to another branch");
+
+        expect(eformsignDocModel.upsert).not.toHaveBeenCalled();
+    });
+
+    it("atomically upserts an unassigned document by documentId and only updates status fields", async () => {
+        eformsignDocModel.upsert.mockResolvedValue({
+            ...legacyRow,
+            branchId: null,
+            clientId: null,
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: "template-1",
+            documentName: "외부 문서",
+            documentNumber: "DOC-001",
+        });
+        const doc = EformsignDocEntity.reconstitute({
+            ...legacyRow,
+            clientId: null,
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: "template-1",
+            documentName: "외부 문서",
+            documentNumber: "DOC-001",
+        });
+
+        await repository.upsertUnassignedByDocumentId(doc);
+
+        const args = eformsignDocModel.upsert.mock.calls[0][0];
+        expect(args.where).toEqual({ documentId: "doc-1" });
+        expect(args.where).not.toHaveProperty("branchId");
+        expect(args.create).toEqual(expect.objectContaining({
+            documentId: "doc-1",
+            branchId: null,
+            clientId: null,
+            documentKind: null,
+        }));
+        expect(args.update).toEqual({
+            statusType: "050",
+            statusDetail: "완료",
+            stepType: "05",
+            stepIndex: "1",
+            stepName: "이용자",
+            expired: false,
+            updatedDate: legacyRow.updatedDate,
+            documentName: "외부 문서",
+            templateId: "template-1",
+        });
+        expect(args.update).not.toHaveProperty("branchId");
+        expect(args.update).not.toHaveProperty("clientId");
+        expect(args.update).not.toHaveProperty("documentKind");
+        expect(args.update).not.toHaveProperty("expiredDate");
+        expect(args.update).not.toHaveProperty("stepRecipientName");
+    });
+
+    it("omits blank optional metadata when updating an unassigned document", async () => {
+        eformsignDocModel.upsert.mockResolvedValue({
+            ...legacyRow,
+            branchId: null,
+            clientId: null,
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: null,
+            documentName: "기존 문서명",
+            documentNumber: null,
+        });
+        const doc = EformsignDocEntity.reconstitute({
+            ...legacyRow,
+            clientId: null,
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: "   ",
+            documentName: "   ",
+            documentNumber: null,
+        });
+
+        await repository.upsertUnassignedByDocumentId(doc);
+
+        const update = eformsignDocModel.upsert.mock.calls[0][0].update;
+        expect(update).not.toHaveProperty("documentName");
+        expect(update).not.toHaveProperty("templateId");
     });
 
     it.each(["", "   "])(

--- a/backend/test/services/eformsign-webhook-service-record-gate.spec.ts
+++ b/backend/test/services/eformsign-webhook-service-record-gate.spec.ts
@@ -27,6 +27,7 @@ function makeService() {
         eformsignDocRepository,
         employeeScheduleRepository: {},
         employeeRepository: {},
+        mirrorUnassignedDocUsecase: { execute: jest.fn() },
     };
     const service = new EformsignWebhookService(
         deps.updateStatusUsecase as any,
@@ -39,6 +40,7 @@ function makeService() {
         deps.eformsignDocRepository as any,
         deps.employeeScheduleRepository as any,
         deps.employeeRepository as any,
+        deps.mirrorUnassignedDocUsecase as any,
     );
     // Isolate the units downstream of the gate so the test targets the gate decision only.
     const handleCompleted = jest.spyOn(service as any, "handleCompletedDocument").mockResolvedValue(undefined);

--- a/backend/test/services/eformsign-webhook.service.spec.ts
+++ b/backend/test/services/eformsign-webhook.service.spec.ts
@@ -1,6 +1,7 @@
 import { EformsignWebhookService } from "application/services/eformsign-webhook.service";
 import { LinkDocumentToClientUsecase } from "application/usecases/eformsign-doc/link-document-to-client.usecase";
 import { UpdateEformsignDocStatusUsecase } from "application/usecases/eformsign-doc/update-eformsign-doc-status.usecase";
+import { EformsignDocMappingError } from "domain/repositories/eformsign-doc.repository.interface";
 import { ClientEntity } from "domain/entities/client.entity";
 import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
 import { EformsignDocMapper } from "infrastructure/database/mapper/eformsign-doc.mapper";
@@ -13,6 +14,7 @@ describe("EformsignWebhookService", () => {
     const createDocEntity = (overrides: Partial<{
         clientId: number | null;
         documentName: string | null;
+        statusType: string;
     }> = {}): EformsignDocEntity =>
         EformsignDocEntity.reconstitute({
             id: 1,
@@ -20,7 +22,7 @@ describe("EformsignWebhookService", () => {
             documentName: overrides.documentName ?? null,
             createdDate: new Date("2026-05-01T00:00:00.000Z"),
             updatedDate: new Date("2026-05-02T00:00:00.000Z"),
-            statusType: "060",
+            statusType: overrides.statusType ?? "060",
             statusDetail: "서명 요청됨",
             stepType: "06",
             stepIndex: "3",
@@ -110,9 +112,14 @@ describe("EformsignWebhookService", () => {
     };
     const eformsignDocRepository = {
         findByDocumentId: jest.fn(),
+        findByDocumentIdUnscoped: jest.fn(),
         findBranchIdByDocumentId: jest.fn(),
         claimCompletionStatus: jest.fn(),
+        upsertUnassignedByDocumentId: jest.fn(),
         update: jest.fn(),
+    };
+    const mirrorUnassignedDocUsecase = {
+        execute: jest.fn(),
     };
     const employeeScheduleRepository = {
         findByClientId: jest.fn(),
@@ -142,6 +149,7 @@ describe("EformsignWebhookService", () => {
             eformsignDocRepository as never,
             employeeScheduleRepository as never,
             employeeRepository as never,
+            mirrorUnassignedDocUsecase as never,
             undefined,
             serviceRecordLifecycle as never,
         );
@@ -164,9 +172,17 @@ describe("EformsignWebhookService", () => {
             },
         });
         notificationService.sendToBranchUsers.mockResolvedValue({ sent: 1, failed: 0 });
-        eformsignDocRepository.findBranchIdByDocumentId.mockResolvedValue(branchId);
+        eformsignDocRepository.findByDocumentIdUnscoped.mockResolvedValue({
+            document: createDocEntity(),
+            branchId,
+        });
         eformsignDocRepository.findByDocumentId.mockResolvedValue(createDocEntity());
+        eformsignDocRepository.findBranchIdByDocumentId.mockResolvedValue(branchId);
         eformsignDocRepository.claimCompletionStatus.mockResolvedValue("claimed");
+        eformsignDocRepository.upsertUnassignedByDocumentId.mockImplementation(
+            (doc: EformsignDocEntity) => Promise.resolve(doc),
+        );
+        mirrorUnassignedDocUsecase.execute.mockResolvedValue(createDocEntity({ clientId: null }));
         clientRepository.findById.mockResolvedValue(createClientEntity());
         employeeScheduleRepository.findByClientId.mockResolvedValue([]);
         employeeRepository.findById.mockResolvedValue(null);
@@ -206,7 +222,7 @@ describe("EformsignWebhookService", () => {
     it("should resolve the branch from the local document before processing webhook status", async () => {
         await expect(service.processWebhook(createDocumentPayload())).resolves.toBeUndefined();
 
-        expect(eformsignDocRepository.findBranchIdByDocumentId).toHaveBeenCalledWith(documentId);
+        expect(eformsignDocRepository.findByDocumentIdUnscoped).toHaveBeenCalledWith(documentId);
         expect(eformsignDocRepository.claimCompletionStatus).toHaveBeenCalledWith(
             branchId,
             expect.objectContaining({
@@ -214,6 +230,170 @@ describe("EformsignWebhookService", () => {
                 documentName: "산모신생아건강관리서비스 계약서",
             }),
         );
+    });
+
+    it("mirrors a missing document without running branch-owned side effects", async () => {
+        eformsignDocRepository.findByDocumentIdUnscoped.mockResolvedValue(null);
+
+        await expect(service.processWebhook(createDocumentPayload())).resolves.toBeUndefined();
+
+        expect(mirrorUnassignedDocUsecase.execute).toHaveBeenCalledWith(documentId);
+        expect(eformsignDocRepository.claimCompletionStatus).not.toHaveBeenCalled();
+        expect(updateStatusUsecase.execute).not.toHaveBeenCalled();
+        expect(linkDocumentUsecase.execute).not.toHaveBeenCalled();
+        expect(syncClientEndDateUsecase.execute).not.toHaveBeenCalled();
+        expect(notificationService.sendToBranchUsers).not.toHaveBeenCalled();
+        expect(eventBus.emit).not.toHaveBeenCalled();
+    });
+
+    it("updates an existing unassigned document from webhook data without an external API call", async () => {
+        eformsignDocRepository.findByDocumentIdUnscoped.mockResolvedValue({
+            document: createDocEntity({ clientId: null, documentName: "기존 문서명" }),
+            branchId: null,
+        });
+        const payload = createDocumentPayload();
+        if (!payload.document) {
+            throw new Error("document payload is required");
+        }
+        payload.document.status = "doc_request_participant";
+
+        await expect(service.processWebhook(payload)).resolves.toBeUndefined();
+
+        expect(mirrorUnassignedDocUsecase.execute).not.toHaveBeenCalled();
+        expect(eformsignApiClient.getAccessToken).not.toHaveBeenCalled();
+        expect(eformsignApiClient.getDocument).not.toHaveBeenCalled();
+        expect(eformsignDocRepository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
+            expect.objectContaining({
+                documentId,
+                statusType: "060",
+                documentName: "산모신생아건강관리서비스 계약서",
+                templateId: "template-1",
+            }),
+        );
+        expect(updateStatusUsecase.execute).not.toHaveBeenCalled();
+        expect(linkDocumentUsecase.execute).not.toHaveBeenCalled();
+        expect(syncClientEndDateUsecase.execute).not.toHaveBeenCalled();
+        expect(notificationService.sendToBranchUsers).not.toHaveBeenCalled();
+        expect(eventBus.emit).not.toHaveBeenCalled();
+    });
+
+    it("updates an existing unassigned document from ready_document_pdf without branch side effects", async () => {
+        eformsignDocRepository.findByDocumentIdUnscoped.mockResolvedValue({
+            document: createDocEntity({ clientId: null }),
+            branchId: null,
+        });
+
+        await expect(service.processWebhook(createReadyPdfPayload())).resolves.toBeUndefined();
+
+        expect(eformsignDocRepository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
+            expect.objectContaining({
+                documentId,
+                statusType: "050",
+                documentName: "산모신생아건강관리서비스 계약서",
+                templateId: "template-1",
+            }),
+        );
+        expect(eformsignDocRepository.claimCompletionStatus).not.toHaveBeenCalled();
+        expect(linkDocumentUsecase.execute).not.toHaveBeenCalled();
+        expect(syncClientEndDateUsecase.execute).not.toHaveBeenCalled();
+        expect(notificationService.sendToBranchUsers).not.toHaveBeenCalled();
+        expect(eventBus.emit).not.toHaveBeenCalled();
+    });
+
+    it("ignores a stale non-terminal webhook for a terminal unassigned document", async () => {
+        eformsignDocRepository.findByDocumentIdUnscoped.mockResolvedValue({
+            document: createDocEntity({ clientId: null, statusType: "050" }),
+            branchId: null,
+        });
+        const payload = createDocumentPayload();
+        payload.event_type = "document_action";
+        if (!payload.document) {
+            throw new Error("document payload is required");
+        }
+        payload.document.action = "doc_open_participant";
+
+        await expect(service.processWebhook(payload)).resolves.toBeUndefined();
+
+        expect(eformsignDocRepository.upsertUnassignedByDocumentId).not.toHaveBeenCalled();
+    });
+
+    it("allows a terminal to terminal transition for an unassigned document", async () => {
+        eformsignDocRepository.findByDocumentIdUnscoped.mockResolvedValue({
+            document: createDocEntity({ clientId: null, statusType: "050" }),
+            branchId: null,
+        });
+        const payload = createDocumentPayload();
+        if (!payload.document) {
+            throw new Error("document payload is required");
+        }
+        payload.document.status = "doc_decline";
+
+        await expect(service.processWebhook(payload)).resolves.toBeUndefined();
+
+        expect(eformsignDocRepository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
+            expect.objectContaining({ statusType: "080" }),
+        );
+    });
+
+    it("swallows unassigned status update failures", async () => {
+        eformsignDocRepository.findByDocumentIdUnscoped.mockResolvedValue({
+            document: createDocEntity({ clientId: null }),
+            branchId: null,
+        });
+        eformsignDocRepository.upsertUnassignedByDocumentId.mockRejectedValue(
+            new Error("write failed"),
+        );
+
+        await expect(service.processWebhook(createDocumentPayload())).resolves.toBeUndefined();
+
+        expect(eformsignDocRepository.upsertUnassignedByDocumentId).toHaveBeenCalled();
+        expect(eformsignDocRepository.claimCompletionStatus).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the branch-only lookup when a local row cannot be mapped", async () => {
+        eformsignDocRepository.findByDocumentIdUnscoped.mockRejectedValue(
+            new EformsignDocMappingError(documentId, new Error("invalid row")),
+        );
+        eformsignDocRepository.findBranchIdByDocumentId.mockResolvedValue(branchId);
+
+        await expect(service.processWebhook(createDocumentPayload())).resolves.toBeUndefined();
+
+        expect(eformsignDocRepository.findBranchIdByDocumentId).toHaveBeenCalledWith(documentId);
+        expect(eformsignDocRepository.claimCompletionStatus).toHaveBeenCalledWith(
+            branchId,
+            expect.objectContaining({ documentId }),
+        );
+    });
+
+    it("omits an unassigned document name update when webhook document_title is blank", async () => {
+        eformsignDocRepository.findByDocumentIdUnscoped.mockResolvedValue({
+            document: createDocEntity({ clientId: null, documentName: "기존 문서명" }),
+            branchId: null,
+        });
+        const payload = createDocumentPayload();
+        if (!payload.document) {
+            throw new Error("document payload is required");
+        }
+        payload.document.document_title = "   ";
+
+        await expect(service.processWebhook(payload)).resolves.toBeUndefined();
+
+        expect(eformsignDocRepository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
+            expect.objectContaining({ documentName: null }),
+        );
+    });
+
+    it("swallows external API failures while mirroring a missing document", async () => {
+        eformsignDocRepository.findByDocumentIdUnscoped.mockResolvedValue(null);
+        mirrorUnassignedDocUsecase.execute.mockRejectedValue(new Error("rate limited"));
+
+        await expect(service.processWebhook(createDocumentPayload())).resolves.toBeUndefined();
+
+        expect(mirrorUnassignedDocUsecase.execute).toHaveBeenCalledWith(documentId);
+        expect(updateStatusUsecase.execute).not.toHaveBeenCalled();
+        expect(linkDocumentUsecase.execute).not.toHaveBeenCalled();
+        expect(syncClientEndDateUsecase.execute).not.toHaveBeenCalled();
+        expect(eventBus.emit).not.toHaveBeenCalled();
     });
 
     it("should keep processing document events when sync throws", async () => {
@@ -329,7 +509,10 @@ describe("EformsignWebhookService", () => {
             documentName: "기존 문서명",
         });
         const statefulDocRepository = {
-            findBranchIdByDocumentId: jest.fn().mockResolvedValue(branchId),
+            findByDocumentIdUnscoped: jest.fn().mockImplementation(() => Promise.resolve({
+                document: storedDoc,
+                branchId,
+            })),
             findByDocumentId: jest.fn().mockImplementation(() => Promise.resolve(storedDoc)),
             update: jest.fn().mockImplementation((_branchid, doc: EformsignDocEntity) => {
                 const storedId = storedDoc.id;
@@ -368,6 +551,7 @@ describe("EformsignWebhookService", () => {
             statefulDocRepository as never,
             employeeScheduleRepository as never,
             employeeRepository as never,
+            mirrorUnassignedDocUsecase as never,
         );
         const payload = createDocumentPayload();
         if (!payload.document) {
@@ -480,6 +664,7 @@ describe("EformsignWebhookService", () => {
             eformsignDocRepository as never,
             employeeScheduleRepository as never,
             employeeRepository as never,
+            mirrorUnassignedDocUsecase as never,
             undefined,
             serviceRecordLifecycle as never,
         );

--- a/backend/test/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.spec.ts
@@ -1,0 +1,186 @@
+import { Logger } from "@nestjs/common";
+
+import { MirrorUnassignedEformsignDocUsecase } from "application/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase";
+import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
+
+describe("MirrorUnassignedEformsignDocUsecase", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("fetches one remote document and persists it with unassigned defaults", async () => {
+        const getAccessTokenUsecase = {
+            execute: jest.fn().mockResolvedValue({
+                oauth_token: { access_token: "access-token" },
+            }),
+        };
+        const fetchEformsignDocFromApiUsecase = {
+            execute: jest.fn().mockResolvedValue({
+                id: "remote-doc",
+                document_number: "DOC-2026-001",
+                document_name: "외부 생성 계약서",
+                created_date: Date.parse("2026-07-01T01:00:00.000Z"),
+                updated_date: Date.parse("2026-07-02T02:00:00.000Z"),
+                template: { id: "template-1", name: "계약서" },
+                current_status: {
+                    status_type: "060",
+                    status_doc_detail: "서명 요청됨",
+                    step_type: "",
+                    step_index: "",
+                    step_name: "",
+                    step_recipients: [],
+                    expired_date: 0,
+                    _expired: false,
+                },
+            }),
+        };
+        const repository = {
+            upsertUnassignedByDocumentId: jest.fn(
+                (doc: EformsignDocEntity) => Promise.resolve(doc),
+            ),
+        };
+        const now = Date.parse("2026-07-03T00:00:00.000Z");
+        jest.spyOn(Date, "now").mockReturnValue(now);
+        const usecase = new MirrorUnassignedEformsignDocUsecase(
+            getAccessTokenUsecase as never,
+            fetchEformsignDocFromApiUsecase as never,
+            repository as never,
+        );
+
+        const result = await usecase.execute("webhook-doc");
+
+        expect(getAccessTokenUsecase.execute).toHaveBeenCalledWith(now);
+        expect(fetchEformsignDocFromApiUsecase.execute).toHaveBeenCalledWith(
+            "access-token",
+            "webhook-doc",
+        );
+        expect(repository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
+            expect.objectContaining({
+                documentId: "remote-doc",
+                clientId: null,
+                documentKind: null,
+                documentName: "외부 생성 계약서",
+                documentNumber: "DOC-2026-001",
+                templateId: "template-1",
+                createdDate: new Date("2026-07-01T01:00:00.000Z"),
+                updatedDate: new Date("2026-07-02T02:00:00.000Z"),
+                stepType: "01",
+                stepIndex: "1",
+                stepName: "서명 요청",
+                stepRecipientType: "01",
+                stepRecipientName: "외부 생성 계약서",
+                stepRecipientSms: "미확인",
+                expiredDate: new Date(now + 30 * 24 * 60 * 60 * 1000),
+            }),
+        );
+        expect(result.documentId).toBe("remote-doc");
+    });
+
+    it("falls back to updated_date when remote created_date is invalid", async () => {
+        const updatedDate = Date.parse("2026-07-02T02:00:00.000Z");
+        const getAccessTokenUsecase = {
+            execute: jest.fn().mockResolvedValue({
+                oauth_token: { access_token: "access-token" },
+            }),
+        };
+        const fetchEformsignDocFromApiUsecase = {
+            execute: jest.fn().mockResolvedValue({
+                id: "remote-doc",
+                document_number: null,
+                document_name: "외부 생성 계약서",
+                created_date: undefined,
+                updated_date: updatedDate,
+                template: { id: "template-1", name: "계약서" },
+                current_status: {
+                    status_type: "060",
+                    status_doc_detail: "서명 요청됨",
+                    step_type: "01",
+                    step_index: "1",
+                    step_name: "서명 요청",
+                    step_recipients: [],
+                    expired_date: 0,
+                    _expired: false,
+                },
+            }),
+        };
+        const repository = {
+            upsertUnassignedByDocumentId: jest.fn(
+                (doc: EformsignDocEntity) => Promise.resolve(doc),
+            ),
+        };
+        const warn = jest.spyOn(Logger.prototype, "warn").mockImplementation();
+        const usecase = new MirrorUnassignedEformsignDocUsecase(
+            getAccessTokenUsecase as never,
+            fetchEformsignDocFromApiUsecase as never,
+            repository as never,
+        );
+
+        await expect(usecase.execute("webhook-doc")).resolves.toBeDefined();
+
+        expect(repository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
+            expect.objectContaining({
+                createdDate: new Date(updatedDate),
+                updatedDate: new Date(updatedDate),
+            }),
+        );
+        expect(warn).toHaveBeenCalledWith(
+            expect.stringContaining("remote-doc"),
+        );
+    });
+
+    it("mirrors a document whose remote updated_date precedes its created_date", async () => {
+        // The entity rejects updatedDate < createdDate, and processWebhook swallows a
+        // mirror failure, so without the clamp such a document is dropped on every
+        // webhook forever — there is no backfill yet to pick it back up.
+        const createdDate = Date.parse("2026-07-03T05:00:00.000Z");
+        const updatedDate = Date.parse("2026-07-03T04:00:00.000Z");
+        const getAccessTokenUsecase = {
+            execute: jest.fn().mockResolvedValue({
+                oauth_token: { access_token: "access-token" },
+            }),
+        };
+        const fetchEformsignDocFromApiUsecase = {
+            execute: jest.fn().mockResolvedValue({
+                id: "reversed-doc",
+                document_number: null,
+                document_name: "외부 생성 계약서",
+                created_date: createdDate,
+                updated_date: updatedDate,
+                template: { id: "template-1", name: "계약서" },
+                current_status: {
+                    status_type: "060",
+                    status_doc_detail: "서명 요청됨",
+                    step_type: "01",
+                    step_index: "1",
+                    step_name: "서명 요청",
+                    step_recipients: [],
+                    expired_date: 0,
+                    _expired: false,
+                },
+            }),
+        };
+        const repository = {
+            upsertUnassignedByDocumentId: jest.fn(
+                (doc: EformsignDocEntity) => Promise.resolve(doc),
+            ),
+        };
+        const warn = jest.spyOn(Logger.prototype, "warn").mockImplementation();
+        const usecase = new MirrorUnassignedEformsignDocUsecase(
+            getAccessTokenUsecase as never,
+            fetchEformsignDocFromApiUsecase as never,
+            repository as never,
+        );
+
+        await expect(usecase.execute("webhook-doc")).resolves.toBeDefined();
+
+        expect(repository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
+            expect.objectContaining({
+                createdDate: new Date(createdDate),
+                updatedDate: new Date(createdDate),
+            }),
+        );
+        expect(warn).toHaveBeenCalledWith(
+            expect.stringContaining("reversed-doc"),
+        );
+    });
+});


### PR DESCRIPTION
## 무엇을 하나

BJJ-288 1b단계. 로컬에 행이 없는 문서의 웹훅은 **통째로 버려지고 있어서**, 우리 시스템 밖에서 생긴 문서는 영원히 미러에 들어올 수 없었습니다. 인천 본사 목록은 "회사 전체 − 다른 지점 소유분"이라 우리 DB에 없는 문서까지 포함하므로, 미러 전환 시 그 문서들이 통째로 사라집니다.

**조회 경로는 손대지 않았습니다.** 저장만 늘리므로 이 PR로 화면 동작이 바뀌지 않습니다.

## 설계 — `branchId` 타입을 넓히지 않은 이유

`resolvedBranchId` 를 `string | null` 로 넓히는 건 **5개 파일 33개 메서드 시그니처와 26곳 이상의 Prisma where 절**을 건드립니다. 그런데 지점 미지정 문서에는 그 부수효과들(알림 발송, 고객 연결, 종료일 동기화, 제공기록지 스냅샷 집계)이 **애초에 의미가 없고, 지금도 아무 처리를 받지 않습니다.**

그래서 미러링 전용 좁은 경로를 따로 냈습니다:

| 상태 | 처리 | 외부 API |
|---|---|---|
| 로컬 행 없음 | 외부 단건 조회 → `branchId=null` 로 생성 → 부수효과 없이 종료 | 문서 생애당 1회 |
| 행 있고 `branchId=null` | 웹훅 페이로드만으로 상태 필드 갱신 → 부수효과 없이 종료 | 0회 |
| `branchId` 있음 | **기존 경로 그대로** | 변화 없음 |

`branchId` 는 이미 nullable 이고, 지점 미지정 행은 이미 인천 본사 목록에만 포함되도록 처리돼 있어(`eformsign.controller.ts:678-688`) 현재 의미론과 정확히 일치합니다. **스키마 변경 없음.**

미러링 실패는 던지지 않고 로그만 남깁니다 — 웹훅 컨트롤러가 실패 시 503을 돌려 eformsign 재시도를 유도하는데, 소유하지도 않은 문서로 재시도 루프에 빠지면 안 되기 때문입니다.

## 리뷰에서 잡힌 MAJOR 2건 (반영됨)

**1. `upsertByDocumentId` 가 P2002로 채택을 깨뜨렸습니다.** 존재 확인을 `where: { documentId, branchId }` 로 **지점 스코프**로 하는데 unique 제약은 `documentId` **단독**(`schema.prisma:167`)이라, 지점 미지정 행이 있으면 조회가 빗나가 `create` 로 떨어져 **P2002** 가 났습니다.

1b는 웹훅을 받은 외부 문서마다 그런 행을 만듭니다. 그런데 **채택 대상이 정확히 그 문서들**이라 채택이 확률이 아니라 **결정적으로** 실패합니다. 게다가 계약 생성이 웹훅과 레이스로 실패했을 때 UI가 쓰는 복구 경로가 바로 그 채택이라(`ContractCreationForm.tsx:855-865`) 복구까지 함께 막힙니다.

→ `documentId` 기준 Prisma `upsert` 로 바꾸고, 지점 미지정 행은 해당 지점 것으로 **채택**하며, 다른 지점이 이미 소유한 행만 거부합니다.

**2. 지점 미지정 갱신에 stale downgrade 보호가 없었습니다.** 웹훅은 순서를 보장하지 않고, 컨트롤러가 실패 시 503으로 재시도를 유도하도록 **설계돼 있어** 늦은 재전송은 내장 동작입니다. 완료된 문서에 늦게 도착한 진행중 웹훅 하나면 상태가 되돌아갑니다.

→ 기존 경로의 `TERMINAL_STATUS_CODES` 를 공유 상수로 빼서 같은 가드를 적용했습니다(값 동일, terminal → terminal 전이 허용도 동일).

## 그 외 반영

- 지점 미지정 갱신 경로에도 try/catch (미러 생성 경로와 대칭) — 형제 경로만 503을 유발하던 비대칭 제거
- `findLocalDocument` 가 매핑 실패와 저장소 오류를 구분하고, 매핑 실패 시 지점 조회로 폴백해 **지점 보유 문서의 웹훅이 조용히 유실되지 않도록** 함
- `created_date`/`updated_date` 방어. 특히 `updatedDate < createdDate` 클램프가 없으면 엔티티 불변식에서 throw → 삼켜짐 → **그 문서는 영구 미러링 실패**로 남습니다(백필이 아직 없어 회복 수단 없음). 웹훅 경로에 이미 있던 방어를 맞췄습니다

## 검증

- `npx tsc --noEmit` exit 0
- Jest **167 suites / 1714 passed / 8 skipped** (dev 기준선 1702에서 신규 12개, 회귀 0)
- ESLint 신규 에러 0
- 새 리포지토리 메서드의 `where` 절에 `branchId` 없음, `upsertUnassignedByDocumentId` 는 Prisma 네이티브 `INSERT ... ON CONFLICT DO UPDATE` 조건을 만족해 동시 호출에 안전

## 후속으로 남긴 것

- `upsertUnassignedByDocumentId` 가 미러 조회 중 새로 생긴 지점 보유 행도 갱신할 수 있음(소유권·연결은 보존되고 창이 ~1초라 실질 위험 낮음)
- 채택 시 `createdDate` 가 채택 시각으로 덮임 — 매퍼의 기존 동작이지만 4단계 정렬에서 드러남
- 미러 fetch 가 지속 실패하는 문서는 백오프·네거티브 캐시 없이 웹훅마다 2콜 반복

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG