### PR TITLE
feat(backend): reconcile the document mirror on a schedule (BJJ-288 C)

### DIFF
--- a/backend/application/services/eformsign-doc-reconcile-scheduler.service.ts
+++ b/backend/application/services/eformsign-doc-reconcile-scheduler.service.ts
@@ -1,11 +1,7 @@
-import { Inject, Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Cron } from "@nestjs/schedule";
 
-import {
-    EFORMSIGN_DOC_REPOSITORY,
-    IEformsignDocRepository,
-} from "domain/repositories/eformsign-doc.repository.interface";
 import {
     isTransientPrismaConnectivityError,
     summarizePrismaError,
@@ -25,19 +21,24 @@ const KOREA_TIME_ZONE = "Asia/Seoul";
 
 /** The sweep pages the whole document list; give it room without letting it wedge. */
 const RECONCILE_MAX_RUN_MS = 30 * 60 * 1000;
-const EXPIRY_MAX_RUN_MS = 5 * 60 * 1000;
 const DB_COOLDOWN_MS = 5 * 60 * 1000;
+/**
+ * Nights in a row that may fail before the log stops being a warning. A sweep that
+ * cannot finish is normal once — a document moved mid-pagination, the vendor blipped.
+ * Several nights running means the mirror is drifting and nobody has noticed.
+ */
+const RECONCILE_FAILURE_ALERT_THRESHOLD = 3;
 
 /**
  * Keeps the local `eformsign_doc` mirror honest between webhooks.
  *
- * Two jobs with different costs, so they run on different clocks. The expiry flip is a
- * single conditional UPDATE and runs hourly. The reconciliation sweep re-reads every
- * document from eformsign and runs once a night, because a dropped webhook is the only
- * thing it fixes and a day of staleness is the exposure we already accept.
+ * A dropped webhook is the only thing this fixes, so it runs once a night: a day of
+ * staleness is the exposure we already carry, and the sweep re-reads every document from
+ * eformsign. Expiry comes along for free — the vendor reports status 080 — which is why
+ * there is no separate time-based pass over `expiredDate`.
  *
- * Both are off unless `EFORMSIGN_RECONCILE_ENABLED=true`. This is the phase where the
- * mirror stops being write-only, and the switch is what makes that reversible.
+ * Off unless `EFORMSIGN_RECONCILE_ENABLED=true`. This is the phase where the mirror
+ * stops being write-only, and the switch is what makes that reversible.
  */
 @Injectable()
 export class EformsignDocReconcileSchedulerService {
@@ -50,53 +51,14 @@ export class EformsignDocReconcileSchedulerService {
         maxRunMs: RECONCILE_MAX_RUN_MS,
         cooldownMs: DB_COOLDOWN_MS,
     });
-    private readonly expiryGuard = new SchedulerExecutionGuard({
-        logger: this.logger,
-        runningWarning: "[Eformsign Expiry] Previous expiry pass is still running; skipping tick",
-        staleRunError: "[Eformsign Expiry] Previous expiry pass exceeded the max runtime",
-        cooldownWarning: "[Eformsign Expiry] Database connectivity issue during the expiry pass",
-        maxRunMs: EXPIRY_MAX_RUN_MS,
-        cooldownMs: DB_COOLDOWN_MS,
-    });
     private warnedLockUnavailable = false;
+    private consecutiveFailures = 0;
 
     constructor(
         private readonly configService: ConfigService,
         private readonly backfillUsecase: BackfillEformsignDocsUsecase,
         private readonly lockService: EformsignBackfillLockService,
-        @Inject(EFORMSIGN_DOC_REPOSITORY)
-        private readonly eformsignDocRepository: IEformsignDocRepository,
     ) {}
-
-    @Cron("30 * * * *", { timeZone: KOREA_TIME_ZONE })
-    async markExpiredDocuments(): Promise<void> {
-        if (!this.isEnabled()) {
-            return;
-        }
-
-        const runToken = this.expiryGuard.tryStart();
-        if (!runToken) {
-            return;
-        }
-
-        try {
-            const count = await this.eformsignDocRepository.markExpiredDocuments(new Date());
-            if (count > 0) {
-                this.logger.log(`[Eformsign Expiry] Marked ${count} documents expired`);
-            }
-        } catch (error) {
-            if (isTransientPrismaConnectivityError(error)) {
-                this.expiryGuard.enterCooldown(summarizePrismaError(error));
-                return;
-            }
-
-            this.logger.error(
-                `[Eformsign Expiry] Failed to mark expired documents: ${describeError(error)}`,
-            );
-        } finally {
-            this.expiryGuard.finish(runToken);
-        }
-    }
 
     @Cron("0 4 * * *", { timeZone: KOREA_TIME_ZONE })
     async reconcileDocuments(): Promise<void> {
@@ -111,10 +73,12 @@ export class EformsignDocReconcileSchedulerService {
 
         try {
             const summary = await this.runSweep();
+            this.consecutiveFailures = 0;
             this.logger.log(
                 "[Eformsign Reconcile] Sweep completed"
                 + ` fetched=${summary.fetched} created=${summary.created}`
-                + ` updated=${summary.updated} skipped=${summary.skipped}`,
+                + ` updated=${summary.updated} skipped=${summary.skipped}`
+                + ` duplicates=${summary.duplicates}`,
             );
         } catch (error) {
             if (error instanceof EformsignBackfillAlreadyRunningError) {
@@ -130,18 +94,35 @@ export class EformsignDocReconcileSchedulerService {
             // A sweep that fails closed — incomplete coverage, a document it could not
             // write — is telling us this run did not fully reconcile, not that anything
             // is broken. Tomorrow's run starts from whatever this one managed to land.
-            this.logger.warn(
-                `[Eformsign Reconcile] Sweep did not complete: ${describeError(error)}`,
-            );
+            // But a run that fails every night is drift nobody is watching, and this job
+            // has no other operator signal: Sentry here is filtered to service-records
+            // only, so an error-level log is the loudest thing available.
+            this.consecutiveFailures += 1;
+            const message = `[Eformsign Reconcile] Sweep did not complete`
+                + ` (${this.consecutiveFailures} in a row): ${describeError(error)}`;
+            if (this.consecutiveFailures >= RECONCILE_FAILURE_ALERT_THRESHOLD) {
+                this.logger.error(message);
+            } else {
+                this.logger.warn(message);
+            }
         } finally {
             this.reconcileGuard.finish(runToken);
         }
     }
 
     private async runSweep(): Promise<EformsignDocsBackfillSummary> {
+        // The execution guard only ages a stale token out at the *next* tick, which is a
+        // day away — it never stops a run already under way. The sweep polls this before
+        // every fetch and write, so putting the deadline here is what makes the advertised
+        // bound real rather than letting a wedged run meet tomorrow's run still alive.
+        const deadline = Date.now() + RECONCILE_MAX_RUN_MS;
+        const withinDeadline = () => Date.now() < deadline;
+
         if (this.lockService.isAvailable()) {
             return this.lockService.runExclusive((lease) =>
-                this.backfillUsecase.execute({ shouldContinue: lease.isHeld }));
+                this.backfillUsecase.execute({
+                    shouldContinue: () => withinDeadline() && lease.isHeld(),
+                }));
         }
 
         // No VALKEY_URL, so there is no cross-instance lock to take. The in-memory guard
@@ -157,7 +138,7 @@ export class EformsignDocReconcileSchedulerService {
             );
         }
 
-        return this.backfillUsecase.execute();
+        return this.backfillUsecase.execute({ shouldContinue: withinDeadline });
     }
 
     private isEnabled(): boolean {

--- a/backend/application/services/eformsign-doc-reconcile-scheduler.service.ts
+++ b/backend/application/services/eformsign-doc-reconcile-scheduler.service.ts
@@ -1,0 +1,170 @@
+import { Inject, Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Cron } from "@nestjs/schedule";
+
+import {
+    EFORMSIGN_DOC_REPOSITORY,
+    IEformsignDocRepository,
+} from "domain/repositories/eformsign-doc.repository.interface";
+import {
+    isTransientPrismaConnectivityError,
+    summarizePrismaError,
+} from "infrastructure/database/prisma-error.utils";
+import {
+    EformsignBackfillAlreadyRunningError,
+    EformsignBackfillLockService,
+} from "infrastructure/locking/eformsign-backfill-lock.service";
+
+import {
+    BackfillEformsignDocsUsecase,
+    EformsignDocsBackfillSummary,
+} from "../usecases/eformsign-doc/backfill-eformsign-docs.usecase";
+import { SchedulerExecutionGuard } from "./scheduler-execution.guard";
+
+const KOREA_TIME_ZONE = "Asia/Seoul";
+
+/** The sweep pages the whole document list; give it room without letting it wedge. */
+const RECONCILE_MAX_RUN_MS = 30 * 60 * 1000;
+const EXPIRY_MAX_RUN_MS = 5 * 60 * 1000;
+const DB_COOLDOWN_MS = 5 * 60 * 1000;
+
+/**
+ * Keeps the local `eformsign_doc` mirror honest between webhooks.
+ *
+ * Two jobs with different costs, so they run on different clocks. The expiry flip is a
+ * single conditional UPDATE and runs hourly. The reconciliation sweep re-reads every
+ * document from eformsign and runs once a night, because a dropped webhook is the only
+ * thing it fixes and a day of staleness is the exposure we already accept.
+ *
+ * Both are off unless `EFORMSIGN_RECONCILE_ENABLED=true`. This is the phase where the
+ * mirror stops being write-only, and the switch is what makes that reversible.
+ */
+@Injectable()
+export class EformsignDocReconcileSchedulerService {
+    private readonly logger = new Logger(EformsignDocReconcileSchedulerService.name);
+    private readonly reconcileGuard = new SchedulerExecutionGuard({
+        logger: this.logger,
+        runningWarning: "[Eformsign Reconcile] Previous sweep is still running; skipping tick",
+        staleRunError: "[Eformsign Reconcile] Previous sweep exceeded the max runtime",
+        cooldownWarning: "[Eformsign Reconcile] Database connectivity issue during the sweep",
+        maxRunMs: RECONCILE_MAX_RUN_MS,
+        cooldownMs: DB_COOLDOWN_MS,
+    });
+    private readonly expiryGuard = new SchedulerExecutionGuard({
+        logger: this.logger,
+        runningWarning: "[Eformsign Expiry] Previous expiry pass is still running; skipping tick",
+        staleRunError: "[Eformsign Expiry] Previous expiry pass exceeded the max runtime",
+        cooldownWarning: "[Eformsign Expiry] Database connectivity issue during the expiry pass",
+        maxRunMs: EXPIRY_MAX_RUN_MS,
+        cooldownMs: DB_COOLDOWN_MS,
+    });
+    private warnedLockUnavailable = false;
+
+    constructor(
+        private readonly configService: ConfigService,
+        private readonly backfillUsecase: BackfillEformsignDocsUsecase,
+        private readonly lockService: EformsignBackfillLockService,
+        @Inject(EFORMSIGN_DOC_REPOSITORY)
+        private readonly eformsignDocRepository: IEformsignDocRepository,
+    ) {}
+
+    @Cron("30 * * * *", { timeZone: KOREA_TIME_ZONE })
+    async markExpiredDocuments(): Promise<void> {
+        if (!this.isEnabled()) {
+            return;
+        }
+
+        const runToken = this.expiryGuard.tryStart();
+        if (!runToken) {
+            return;
+        }
+
+        try {
+            const count = await this.eformsignDocRepository.markExpiredDocuments(new Date());
+            if (count > 0) {
+                this.logger.log(`[Eformsign Expiry] Marked ${count} documents expired`);
+            }
+        } catch (error) {
+            if (isTransientPrismaConnectivityError(error)) {
+                this.expiryGuard.enterCooldown(summarizePrismaError(error));
+                return;
+            }
+
+            this.logger.error(
+                `[Eformsign Expiry] Failed to mark expired documents: ${describeError(error)}`,
+            );
+        } finally {
+            this.expiryGuard.finish(runToken);
+        }
+    }
+
+    @Cron("0 4 * * *", { timeZone: KOREA_TIME_ZONE })
+    async reconcileDocuments(): Promise<void> {
+        if (!this.isEnabled()) {
+            return;
+        }
+
+        const runToken = this.reconcileGuard.tryStart();
+        if (!runToken) {
+            return;
+        }
+
+        try {
+            const summary = await this.runSweep();
+            this.logger.log(
+                "[Eformsign Reconcile] Sweep completed"
+                + ` fetched=${summary.fetched} created=${summary.created}`
+                + ` updated=${summary.updated} skipped=${summary.skipped}`,
+            );
+        } catch (error) {
+            if (error instanceof EformsignBackfillAlreadyRunningError) {
+                this.logger.log("[Eformsign Reconcile] Another sweep holds the lock; skipping");
+                return;
+            }
+
+            if (isTransientPrismaConnectivityError(error)) {
+                this.reconcileGuard.enterCooldown(summarizePrismaError(error));
+                return;
+            }
+
+            // A sweep that fails closed — incomplete coverage, a document it could not
+            // write — is telling us this run did not fully reconcile, not that anything
+            // is broken. Tomorrow's run starts from whatever this one managed to land.
+            this.logger.warn(
+                `[Eformsign Reconcile] Sweep did not complete: ${describeError(error)}`,
+            );
+        } finally {
+            this.reconcileGuard.finish(runToken);
+        }
+    }
+
+    private async runSweep(): Promise<EformsignDocsBackfillSummary> {
+        if (this.lockService.isAvailable()) {
+            return this.lockService.runExclusive((lease) =>
+                this.backfillUsecase.execute({ shouldContinue: lease.isHeld }));
+        }
+
+        // No VALKEY_URL, so there is no cross-instance lock to take. The in-memory guard
+        // above still serialises this within the process, which is the single-instance
+        // assumption the snapshot cache already makes when Valkey is absent. Concurrent
+        // sweeps would still be safe — the mirror writes carry ownership and staleness
+        // predicates — but they would multiply the load on eformsign, so say it once.
+        if (!this.warnedLockUnavailable) {
+            this.warnedLockUnavailable = true;
+            this.logger.warn(
+                "[Eformsign Reconcile] VALKEY_URL is unset, so the sweep runs without a"
+                + " cross-instance lock. Set it to stop replicas sweeping in parallel.",
+            );
+        }
+
+        return this.backfillUsecase.execute();
+    }
+
+    private isEnabled(): boolean {
+        return this.configService.get<string>("EFORMSIGN_RECONCILE_ENABLED") === "true";
+    }
+}
+
+function describeError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/backend/application/services/eformsign-doc-reconcile-scheduler.service.ts
+++ b/backend/application/services/eformsign-doc-reconcile-scheduler.service.ts
@@ -86,11 +86,6 @@ export class EformsignDocReconcileSchedulerService {
                 return;
             }
 
-            if (isTransientPrismaConnectivityError(error)) {
-                this.reconcileGuard.enterCooldown(summarizePrismaError(error));
-                return;
-            }
-
             // A sweep that fails closed — incomplete coverage, a document it could not
             // write — is telling us this run did not fully reconcile, not that anything
             // is broken. Tomorrow's run starts from whatever this one managed to land.
@@ -98,6 +93,16 @@ export class EformsignDocReconcileSchedulerService {
             // has no other operator signal: Sentry here is filtered to service-records
             // only, so an error-level log is the loudest thing available.
             this.consecutiveFailures += 1;
+
+            if (isTransientPrismaConnectivityError(error)) {
+                // The cooldown is built for the minute-by-minute jobs; on a nightly one
+                // it has always lapsed by the next tick, so it cannot be what surfaces a
+                // database outage lasting days. The streak below is. Counting these is
+                // the whole point — an outage that never lets a sweep finish is exactly
+                // the drift the escalation exists to report.
+                this.reconcileGuard.enterCooldown(summarizePrismaError(error));
+            }
+
             const message = `[Eformsign Reconcile] Sweep did not complete`
                 + ` (${this.consecutiveFailures} in a row): ${describeError(error)}`;
             if (this.consecutiveFailures >= RECONCILE_FAILURE_ALERT_THRESHOLD) {

--- a/backend/application/services/eformsign-doc-reconcile-scheduler.service.ts
+++ b/backend/application/services/eformsign-doc-reconcile-scheduler.service.ts
@@ -12,6 +12,7 @@ import {
 } from "infrastructure/locking/eformsign-backfill-lock.service";
 
 import {
+    BackfillEformsignDocsError,
     BackfillEformsignDocsUsecase,
     EformsignDocsBackfillSummary,
 } from "../usecases/eformsign-doc/backfill-eformsign-docs.usecase";
@@ -151,6 +152,31 @@ export class EformsignDocReconcileSchedulerService {
     }
 }
 
+/**
+ * The sweep wraps a vendor failure twice — once per document type, once for the run — so
+ * the outermost message is only ever "failed for types=01". The scheduled run passes no
+ * onProgress callback, so this log is the only place the HTTP status or root exception
+ * can surface; without unwrapping, even the error-level escalation says nothing useful.
+ */
 function describeError(error: unknown): string {
-    return error instanceof Error ? error.message : String(error);
+    const messages: string[] = [];
+    const seen = new Set<unknown>();
+    const visit = (value: unknown): void => {
+        if (value === undefined || value === null || seen.has(value)) {
+            return;
+        }
+        seen.add(value);
+        if (Array.isArray(value)) {
+            value.forEach(visit);
+            return;
+        }
+
+        messages.push(value instanceof Error ? value.message : String(value));
+        if (value instanceof BackfillEformsignDocsError) {
+            visit(value.cause);
+        }
+    };
+
+    visit(error);
+    return messages.join(" <- ") || String(error);
 }

--- a/backend/application/usecases/eformsign-doc/backfill-eformsign-docs.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/backfill-eformsign-docs.usecase.ts
@@ -26,6 +26,8 @@ export interface EformsignDocsBackfillTypeSummary {
     created: number;
     updated: number;
     skipped: number;
+    /** Already mirrored by an earlier scan in the same run; see `duplicates` below. */
+    duplicates: number;
     failed: number;
     pages: number;
     error: string | null;
@@ -36,6 +38,12 @@ export interface EformsignDocsBackfillSummary {
     created: number;
     updated: number;
     skipped: number;
+    /**
+     * Documents an earlier scan in this run already mirrored. Type "04" is eformsign's
+     * document-management inbox, not a rejected-only one, so it overlaps the in-progress
+     * and completed scans — writing those rows a second time would achieve nothing.
+     */
+    duplicates: number;
     failed: number;
     pages: number;
     byDocumentType: Record<
@@ -82,6 +90,7 @@ function createTypeSummary(): EformsignDocsBackfillTypeSummary {
         created: 0,
         updated: 0,
         skipped: 0,
+        duplicates: 0,
         failed: 0,
         pages: 0,
         error: null,
@@ -119,6 +128,7 @@ export class BackfillEformsignDocsUsecase {
             created: 0,
             updated: 0,
             skipped: 0,
+            duplicates: 0,
             failed: 0,
             pages: 0,
             byDocumentType: {
@@ -188,6 +198,10 @@ export class BackfillEformsignDocsUsecase {
                     return fetchPage(limit, skip);
                 }
             };
+            // Run-level, not per-scan: the per-scan set drives pagination and the coverage
+            // check and has to stay scoped to its own type's total_rows. This one only
+            // stops us writing the same document twice because two inboxes both list it.
+            const mirroredDocumentIds = new Set<string>();
             const scanFailures: BackfillEformsignDocsError[] = [];
             for (const scan of scans) {
                 const typeSummary = summary.byDocumentType[scan.documentType];
@@ -199,6 +213,7 @@ export class BackfillEformsignDocsUsecase {
                         options,
                         summary,
                         typeSummary,
+                        mirroredDocumentIds,
                     });
                     // Swallowing a single document's write error to finish the sweep is
                     // deliberate, but the run still left the mirror incomplete and nothing
@@ -281,6 +296,7 @@ export class BackfillEformsignDocsUsecase {
         options: BackfillEformsignDocsOptions;
         summary: EformsignDocsBackfillSummary;
         typeSummary: EformsignDocsBackfillTypeSummary;
+        mirroredDocumentIds: Set<string>;
     }): Promise<void> {
         let skip = 0;
         let initialTotalRows: number | undefined;
@@ -365,6 +381,13 @@ export class BackfillEformsignDocsUsecase {
             for (const document of newDocuments) {
                 seenDocumentIds.add(document.id);
                 this.assertCanContinue(params.options, params.summary);
+                if (params.mirroredDocumentIds.has(document.id)) {
+                    params.summary.duplicates += 1;
+                    params.typeSummary.duplicates += 1;
+                    continue;
+                }
+
+                params.mirroredDocumentIds.add(document.id);
                 await this.persistDocument(document, params.summary, params.typeSummary);
             }
 

--- a/backend/application/usecases/eformsign-doc/backfill-eformsign-docs.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/backfill-eformsign-docs.usecase.ts
@@ -201,7 +201,10 @@ export class BackfillEformsignDocsUsecase {
             // Run-level, not per-scan: the per-scan set drives pagination and the coverage
             // check and has to stay scoped to its own type's total_rows. This one only
             // stops us writing the same document twice because two inboxes both list it.
-            const mirroredDocumentIds = new Set<string>();
+            // It records what each copy was worth, not just that we saw it — a document
+            // that completes mid-sweep appears again in a later inbox carrying newer
+            // state, and skipping on identity alone would throw that away.
+            const mirroredUpdatedDates = new Map<string, number>();
             const scanFailures: BackfillEformsignDocsError[] = [];
             for (const scan of scans) {
                 const typeSummary = summary.byDocumentType[scan.documentType];
@@ -213,7 +216,7 @@ export class BackfillEformsignDocsUsecase {
                         options,
                         summary,
                         typeSummary,
-                        mirroredDocumentIds,
+                        mirroredUpdatedDates,
                     });
                     // Swallowing a single document's write error to finish the sweep is
                     // deliberate, but the run still left the mirror incomplete and nothing
@@ -296,7 +299,7 @@ export class BackfillEformsignDocsUsecase {
         options: BackfillEformsignDocsOptions;
         summary: EformsignDocsBackfillSummary;
         typeSummary: EformsignDocsBackfillTypeSummary;
-        mirroredDocumentIds: Set<string>;
+        mirroredUpdatedDates: Map<string, number>;
     }): Promise<void> {
         let skip = 0;
         let initialTotalRows: number | undefined;
@@ -381,13 +384,14 @@ export class BackfillEformsignDocsUsecase {
             for (const document of newDocuments) {
                 seenDocumentIds.add(document.id);
                 this.assertCanContinue(params.options, params.summary);
-                if (params.mirroredDocumentIds.has(document.id)) {
+                const mirroredAt = params.mirroredUpdatedDates.get(document.id);
+                if (mirroredAt !== undefined && document.updated_date <= mirroredAt) {
                     params.summary.duplicates += 1;
                     params.typeSummary.duplicates += 1;
                     continue;
                 }
 
-                params.mirroredDocumentIds.add(document.id);
+                params.mirroredUpdatedDates.set(document.id, document.updated_date);
                 await this.persistDocument(document, params.summary, params.typeSummary);
             }
 

--- a/backend/application/usecases/eformsign-doc/create-and-send-service-record-snapshot.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/create-and-send-service-record-snapshot.usecase.ts
@@ -17,6 +17,7 @@ import {
     omitPendingEformsignDocColumns,
 } from "infrastructure/database/eformsign-doc-compat";
 import { PrismaService } from "infrastructure/database/prisma.service";
+import { eformsignExpiryDateFromRemainingDays } from "domain/utils/eformsign-expiry-date";
 import { captureServiceRecordError } from "infrastructure/observability/service-record-sentry";
 import { GetEformsignAccessTokenUsecase } from "./get-eformsign-access-token.usecase";
 import {
@@ -28,6 +29,8 @@ import {
     SERVICE_RECORD_TEMPLATE_SESSIONS_PER_DOCUMENT,
     SERVICE_RECORD_TEMPLATE_TIER_ENV_KEYS,
 } from "./service-record-field-ids";
+
+const SNAPSHOT_FALLBACK_EXPIRY_MS = 14 * 24 * 60 * 60 * 1000;
 
 const CASE_SNAPSHOT_INCLUDE = {
     client: { select: { name: true } },
@@ -765,9 +768,13 @@ export class CreateAndSendServiceRecordSnapshotUsecase {
         const updatedDate = params.remoteDocument?.updated_date
             ? new Date(params.remoteDocument.updated_date)
             : now;
-        const expiredDate = remoteStatus?.expired_date
-            ? new Date(remoteStatus.expired_date)
-            : new Date(Date.now() + 14 * 24 * 60 * 60 * 1000);
+        // expired_date is days remaining, not an epoch — reading it as one stored a 1970
+        // date for every document eformsign said had a few days left. Its own fallback
+        // stays 14 days: that is this path's guess for "the vendor did not say", and the
+        // shared helper's 30 is a different guess for a different caller.
+        const expiredDate = remoteStatus?.expired_date === undefined
+            ? new Date(Date.now() + SNAPSHOT_FALLBACK_EXPIRY_MS)
+            : eformsignExpiryDateFromRemainingDays(remoteStatus.expired_date, Date.now());
         const marker = `제공기록지 C${params.record.id.slice(0, 8)} V${params.record.formVersion} ${params.chunk.chunkIndex}/${params.chunk.chunkCount}`;
         const create = {
             documentId: params.documentId,

--- a/backend/application/usecases/eformsign-doc/dispatch-document-headless.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/dispatch-document-headless.usecase.ts
@@ -13,6 +13,7 @@ import { FetchAllEformsignDocsFromApiUsecase } from "./fetch-all-eformsign-docs-
 import { EformsignHeadlessProgressService } from "application/services/eformsign-headless-progress.service";
 import type { EformsignHeadlessProgressStep } from "application/services/eformsign-headless-progress.service";
 import { ContractClientAssignmentGuardService } from "application/services/contract-client-assignment-guard.service";
+import { eformsignExpiryDateFromRemainingDays } from "domain/utils/eformsign-expiry-date";
 
 const DEFAULT_DOCUMENT_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000;
 const COMPLETED_STATUS_CODES = new Set(["003", "012", "022", "032", "050", "062", "072", "092"]);
@@ -280,7 +281,10 @@ export class DispatchDocumentHeadlessUsecase {
                 stepType: currentStatus?.step_type?.trim() || fallback.stepType,
                 stepIndex: currentStatus?.step_index?.trim() || fallback.stepIndex,
                 stepName: currentStatus?.step_name?.trim() || fallback.stepName,
-                expiredDate: this.expiredDateFromEpoch(currentStatus?.expired_date) ?? fallback.expiredDate,
+                expiredDate: eformsignExpiryDateFromRemainingDays(
+                    currentStatus?.expired_date,
+                    Date.now(),
+                ),
                 templateName: document.template?.name?.trim() || undefined,
             };
         } catch (error) {
@@ -317,10 +321,4 @@ export class DispatchDocumentHeadlessUsecase {
         return stepName?.trim() || "진행중";
     }
 
-    private expiredDateFromEpoch(expiredDate: number | null | undefined): Date | null {
-        if (!expiredDate || expiredDate <= 0) {
-            return null;
-        }
-        return new Date(expiredDate);
-    }
 }

--- a/backend/application/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.ts
@@ -4,6 +4,7 @@ import { documentCustomerNameValue } from "application/utils/eformsign-document-
 import { eformsignDocumentTemplateId } from "application/utils/eformsign-document-template-id";
 import {
     EFORMSIGN_EXPIRED_STATUS_CODE,
+    EFORMSIGN_TERMINAL_STATUS_DETAILS,
     TERMINAL_STATUS_CODES,
 } from "domain/constants/eformsign-doc-status.constants";
 import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
@@ -69,6 +70,10 @@ export class MirrorUnassignedEformsignDocUsecase {
         // sweep learned the document had actually completed, and nothing would clear it.
         const knowsExpiredState = hasRemoteExpiredState
             || TERMINAL_STATUS_CODES.has(statusType);
+        // A list response carries no detail, so a document whose ending we only learn
+        // from this sweep would otherwise keep whatever it read while it was open. The
+        // status code says plainly what happened for the endings we can name.
+        const terminalStatusDetail = EFORMSIGN_TERMINAL_STATUS_DETAILS[statusType];
         const remoteUpdatedDate = new Date(remote.updated_date);
         const updatedDate = Number.isNaN(remoteUpdatedDate.getTime())
             ? new Date(now)
@@ -118,6 +123,7 @@ export class MirrorUnassignedEformsignDocUsecase {
             statusType,
             statusDetail:
                 remote.current_status.status_doc_detail
+                || terminalStatusDetail
                 || remote.current_status.step_name
                 || "진행중",
             stepType: remote.current_status.step_type.trim() || "01",
@@ -141,9 +147,16 @@ export class MirrorUnassignedEformsignDocUsecase {
             ...(options.allowAssignedUpdate ? { allowAssignedUpdate: true } : {}),
             updateListDisplayFields: true,
             ...(knowsExpiredState ? {} : { updateExpired: false }),
-            // A detail derived from the step name must not replace one a webhook wrote.
+            // A detail derived from the step name must not replace one a webhook wrote —
+            // but one derived from a terminal status code must, because the stored detail
+            // describes a state the document has already left.
             ...(remote.current_status.status_doc_detail === undefined
+                && terminalStatusDetail === undefined
                 ? { updateStatusDetail: false }
+                : {}),
+            // The list has no expired_date either, so what we computed is only a fallback.
+            ...(remote.current_status.expired_date === undefined
+                ? { updateExpiredDate: false }
                 : {}),
         });
     }

--- a/backend/application/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.ts
@@ -2,7 +2,10 @@ import { Inject, Injectable, Logger } from "@nestjs/common";
 
 import { documentCustomerNameValue } from "application/utils/eformsign-document-customer-name";
 import { eformsignDocumentTemplateId } from "application/utils/eformsign-document-template-id";
-import { EFORMSIGN_EXPIRED_STATUS_CODE } from "domain/constants/eformsign-doc-status.constants";
+import {
+    EFORMSIGN_EXPIRED_STATUS_CODE,
+    TERMINAL_STATUS_CODES,
+} from "domain/constants/eformsign-doc-status.constants";
 import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
 import {
     EFORMSIGN_DOC_REPOSITORY,
@@ -59,7 +62,13 @@ export class MirrorUnassignedEformsignDocUsecase {
         // anything else means the list simply did not say.
         const expiredFromStatus = statusType === EFORMSIGN_EXPIRED_STATUS_CODE;
         const hasRemoteExpiredState = remote.current_status._expired !== undefined;
-        const knowsExpiredState = hasRemoteExpiredState || expiredFromStatus;
+        // A terminal status settles the question both ways: 080 means expired, and any
+        // other ending — completed, rejected, revoked — means it is not. Only the open
+        // states leave it genuinely unknown. Without the negative direction, a row the
+        // hourly expiry pass guessed wrong about would keep expired=true even after this
+        // sweep learned the document had actually completed, and nothing would clear it.
+        const knowsExpiredState = hasRemoteExpiredState
+            || TERMINAL_STATUS_CODES.has(statusType);
         const remoteUpdatedDate = new Date(remote.updated_date);
         const updatedDate = Number.isNaN(remoteUpdatedDate.getTime())
             ? new Date(now)

--- a/backend/domain/constants/eformsign-doc-status.constants.ts
+++ b/backend/domain/constants/eformsign-doc-status.constants.ts
@@ -61,3 +61,22 @@ export const UNASSIGNED_FORWARD_STATUS_CODES_AFTER_REVIEW_STAGE = new Set<string
 
 /** The one code that means the document passed its expiry date. */
 export const EFORMSIGN_EXPIRED_STATUS_CODE = "080";
+
+/**
+ * What an ended document's status detail should read when the vendor did not supply one.
+ * List responses carry no `status_doc_detail`, and the detail a document held while it
+ * was open — "서명 요청됨" — is plainly wrong once it has finished; the UI renders this
+ * string directly. Wording matches the webhook's own mapping so a row reads the same
+ * however it was reconciled. Codes whose meaning is not unambiguous from the code alone
+ * are deliberately absent: for those, keeping the stored detail beats inventing one.
+ */
+export const EFORMSIGN_TERMINAL_STATUS_DETAILS: Readonly<Record<string, string>> = {
+    "003": "완료",
+    "050": "완료",
+    "061": "거부",
+    "071": "검토 반려",
+    "072": "검토 완료",
+    "080": "만료",
+    "090": "철회",
+    "099": "삭제됨",
+};

--- a/backend/domain/repositories/eformsign-doc.repository.interface.ts
+++ b/backend/domain/repositories/eformsign-doc.repository.interface.ts
@@ -74,12 +74,6 @@ export interface UpsertUnassignedEformsignDocOptions {
 }
 
 export interface IEformsignDocRepository {
-    /**
-     * Flip `expired` on rows whose expiry date has passed while they were still open.
-     * Eformsign sends an 080 webhook when a document expires, but a dropped one leaves
-     * the mirror claiming a document is still live forever. Returns the rows changed.
-     */
-    markExpiredDocuments(now: Date): Promise<number>;
     findById(branchid: string, id: number): Promise<EformsignDocEntity | null>;
     findByDocumentId(branchid: string, documentId: string): Promise<EformsignDocEntity | null>;
     findByDocumentIdUnscoped(documentId: string): Promise<EformsignDocUnscopedResult | null>;

--- a/backend/domain/repositories/eformsign-doc.repository.interface.ts
+++ b/backend/domain/repositories/eformsign-doc.repository.interface.ts
@@ -71,6 +71,12 @@ export interface UpsertUnassignedEformsignDocOptions {
      * but overwriting a stored detail — "만료", "거부" — with the derived one loses it.
      */
     updateStatusDetail?: boolean;
+    /**
+     * Same reasoning as `updateStatusDetail`: the list endpoint carries no `expired_date`,
+     * so a caller working from it only has a fallback guess. Set false there rather than
+     * overwriting a real stored expiry with it.
+     */
+    updateExpiredDate?: boolean;
 }
 
 export interface IEformsignDocRepository {

--- a/backend/domain/repositories/eformsign-doc.repository.interface.ts
+++ b/backend/domain/repositories/eformsign-doc.repository.interface.ts
@@ -74,6 +74,12 @@ export interface UpsertUnassignedEformsignDocOptions {
 }
 
 export interface IEformsignDocRepository {
+    /**
+     * Flip `expired` on rows whose expiry date has passed while they were still open.
+     * Eformsign sends an 080 webhook when a document expires, but a dropped one leaves
+     * the mirror claiming a document is still live forever. Returns the rows changed.
+     */
+    markExpiredDocuments(now: Date): Promise<number>;
     findById(branchid: string, id: number): Promise<EformsignDocEntity | null>;
     findByDocumentId(branchid: string, documentId: string): Promise<EformsignDocEntity | null>;
     findByDocumentIdUnscoped(documentId: string): Promise<EformsignDocUnscopedResult | null>;

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -398,6 +398,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
             stepIndex: doc.stepIndex,
             stepName: doc.stepName,
             ...(options?.updateExpired === false ? {} : { expired: doc.expired }),
+            ...(options?.updateExpiredDate === false ? {} : { expiredDate: doc.expiredDate }),
             updatedDate: doc.updatedDate,
             ...(documentName ? { documentName } : {}),
             ...(documentNumber ? { documentNumber } : {}),

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -1,7 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
 import {
-    TERMINAL_STATUS_CODES,
     UNASSIGNED_FORWARD_STATUS_CODES_AFTER_REVIEW_STAGE,
     UNASSIGNED_REVIEW_STAGE_STATUS_CODES,
     UNASSIGNED_TERMINAL_STATUS_CODES,
@@ -51,21 +50,6 @@ const toUnscopedResult = (
 @Injectable()
 export class SbEformsignDocRepository implements IEformsignDocRepository {
     constructor(private readonly prismaService: PrismaService) {}
-
-    async markExpiredDocuments(now: Date): Promise<number> {
-        const result = await this.prismaService.eformsign_doc.updateMany({
-            where: {
-                expired: false,
-                expiredDate: { lte: now },
-                // A terminal document is finished, not expired — a contract completed
-                // last year is past its expiry date and must not be relabelled. The
-                // "no expiry" sentinel is year 9999, so it never matches lte either.
-                statusType: { notIn: [...TERMINAL_STATUS_CODES] },
-            },
-            data: { expired: true },
-        });
-        return result.count;
-    }
 
     async findById(branchid: string, id: number): Promise<EformsignDocEntity | null> {
         return this.findFirstDomain({ id, branchId: branchid });

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
 import {
+    TERMINAL_STATUS_CODES,
     UNASSIGNED_FORWARD_STATUS_CODES_AFTER_REVIEW_STAGE,
     UNASSIGNED_REVIEW_STAGE_STATUS_CODES,
     UNASSIGNED_TERMINAL_STATUS_CODES,
@@ -50,6 +51,21 @@ const toUnscopedResult = (
 @Injectable()
 export class SbEformsignDocRepository implements IEformsignDocRepository {
     constructor(private readonly prismaService: PrismaService) {}
+
+    async markExpiredDocuments(now: Date): Promise<number> {
+        const result = await this.prismaService.eformsign_doc.updateMany({
+            where: {
+                expired: false,
+                expiredDate: { lte: now },
+                // A terminal document is finished, not expired — a contract completed
+                // last year is past its expiry date and must not be relabelled. The
+                // "no expiry" sentinel is year 9999, so it never matches lte either.
+                statusType: { notIn: [...TERMINAL_STATUS_CODES] },
+            },
+            data: { expired: true },
+        });
+        return result.count;
+    }
 
     async findById(branchid: string, id: number): Promise<EformsignDocEntity | null> {
         return this.findFirstDomain({ id, branchId: branchid });

--- a/backend/infrastructure/locking/eformsign-backfill-lock.service.ts
+++ b/backend/infrastructure/locking/eformsign-backfill-lock.service.ts
@@ -98,6 +98,15 @@ export class EformsignBackfillLockService implements OnModuleDestroy {
         this.redis?.disconnect();
     }
 
+    /**
+     * Whether a lock can be taken at all — false when VALKEY_URL is unset. Callers that
+     * want to decide their own fallback ask first rather than catching the unavailable
+     * error, which `runExclusive` can also raise once a run is already under way.
+     */
+    isAvailable(): boolean {
+        return this.redis !== null;
+    }
+
     async runExclusive<TResult>(
         work: (lease: EformsignBackfillLease) => Promise<TResult>,
     ): Promise<TResult> {

--- a/backend/module/eformsign-doc.module.ts
+++ b/backend/module/eformsign-doc.module.ts
@@ -40,6 +40,7 @@ import { EformsignDocController } from "interface/controllers/eformsign-doc.cont
 import { CreateAndSendServiceRecordSnapshotUsecase } from "application/usecases/eformsign-doc/create-and-send-service-record-snapshot.usecase";
 import { ContractClientAssignmentGuardService } from "application/services/contract-client-assignment-guard.service";
 import { EformsignDocumentSnapshotService } from "application/services/eformsign-document-snapshot.service";
+import { EformsignDocReconcileSchedulerService } from "application/services/eformsign-doc-reconcile-scheduler.service";
 import {
     createEformsignBackfillRedisClient,
     EFORMSIGN_BACKFILL_REDIS_CLIENT,
@@ -86,6 +87,7 @@ import {
         ContractClientAssignmentGuardService,
         EformsignDocumentSnapshotService,
         EformsignBackfillLockService,
+        EformsignDocReconcileSchedulerService,
         // Repository bindings
         {
             provide: EFORMSIGN_DOC_REPOSITORY,

--- a/backend/scripts/backfill-eformsign-docs.ts
+++ b/backend/scripts/backfill-eformsign-docs.ts
@@ -79,6 +79,25 @@ function confirmOperatorTarget(): void {
     );
 }
 
+async function runWithoutDistributedLock(
+    configService: ConfigService,
+    backfill: BackfillEformsignDocsUsecase,
+): Promise<EformsignDocsBackfillSummary> {
+    if (configService.get<string>("EFORMSIGN_BACKFILL_ALLOW_UNLOCKED") !== "true") {
+        throw new Error(
+            "VALKEY_URL is unset, so this run cannot take a cross-instance lock."
+            + " Nothing would stop a second backfill writing at the same time."
+            + " Set VALKEY_URL, or set EFORMSIGN_BACKFILL_ALLOW_UNLOCKED=true once you"
+            + " have confirmed no other backfill is running.",
+        );
+    }
+
+    process.stderr.write(
+        "Running without a distributed lock (EFORMSIGN_BACKFILL_ALLOW_UNLOCKED=true).\n",
+    );
+    return backfill.execute({ onProgress: logProgress });
+}
+
 async function main(): Promise<void> {
     // ConfigModule.forRoot loads ENV_FILE_PATHS while this module is evaluated.
     // Keep confirmation before Nest bootstrap because Prisma connects during bootstrap.
@@ -96,12 +115,18 @@ async function main(): Promise<void> {
 
         const backfill = app.get(BackfillEformsignDocsUsecase);
         const lock = app.get(EformsignBackfillLockService);
-        const summary = await lock.runExclusive((lease) =>
-            backfill.execute({
-                onProgress: logProgress,
-                shouldContinue: lease.isHeld,
-            }),
-        );
+        // No Valkey is provisioned in any environment, and adding one was deliberately
+        // deferred — so requiring the lock unconditionally would leave this script
+        // unrunnable everywhere. Running a full write sweep with nothing stopping a
+        // second operator is a real risk, though, so it takes its own acknowledgement
+        // rather than degrading quietly the way the nightly reconcile does.
+        const summary = lock.isAvailable()
+            ? await lock.runExclusive((lease) =>
+                backfill.execute({
+                    onProgress: logProgress,
+                    shouldContinue: lease.isHeld,
+                }))
+            : await runWithoutDistributedLock(configService, backfill);
         // Reaching here means every document was mirrored: the usecase now throws rather
         // than returning a summary that carries failures.
         logSummary("completed", summary);

--- a/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
@@ -78,6 +78,24 @@ describe("SbEformsignDocRepository", () => {
         jest.clearAllMocks();
     });
 
+    it("flips expired only on open documents whose expiry date has passed", async () => {
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 3 });
+        const now = new Date("2026-07-29T00:00:00.000Z");
+
+        await expect(repository.markExpiredDocuments(now)).resolves.toBe(3);
+
+        const { where, data } = eformsignDocModel.updateMany.mock.calls[0][0];
+        expect(data).toEqual({ expired: true });
+        expect(where.expired).toBe(false);
+        expect(where.expiredDate).toEqual({ lte: now });
+        // A contract completed last year is past its expiry date too. Relabelling it
+        // expired would be a lie the list would then show.
+        expect(where.statusType.notIn).toEqual(
+            expect.arrayContaining(["003", "050", "080", "099"]),
+        );
+        expect(where.statusType.notIn).not.toContain("060");
+    });
+
     it("retries client document reads with legacy columns when classification columns are pending", async () => {
         eformsignDocModel.findMany
             .mockRejectedValueOnce(pendingColumnError)

--- a/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
@@ -78,24 +78,6 @@ describe("SbEformsignDocRepository", () => {
         jest.clearAllMocks();
     });
 
-    it("flips expired only on open documents whose expiry date has passed", async () => {
-        eformsignDocModel.updateMany.mockResolvedValue({ count: 3 });
-        const now = new Date("2026-07-29T00:00:00.000Z");
-
-        await expect(repository.markExpiredDocuments(now)).resolves.toBe(3);
-
-        const { where, data } = eformsignDocModel.updateMany.mock.calls[0][0];
-        expect(data).toEqual({ expired: true });
-        expect(where.expired).toBe(false);
-        expect(where.expiredDate).toEqual({ lte: now });
-        // A contract completed last year is past its expiry date too. Relabelling it
-        // expired would be a lie the list would then show.
-        expect(where.statusType.notIn).toEqual(
-            expect.arrayContaining(["003", "050", "080", "099"]),
-        );
-        expect(where.statusType.notIn).not.toContain("060");
-    });
-
     it("retries client document reads with legacy columns when classification columns are pending", async () => {
         eformsignDocModel.findMany
             .mockRejectedValueOnce(pendingColumnError)

--- a/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
@@ -472,6 +472,7 @@ describe("SbEformsignDocRepository", () => {
         expect(args.data).toEqual({
             statusType: "050",
             statusDetail: "완료",
+            expiredDate: new Date("2026-08-01T00:00:00.000Z"),
             stepType: "05",
             stepIndex: "1",
             stepName: "이용자",
@@ -485,7 +486,6 @@ describe("SbEformsignDocRepository", () => {
         expect(args.data).not.toHaveProperty("branchId");
         expect(args.data).not.toHaveProperty("clientId");
         expect(args.data).not.toHaveProperty("documentKind");
-        expect(args.data).not.toHaveProperty("expiredDate");
         expect(args.data).not.toHaveProperty("stepRecipientName");
         expect(args.data).not.toHaveProperty("customerName");
         expect(args.data).not.toHaveProperty("creatorName");
@@ -732,6 +732,27 @@ describe("SbEformsignDocRepository", () => {
 
         expect(eformsignDocModel.updateMany.mock.calls[0][0].data)
             .not.toHaveProperty("expired");
+    });
+
+    it("omits expiredDate from list-sourced updates so a real expiry survives", async () => {
+        // The list carries no expired_date, so what the mirror computed is only its
+        // fallback guess — writing it would overwrite a date the vendor actually gave us.
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 1 });
+        eformsignDocModel.findFirst.mockResolvedValue({
+            ...legacyRow,
+            branchId: null,
+            clientId: null,
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: null,
+        });
+
+        await repository.upsertUnassignedByDocumentId(createEntity(), {
+            updateExpiredDate: false,
+        });
+
+        expect(eformsignDocModel.updateMany.mock.calls[0][0].data)
+            .not.toHaveProperty("expiredDate");
     });
 
     it("omits statusDetail from list-sourced updates so a webhook-written detail survives", async () => {

--- a/backend/test/services/eformsign-doc-reconcile-scheduler.service.spec.ts
+++ b/backend/test/services/eformsign-doc-reconcile-scheduler.service.spec.ts
@@ -16,6 +16,7 @@ function createSummary(overrides: Record<string, number> = {}) {
         created: 0,
         updated: 0,
         skipped: 0,
+        duplicates: 0,
         failed: 0,
         pages: 0,
         byDocumentType: {},
@@ -25,12 +26,10 @@ function createSummary(overrides: Record<string, number> = {}) {
 
 describe("EformsignDocReconcileSchedulerService", () => {
     let backfill: { execute: jest.Mock };
-    let repository: { markExpiredDocuments: jest.Mock };
     let lockService: { isAvailable: jest.Mock; runExclusive: jest.Mock };
 
     beforeEach(() => {
         backfill = { execute: jest.fn().mockResolvedValue(createSummary()) };
-        repository = { markExpiredDocuments: jest.fn().mockResolvedValue(0) };
         lockService = {
             isAvailable: jest.fn().mockReturnValue(true),
             runExclusive: jest.fn((work: (lease: { isHeld: () => boolean }) => Promise<unknown>) =>
@@ -49,7 +48,6 @@ describe("EformsignDocReconcileSchedulerService", () => {
             createConfigService(enabled),
             backfill as never,
             lockService as never,
-            repository as never,
         );
     }
 
@@ -61,37 +59,12 @@ describe("EformsignDocReconcileSchedulerService", () => {
             async (value) => {
                 const service = createService(value);
 
-                await service.markExpiredDocuments();
                 await service.reconcileDocuments();
 
-                expect(repository.markExpiredDocuments).not.toHaveBeenCalled();
                 expect(backfill.execute).not.toHaveBeenCalled();
                 expect(lockService.runExclusive).not.toHaveBeenCalled();
             },
         );
-    });
-
-    describe("expiry pass", () => {
-        it("marks documents expired as of now", async () => {
-            repository.markExpiredDocuments.mockResolvedValue(4);
-            const service = createService("true");
-
-            await service.markExpiredDocuments();
-
-            expect(repository.markExpiredDocuments).toHaveBeenCalledTimes(1);
-            expect(repository.markExpiredDocuments.mock.calls[0][0]).toBeInstanceOf(Date);
-        });
-
-        it("survives a repository failure so the next tick still runs", async () => {
-            repository.markExpiredDocuments.mockRejectedValueOnce(new Error("db down"));
-            const service = createService("true");
-
-            await expect(service.markExpiredDocuments()).resolves.toBeUndefined();
-
-            repository.markExpiredDocuments.mockResolvedValueOnce(1);
-            await expect(service.markExpiredDocuments()).resolves.toBeUndefined();
-            expect(repository.markExpiredDocuments).toHaveBeenCalledTimes(2);
-        });
     });
 
     describe("reconciliation sweep", () => {
@@ -131,9 +104,60 @@ describe("EformsignDocReconcileSchedulerService", () => {
 
             expect(lockService.runExclusive).not.toHaveBeenCalled();
             expect(backfill.execute).toHaveBeenCalledTimes(2);
-            expect(backfill.execute).toHaveBeenCalledWith();
+            expect(backfill.execute).toHaveBeenCalledWith(
+                expect.objectContaining({ shouldContinue: expect.any(Function) }),
+            );
             expect(warn.mock.calls.filter(([message]) => message.includes("VALKEY_URL")))
                 .toHaveLength(1);
+        });
+
+        it("stops the sweep once the advertised runtime is spent", async () => {
+            // SchedulerExecutionGuard only ages a stale token out on the next tick, a day
+            // later, so the 30-minute bound is only real if the sweep itself polls it.
+            let shouldContinue: (() => boolean) | undefined;
+            backfill.execute.mockImplementation((options: { shouldContinue?: () => boolean }) => {
+                shouldContinue = options.shouldContinue;
+                return Promise.resolve(createSummary());
+            });
+            const nowSpy = jest.spyOn(Date, "now");
+            nowSpy.mockReturnValue(1_000_000);
+            const service = createService("true");
+
+            await service.reconcileDocuments();
+
+            expect(shouldContinue?.()).toBe(true);
+            nowSpy.mockReturnValue(1_000_000 + 31 * 60 * 1000);
+            expect(shouldContinue?.()).toBe(false);
+        });
+
+        it("escalates to error only once the sweep has failed several nights running", async () => {
+            // This job has no other operator signal — Sentry here is filtered to
+            // service-records — so a single bad night stays a warning and a streak does not.
+            lockService.runExclusive.mockRejectedValue(new Error("coverage incomplete"));
+            const service = createService("true");
+            const logger = (service as unknown as {
+                logger: { warn: (message: string) => void; error: (message: string) => void };
+            }).logger;
+            const warn = jest.spyOn(logger, "warn").mockImplementation(() => undefined);
+            const error = jest.spyOn(logger, "error").mockImplementation(() => undefined);
+
+            await service.reconcileDocuments();
+            await service.reconcileDocuments();
+            expect(error).not.toHaveBeenCalled();
+            expect(warn).toHaveBeenCalledTimes(2);
+
+            await service.reconcileDocuments();
+            expect(error).toHaveBeenCalledTimes(1);
+            expect(error.mock.calls[0]?.[0]).toContain("3 in a row");
+
+            // A good night clears the streak, so the next failure is a warning again.
+            lockService.runExclusive.mockImplementationOnce(
+                (work: (lease: { isHeld: () => boolean }) => Promise<unknown>) =>
+                    work({ isHeld: () => true }),
+            );
+            await service.reconcileDocuments();
+            await service.reconcileDocuments();
+            expect(error).toHaveBeenCalledTimes(1);
         });
 
         it("treats a fail-closed sweep as an incomplete run, not a crash", async () => {

--- a/backend/test/services/eformsign-doc-reconcile-scheduler.service.spec.ts
+++ b/backend/test/services/eformsign-doc-reconcile-scheduler.service.spec.ts
@@ -1,0 +1,157 @@
+import { ConfigService } from "@nestjs/config";
+
+import { EformsignDocReconcileSchedulerService } from "application/services/eformsign-doc-reconcile-scheduler.service";
+import { EformsignBackfillAlreadyRunningError } from "infrastructure/locking/eformsign-backfill-lock.service";
+
+function createConfigService(enabled: string | undefined): ConfigService {
+    return {
+        get: jest.fn((key: string) =>
+            key === "EFORMSIGN_RECONCILE_ENABLED" ? enabled : undefined),
+    } as unknown as ConfigService;
+}
+
+function createSummary(overrides: Record<string, number> = {}) {
+    return {
+        fetched: 0,
+        created: 0,
+        updated: 0,
+        skipped: 0,
+        failed: 0,
+        pages: 0,
+        byDocumentType: {},
+        ...overrides,
+    };
+}
+
+describe("EformsignDocReconcileSchedulerService", () => {
+    let backfill: { execute: jest.Mock };
+    let repository: { markExpiredDocuments: jest.Mock };
+    let lockService: { isAvailable: jest.Mock; runExclusive: jest.Mock };
+
+    beforeEach(() => {
+        backfill = { execute: jest.fn().mockResolvedValue(createSummary()) };
+        repository = { markExpiredDocuments: jest.fn().mockResolvedValue(0) };
+        lockService = {
+            isAvailable: jest.fn().mockReturnValue(true),
+            runExclusive: jest.fn((work: (lease: { isHeld: () => boolean }) => Promise<unknown>) =>
+                work({ isHeld: () => true })),
+        };
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    // No default argument: it.each passes undefined deliberately, and a default would
+    // silently turn that case into the enabled one.
+    function createService(enabled: string | undefined) {
+        return new EformsignDocReconcileSchedulerService(
+            createConfigService(enabled),
+            backfill as never,
+            lockService as never,
+            repository as never,
+        );
+    }
+
+    describe("when the feature switch is off", () => {
+        // This is the phase where the mirror stops being write-only. Everything stays
+        // dormant until an environment opts in, so the step is reversible by config.
+        it.each([undefined, "false", "1", "TRUE"])(
+            "does nothing with EFORMSIGN_RECONCILE_ENABLED=%s",
+            async (value) => {
+                const service = createService(value);
+
+                await service.markExpiredDocuments();
+                await service.reconcileDocuments();
+
+                expect(repository.markExpiredDocuments).not.toHaveBeenCalled();
+                expect(backfill.execute).not.toHaveBeenCalled();
+                expect(lockService.runExclusive).not.toHaveBeenCalled();
+            },
+        );
+    });
+
+    describe("expiry pass", () => {
+        it("marks documents expired as of now", async () => {
+            repository.markExpiredDocuments.mockResolvedValue(4);
+            const service = createService("true");
+
+            await service.markExpiredDocuments();
+
+            expect(repository.markExpiredDocuments).toHaveBeenCalledTimes(1);
+            expect(repository.markExpiredDocuments.mock.calls[0][0]).toBeInstanceOf(Date);
+        });
+
+        it("survives a repository failure so the next tick still runs", async () => {
+            repository.markExpiredDocuments.mockRejectedValueOnce(new Error("db down"));
+            const service = createService("true");
+
+            await expect(service.markExpiredDocuments()).resolves.toBeUndefined();
+
+            repository.markExpiredDocuments.mockResolvedValueOnce(1);
+            await expect(service.markExpiredDocuments()).resolves.toBeUndefined();
+            expect(repository.markExpiredDocuments).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe("reconciliation sweep", () => {
+        it("runs under the distributed lock and hands the lease to the sweep", async () => {
+            const service = createService("true");
+
+            await service.reconcileDocuments();
+
+            expect(lockService.runExclusive).toHaveBeenCalledTimes(1);
+            expect(backfill.execute).toHaveBeenCalledWith(
+                expect.objectContaining({ shouldContinue: expect.any(Function) }),
+            );
+        });
+
+        it("skips quietly when another sweep already holds the lock", async () => {
+            lockService.runExclusive.mockRejectedValue(
+                new EformsignBackfillAlreadyRunningError(),
+            );
+            const service = createService("true");
+
+            await expect(service.reconcileDocuments()).resolves.toBeUndefined();
+        });
+
+        it("sweeps without a lock when VALKEY_URL is unset, warning once", async () => {
+            // No Valkey is configured in any environment today, so refusing to run would
+            // ship this phase inert. The mirror writes are already safe under concurrency;
+            // what we lose is protection against replicas doubling the vendor load.
+            lockService.isAvailable.mockReturnValue(false);
+            const service = createService("true");
+            const warn = jest.spyOn(
+                (service as unknown as { logger: { warn: (message: string) => void } }).logger,
+                "warn",
+            ).mockImplementation(() => undefined);
+
+            await service.reconcileDocuments();
+            await service.reconcileDocuments();
+
+            expect(lockService.runExclusive).not.toHaveBeenCalled();
+            expect(backfill.execute).toHaveBeenCalledTimes(2);
+            expect(backfill.execute).toHaveBeenCalledWith();
+            expect(warn.mock.calls.filter(([message]) => message.includes("VALKEY_URL")))
+                .toHaveLength(1);
+        });
+
+        it("treats a fail-closed sweep as an incomplete run, not a crash", async () => {
+            // The sweep fails closed on incomplete coverage. Nightly, that means "this run
+            // did not finish reconciling" — tomorrow's run picks up from what landed.
+            lockService.runExclusive.mockRejectedValueOnce(
+                new Error("Eformsign document coverage incomplete type=01 missing=2"),
+            );
+            const service = createService("true");
+
+            await expect(service.reconcileDocuments()).resolves.toBeUndefined();
+
+            lockService.runExclusive.mockImplementationOnce(
+                (work: (lease: { isHeld: () => boolean }) => Promise<unknown>) =>
+                    work({ isHeld: () => true }),
+            );
+            await service.reconcileDocuments();
+            expect(backfill.execute).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/backend/test/services/eformsign-doc-reconcile-scheduler.service.spec.ts
+++ b/backend/test/services/eformsign-doc-reconcile-scheduler.service.spec.ts
@@ -160,6 +160,34 @@ describe("EformsignDocReconcileSchedulerService", () => {
             expect(error).toHaveBeenCalledTimes(1);
         });
 
+        it("counts nightly database outages toward the same escalation", async () => {
+            // The cooldown lapses hours before the next nightly tick, so it cannot be what
+            // surfaces a multi-day outage. If these did not count, a database that never
+            // let a sweep finish would stay warning-level forever.
+            const connectivityError = Object.assign(new Error("Can't reach database server"), {
+                code: "P1001",
+            });
+            lockService.runExclusive.mockRejectedValue(connectivityError);
+            const service = createService("true");
+            const logger = (service as unknown as {
+                logger: { warn: (message: string) => void; error: (message: string) => void };
+            }).logger;
+            jest.spyOn(logger, "warn").mockImplementation(() => undefined);
+            const error = jest.spyOn(logger, "error").mockImplementation(() => undefined);
+
+            // Ticks are a day apart, so the connectivity cooldown has long lapsed by the
+            // next one — without advancing the clock the guard would refuse to start.
+            let now = 1_000_000;
+            jest.spyOn(Date, "now").mockImplementation(() => now);
+            for (let night = 0; night < 3; night += 1) {
+                await service.reconcileDocuments();
+                now += 24 * 60 * 60 * 1000;
+            }
+
+            expect(error).toHaveBeenCalledTimes(1);
+            expect(error.mock.calls[0]?.[0]).toContain("3 in a row");
+        });
+
         it("treats a fail-closed sweep as an incomplete run, not a crash", async () => {
             // The sweep fails closed on incomplete coverage. Nightly, that means "this run
             // did not finish reconciling" — tomorrow's run picks up from what landed.

--- a/backend/test/usecases/eformsign-doc/backfill-eformsign-docs.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/backfill-eformsign-docs.usecase.spec.ts
@@ -871,6 +871,54 @@ describe("BackfillEformsignDocsUsecase", () => {
         );
     });
 
+    it("re-mirrors a document when a later inbox carries newer state", async () => {
+        // A document that completes between the in-progress scan and the completed scan
+        // shows up twice, the second copy newer. Skipping on identity alone would keep the
+        // mirror a night behind on exactly the documents that just changed.
+        const earlier = createRemoteDocument("moving-doc");
+        const later = {
+            ...createRemoteDocument("moving-doc", "050"),
+            updated_date: earlier.updated_date + 60_000,
+        };
+        const client = {
+            getAccessToken: jest.fn().mockResolvedValue({
+                oauth_token: { access_token: accessToken },
+            }),
+            getInProgressDocumentsPage: jest.fn().mockResolvedValue({
+                documents: [earlier],
+                total_rows: 1,
+            }),
+            getCompletedDocumentsPage: jest.fn().mockResolvedValue({
+                documents: [later],
+                total_rows: 1,
+            }),
+            getRejectedDocumentsPage: jest.fn().mockResolvedValue({
+                documents: [],
+                total_rows: 0,
+            }),
+        };
+        const repository = {
+            findByDocumentIdUnscoped: jest.fn().mockResolvedValue(null),
+        };
+        const mirror = {
+            mirrorRemoteDocument: jest.fn().mockResolvedValue({ documentId: "moving-doc" }),
+        };
+        const usecase = new BackfillEformsignDocsUsecase(
+            client as never,
+            repository as never,
+            mirror as never,
+        );
+
+        const summary = await usecase.execute();
+
+        expect(mirror.mirrorRemoteDocument).toHaveBeenCalledTimes(2);
+        expect(mirror.mirrorRemoteDocument).toHaveBeenLastCalledWith(
+            expect.objectContaining({ current_status: expect.objectContaining({ status_type: "050" }) }),
+            { allowAssignedUpdate: true },
+        );
+        expect(summary.duplicates).toBe(0);
+    });
+
     it("keeps a stored status detail when the list response carries none", async () => {
         // The list schema has no status_doc_detail, so the mirror falls back to the step
         // name. That derived value may seed a new row but must not replace "만료"/"거부"

--- a/backend/test/usecases/eformsign-doc/backfill-eformsign-docs.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/backfill-eformsign-docs.usecase.spec.ts
@@ -818,6 +818,8 @@ describe("BackfillEformsignDocsUsecase", () => {
             {
                 allowAssignedUpdate: true,
                 updateListDisplayFields: true,
+                // The list has no expired_date, so the computed date is only a fallback.
+                updateExpiredDate: false,
             },
         );
     });

--- a/backend/test/usecases/eformsign-doc/backfill-eformsign-docs.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/backfill-eformsign-docs.usecase.spec.ts
@@ -822,6 +822,55 @@ describe("BackfillEformsignDocsUsecase", () => {
         );
     });
 
+    it("mirrors a document once when two inboxes both list it", async () => {
+        // Type "04" is eformsign's document-management inbox, not a rejected-only one, so
+        // it overlaps the other scans. Now that this runs nightly, writing those rows a
+        // second time every night would be pure waste.
+        const shared = createRemoteDocument("shared-doc");
+        const client = {
+            getAccessToken: jest.fn().mockResolvedValue({
+                oauth_token: { access_token: accessToken },
+            }),
+            getInProgressDocumentsPage: jest.fn().mockResolvedValue({
+                documents: [shared],
+                total_rows: 1,
+            }),
+            getCompletedDocumentsPage: jest.fn().mockResolvedValue({
+                documents: [],
+                total_rows: 0,
+            }),
+            getRejectedDocumentsPage: jest.fn().mockResolvedValue({
+                documents: [shared],
+                total_rows: 1,
+            }),
+        };
+        const repository = {
+            findByDocumentIdUnscoped: jest.fn().mockResolvedValue(null),
+        };
+        const mirror = {
+            mirrorRemoteDocument: jest.fn().mockResolvedValue({ documentId: "shared-doc" }),
+        };
+        const usecase = new BackfillEformsignDocsUsecase(
+            client as never,
+            repository as never,
+            mirror as never,
+        );
+
+        const summary = await usecase.execute();
+
+        expect(mirror.mirrorRemoteDocument).toHaveBeenCalledTimes(1);
+        // Both scans still have to page it: each inbox's coverage check compares against
+        // its own total_rows, so the duplicate has to count as seen for type 04 as well.
+        expect(summary).toEqual(expect.objectContaining({
+            fetched: 2,
+            created: 1,
+            duplicates: 1,
+        }));
+        expect(summary.byDocumentType["04"]).toEqual(
+            expect.objectContaining({ status: "completed", duplicates: 1, created: 0 }),
+        );
+    });
+
     it("keeps a stored status detail when the list response carries none", async () => {
         // The list schema has no status_doc_detail, so the mirror falls back to the step
         // name. That derived value may seed a new row but must not replace "만료"/"거부"

--- a/backend/test/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.spec.ts
@@ -299,6 +299,46 @@ describe("MirrorUnassignedEformsignDocUsecase", () => {
         );
     });
 
+    it("clears a wrongly-set expired flag once the remote reports a non-expiry ending", async () => {
+        // The list carries no _expired, so this used to be treated as "unknown" for every
+        // status. A row that got expired=true by any route then kept it forever, even once
+        // the vendor said the document had completed. A terminal status settles it: 080
+        // means expired, and any other ending means it is not.
+        const repository = {
+            upsertUnassignedByDocumentId: jest.fn(
+                (doc: EformsignDocEntity) => Promise.resolve(doc),
+            ),
+        };
+        const usecase = new MirrorUnassignedEformsignDocUsecase(
+            { execute: jest.fn() } as never,
+            { execute: jest.fn() } as never,
+            repository as never,
+        );
+
+        await usecase.mirrorRemoteDocument({
+            id: "completed-doc",
+            document_number: "DOC-200",
+            document_name: "완료 문서",
+            created_date: Date.parse("2026-07-01T00:00:00.000Z"),
+            updated_date: Date.parse("2026-07-02T00:00:00.000Z"),
+            template: { id: "template-1", name: "계약서" },
+            creator: { recipient_type: "01", id: "creator", name: "생성자" },
+            current_status: {
+                status_type: "050",
+                step_type: "05",
+                step_index: "1",
+                step_name: "이용자",
+                step_recipients: [],
+                step_group: 1,
+            },
+        }, { now: Date.parse("2026-07-03T00:00:00.000Z") });
+
+        expect(repository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
+            expect.objectContaining({ statusType: "050", expired: false }),
+            expect.not.objectContaining({ updateExpired: false }),
+        );
+    });
+
     it("converts remaining expiry days to a date from the mirror reference time", async () => {
         const repository = {
             upsertUnassignedByDocumentId: jest.fn(

--- a/backend/test/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.spec.ts
@@ -253,6 +253,8 @@ describe("MirrorUnassignedEformsignDocUsecase", () => {
                 allowAssignedUpdate: true,
                 updateListDisplayFields: true,
                 updateExpired: false,
+                // The 30-day value above is a fallback, not something the list told us.
+                updateExpiredDate: false,
             },
         );
     });
@@ -296,6 +298,45 @@ describe("MirrorUnassignedEformsignDocUsecase", () => {
                 stepIndex: "0",
             }),
             expect.objectContaining({ updateExpired: false }),
+        );
+    });
+
+    it("replaces an open-state detail once the remote reports the document ended", async () => {
+        // The list carries no status_doc_detail, so a document whose completion webhook was
+        // dropped would keep reading "서명 요청됨" next to a completed status — and the
+        // client tab renders that string straight into its status pill.
+        const repository = {
+            upsertUnassignedByDocumentId: jest.fn(
+                (doc: EformsignDocEntity) => Promise.resolve(doc),
+            ),
+        };
+        const usecase = new MirrorUnassignedEformsignDocUsecase(
+            { execute: jest.fn() } as never,
+            { execute: jest.fn() } as never,
+            repository as never,
+        );
+
+        await usecase.mirrorRemoteDocument({
+            id: "expired-doc",
+            document_number: "DOC-300",
+            document_name: "만료 문서",
+            created_date: Date.parse("2026-07-01T00:00:00.000Z"),
+            updated_date: Date.parse("2026-07-02T00:00:00.000Z"),
+            template: { id: "template-1", name: "계약서" },
+            creator: { recipient_type: "01", id: "creator", name: "생성자" },
+            current_status: {
+                status_type: "080",
+                step_type: "05",
+                step_index: "1",
+                step_name: "이용자",
+                step_recipients: [],
+                step_group: 1,
+            },
+        }, { now: Date.parse("2026-07-03T00:00:00.000Z") });
+
+        expect(repository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
+            expect.objectContaining({ statusType: "080", statusDetail: "만료" }),
+            expect.not.objectContaining({ updateStatusDetail: false }),
         );
     });
 


### PR DESCRIPTION
BJJ-288 C단계. 미러가 웹훅에만 의존하는 상태를 벗어나, 누락분을 주기적으로 바로잡는다.

## 무엇이 들어갔나

**매일 04:00 KST 대조 스윕.** 전체 문서를 eformsign에서 다시 읽어 미러에 반영한다. 떨어진 웹훅이 이 작업이 고치는 유일한 대상이고, 하루치 staleness는 지금도 이미 감수하고 있는 노출이다. `EFORMSIGN_RECONCILE_ENABLED=true` 가 아니면 동작하지 않는다 — 미러가 write-only를 벗어나는 단계이므로 설정만으로 되돌릴 수 있어야 한다.

**계획에 있던 시간 기반 만료 갱신은 넣지 않았다.** 리뷰 과정에서 `expiredDate` 자체를 신뢰할 수 없다는 것이 드러났기 때문이다(아래 참조). 만료는 벤더가 상태 080으로 알려주므로 야간 스윕이 그대로 가져온다.

## 리뷰가 찾아낸 것들

`expired_date` 는 epoch가 아니라 **남은 일수**다. 두 경로가 아직 epoch로 읽고 있었다 — `expired_date: 3`(3일 남음)이 **1970-01-01** 로 저장됐다. 둘 다 공용 헬퍼로 교체했다. 이 상태에서 "만료일이 지나면 expired를 켠다"는 작업을 돌렸다면 **정상 진행 중인 문서를 만료 처리**했을 것이고, 스윕은 목록 응답으로 동작하므로(`_expired` 없음) 되돌리지도 못했다.

이미 잘못 저장된 날짜는 건드리지 않았다. "0 = 만료 없음 → 14일 뒤"로 쓰인 값은 사후에 진짜 14일짜리와 구분할 수 없어, 복구하려면 eformsign에서 다시 읽어야 한다.

그 밖에:

- **종료 상태가 `expired` 를 양방향으로 확정한다.** 080만 만료이고 완료·거부·철회는 만료가 아니다. 음의 방향이 없으면 잘못 켜진 플래그가 영원히 남는다.
- **`statusDetail` 이 옛 상태에 머물렀다.** 완료 웹훅이 떨어진 문서가 상태는 "완료", 상세는 "서명 요청됨" 으로 표시됐다 — 고객 탭이 이 문자열을 그대로 상태 pill에 렌더한다. 의미가 명확한 종료 코드만 상세를 유도해 기록하고, 진행 상태에서는 기존 동작(웹훅이 쓴 값 보존)을 유지한다.
- **`expiredDate` 가 update 페이로드에 없어** 어떤 대조로도 복구가 불가능했다. 목록에는 `expired_date` 가 없으므로 같은 방식으로 가드해 추가했다.
- **type 04는 "반려 전용"이 아니라 문서 관리함**이라 01/03과 겹친다(프론트엔드도 같은 이유로 스트림 간 dedupe 중). 야간 반복 작업이 되었으니 같은 행을 매일 두 번 쓰지 않도록 실행 단위로 걸러내되, **더 새로운 사본은 버리지 않는다** — 스윕 도중 상태가 바뀐 문서가 정확히 그 경우다.
- **30분 한도가 실제로 강제되지 않았다.** 가드는 다음 tick(하루 뒤)에만 stale 토큰을 정리하므로, 멈춘 스윕이 다음 날 스윕과 겹칠 수 있었다. 스윕이 마감 시각을 직접 폴링한다.
- **매일 실패해도 하루 실패와 구분되지 않았다.** 3회 연속이면 error 레벨로 올린다. 여기 Sentry는 service-records 전용 필터라 로그가 이 작업의 유일한 신호다. DB 장애로 인한 실패도 함께 집계한다.
- **로그가 근본 원인을 버렸다.** 스윕은 오류를 두 번 감싸므로 최상위 메시지는 "failed for types=01" 뿐이었다. cause 체인을 펼친다.

## 락에 대해

**어떤 환경에도 `VALKEY_URL`이 없다**(프로덕션 실측). Valkey 도입은 계획 단계에서 의도적으로 보류됐다. 분산 락을 필수로 걸면 이 단계가 무동작으로 배포되므로, 스윕은 인프로세스 가드로 폴백하고 그 사실을 한 번 로그로 남긴다 — Valkey가 없을 때 스냅샷 캐시가 이미 취하는 것과 같은 단일 인스턴스 가정이다. 미러 쓰기는 어느 쪽이든 소유권·staleness 술어를 달고 나가므로 **정합성이 락에 걸려 있지는 않다.** 락이 사주는 것은 레플리카가 벤더 부하를 배로 늘리지 않게 하는 것이다.

같은 이유로 B단계의 운영자 백필 스크립트가 **Valkey 없이는 아예 실행되지 않던 것**도 고쳤다. 다만 이쪽은 사람이 돌리는 전체 쓰기 스윕이라 조용히 degrade시키지 않는다 — `EFORMSIGN_BACKFILL_ALLOW_UNLOCKED=true` 를 명시적으로 요구하고 이유를 설명한다.

## 검증

- `npx tsc --noEmit` 통과, `npx nest build` 통과
- **176 suites / 1861 passed / 8 skipped**
- ESLint 0 errors / 76 warnings(기준선 그대로)
- DB 스키마 변경 없음, 마이그레이션 없음
- 로컬 Codex 리뷰 MAJOR 2건 + 봇 리뷰 8건 반영, 최종 리뷰 clean

## 배포 후 필요한 설정

`EFORMSIGN_RECONCILE_ENABLED=true` 를 대상 환경에 설정해야 활성화된다. 기본값은 꺼짐.

## 남은 후속

- 잘못 저장된 `expiredDate` 복구 — eformsign 단건 조회로만 가능
- Valkey 도입 시 락 폴백 경고가 사라지고 레플리카 중복 스윕이 막힌다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG