### PR TITLE
feat(backend): shadow-compare the contract list against the mirror (BJJ-288 D)

### DIFF
--- a/backend/app.module.ts
+++ b/backend/app.module.ts
@@ -5,6 +5,7 @@ import { JwtModule } from "@nestjs/jwt";
 import { JwtStrategy } from "./infrastructure/auth/jwt.strategy";
 import { EformsignController } from "interface/controllers/eformsign.controller";
 import { EformsignService } from "application/services/eformsign.service";
+import { EformsignListShadowCompareService } from "application/services/eformsign-list-shadow-compare.service";
 import { ConfigModule } from "@nestjs/config";
 import { PassportModule } from "@nestjs/passport";
 import { ScheduleModule } from "@nestjs/schedule";
@@ -87,6 +88,7 @@ const ENV_FILE_PATHS = [
         EformsignService,
         JwtStrategy,
         ContractClientAssignmentGuardService,
+        EformsignListShadowCompareService,
     ],
 })
 export class AppModule {}

--- a/backend/application/services/eformsign-list-shadow-compare.service.ts
+++ b/backend/application/services/eformsign-list-shadow-compare.service.ts
@@ -1,0 +1,198 @@
+import { Inject, Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+
+import {
+    documentSearchValues,
+    filterDocumentsByStatusCategory,
+    filterDocumentsByTemplate,
+    filterOutDeletedDocuments,
+    matchesKoreanSearch,
+    sortDocumentsByCreatedDate,
+    type DocumentStatusCategory,
+    type EformsignListDoc,
+    type TemplateMatch,
+} from "application/utils/eformsign-document-list";
+import { eformsignListDocFromMirror } from "application/utils/eformsign-list-doc-from-mirror";
+import {
+    EFORMSIGN_DOC_REPOSITORY,
+    IEformsignDocRepository,
+} from "domain/repositories/eformsign-doc.repository.interface";
+
+export interface ListShadowCompareQuery {
+    branchId: string;
+    isHeadquarters: boolean;
+    scope: string;
+    limit: number;
+    skip: number;
+    templateId?: string;
+    templateMatch: TemplateMatch;
+    statusCategory?: DocumentStatusCategory;
+    search?: string;
+    excludeDeleted?: boolean;
+}
+
+export interface ListShadowCompareServed {
+    documentIds: string[];
+    totalRows: number;
+}
+
+/** How many differing ids to name before the log becomes noise rather than evidence. */
+const MAX_LOGGED_IDS = 10;
+
+/**
+ * Runs the contract list a second time against the local mirror and reports only where the
+ * two disagree. Nothing it computes is ever served — this is the evidence for whether the
+ * mirror is ready to become the source, and the only honest way to get that evidence is to
+ * answer the same question both ways on real traffic.
+ *
+ * It reuses the list rules rather than reimplementing them, so a difference here means the
+ * mirror's *data* differs, never that the two paths filtered differently.
+ *
+ * Off unless `EFORMSIGN_SHADOW_COMPARE_ENABLED=true`.
+ */
+@Injectable()
+export class EformsignListShadowCompareService {
+    private readonly logger = new Logger(EformsignListShadowCompareService.name);
+
+    constructor(
+        private readonly configService: ConfigService,
+        @Inject(EFORMSIGN_DOC_REPOSITORY)
+        private readonly eformsignDocRepository: IEformsignDocRepository,
+    ) {}
+
+    isEnabled(): boolean {
+        return this.configService.get<string>("EFORMSIGN_SHADOW_COMPARE_ENABLED") === "true";
+    }
+
+    /**
+     * Fire-and-forget: the caller has already answered the request. A comparison that
+     * throws must never turn a served page into an error, so everything is swallowed
+     * into a log — this feature exists to observe, not to participate.
+     */
+    compareInBackground(query: ListShadowCompareQuery, served: ListShadowCompareServed): void {
+        if (!this.isEnabled()) {
+            return;
+        }
+
+        void this.compare(query, served).catch((error: unknown) => {
+            this.logger.warn(
+                `[Shadow] comparison failed scope=${query.scope}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        });
+    }
+
+    private async compare(
+        query: ListShadowCompareQuery,
+        served: ListShadowCompareServed,
+    ): Promise<void> {
+        const local = await this.buildLocalPage(query);
+        const differences: string[] = [];
+
+        if (local.totalRows !== served.totalRows) {
+            differences.push(`total_rows served=${served.totalRows} local=${local.totalRows}`);
+        }
+
+        const servedSet = new Set(served.documentIds);
+        const localSet = new Set(local.documentIds);
+        const missing = served.documentIds.filter((id) => !localSet.has(id));
+        const extra = local.documentIds.filter((id) => !servedSet.has(id));
+
+        if (missing.length > 0) {
+            differences.push(`missing=${summariseIds(missing)}`);
+        }
+        if (extra.length > 0) {
+            differences.push(`extra=${summariseIds(extra)}`);
+        }
+        // Only worth reporting when both pages hold the same documents: otherwise the
+        // order difference is just a restatement of the membership difference above.
+        if (missing.length === 0
+            && extra.length === 0
+            && local.documentIds.join(",") !== served.documentIds.join(",")) {
+            differences.push("order differs");
+        }
+
+        if (differences.length === 0) {
+            this.logger.log(
+                `[Shadow] match scope=${query.scope} branch=${query.branchId}`
+                + ` skip=${query.skip} rows=${served.totalRows}`,
+            );
+            return;
+        }
+
+        this.logger.warn(
+            `[Shadow] diff scope=${query.scope} branch=${query.branchId}`
+            + ` skip=${query.skip} limit=${query.limit}`
+            + `${query.search ? ` search="${query.search}"` : ""}`
+            + `${query.statusCategory ? ` status=${query.statusCategory}` : ""}`
+            + ` :: ${differences.join("; ")}`,
+        );
+    }
+
+    private async buildLocalPage(
+        query: ListShadowCompareQuery,
+    ): Promise<{ documentIds: string[]; totalRows: number }> {
+        const mirrored = query.isHeadquarters
+            ? await this.eformsignDocRepository.findAllForHeadquarters(query.branchId)
+            : await this.eformsignDocRepository.findAll(query.branchId);
+        // Recipient names come from the same rows, so unlike the served path this does not
+        // need a second lookup to search them.
+        const localSearchValues = new Map(
+            mirrored.map((document) => [
+                document.documentId,
+                [document.stepRecipientName].filter((value) => Boolean(value)),
+            ] as const),
+        );
+        const documents = mirrored.map(eformsignListDocFromMirror);
+
+        const templateFiltered = filterDocumentsByTemplate(
+            documents,
+            query.templateId,
+            query.templateMatch,
+        );
+        const deletionFiltered = filterOutDeletedDocuments(
+            templateFiltered,
+            query.excludeDeleted ?? false,
+        );
+        const statusFiltered = filterDocumentsByStatusCategory(
+            deletionFiltered,
+            query.statusCategory,
+        );
+        const searchFiltered = this.filterBySearch(statusFiltered, localSearchValues, query.search);
+        const sorted = sortDocumentsByCreatedDate(searchFiltered);
+
+        return {
+            documentIds: sorted
+                .slice(query.skip, query.skip + query.limit)
+                .map((document) => document.id),
+            totalRows: sorted.length,
+        };
+    }
+
+    private filterBySearch(
+        documents: EformsignListDoc[],
+        localSearchValues: Map<string, string[]>,
+        search: string | undefined,
+    ): EformsignListDoc[] {
+        const query = search?.trim() ?? "";
+        if (!query) {
+            return documents;
+        }
+
+        return documents.filter((document) => {
+            const values = documentSearchValues(
+                document,
+                localSearchValues.get(document.id) ?? [],
+            );
+            return values.some((value) => matchesKoreanSearch(value, query));
+        });
+    }
+}
+
+function summariseIds(ids: string[]): string {
+    const shown = ids.slice(0, MAX_LOGGED_IDS).join(",");
+    return ids.length > MAX_LOGGED_IDS
+        ? `${shown}(+${ids.length - MAX_LOGGED_IDS} more)`
+        : shown;
+}

--- a/backend/application/services/eformsign-list-shadow-compare.service.ts
+++ b/backend/application/services/eformsign-list-shadow-compare.service.ts
@@ -83,6 +83,12 @@ export interface ListShadowCompareServed {
      * the scan's own warning in the same logs.
      */
     oldestScannedAt: number | undefined;
+    /**
+     * Whether the vendor scan stopped at its page cap. A scan that simply ran out is
+     * exhaustive, so a mirrored row the vendor did not return is stale however old it is —
+     * suppressing those would be the one way this comparison could bless a wrong mirror.
+     */
+    scanCapped: boolean;
 }
 
 /** How many differing ids to name before the log becomes noise rather than evidence. */
@@ -164,6 +170,12 @@ export class EformsignListShadowCompareService {
         const unclassifiable: string[] = [];
         for (const id of local.documentIds) {
             if (servedSet.has(id)) {
+                continue;
+            }
+            if (!served.scanCapped) {
+                // Exhaustive scan: the vendor does not have this document, whatever its
+                // age. That is a real disagreement.
+                extra.push(id);
                 continue;
             }
             if (served.oldestScannedAt === undefined) {

--- a/backend/application/services/eformsign-list-shadow-compare.service.ts
+++ b/backend/application/services/eformsign-list-shadow-compare.service.ts
@@ -32,8 +32,16 @@ export interface ListShadowCompareQuery {
 }
 
 export interface ListShadowCompareServed {
+    /** Every document that survived the filters, in served order — not just the page. */
     documentIds: string[];
-    totalRows: number;
+    /**
+     * Created time of the oldest served document, or undefined when nothing survived.
+     * The served path scans at most 10 vendor pages of 100, and says so in its own log,
+     * so anything the mirror holds from before this point is outside the window the API
+     * path can even see. Attributing those separately is what keeps the zero-diff gate
+     * reachable: they are what the switch recovers, not evidence the mirror is wrong.
+     */
+    oldestCreatedAt: number | undefined;
 }
 
 /** How many differing ids to name before the log becomes noise rather than evidence. */
@@ -53,6 +61,14 @@ const MAX_LOGGED_IDS = 10;
 @Injectable()
 export class EformsignListShadowCompareService {
     private readonly logger = new Logger(EformsignListShadowCompareService.name);
+    /**
+     * One comparison at a time. Every list request would otherwise load the branch's whole
+     * mirror and sort it, and a burst of page-throughs or searches would put that in front
+     * of the Prisma pool the served requests are using. Skipping is fine: this is sampling
+     * for evidence, not an audit that must see every request.
+     */
+    private comparisonInFlight = false;
+    private skippedWhileBusy = 0;
 
     constructor(
         private readonly configService: ConfigService,
@@ -74,74 +90,114 @@ export class EformsignListShadowCompareService {
             return;
         }
 
-        void this.compare(query, served).catch((error: unknown) => {
-            this.logger.warn(
-                `[Shadow] comparison failed scope=${query.scope}: ${
-                    error instanceof Error ? error.message : String(error)
-                }`,
-            );
-        });
+        if (this.comparisonInFlight) {
+            this.skippedWhileBusy += 1;
+            return;
+        }
+
+        this.comparisonInFlight = true;
+        void this.compare(query, served)
+            .catch((error: unknown) => {
+                this.logger.warn(
+                    `[Shadow] comparison failed scope=${query.scope}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            })
+            .finally(() => {
+                this.comparisonInFlight = false;
+            });
     }
 
     private async compare(
         query: ListShadowCompareQuery,
         served: ListShadowCompareServed,
     ): Promise<void> {
-        const local = await this.buildLocalPage(query);
-        const differences: string[] = [];
-
-        if (local.totalRows !== served.totalRows) {
-            differences.push(`total_rows served=${served.totalRows} local=${local.totalRows}`);
-        }
-
+        const local = await this.buildLocalList(query);
         const servedSet = new Set(served.documentIds);
         const localSet = new Set(local.documentIds);
-        const missing = served.documentIds.filter((id) => !localSet.has(id));
-        const extra = local.documentIds.filter((id) => !servedSet.has(id));
 
+        const missing = served.documentIds.filter((id) => !localSet.has(id));
+        const beyondWindow: string[] = [];
+        const extra: string[] = [];
+        for (const id of local.documentIds) {
+            if (servedSet.has(id)) {
+                continue;
+            }
+            const createdAt = local.createdAtById.get(id);
+            const outsideScanWindow = served.oldestCreatedAt !== undefined
+                && createdAt !== undefined
+                && createdAt < served.oldestCreatedAt;
+            (outsideScanWindow ? beyondWindow : extra).push(id);
+        }
+
+        const differences: string[] = [];
         if (missing.length > 0) {
             differences.push(`missing=${summariseIds(missing)}`);
         }
         if (extra.length > 0) {
             differences.push(`extra=${summariseIds(extra)}`);
         }
-        // Only worth reporting when both pages hold the same documents: otherwise the
-        // order difference is just a restatement of the membership difference above.
+        // An order difference is only its own finding when both sides hold the same
+        // documents; otherwise it just restates the membership difference above.
         if (missing.length === 0
             && extra.length === 0
+            && beyondWindow.length === 0
             && local.documentIds.join(",") !== served.documentIds.join(",")) {
             differences.push("order differs");
         }
 
+        // Named separately from `rows` so a reader cannot mistake it for a disagreement.
+        const windowNote = beyondWindow.length > 0
+            ? ` beyondScanWindow=${beyondWindow.length}`
+            : "";
+        // Enough of the query to tell one difference apart from another without carrying
+        // anything a customer could be identified by. The search term itself is a customer
+        // name often enough that it stays out; that a search happened is what explains a
+        // difference, and the ids below say which documents to go and look at.
+        const skipped = this.skippedWhileBusy;
+        this.skippedWhileBusy = 0;
+        const context = `scope=${query.scope} branch=${query.branchId}`
+            + ` rows=${served.documentIds.length}`
+            + windowNote
+            + `${query.search?.trim() ? " search=present" : ""}`
+            + `${query.statusCategory ? ` status=${query.statusCategory}` : ""}`
+            + `${query.templateId ? ` template=${query.templateMatch}` : ""}`
+            + `${query.excludeDeleted ? " excludeDeleted" : ""}`
+            + `${skipped > 0 ? ` skippedWhileBusy=${skipped}` : ""}`;
+
         if (differences.length === 0) {
-            this.logger.log(
-                `[Shadow] match scope=${query.scope} branch=${query.branchId}`
-                + ` skip=${query.skip} rows=${served.totalRows}`,
-            );
+            this.logger.log(`[Shadow] match ${context}`);
             return;
         }
 
-        this.logger.warn(
-            `[Shadow] diff scope=${query.scope} branch=${query.branchId}`
-            + ` skip=${query.skip} limit=${query.limit}`
-            + `${query.search ? ` search="${query.search}"` : ""}`
-            + `${query.statusCategory ? ` status=${query.statusCategory}` : ""}`
-            + ` :: ${differences.join("; ")}`,
-        );
+        this.logger.warn(`[Shadow] diff ${context} :: ${differences.join("; ")}`);
     }
 
-    private async buildLocalPage(
+    private async buildLocalList(
         query: ListShadowCompareQuery,
-    ): Promise<{ documentIds: string[]; totalRows: number }> {
+    ): Promise<{ documentIds: string[]; createdAtById: Map<string, number> }> {
+        // For a regular branch the corpus and the search rows are the same query, so it
+        // is read once; only headquarters needs the wider set as well.
+        const branchOwned = await this.eformsignDocRepository.findAll(query.branchId);
         const mirrored = query.isHeadquarters
             ? await this.eformsignDocRepository.findAllForHeadquarters(query.branchId)
-            : await this.eformsignDocRepository.findAll(query.branchId);
-        // Recipient names come from the same rows, so unlike the served path this does not
-        // need a second lookup to search them.
+            : branchOwned;
+        // Deliberately the branch-owned rows only, even for headquarters. The served path
+        // builds its recipient-name search corpus from findAll(branchId), so an unassigned
+        // document's recipient name is not searchable there — reproducing that is the
+        // point, and "fixing" it here would report a difference that is ours, not the
+        // mirror's.
         const localSearchValues = new Map(
-            mirrored.map((document) => [
+            branchOwned.map((document) => [
                 document.documentId,
                 [document.stepRecipientName].filter((value) => Boolean(value)),
+            ] as const),
+        );
+        const createdAtById = new Map(
+            mirrored.map((document) => [
+                document.documentId,
+                document.createdDate.getTime(),
             ] as const),
         );
         const documents = mirrored.map(eformsignListDocFromMirror);
@@ -163,10 +219,8 @@ export class EformsignListShadowCompareService {
         const sorted = sortDocumentsByCreatedDate(searchFiltered);
 
         return {
-            documentIds: sorted
-                .slice(query.skip, query.skip + query.limit)
-                .map((document) => document.id),
-            totalRows: sorted.length,
+            documentIds: sorted.map((document) => document.id),
+            createdAtById,
         };
     }
 

--- a/backend/application/services/eformsign-list-shadow-compare.service.ts
+++ b/backend/application/services/eformsign-list-shadow-compare.service.ts
@@ -63,6 +63,8 @@ export interface ListShadowCompareFields {
     stepIndex: string;
     stepName: string;
     createdAt: number;
+    /** Rendered as the signed/completion date, so a stale one shows users a wrong date. */
+    updatedAt: number;
 }
 
 export interface ListShadowCompareServed {
@@ -159,13 +161,21 @@ export class EformsignListShadowCompareService {
         const missing = served.documentIds.filter((id) => !localSet.has(id));
         const beyondWindow: string[] = [];
         const extra: string[] = [];
+        const unclassifiable: string[] = [];
         for (const id of local.documentIds) {
             if (servedSet.has(id)) {
                 continue;
             }
+            if (served.oldestScannedAt === undefined) {
+                // The vendor scan produced nothing for this scope, so there is no range to
+                // place these against. A branch whose documents all sit past the scan cap
+                // looks exactly like a branch whose mirror is wrong, and claiming either
+                // would be inventing a verdict — say what we have instead.
+                unclassifiable.push(id);
+                continue;
+            }
             const createdAt = local.fieldsById.get(id)?.createdAt;
-            const olderThanScanned = served.oldestScannedAt !== undefined
-                && createdAt !== undefined
+            const olderThanScanned = createdAt !== undefined
                 && createdAt < served.oldestScannedAt;
             (olderThanScanned ? beyondWindow : extra).push(id);
         }
@@ -176,6 +186,12 @@ export class EformsignListShadowCompareService {
         }
         if (extra.length > 0) {
             differences.push(`extra=${summariseIds(extra)}`);
+        }
+        if (unclassifiable.length > 0) {
+            differences.push(
+                `localOnlyNoScanRange=${summariseIds(unclassifiable)}`
+                + " (vendor scan returned nothing for this scope)",
+            );
         }
         // Compare order over the documents both sides can hold — dropping the out-of-range
         // ones rather than giving up on the check whenever any exist, which would have hid
@@ -325,7 +341,19 @@ export function eformsignListCompareFields(
         stepIndex: stringFromUnknown(currentStatus?.["step_index"]) ?? "",
         stepName: stringFromUnknown(currentStatus?.["step_name"]) ?? "",
         createdAt: getDocumentCreatedTimestamp(document),
+        updatedAt: numberFromUnknown(document["updated_date"]),
     };
+}
+
+function numberFromUnknown(value: unknown): number {
+    if (typeof value === "number") {
+        return Number.isFinite(value) ? value : 0;
+    }
+    if (typeof value === "string") {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) && value.trim() !== "" ? parsed : Date.parse(value) || 0;
+    }
+    return 0;
 }
 
 /** Ids whose served and mirrored values disagree, each tagged with the fields that did. */

--- a/backend/application/services/eformsign-list-shadow-compare.service.ts
+++ b/backend/application/services/eformsign-list-shadow-compare.service.ts
@@ -6,13 +6,24 @@ import {
     filterDocumentsByStatusCategory,
     filterDocumentsByTemplate,
     filterOutDeletedDocuments,
+    getDocumentStatusCategory,
     matchesKoreanSearch,
     sortDocumentsByCreatedDate,
     type DocumentStatusCategory,
     type EformsignListDoc,
     type TemplateMatch,
 } from "application/utils/eformsign-document-list";
+import {
+    isRecord,
+    stringFromUnknown,
+} from "application/utils/eformsign-document-customer-name";
+import { eformsignDocumentTemplateId } from "application/utils/eformsign-document-template-id";
 import { eformsignListDocFromMirror } from "application/utils/eformsign-list-doc-from-mirror";
+import { getDocumentCreatedTimestamp } from "application/services/eformsign.service";
+import {
+    normalizeEformsignStatusCode,
+    normalizeEformsignStepType,
+} from "domain/utils/eformsign-status-code";
 import {
     EFORMSIGN_DOC_REPOSITORY,
     IEformsignDocRepository,
@@ -22,6 +33,16 @@ export interface ListShadowCompareQuery {
     branchId: string;
     isHeadquarters: boolean;
     scope: string;
+    /**
+     * For the per-tab endpoints, the status categories a local list would use in place of
+     * "whichever vendor inbox the document sits in" — the mirror does not record that, and
+     * the switch has to answer those tabs from status codes instead.
+     *
+     * So a difference on these scopes means one of two things: the mirror is stale, or the
+     * vendor's inbox and its own status code disagree about where a document belongs. Both
+     * are worth knowing before the switch; neither shows up on the merged list.
+     */
+    scopeCategories?: DocumentStatusCategory[];
     limit: number;
     skip: number;
     templateId?: string;
@@ -31,17 +52,35 @@ export interface ListShadowCompareQuery {
     excludeDeleted?: boolean;
 }
 
+/** The list values the contracts UI actually renders, normalised for comparison. */
+export interface ListShadowCompareFields {
+    documentName: string;
+    documentNumber: string;
+    templateId: string;
+    templateName: string;
+    statusType: string;
+    stepType: string;
+    stepIndex: string;
+    stepName: string;
+    createdAt: number;
+}
+
 export interface ListShadowCompareServed {
     /** Every document that survived the filters, in served order — not just the page. */
     documentIds: string[];
+    /** Same documents, by id, projected to the values the UI reads. */
+    fieldsById: Map<string, ListShadowCompareFields>;
     /**
-     * Created time of the oldest served document, or undefined when nothing survived.
-     * The served path scans at most 10 vendor pages of 100, and says so in its own log,
-     * so anything the mirror holds from before this point is outside the window the API
-     * path can even see. Attributing those separately is what keeps the zero-diff gate
-     * reachable: they are what the switch recovers, not evidence the mirror is wrong.
+     * Created time of the oldest document the vendor scan produced for this scope, taken
+     * before any per-request filter — undefined when the scan returned nothing.
+     *
+     * The served path scans at most 10 vendor pages of 100 and warns in its own log when
+     * it hits that cap. A mirrored row older than this is outside the range the API path
+     * returned, so it is reported apart from a real disagreement rather than counted as
+     * one; whether that is the cap or a document the vendor no longer has is answered by
+     * the scan's own warning in the same logs.
      */
-    oldestCreatedAt: number | undefined;
+    oldestScannedAt: number | undefined;
 }
 
 /** How many differing ids to name before the log becomes noise rather than evidence. */
@@ -124,11 +163,11 @@ export class EformsignListShadowCompareService {
             if (servedSet.has(id)) {
                 continue;
             }
-            const createdAt = local.createdAtById.get(id);
-            const outsideScanWindow = served.oldestCreatedAt !== undefined
+            const createdAt = local.fieldsById.get(id)?.createdAt;
+            const olderThanScanned = served.oldestScannedAt !== undefined
                 && createdAt !== undefined
-                && createdAt < served.oldestCreatedAt;
-            (outsideScanWindow ? beyondWindow : extra).push(id);
+                && createdAt < served.oldestScannedAt;
+            (olderThanScanned ? beyondWindow : extra).push(id);
         }
 
         const differences: string[] = [];
@@ -138,18 +177,29 @@ export class EformsignListShadowCompareService {
         if (extra.length > 0) {
             differences.push(`extra=${summariseIds(extra)}`);
         }
-        // An order difference is only its own finding when both sides hold the same
-        // documents; otherwise it just restates the membership difference above.
+        // Compare order over the documents both sides can hold — dropping the out-of-range
+        // ones rather than giving up on the check whenever any exist, which would have hid
+        // a reversal behind a single ancient row.
+        const beyondWindowSet = new Set(beyondWindow);
+        const comparableLocalIds = local.documentIds.filter((id) => !beyondWindowSet.has(id));
         if (missing.length === 0
             && extra.length === 0
-            && beyondWindow.length === 0
-            && local.documentIds.join(",") !== served.documentIds.join(",")) {
+            && comparableLocalIds.join(",") !== served.documentIds.join(",")) {
             differences.push("order differs");
+        }
+
+        // Same documents in the same order still serves different content if the values
+        // differ, and the UI reads these directly — status drives the pill and which
+        // actions are offered. A zero-diff gate that never looked at them would be a
+        // gate on membership alone.
+        const fieldDifferences = collectFieldDifferences(served, local.fieldsById);
+        if (fieldDifferences.length > 0) {
+            differences.push(`fields=${summariseIds(fieldDifferences)}`);
         }
 
         // Named separately from `rows` so a reader cannot mistake it for a disagreement.
         const windowNote = beyondWindow.length > 0
-            ? ` beyondScanWindow=${beyondWindow.length}`
+            ? ` olderThanScanned=${beyondWindow.length}`
             : "";
         // Enough of the query to tell one difference apart from another without carrying
         // anything a customer could be identified by. The search term itself is a customer
@@ -176,7 +226,7 @@ export class EformsignListShadowCompareService {
 
     private async buildLocalList(
         query: ListShadowCompareQuery,
-    ): Promise<{ documentIds: string[]; createdAtById: Map<string, number> }> {
+    ): Promise<{ documentIds: string[]; fieldsById: Map<string, ListShadowCompareFields> }> {
         // For a regular branch the corpus and the search rows are the same query, so it
         // is read once; only headquarters needs the wider set as well.
         const branchOwned = await this.eformsignDocRepository.findAll(query.branchId);
@@ -194,13 +244,13 @@ export class EformsignListShadowCompareService {
                 [document.stepRecipientName].filter((value) => Boolean(value)),
             ] as const),
         );
-        const createdAtById = new Map(
-            mirrored.map((document) => [
-                document.documentId,
-                document.createdDate.getTime(),
+        const documents = mirrored.map(eformsignListDocFromMirror);
+        const fieldsById = new Map(
+            documents.map((document) => [
+                document.id,
+                eformsignListCompareFields(document),
             ] as const),
         );
-        const documents = mirrored.map(eformsignListDocFromMirror);
 
         const templateFiltered = filterDocumentsByTemplate(
             documents,
@@ -211,8 +261,12 @@ export class EformsignListShadowCompareService {
             templateFiltered,
             query.excludeDeleted ?? false,
         );
+        const scopeFiltered = query.scopeCategories === undefined
+            ? deletionFiltered
+            : deletionFiltered.filter((document) =>
+                query.scopeCategories!.includes(getDocumentStatusCategory(document)));
         const statusFiltered = filterDocumentsByStatusCategory(
-            deletionFiltered,
+            scopeFiltered,
             query.statusCategory,
         );
         const searchFiltered = this.filterBySearch(statusFiltered, localSearchValues, query.search);
@@ -220,7 +274,7 @@ export class EformsignListShadowCompareService {
 
         return {
             documentIds: sorted.map((document) => document.id),
-            createdAtById,
+            fieldsById,
         };
     }
 
@@ -242,6 +296,57 @@ export class EformsignListShadowCompareService {
             return values.some((value) => matchesKoreanSearch(value, query));
         });
     }
+}
+
+/**
+ * Projects a list document — vendor's or mirror's — to the values the contracts UI reads.
+ * Both sides go through this same function so a difference is a difference in the data,
+ * never in how the two were read.
+ */
+export function eformsignListCompareFields(
+    document: EformsignListDoc,
+): ListShadowCompareFields {
+    const template = isRecord(document["template"]) ? document["template"] : null;
+    const currentStatus = isRecord(document["current_status"])
+        ? document["current_status"]
+        : null;
+
+    return {
+        documentName: stringFromUnknown(document["document_name"]) ?? "",
+        documentNumber: stringFromUnknown(document["document_number"]) ?? "",
+        // Resolved rather than read straight off `template`, because the vendor supplies
+        // it through three different places and the filter already agrees on the order.
+        templateId: eformsignDocumentTemplateId(document) ?? "",
+        templateName: stringFromUnknown(template?.["name"]) ?? "",
+        statusType: normalizeEformsignStatusCode(
+            stringFromUnknown(currentStatus?.["status_type"]),
+        ),
+        stepType: normalizeEformsignStepType(stringFromUnknown(currentStatus?.["step_type"])),
+        stepIndex: stringFromUnknown(currentStatus?.["step_index"]) ?? "",
+        stepName: stringFromUnknown(currentStatus?.["step_name"]) ?? "",
+        createdAt: getDocumentCreatedTimestamp(document),
+    };
+}
+
+/** Ids whose served and mirrored values disagree, each tagged with the fields that did. */
+function collectFieldDifferences(
+    served: ListShadowCompareServed,
+    localFieldsById: Map<string, ListShadowCompareFields>,
+): string[] {
+    const differing: string[] = [];
+    for (const [documentId, servedFields] of served.fieldsById) {
+        const localFields = localFieldsById.get(documentId);
+        if (!localFields) {
+            continue;
+        }
+
+        const names = (Object.keys(servedFields) as Array<keyof ListShadowCompareFields>)
+            .filter((name) => servedFields[name] !== localFields[name]);
+        if (names.length > 0) {
+            differing.push(`${documentId}[${names.join("|")}]`);
+        }
+    }
+    return differing;
 }
 
 function summariseIds(ids: string[]): string {

--- a/backend/application/services/eformsign-list-shadow-compare.service.ts
+++ b/backend/application/services/eformsign-list-shadow-compare.service.ts
@@ -5,8 +5,8 @@ import {
     documentSearchValues,
     filterDocumentsByStatusCategory,
     filterDocumentsByTemplate,
+    eformsignListScopeSelector,
     filterOutDeletedDocuments,
-    getDocumentStatusCategory,
     matchesKoreanSearch,
     sortDocumentsByCreatedDate,
     type DocumentStatusCategory,
@@ -34,15 +34,10 @@ export interface ListShadowCompareQuery {
     isHeadquarters: boolean;
     scope: string;
     /**
-     * For the per-tab endpoints, the status categories a local list would use in place of
-     * "whichever vendor inbox the document sits in" — the mirror does not record that, and
-     * the switch has to answer those tabs from status codes instead.
-     *
-     * So a difference on these scopes means one of two things: the mirror is stale, or the
-     * vendor's inbox and its own status code disagree about where a document belongs. Both
-     * are worth knowing before the switch; neither shows up on the merged list.
+     * A difference on a tab scope means one of two things: the mirror is stale, or the
+     * vendor's inbox and its own status code disagree about where a document belongs.
+     * Both are worth knowing before the switch; neither shows up on the merged list.
      */
-    scopeCategories?: DocumentStatusCategory[];
     limit: number;
     skip: number;
     templateId?: string;
@@ -72,23 +67,6 @@ export interface ListShadowCompareServed {
     documentIds: string[];
     /** Same documents, by id, projected to the values the UI reads. */
     fieldsById: Map<string, ListShadowCompareFields>;
-    /**
-     * Created time of the oldest document the vendor scan produced for this scope, taken
-     * before any per-request filter — undefined when the scan returned nothing.
-     *
-     * The served path scans at most 10 vendor pages of 100 and warns in its own log when
-     * it hits that cap. A mirrored row older than this is outside the range the API path
-     * returned, so it is reported apart from a real disagreement rather than counted as
-     * one; whether that is the cap or a document the vendor no longer has is answered by
-     * the scan's own warning in the same logs.
-     */
-    oldestScannedAt: number | undefined;
-    /**
-     * Whether the vendor scan stopped at its page cap. A scan that simply ran out is
-     * exhaustive, so a mirrored row the vendor did not return is stale however old it is —
-     * suppressing those would be the one way this comparison could bless a wrong mirror.
-     */
-    scanCapped: boolean;
 }
 
 /** How many differing ids to name before the log becomes noise rather than evidence. */
@@ -165,32 +143,14 @@ export class EformsignListShadowCompareService {
         const localSet = new Set(local.documentIds);
 
         const missing = served.documentIds.filter((id) => !localSet.has(id));
-        const beyondWindow: string[] = [];
-        const extra: string[] = [];
-        const unclassifiable: string[] = [];
-        for (const id of local.documentIds) {
-            if (servedSet.has(id)) {
-                continue;
-            }
-            if (!served.scanCapped) {
-                // Exhaustive scan: the vendor does not have this document, whatever its
-                // age. That is a real disagreement.
-                extra.push(id);
-                continue;
-            }
-            if (served.oldestScannedAt === undefined) {
-                // The vendor scan produced nothing for this scope, so there is no range to
-                // place these against. A branch whose documents all sit past the scan cap
-                // looks exactly like a branch whose mirror is wrong, and claiming either
-                // would be inventing a verdict — say what we have instead.
-                unclassifiable.push(id);
-                continue;
-            }
-            const createdAt = local.fieldsById.get(id)?.createdAt;
-            const olderThanScanned = createdAt !== undefined
-                && createdAt < served.oldestScannedAt;
-            (olderThanScanned ? beyondWindow : extra).push(id);
-        }
+        // Every document the mirror has and the served list did not is reported, with no
+        // attempt to decide which of them the vendor's ten-page scan simply could not
+        // reach. Three rounds of inferring that boundary — from filtered results, from a
+        // cached flag, from where the scan stopped — each produced a way to log a match
+        // for a mirror that was wrong, which is the one thing this evidence must never do.
+        // The scan says in its own log when it hits the cap; a reader with both lines can
+        // tell an unreachable document from a stale one, and this cannot.
+        const extra = local.documentIds.filter((id) => !servedSet.has(id));
 
         const differences: string[] = [];
         if (missing.length > 0) {
@@ -199,20 +159,11 @@ export class EformsignListShadowCompareService {
         if (extra.length > 0) {
             differences.push(`extra=${summariseIds(extra)}`);
         }
-        if (unclassifiable.length > 0) {
-            differences.push(
-                `localOnlyNoScanRange=${summariseIds(unclassifiable)}`
-                + " (vendor scan returned nothing for this scope)",
-            );
-        }
-        // Compare order over the documents both sides can hold — dropping the out-of-range
-        // ones rather than giving up on the check whenever any exist, which would have hid
-        // a reversal behind a single ancient row.
-        const beyondWindowSet = new Set(beyondWindow);
-        const comparableLocalIds = local.documentIds.filter((id) => !beyondWindowSet.has(id));
+        // An order difference is only its own finding when both sides hold the same
+        // documents; otherwise it just restates the membership difference above.
         if (missing.length === 0
             && extra.length === 0
-            && comparableLocalIds.join(",") !== served.documentIds.join(",")) {
+            && local.documentIds.join(",") !== served.documentIds.join(",")) {
             differences.push("order differs");
         }
 
@@ -225,10 +176,6 @@ export class EformsignListShadowCompareService {
             differences.push(`fields=${summariseIds(fieldDifferences)}`);
         }
 
-        // Named separately from `rows` so a reader cannot mistake it for a disagreement.
-        const windowNote = beyondWindow.length > 0
-            ? ` olderThanScanned=${beyondWindow.length}`
-            : "";
         // Enough of the query to tell one difference apart from another without carrying
         // anything a customer could be identified by. The search term itself is a customer
         // name often enough that it stays out; that a search happened is what explains a
@@ -237,7 +184,6 @@ export class EformsignListShadowCompareService {
         this.skippedWhileBusy = 0;
         const context = `scope=${query.scope} branch=${query.branchId}`
             + ` rows=${served.documentIds.length}`
-            + windowNote
             + `${query.search?.trim() ? " search=present" : ""}`
             + `${query.statusCategory ? ` status=${query.statusCategory}` : ""}`
             + `${query.templateId ? ` template=${query.templateMatch}` : ""}`
@@ -289,10 +235,10 @@ export class EformsignListShadowCompareService {
             templateFiltered,
             query.excludeDeleted ?? false,
         );
-        const scopeFiltered = query.scopeCategories === undefined
+        const scopeSelector = eformsignListScopeSelector(query.scope);
+        const scopeFiltered = scopeSelector === undefined
             ? deletionFiltered
-            : deletionFiltered.filter((document) =>
-                query.scopeCategories!.includes(getDocumentStatusCategory(document)));
+            : deletionFiltered.filter(scopeSelector);
         const statusFiltered = filterDocumentsByStatusCategory(
             scopeFiltered,
             query.statusCategory,

--- a/backend/application/services/eformsign-webhook.service.ts
+++ b/backend/application/services/eformsign-webhook.service.ts
@@ -776,7 +776,12 @@ export class EformsignWebhookService {
             stepName,
             expired,
         });
-        await this.eformsignDocRepository.upsertUnassignedByDocumentId(updated);
+        // A webhook carries no creation time; this entity copies it from the row we just
+        // read. Writing it back would undo a creation-time repair the nightly sweep made
+        // between that read and this write, and put the list's sort key wrong again.
+        await this.eformsignDocRepository.upsertUnassignedByDocumentId(updated, {
+            updateCreatedDate: false,
+        });
         this.logger.log(
             `Updated unassigned document ${existing.documentId} from webhook ${webhook_id}: event_type=${event_type}`,
         );

--- a/backend/application/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.ts
@@ -85,9 +85,10 @@ export class MirrorUnassignedEformsignDocUsecase {
         }
 
         const remoteCreatedDate = new Date(remote.created_date);
-        const createdDate = Number.isNaN(remoteCreatedDate.getTime())
-            ? new Date(updatedDate)
-            : remoteCreatedDate;
+        const hasRemoteCreatedDate = !Number.isNaN(remoteCreatedDate.getTime());
+        const createdDate = hasRemoteCreatedDate
+            ? remoteCreatedDate
+            : new Date(updatedDate);
         if (Number.isNaN(remoteCreatedDate.getTime())) {
             this.logger.warn(
                 `Invalid remote created_date for eformsign document ${remote.id || fallbackDocumentId}; using updated_date`,
@@ -158,6 +159,11 @@ export class MirrorUnassignedEformsignDocUsecase {
             ...(remote.current_status.expired_date === undefined
                 ? { updateExpiredDate: false }
                 : {}),
+            // Creation time is the list's sort key. The create and adopt paths store the
+            // moment we wrote the row, so a document adopted long after it was created
+            // sorts in the wrong place forever unless a response that really carries
+            // created_date puts it right. Only a clamped-away value is not worth writing.
+            ...(hasRemoteCreatedDate ? {} : { updateCreatedDate: false }),
         });
     }
 }

--- a/backend/application/utils/eformsign-document-list.ts
+++ b/backend/application/utils/eformsign-document-list.ts
@@ -202,3 +202,44 @@ export function documentSearchValues(document: EformsignListDoc, localValues: st
 export function documentSearchIndex(document: EformsignListDoc): string[] {
     return documentSearchValues(document, []).filter((value) => value.length > 0);
 }
+
+/**
+ * Which documents a local list would put in each tab, standing in for "whichever vendor
+ * inbox the document sits in" — the mirror does not record that, so the switch has to
+ * answer the tabs from status codes instead.
+ *
+ * Deleted codes are named here rather than folded into a category, because
+ * getDocumentStatusCategory puts them in "unknown" alongside every blank or unrecognised
+ * status, and the UI does not treat those alike: it shows the deleted ones under 기간 만료
+ * and everything else it cannot place under 진행 중.
+ */
+const SCOPE_SELECTORS: Readonly<Record<string, (document: EformsignListDoc) => boolean>> = {
+    "in-progress": (document) => {
+        const category = getDocumentStatusCategory(document);
+        return category === "drafting"
+            || category === "in-progress"
+            || (category === "unknown" && !isDeletedDocument(document));
+    },
+    completed: (document) => getDocumentStatusCategory(document) === "completed",
+    rejected: (document) => {
+        const category = getDocumentStatusCategory(document);
+        return category === "expired"
+            || (category === "unknown" && isDeletedDocument(document));
+    },
+};
+
+export function isDeletedDocument(document: EformsignListDoc): boolean {
+    const statusType = stringFromUnknown(getCurrentStatus(document)?.["status_type"]);
+    return DELETED_STATUS_CODES.has(normalizeEformsignStatusCode(statusType));
+}
+
+/**
+ * The tab selector for a scope, or undefined for the merged list, which does not filter by
+ * inbox at all. Both sides of the shadow comparison resolve it from here by name so they
+ * cannot come to different conclusions about what a tab contains.
+ */
+export function eformsignListScopeSelector(
+    scope: string,
+): ((document: EformsignListDoc) => boolean) | undefined {
+    return SCOPE_SELECTORS[scope];
+}

--- a/backend/application/utils/eformsign-document-list.ts
+++ b/backend/application/utils/eformsign-document-list.ts
@@ -1,0 +1,204 @@
+import { normalizeEformsignStatusCode, normalizeEformsignStepType } from "domain/utils/eformsign-status-code";
+
+import { documentCustomerNameValue, isRecord, stringFromUnknown, type UnknownRecord } from "application/utils/eformsign-document-customer-name";
+import { eformsignDocumentTemplateId } from "application/utils/eformsign-document-template-id";
+import { getDocumentCreatedTimestamp } from "application/services/eformsign.service";
+
+/**
+ * The rules that turn a set of eformsign documents into what the contract list shows:
+ * which documents survive each filter, how they are searched, and what order they end in.
+ *
+ * These live apart from the controller because the local mirror has to reproduce the list
+ * exactly, and the only way to be sure of that is for both paths to run the same code.
+ * Duplicating a rule here has already cost this codebase three separate defects.
+ */
+
+export type EformsignListDoc = {
+    id: string;
+    created_date?: unknown;
+    createdDate?: unknown;
+    fields?: unknown;
+    detail_template_info?: unknown;
+} & Record<string, unknown>;
+
+export type TemplateMatch = "include" | "exclude";
+export type DocumentStatusCategory =
+    | "drafting"
+    | "in-progress"
+    | "completed"
+    | "expired"
+    | "unknown";
+
+export const COMPLETED_STATUS_CODES = new Set(["003", "012", "022", "032", "050", "062", "072", "092"]);
+export const EXPIRED_STATUS_CODES = new Set(["011", "021", "031", "040", "042", "045", "047", "049", "061", "071", "080", "090"]);
+export const DELETED_STATUS_CODES = new Set(["047", "049"]);
+export const IN_PROGRESS_STATUS_CODES = new Set(["001", "002", "010", "020", "030", "043", "060", "063", "064", "070"]);
+export const PROVIDER_REVIEW_STEP_TYPES = new Set(["06"]);
+export const PROVIDER_REVIEW_OWNER_KEYWORDS = ["제공기관", "관리자", "담당자"];
+export const PROVIDER_REVIEW_ACTION_KEYWORDS = ["확인", "검토"];
+export const CUSTOMER_STEP_KEYWORDS = ["이용자", "고객", "산모"];
+export const CHOSUNG_LIST = [
+    "ㄱ", "ㄲ", "ㄴ", "ㄷ", "ㄸ", "ㄹ", "ㅁ", "ㅂ", "ㅃ",
+    "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅉ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ",
+] as const;
+
+
+
+/**
+ * `templateId` may be a single id or a comma-separated list (BJJ-multi-tier: the UI passes every
+ * configured 제공기록지 tier so documents created on any tier's template are matched). A single id
+ * is naturally backward-compatible since it round-trips through the same split/trim/Set path.
+ */
+export function filterDocumentsByTemplate(
+    documents: EformsignListDoc[],
+    templateId: string | undefined,
+    templateMatch: TemplateMatch,
+): EformsignListDoc[] {
+    if (!templateId) {
+        return documents;
+    }
+    const templateIds = new Set(
+        templateId.split(",").map((id) => id.trim()).filter((id) => id.length > 0),
+    );
+    if (templateIds.size === 0) {
+        return documents;
+    }
+
+    return documents.filter((document) => {
+        const documentTemplateId = eformsignDocumentTemplateId(document);
+        const matches = documentTemplateId !== null && templateIds.has(documentTemplateId);
+        return templateMatch === "include" ? matches : !matches;
+    });
+}
+
+export function getCurrentStatus(document: EformsignListDoc): UnknownRecord | null {
+    return isRecord(document["current_status"]) ? document["current_status"] : null;
+}
+
+export function isProviderReviewStep(document: EformsignListDoc): boolean {
+    const currentStatus = getCurrentStatus(document);
+    const stepType = normalizeEformsignStepType(
+        stringFromUnknown(currentStatus?.["step_type"]),
+    );
+    const stepName = stringFromUnknown(currentStatus?.["step_name"]) ?? "";
+
+    if (PROVIDER_REVIEW_STEP_TYPES.has(stepType)) {
+        return true;
+    }
+    if (!stepName || CUSTOMER_STEP_KEYWORDS.some((keyword) => stepName.includes(keyword))) {
+        return false;
+    }
+
+    const hasProviderOwner = PROVIDER_REVIEW_OWNER_KEYWORDS.some((keyword) => stepName.includes(keyword));
+    const hasReviewAction = PROVIDER_REVIEW_ACTION_KEYWORDS.some((keyword) => stepName.includes(keyword));
+    return hasProviderOwner && hasReviewAction;
+}
+
+export function getDocumentStatusCategory(document: EformsignListDoc): DocumentStatusCategory {
+    const statusType = stringFromUnknown(getCurrentStatus(document)?.["status_type"]);
+    const normalized = normalizeEformsignStatusCode(statusType);
+    if (COMPLETED_STATUS_CODES.has(normalized)) {
+        return "completed";
+    }
+    if (EXPIRED_STATUS_CODES.has(normalized) && !DELETED_STATUS_CODES.has(normalized)) {
+        return "expired";
+    }
+    if (DELETED_STATUS_CODES.has(normalized)) {
+        return "unknown";
+    }
+    if (!IN_PROGRESS_STATUS_CODES.has(normalized)) {
+        return "unknown";
+    }
+    return isProviderReviewStep(document) ? "in-progress" : "drafting";
+}
+
+export function filterDocumentsByStatusCategory(
+    documents: EformsignListDoc[],
+    statusCategory: DocumentStatusCategory | undefined,
+): EformsignListDoc[] {
+    if (!statusCategory) {
+        return documents;
+    }
+
+    return documents.filter((document) => {
+        const statusType = stringFromUnknown(getCurrentStatus(document)?.["status_type"]);
+        if (DELETED_STATUS_CODES.has(normalizeEformsignStatusCode(statusType))) {
+            return false;
+        }
+        return getDocumentStatusCategory(document) === statusCategory;
+    });
+}
+
+export function filterOutDeletedDocuments(
+    documents: EformsignListDoc[],
+    excludeDeleted: boolean,
+): EformsignListDoc[] {
+    if (!excludeDeleted) {
+        return documents;
+    }
+    return documents.filter((document) => {
+        const statusType = stringFromUnknown(getCurrentStatus(document)?.["status_type"]);
+        return !DELETED_STATUS_CODES.has(normalizeEformsignStatusCode(statusType));
+    });
+}
+
+export function getChosung(character: string): string {
+    const code = character.charCodeAt(0);
+    if (code >= 0xac00 && code <= 0xd7a3) {
+        return CHOSUNG_LIST[Math.floor((code - 0xac00) / 588)] ?? character;
+    }
+    return character;
+}
+
+export function matchesKoreanSearch(target: string, query: string): boolean {
+    const normalizedTarget = target.normalize("NFC");
+    if (normalizedTarget.toLowerCase().includes(query.toLowerCase())) {
+        return true;
+    }
+
+    const hasChosung = query.split("").some((character) =>
+        CHOSUNG_LIST.includes(character as (typeof CHOSUNG_LIST)[number]),
+    );
+    if (!hasChosung) {
+        return false;
+    }
+
+    const targetChosung = normalizedTarget.split("").map(getChosung).join("").replace(/\s/g, "");
+    return targetChosung.startsWith(query);
+}
+
+export function sortDocumentsByCreatedDate(documents: EformsignListDoc[]): EformsignListDoc[] {
+    return [...documents].sort((a, b) => {
+        const byCreated = getDocumentCreatedTimestamp(b) - getDocumentCreatedTimestamp(a);
+        if (byCreated !== 0) {
+            return byCreated;
+        }
+        return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
+}
+
+export function documentSearchValues(document: EformsignListDoc, localValues: string[]): string[] {
+    const template = isRecord(document["template"]) ? document["template"] : null;
+    const templateName = (stringFromUnknown(template?.["name"]) ?? "").replace(/\s*계약서$/, "");
+    const documentNumber = (
+        stringFromUnknown(document["document_number"]) ?? document.id?.slice(0, 16)
+    ) || "-";
+
+    return [
+        documentCustomerNameValue(document) ?? "고객 미지정",
+        ...localValues,
+        stringFromUnknown(document["document_name"]) ?? "",
+        templateName,
+        documentNumber,
+    ];
+}
+
+/**
+ * 문서 자체에서 파생되는 검색 값(고객명/문서명/템플릿명/문서번호)만 미리 뽑아 스냅샷에 넣는다.
+ * 로컬 DB에서 오는 값(stepRecipientName)은 검색어가 있을 때만 조회하는 기존 동작을 유지하기
+ * 위해 여기에 포함하지 않고, 질의 시점에 합쳐 쓴다. 빈 문자열은 어떤 검색어와도 매칭되지
+ * 않으므로 제거해 스냅샷 크기를 줄인다.
+ */
+export function documentSearchIndex(document: EformsignListDoc): string[] {
+    return documentSearchValues(document, []).filter((value) => value.length > 0);
+}

--- a/backend/application/utils/eformsign-list-doc-from-mirror.ts
+++ b/backend/application/utils/eformsign-list-doc-from-mirror.ts
@@ -16,8 +16,6 @@ import type { EformsignListDoc } from "./eformsign-document-list";
  * list and should fetch the document.
  */
 export function eformsignListDocFromMirror(document: EformsignDocEntity): EformsignListDoc {
-    const customerName = document.customerName;
-
     return {
         id: document.documentId,
         document_name: document.documentName ?? "",
@@ -41,11 +39,14 @@ export function eformsignListDocFromMirror(document: EformsignDocEntity): Eforms
             })),
             _expired: document.expired,
         },
-        // The customer name reaches the vendor list inside `fields`, and the search rules
-        // read it back out through the same extraction. Emitting it here rather than as a
-        // bare property is what lets those rules stay untouched.
-        ...(customerName === null
-            ? {}
-            : { fields: [{ id: "이용자 성명", value: customerName, type: "text" }] }),
+        // No `fields`, deliberately, even though the mirror holds a customerName. The
+        // vendor's list endpoint is fetched without include_fields — only the
+        // single-document fetch asks for them — so the served search never sees a customer
+        // name from the document itself and matches on the local recipient name instead.
+        // Emitting one here would make the mirror find documents the served path cannot,
+        // and every such difference would be this mapper's, not the mirror's.
+        //
+        // Phase E may well decide the list should search customerName. That is a change in
+        // what the feature does and belongs in that decision, not inherited by accident.
     };
 }

--- a/backend/application/utils/eformsign-list-doc-from-mirror.ts
+++ b/backend/application/utils/eformsign-list-doc-from-mirror.ts
@@ -1,0 +1,51 @@
+import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
+
+import type { EformsignListDoc } from "./eformsign-document-list";
+
+/**
+ * Renders a mirrored row into the shape eformsign's list endpoint returns.
+ *
+ * The point is not to fake a vendor response for its own sake — it is that the list rules
+ * (filter, search, sort) must run over local rows byte-for-byte the same way they run over
+ * the vendor's. Projecting into one shape and reusing those functions is the only version
+ * of that which cannot drift; a parallel set of rules for local rows would be the fourth
+ * time this codebase paid for the same mistake.
+ *
+ * Fields the list rules never read — histories, recipients, next/previous status — are
+ * deliberately absent rather than invented. A caller that needs them is not looking at a
+ * list and should fetch the document.
+ */
+export function eformsignListDocFromMirror(document: EformsignDocEntity): EformsignListDoc {
+    const customerName = document.customerName;
+
+    return {
+        id: document.documentId,
+        document_name: document.documentName ?? "",
+        document_number: document.documentNumber ?? "",
+        created_date: document.createdDate.getTime(),
+        updated_date: document.updatedDate.getTime(),
+        template: {
+            id: document.templateId ?? "",
+            name: document.templateName ?? "",
+        },
+        creator: { name: document.creatorName ?? "" },
+        last_editor: { name: document.lastEditorName ?? "" },
+        current_status: {
+            status_type: document.statusType,
+            status_doc_detail: document.statusDetail,
+            step_type: document.stepType,
+            step_index: document.stepIndex,
+            step_name: document.stepName,
+            step_recipients: (document.stepRecipientTypes ?? []).map((recipientType) => ({
+                recipient_type: recipientType,
+            })),
+            _expired: document.expired,
+        },
+        // The customer name reaches the vendor list inside `fields`, and the search rules
+        // read it back out through the same extraction. Emitting it here rather than as a
+        // bare property is what lets those rules stay untouched.
+        ...(customerName === null
+            ? {}
+            : { fields: [{ id: "이용자 성명", value: customerName, type: "text" }] }),
+    };
+}

--- a/backend/domain/repositories/eformsign-doc.repository.interface.ts
+++ b/backend/domain/repositories/eformsign-doc.repository.interface.ts
@@ -77,6 +77,14 @@ export interface UpsertUnassignedEformsignDocOptions {
      * overwriting a real stored expiry with it.
      */
     updateExpiredDate?: boolean;
+    /**
+     * Creation time is the list's sort key, and rows written by the create and adopt paths
+     * carry the moment we wrote them rather than the moment eformsign created the
+     * document — a contract adopted today sorts as today's. Reconciling from a response
+     * that actually carries `created_date` repairs that; a caller that had to invent one
+     * sets this false rather than replacing a stored value with its own guess.
+     */
+    updateCreatedDate?: boolean;
 }
 
 export interface IEformsignDocRepository {

--- a/backend/domain/repositories/eformsign-doc.repository.interface.ts
+++ b/backend/domain/repositories/eformsign-doc.repository.interface.ts
@@ -90,6 +90,12 @@ export interface IEformsignDocRepository {
     ): Promise<EformsignDocCompletionClaimResult>;
     findByClientId(branchid: string, clientId: number): Promise<EformsignDocEntity[]>;
     findAll(branchid: string): Promise<EformsignDocEntity[]>;
+    /**
+     * Every document the headquarters list may show: ours plus the ones no branch has
+     * claimed. Deliberately not "all rows minus other branches" done in memory — that is
+     * the same rule, but expressed where the database can apply it.
+     */
+    findAllForHeadquarters(branchid: string): Promise<EformsignDocEntity[]>;
     findDocumentIdsForOtherBranches(branchid: string): Promise<string[]>;
     findDisplayFieldsByDocumentIds(
         branchid: string,

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -470,6 +470,14 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                 updatedDate: { lte: doc.updatedDate },
                 ...statusGuard,
             },
+            // Creation time is not state, so a refusal on ordering grounds must not take
+            // it down with the rest. It has to be that way: a row written by create or
+            // adopt carries the moment we wrote it, which is *newer* than the vendor's own
+            // updated_date for an unchanged old document — so the guard refuses, and the
+            // rows this repair exists for are exactly the ones it would never reach.
+            ...(options?.updateCreatedDate === false
+                ? {}
+                : { repairCreatedDateWhenStale: doc.createdDate }),
         });
     }
 
@@ -479,6 +487,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
         update: Prisma.eformsign_docUpdateManyMutationInput;
         allowedWhere: Prisma.eformsign_docWhereInput;
         staleGuard?: Prisma.eformsign_docWhereInput;
+        repairCreatedDateWhenStale?: Date;
     }): Promise<EformsignDocEntity> {
         try {
             return await this.attemptConditionalUpsertByDocumentId(params, false);
@@ -502,6 +511,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
             update: Prisma.eformsign_docUpdateManyMutationInput;
             allowedWhere: Prisma.eformsign_docWhereInput;
             staleGuard?: Prisma.eformsign_docWhereInput;
+            repairCreatedDateWhenStale?: Date;
         },
         compatibilityMode: boolean,
     ): Promise<EformsignDocEntity> {
@@ -526,9 +536,26 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
             const ownedCount = await this.prismaService.eformsign_doc.count({
                 where: params.allowedWhere,
             });
-            throw ownedCount > 0
-                ? new EformsignDocStaleUpdateError(params.documentId)
-                : new EformsignDocOwnershipConflictError(params.documentId);
+            if (ownedCount === 0) {
+                throw new EformsignDocOwnershipConflictError(params.documentId);
+            }
+
+            // The row is ours and the event was refused for being older than what we hold.
+            // Creation time is not state, though — it cannot be stale — and this is the
+            // only path that ever reaches an adopted row, whose stored creation time is
+            // the moment of adoption rather than the moment eformsign made the document.
+            if (params.repairCreatedDateWhenStale !== undefined) {
+                await this.prismaService.eformsign_doc.updateMany({
+                    where: {
+                        AND: [
+                            params.allowedWhere,
+                            { createdDate: { not: params.repairCreatedDateWhenStale } },
+                        ],
+                    },
+                    data: { createdDate: params.repairCreatedDateWhenStale },
+                });
+            }
+            throw new EformsignDocStaleUpdateError(params.documentId);
         };
 
         let updated = await updateExisting();

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -410,6 +410,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
             stepName: doc.stepName,
             ...(options?.updateExpired === false ? {} : { expired: doc.expired }),
             ...(options?.updateExpiredDate === false ? {} : { expiredDate: doc.expiredDate }),
+            ...(options?.updateCreatedDate === false ? {} : { createdDate: doc.createdDate }),
             updatedDate: doc.updatedDate,
             ...(documentName ? { documentName } : {}),
             ...(documentNumber ? { documentNumber } : {}),

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -184,6 +184,17 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
         return this.findManyDomain({ branchId: branchid });
     }
 
+    async findAllForHeadquarters(branchid: string): Promise<EformsignDocEntity[]> {
+        // Mirrors the scan filter the API path uses: headquarters keeps everything except
+        // what another branch owns, so an unclaimed document (branchId null) stays in.
+        return this.findManyDomain({
+            OR: [
+                { branchId: branchid },
+                { branchId: null },
+            ],
+        });
+    }
+
     async findDocumentIdsForOtherBranches(branchid: string): Promise<string[]> {
         // 다른 지점이 소유한 문서의 documentId만 추린다. branchId가 null인(미적재) 문서는
         // "지점 미지정"이라 인천(본사) 목록에 남아야 하므로 제외한다. Prisma의 `not`은

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Controller, Post, Get, Delete, Body, Query, Param, HttpException, HttpStatus, UseGuards, Res, Logger } from "@nestjs/common";
-import { EformsignService, getDocumentCreatedTimestamp } from "../../application/services/eformsign.service";
+import { EformsignService } from "../../application/services/eformsign.service";
 import { EformsignDocService } from "../../application/services/eformsign-doc.service";
 import { AreaTemplateService } from "../../application/services/area-template.service";
 import { PrismaService } from "infrastructure/database/prisma.service";
@@ -38,8 +38,8 @@ import {
     documentSearchValues,
     filterDocumentsByStatusCategory,
     filterDocumentsByTemplate,
+    eformsignListScopeSelector,
     filterOutDeletedDocuments,
-    getDocumentStatusCategory,
     matchesKoreanSearch,
     sortDocumentsByCreatedDate,
     type DocumentStatusCategory,
@@ -53,38 +53,18 @@ import {
 import { EformsignApiError } from "infrastructure/api/eformsign-api.error";
 
 /**
- * What a local list would select for each tab, standing in for "whichever vendor inbox the
- * document sits in" — the mirror does not record that. The merged list has no entry here
- * because it does not filter by inbox at all.
- *
- * Applied to both sides of the comparison, because a vendor inbox is not the tab: type 04
- * is eformsign's document-management inbox and carries in-progress and completed documents
- * too, which the client filters out by status before rendering. Comparing the raw inbox
- * against a status-selected mirror would report every one of those as missing.
- */
-const SHADOW_SCOPE_CATEGORIES: Partial<Record<string, DocumentStatusCategory[]>> = {
-    "in-progress": ["drafting", "in-progress"],
-    completed: ["completed"],
-    // "unknown" is here because getDocumentStatusCategory puts the deleted codes 047 and
-    // 049 there, while the desktop's expired set counts them as expired and does not ask
-    // for excludeDeleted — so users do see them in this tab.
-    rejected: ["expired", "unknown"],
-};
-
-/**
  * The served side of a shadow comparison: the whole filtered set rather than the page, so
  * a single disagreement early in the list is not re-reported at every later page boundary.
  */
-function buildShadowServed(
-    filteredDocuments: EformsignListDoc[],
-    scannedDocuments: EformsignListDoc[],
-    scopeCategories: DocumentStatusCategory[] | undefined,
-    scanCapped: boolean,
-) {
-    const comparable = scopeCategories === undefined
+function buildShadowServed(filteredDocuments: EformsignListDoc[], scope: string) {
+    // A vendor inbox is not a tab: type 04 is eformsign's document-management inbox and
+    // carries in-progress and completed documents too, which the client filters out by
+    // status before rendering. Narrowing both sides the same way is what makes the
+    // comparison answer the question that matters — would the tab show the same thing.
+    const scopeSelector = eformsignListScopeSelector(scope);
+    const comparable = scopeSelector === undefined
         ? filteredDocuments
-        : filteredDocuments.filter((document) =>
-            scopeCategories.includes(getDocumentStatusCategory(document)));
+        : filteredDocuments.filter(scopeSelector);
 
     return {
         documentIds: comparable.map((document) => document.id),
@@ -94,24 +74,7 @@ function buildShadowServed(
                 eformsignListCompareFields(document),
             ] as const),
         ),
-        // From the unfiltered scan, not the filtered result: a template or status filter
-        // can drop every old document and would otherwise make the vendor's range look far
-        // newer than it was, hiding real extras.
-        oldestScannedAt: oldestScannedTimestamp(scannedDocuments),
-        scanCapped,
     };
-}
-
-/** Oldest document the vendor scan produced, before any per-request filter. */
-function oldestScannedTimestamp(documents: EformsignListDoc[]): number | undefined {
-    let oldest: number | undefined;
-    for (const document of documents) {
-        const createdAt = getDocumentCreatedTimestamp(document);
-        if (oldest === undefined || createdAt < oldest) {
-            oldest = createdAt;
-        }
-    }
-    return oldest;
 }
 
 function throwHttpOrInternalError(error: unknown): never {
@@ -337,22 +300,6 @@ export class EformsignController {
         private readonly listShadowCompareService: EformsignListShadowCompareService,
     ) { }
 
-    /**
-     * Whether the last vendor scan for a scope stopped at the page cap. Kept here rather
-     * than in the snapshot because the snapshot's cached shape is shared with three other
-     * endpoints and serialised; this is written whenever a scan actually runs, so a cache
-     * hit reuses the value from the scan that produced the very snapshot being served.
-     * Bounded by branches × scopes, and only ever read by the shadow comparison.
-     */
-    private readonly lastScanCapped = new Map<string, boolean>();
-
-    private rememberScan(
-        scanKey: string,
-        scan: { documents: EformsignListDoc[]; capped: boolean },
-    ): EformsignListDoc[] {
-        this.lastScanCapped.set(scanKey, scan.capped);
-        return scan.documents;
-    }
 
     /**
      * 인천점(staff slug=incheon)은 본사 성격이라 지점에 매여 있지 않은 문서까지 본다:
@@ -407,7 +354,7 @@ export class EformsignController {
         branchId: string,
         fetchPage: (limit: number, skip: number) => Promise<{ documents?: EformsignListDoc[] }> =
             (limit, skip) => this.eformsignService.getAllDocuments(accessToken, limit, skip),
-    ): Promise<{ documents: EformsignListDoc[]; capped: boolean }> {
+    ): Promise<EformsignListDoc[]> {
         const PAGE_SIZE = 100;
         const MAX_PAGES = 10;
         const scanStartedAt = Date.now();
@@ -444,21 +391,14 @@ export class EformsignController {
         this.logger.log(
             `scanCompanyDocuments branch=${branchId} pages=${pagesFetched} matched=${collected.size} tookMs=${Date.now() - scanStartedAt}`,
         );
-        // `capped` says the vendor has more we never looked at. Without it, a scan that
-        // simply ran out of documents is indistinguishable from one that stopped at the
-        // page limit — and the shadow comparison would have to treat a genuinely stale
-        // mirror row and an unreachable old one the same way.
-        return {
-            documents: sortDocumentsByCreatedDate(Array.from(collected.values())),
-            capped: !exhausted,
-        };
+        return sortDocumentsByCreatedDate(Array.from(collected.values()));
     }
 
     private async collectBranchScopedDocuments(
         accessToken: string,
         branchId: string,
         fetchPage: (limit: number, skip: number) => Promise<{ documents?: EformsignListDoc[] }>,
-    ): Promise<{ documents: EformsignListDoc[]; capped: boolean }> {
+    ): Promise<EformsignListDoc[]> {
         if (await this.isHeadquartersBranch(branchId)) {
             const otherBranchIds = new Set(
                 await this.eformsignDocService.findDocumentIdsForOtherBranches(branchId),
@@ -475,8 +415,7 @@ export class EformsignController {
         const localDocs = await this.eformsignDocService.findAll(branchId);
         const allowedIds = new Set(localDocs.map((doc) => doc.documentId));
         if (allowedIds.size === 0) {
-            // Nothing local to look for, so nothing was left unscanned either.
-            return { documents: [], capped: false };
+            return [];
         }
         return this.scanCompanyDocuments(
             accessToken,
@@ -561,12 +500,7 @@ export class EformsignController {
         statusCategory: DocumentStatusCategory | undefined,
         search: string | undefined,
         excludeDeleted = false,
-        shadow?: {
-            scope: string;
-            isHeadquarters: boolean;
-            scanCapped: boolean;
-            scopeCategories?: DocumentStatusCategory[];
-        },
+        shadow?: { scope: string; isHeadquarters: boolean },
     ) {
         const documents = snapshot.entries.map((entry) => entry.document);
         const searchIndexByDocumentId = new Map(
@@ -592,9 +526,6 @@ export class EformsignController {
                     branchId,
                     isHeadquarters: shadow.isHeadquarters,
                     scope: shadow.scope,
-                    ...(shadow.scopeCategories
-                        ? { scopeCategories: shadow.scopeCategories }
-                        : {}),
                     limit,
                     skip,
                     templateId,
@@ -603,12 +534,7 @@ export class EformsignController {
                     search,
                     excludeDeleted,
                 },
-                buildShadowServed(
-                    filteredDocuments,
-                    documents,
-                    shadow.scopeCategories,
-                    shadow.scanCapped,
-                ),
+                buildShadowServed(filteredDocuments, shadow.scope),
             );
         }
         return {
@@ -638,14 +564,10 @@ export class EformsignController {
         search?: string,
     ) {
         const isHeadquarters = await this.isHeadquartersBranch(branchId);
-        const scanKey = `${scope}:${branchId}`;
         const snapshot = await this.documentSnapshotService.getOrBuild<EformsignListDoc>(
             { scope, branchId, accessToken, isHeadquarters },
             async () => this.toSnapshotEntries(
-                this.rememberScan(
-                    scanKey,
-                    await this.collectBranchScopedDocuments(accessToken, branchId, fetchPage),
-                ),
+                await this.collectBranchScopedDocuments(accessToken, branchId, fetchPage),
             ),
         );
         return this.paginateSnapshot(
@@ -659,14 +581,7 @@ export class EformsignController {
             statusCategory,
             search,
             false,
-            {
-                scope,
-                isHeadquarters,
-                scanCapped: this.lastScanCapped.get(scanKey) ?? false,
-                ...(SHADOW_SCOPE_CATEGORIES[scope]
-                    ? { scopeCategories: SHADOW_SCOPE_CATEGORIES[scope] }
-                    : {}),
-            },
+            { scope, isHeadquarters },
         );
     }
 
@@ -679,12 +594,11 @@ export class EformsignController {
     private async collectBranchDocuments(
         accessToken: string,
         branchId: string,
-    ): Promise<{ documents: EformsignListDoc[]; capped: boolean }> {
+    ): Promise<EformsignListDoc[]> {
         const localDocs = await this.eformsignDocService.findAll(branchId);
         const allowedIds = new Set(localDocs.map((doc) => doc.documentId));
         if (allowedIds.size === 0) {
-            // Nothing local to look for, so nothing was left unscanned either.
-            return { documents: [], capped: false };
+            return [];
         }
         return this.scanCompanyDocuments(
             accessToken,
@@ -702,7 +616,7 @@ export class EformsignController {
     private async collectHeadquartersDocuments(
         accessToken: string,
         incheonBranchId: string,
-    ): Promise<{ documents: EformsignListDoc[]; capped: boolean }> {
+    ): Promise<EformsignListDoc[]> {
         const otherBranchIds = new Set(
             await this.eformsignDocService.findDocumentIdsForOtherBranches(incheonBranchId),
         );
@@ -968,15 +882,11 @@ export class EformsignController {
 
             // 인천점(본사): 회사 전체에서 다른 지점 소유분만 빼고 모은 뒤 요청 구간만 잘라 반환.
             // (필터링 때문에 외부 페이지네이션을 그대로 흘리면 페이지 경계에 빈틈이 생긴다.)
-            const scanKey = `all:${branchId}`;
             if (await this.isHeadquartersBranch(branchId)) {
                 const hqSnapshot = await this.documentSnapshotService.getOrBuild<EformsignListDoc>(
                     { scope: "all", branchId, accessToken, isHeadquarters: true },
                     async () => this.toSnapshotEntries(
-                        this.rememberScan(
-                            scanKey,
-                            await this.collectHeadquartersDocuments(accessToken, branchId),
-                        ),
+                        await this.collectHeadquartersDocuments(accessToken, branchId),
                     ),
                 );
                 return this.paginateSnapshot(
@@ -993,7 +903,6 @@ export class EformsignController {
                     {
                         scope: "all",
                         isHeadquarters: true,
-                        scanCapped: this.lastScanCapped.get(scanKey) ?? false,
                     },
                 );
             }
@@ -1004,10 +913,7 @@ export class EformsignController {
             const branchSnapshot = await this.documentSnapshotService.getOrBuild<EformsignListDoc>(
                 { scope: "all", branchId, accessToken },
                 async () => this.toSnapshotEntries(
-                    this.rememberScan(
-                        scanKey,
-                        await this.collectBranchDocuments(accessToken, branchId),
-                    ),
+                    await this.collectBranchDocuments(accessToken, branchId),
                 ),
             );
             return this.paginateSnapshot(
@@ -1024,7 +930,6 @@ export class EformsignController {
                 {
                     scope: "all",
                     isHeadquarters: false,
-                    scanCapped: this.lastScanCapped.get(scanKey) ?? false,
                 },
             );
         } catch (error) {
@@ -1063,12 +968,9 @@ export class EformsignController {
             const snapshot = await this.documentSnapshotService.getOrBuild<EformsignListDoc>(
                 { scope: "all", branchId, accessToken, isHeadquarters },
                 async () => this.toSnapshotEntries(
-                    this.rememberScan(
-                        `all:${branchId}`,
-                        isHeadquarters
-                            ? await this.collectHeadquartersDocuments(accessToken, branchId)
-                            : await this.collectBranchDocuments(accessToken, branchId),
-                    ),
+                    isHeadquarters
+                        ? await this.collectHeadquartersDocuments(accessToken, branchId)
+                        : await this.collectBranchDocuments(accessToken, branchId),
                 ),
             );
             // 모바일 필터 pill 카운터용: 목록과 동일한 선(先)필터를 적용한 뒤 신호만 내려준다.

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -29,7 +29,10 @@ import {
     documentCustomerNameValue,
     stringFromUnknown,
 } from "application/utils/eformsign-document-customer-name";
-import { EformsignListShadowCompareService } from "application/services/eformsign-list-shadow-compare.service";
+import {
+    eformsignListCompareFields,
+    EformsignListShadowCompareService,
+} from "application/services/eformsign-list-shadow-compare.service";
 import {
     documentSearchIndex,
     documentSearchValues,
@@ -47,6 +50,29 @@ import {
     normalizeEformsignStepType,
 } from "domain/utils/eformsign-status-code";
 import { EformsignApiError } from "infrastructure/api/eformsign-api.error";
+
+/**
+ * What a local list would select for each tab, standing in for "whichever vendor inbox the
+ * document sits in" — the mirror does not record that. The merged list has no entry here
+ * because it does not filter by inbox at all.
+ */
+const SHADOW_SCOPE_CATEGORIES: Partial<Record<string, DocumentStatusCategory[]>> = {
+    "in-progress": ["drafting", "in-progress"],
+    completed: ["completed"],
+    rejected: ["expired"],
+};
+
+/** Oldest document the vendor scan produced, before any per-request filter. */
+function oldestScannedTimestamp(documents: EformsignListDoc[]): number | undefined {
+    let oldest: number | undefined;
+    for (const document of documents) {
+        const createdAt = getDocumentCreatedTimestamp(document);
+        if (oldest === undefined || createdAt < oldest) {
+            oldest = createdAt;
+        }
+    }
+    return oldest;
+}
 
 function throwHttpOrInternalError(error: unknown): never {
     if (error instanceof HttpException) {
@@ -470,7 +496,11 @@ export class EformsignController {
         statusCategory: DocumentStatusCategory | undefined,
         search: string | undefined,
         excludeDeleted = false,
-        shadow?: { scope: string; isHeadquarters: boolean },
+        shadow?: {
+            scope: string;
+            isHeadquarters: boolean;
+            scopeCategories?: DocumentStatusCategory[];
+        },
     ) {
         const documents = snapshot.entries.map((entry) => entry.document);
         const searchIndexByDocumentId = new Map(
@@ -496,6 +526,9 @@ export class EformsignController {
                     branchId,
                     isHeadquarters: shadow.isHeadquarters,
                     scope: shadow.scope,
+                    ...(shadow.scopeCategories
+                        ? { scopeCategories: shadow.scopeCategories }
+                        : {}),
                     limit,
                     skip,
                     templateId,
@@ -509,11 +542,16 @@ export class EformsignController {
                     // a pagination boundary as a difference every time the two disagree
                     // about a single document earlier in the list.
                     documentIds: filteredDocuments.map((document) => document.id),
-                    oldestCreatedAt: filteredDocuments.length > 0
-                        ? getDocumentCreatedTimestamp(
-                            filteredDocuments[filteredDocuments.length - 1]!,
-                        )
-                        : undefined,
+                    fieldsById: new Map(
+                        filteredDocuments.map((document) => [
+                            document.id,
+                            eformsignListCompareFields(document),
+                        ] as const),
+                    ),
+                    // From the unfiltered scan, not the filtered result: a template or
+                    // status filter can drop every old document and would otherwise make
+                    // the vendor's range look far newer than it was, hiding real extras.
+                    oldestScannedAt: oldestScannedTimestamp(documents),
                 },
             );
         }
@@ -543,8 +581,9 @@ export class EformsignController {
         statusCategory?: DocumentStatusCategory,
         search?: string,
     ) {
+        const isHeadquarters = await this.isHeadquartersBranch(branchId);
         const snapshot = await this.documentSnapshotService.getOrBuild<EformsignListDoc>(
-            { scope, branchId, accessToken, isHeadquarters: await this.isHeadquartersBranch(branchId) },
+            { scope, branchId, accessToken, isHeadquarters },
             async () => this.toSnapshotEntries(
                 await this.collectBranchScopedDocuments(accessToken, branchId, fetchPage),
             ),
@@ -559,6 +598,14 @@ export class EformsignController {
             templateMatch,
             statusCategory,
             search,
+            false,
+            {
+                scope,
+                isHeadquarters,
+                ...(SHADOW_SCOPE_CATEGORIES[scope]
+                    ? { scopeCategories: SHADOW_SCOPE_CATEGORIES[scope] }
+                    : {}),
+            },
         );
     }
 

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Controller, Post, Get, Delete, Body, Query, Param, HttpException, HttpStatus, UseGuards, Res, Logger } from "@nestjs/common";
-import { EformsignService, getDocumentCreatedTimestamp } from "../../application/services/eformsign.service";
+import { EformsignService } from "../../application/services/eformsign.service";
 import { EformsignDocService } from "../../application/services/eformsign-doc.service";
 import { AreaTemplateService } from "../../application/services/area-template.service";
 import { PrismaService } from "infrastructure/database/prisma.service";
@@ -27,11 +27,21 @@ import {
 } from "application/services/eformsign-document-snapshot.service";
 import {
     documentCustomerNameValue,
-    isRecord,
     stringFromUnknown,
-    type UnknownRecord,
 } from "application/utils/eformsign-document-customer-name";
-import { eformsignDocumentTemplateId } from "application/utils/eformsign-document-template-id";
+import { EformsignListShadowCompareService } from "application/services/eformsign-list-shadow-compare.service";
+import {
+    documentSearchIndex,
+    documentSearchValues,
+    filterDocumentsByStatusCategory,
+    filterDocumentsByTemplate,
+    filterOutDeletedDocuments,
+    matchesKoreanSearch,
+    sortDocumentsByCreatedDate,
+    type DocumentStatusCategory,
+    type EformsignListDoc,
+    type TemplateMatch,
+} from "application/utils/eformsign-document-list";
 import {
     normalizeEformsignStatusCode,
     normalizeEformsignStepType,
@@ -77,29 +87,6 @@ function parseDownloadFileType(value: string | undefined): DownloadFileType {
     throw new BadRequestException("fileType must be document or audit_trail");
 }
 
-type EformsignListDoc = {
-    id: string;
-    created_date?: unknown;
-    createdDate?: unknown;
-    fields?: unknown;
-    detail_template_info?: unknown;
-} & Record<string, unknown>;
-
-type TemplateMatch = "include" | "exclude";
-type DocumentStatusCategory = "drafting" | "in-progress" | "completed" | "expired" | "unknown";
-
-const COMPLETED_STATUS_CODES = new Set(["003", "012", "022", "032", "050", "062", "072", "092"]);
-const EXPIRED_STATUS_CODES = new Set(["011", "021", "031", "040", "042", "045", "047", "049", "061", "071", "080", "090"]);
-const DELETED_STATUS_CODES = new Set(["047", "049"]);
-const IN_PROGRESS_STATUS_CODES = new Set(["001", "002", "010", "020", "030", "043", "060", "063", "064", "070"]);
-const PROVIDER_REVIEW_STEP_TYPES = new Set(["06"]);
-const PROVIDER_REVIEW_OWNER_KEYWORDS = ["제공기관", "관리자", "담당자"];
-const PROVIDER_REVIEW_ACTION_KEYWORDS = ["확인", "검토"];
-const CUSTOMER_STEP_KEYWORDS = ["이용자", "고객", "산모"];
-const CHOSUNG_LIST = [
-    "ㄱ", "ㄲ", "ㄴ", "ㄷ", "ㄸ", "ㄹ", "ㅁ", "ㅂ", "ㅃ",
-    "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅉ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ",
-] as const;
 
 function parseStatusCategory(value: string | undefined): DocumentStatusCategory | undefined {
     const normalized = value?.trim();
@@ -140,139 +127,6 @@ function parseTemplateMatch(value: string | undefined): TemplateMatch {
     throw new BadRequestException("templateMatch must be include or exclude");
 }
 
-/**
- * `templateId` may be a single id or a comma-separated list (BJJ-multi-tier: the UI passes every
- * configured 제공기록지 tier so documents created on any tier's template are matched). A single id
- * is naturally backward-compatible since it round-trips through the same split/trim/Set path.
- */
-function filterDocumentsByTemplate(
-    documents: EformsignListDoc[],
-    templateId: string | undefined,
-    templateMatch: TemplateMatch,
-): EformsignListDoc[] {
-    if (!templateId) {
-        return documents;
-    }
-    const templateIds = new Set(
-        templateId.split(",").map((id) => id.trim()).filter((id) => id.length > 0),
-    );
-    if (templateIds.size === 0) {
-        return documents;
-    }
-
-    return documents.filter((document) => {
-        const documentTemplateId = eformsignDocumentTemplateId(document);
-        const matches = documentTemplateId !== null && templateIds.has(documentTemplateId);
-        return templateMatch === "include" ? matches : !matches;
-    });
-}
-
-function getCurrentStatus(document: EformsignListDoc): UnknownRecord | null {
-    return isRecord(document["current_status"]) ? document["current_status"] : null;
-}
-
-function isProviderReviewStep(document: EformsignListDoc): boolean {
-    const currentStatus = getCurrentStatus(document);
-    const stepType = normalizeEformsignStepType(
-        stringFromUnknown(currentStatus?.["step_type"]),
-    );
-    const stepName = stringFromUnknown(currentStatus?.["step_name"]) ?? "";
-
-    if (PROVIDER_REVIEW_STEP_TYPES.has(stepType)) {
-        return true;
-    }
-    if (!stepName || CUSTOMER_STEP_KEYWORDS.some((keyword) => stepName.includes(keyword))) {
-        return false;
-    }
-
-    const hasProviderOwner = PROVIDER_REVIEW_OWNER_KEYWORDS.some((keyword) => stepName.includes(keyword));
-    const hasReviewAction = PROVIDER_REVIEW_ACTION_KEYWORDS.some((keyword) => stepName.includes(keyword));
-    return hasProviderOwner && hasReviewAction;
-}
-
-function getDocumentStatusCategory(document: EformsignListDoc): DocumentStatusCategory {
-    const statusType = stringFromUnknown(getCurrentStatus(document)?.["status_type"]);
-    const normalized = normalizeEformsignStatusCode(statusType);
-    if (COMPLETED_STATUS_CODES.has(normalized)) {
-        return "completed";
-    }
-    if (EXPIRED_STATUS_CODES.has(normalized) && !DELETED_STATUS_CODES.has(normalized)) {
-        return "expired";
-    }
-    if (DELETED_STATUS_CODES.has(normalized)) {
-        return "unknown";
-    }
-    if (!IN_PROGRESS_STATUS_CODES.has(normalized)) {
-        return "unknown";
-    }
-    return isProviderReviewStep(document) ? "in-progress" : "drafting";
-}
-
-function filterDocumentsByStatusCategory(
-    documents: EformsignListDoc[],
-    statusCategory: DocumentStatusCategory | undefined,
-): EformsignListDoc[] {
-    if (!statusCategory) {
-        return documents;
-    }
-
-    return documents.filter((document) => {
-        const statusType = stringFromUnknown(getCurrentStatus(document)?.["status_type"]);
-        if (DELETED_STATUS_CODES.has(normalizeEformsignStatusCode(statusType))) {
-            return false;
-        }
-        return getDocumentStatusCategory(document) === statusCategory;
-    });
-}
-
-function filterOutDeletedDocuments(
-    documents: EformsignListDoc[],
-    excludeDeleted: boolean,
-): EformsignListDoc[] {
-    if (!excludeDeleted) {
-        return documents;
-    }
-    return documents.filter((document) => {
-        const statusType = stringFromUnknown(getCurrentStatus(document)?.["status_type"]);
-        return !DELETED_STATUS_CODES.has(normalizeEformsignStatusCode(statusType));
-    });
-}
-
-function getChosung(character: string): string {
-    const code = character.charCodeAt(0);
-    if (code >= 0xac00 && code <= 0xd7a3) {
-        return CHOSUNG_LIST[Math.floor((code - 0xac00) / 588)] ?? character;
-    }
-    return character;
-}
-
-function matchesKoreanSearch(target: string, query: string): boolean {
-    const normalizedTarget = target.normalize("NFC");
-    if (normalizedTarget.toLowerCase().includes(query.toLowerCase())) {
-        return true;
-    }
-
-    const hasChosung = query.split("").some((character) =>
-        CHOSUNG_LIST.includes(character as (typeof CHOSUNG_LIST)[number]),
-    );
-    if (!hasChosung) {
-        return false;
-    }
-
-    const targetChosung = normalizedTarget.split("").map(getChosung).join("").replace(/\s/g, "");
-    return targetChosung.startsWith(query);
-}
-
-function sortDocumentsByCreatedDate(documents: EformsignListDoc[]): EformsignListDoc[] {
-    return [...documents].sort((a, b) => {
-        const byCreated = getDocumentCreatedTimestamp(b) - getDocumentCreatedTimestamp(a);
-        if (byCreated !== 0) {
-            return byCreated;
-        }
-        return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
-    });
-}
-
 const DEFAULT_DETAIL_ENRICHMENT_CONCURRENCY = 8;
 const DETAIL_ENRICHMENT_CONCURRENCY_ENV = "EFORMSIGN_DETAIL_ENRICHMENT_CONCURRENCY";
 const DETAIL_ENRICHMENT_BUDGET_MS = 5_000;
@@ -310,32 +164,6 @@ async function waitForDetailEnrichmentRetry(delayMs: number): Promise<void> {
 
 function documentHasCustomerNameField(doc: EformsignListDoc): boolean {
     return documentCustomerNameValue(doc) !== null;
-}
-
-function documentSearchValues(document: EformsignListDoc, localValues: string[]): string[] {
-    const template = isRecord(document["template"]) ? document["template"] : null;
-    const templateName = (stringFromUnknown(template?.["name"]) ?? "").replace(/\s*계약서$/, "");
-    const documentNumber = (
-        stringFromUnknown(document["document_number"]) ?? document.id?.slice(0, 16)
-    ) || "-";
-
-    return [
-        documentCustomerNameValue(document) ?? "고객 미지정",
-        ...localValues,
-        stringFromUnknown(document["document_name"]) ?? "",
-        templateName,
-        documentNumber,
-    ];
-}
-
-/**
- * 문서 자체에서 파생되는 검색 값(고객명/문서명/템플릿명/문서번호)만 미리 뽑아 스냅샷에 넣는다.
- * 로컬 DB에서 오는 값(stepRecipientName)은 검색어가 있을 때만 조회하는 기존 동작을 유지하기
- * 위해 여기에 포함하지 않고, 질의 시점에 합쳐 쓴다. 빈 문자열은 어떤 검색어와도 매칭되지
- * 않으므로 제거해 스냅샷 크기를 줄인다.
- */
-function documentSearchIndex(document: EformsignListDoc): string[] {
-    return documentSearchValues(document, []).filter((value) => value.length > 0);
 }
 
 function hasCollectionValues(value: unknown): boolean {
@@ -440,6 +268,7 @@ export class EformsignController {
         private readonly prisma: PrismaService,
         private readonly assignmentGuard: ContractClientAssignmentGuardService,
         private readonly documentSnapshotService: EformsignDocumentSnapshotService,
+        private readonly listShadowCompareService: EformsignListShadowCompareService,
     ) { }
 
     /**
@@ -641,6 +470,7 @@ export class EformsignController {
         statusCategory: DocumentStatusCategory | undefined,
         search: string | undefined,
         excludeDeleted = false,
+        shadow?: { scope: string; isHeadquarters: boolean },
     ) {
         const documents = snapshot.entries.map((entry) => entry.document);
         const searchIndexByDocumentId = new Map(
@@ -657,6 +487,29 @@ export class EformsignController {
             searchIndexByDocumentId,
         );
         const pageDocuments = filteredDocuments.slice(skip, skip + limit);
+        if (shadow) {
+            // Answer the same page from the mirror and report only where the two disagree.
+            // Nothing below waits on it: the served response is the API's, exactly as it
+            // was, until the diffs have been zero for long enough to trust the switch.
+            this.listShadowCompareService.compareInBackground(
+                {
+                    branchId,
+                    isHeadquarters: shadow.isHeadquarters,
+                    scope: shadow.scope,
+                    limit,
+                    skip,
+                    templateId,
+                    templateMatch,
+                    statusCategory,
+                    search,
+                    excludeDeleted,
+                },
+                {
+                    documentIds: pageDocuments.map((document) => document.id),
+                    totalRows: filteredDocuments.length,
+                },
+            );
+        }
         return {
             documents: await this.enrichDocumentsWithDisplayFields(
                 branchId,
@@ -1011,6 +864,7 @@ export class EformsignController {
                     statusCategory,
                     search,
                     excludeDeleted,
+                    { scope: "all", isHeadquarters: true },
                 );
             }
 
@@ -1034,6 +888,7 @@ export class EformsignController {
                 statusCategory,
                 search,
                 excludeDeleted,
+                { scope: "all", isHeadquarters: false },
             );
         } catch (error) {
             throwHttpOrInternalError(error);

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Controller, Post, Get, Delete, Body, Query, Param, HttpException, HttpStatus, UseGuards, Res, Logger } from "@nestjs/common";
-import { EformsignService } from "../../application/services/eformsign.service";
+import { EformsignService, getDocumentCreatedTimestamp } from "../../application/services/eformsign.service";
 import { EformsignDocService } from "../../application/services/eformsign-doc.service";
 import { AreaTemplateService } from "../../application/services/area-template.service";
 import { PrismaService } from "infrastructure/database/prisma.service";
@@ -505,8 +505,15 @@ export class EformsignController {
                     excludeDeleted,
                 },
                 {
-                    documentIds: pageDocuments.map((document) => document.id),
-                    totalRows: filteredDocuments.length,
+                    // The whole filtered set, not the page: comparing pages would report
+                    // a pagination boundary as a difference every time the two disagree
+                    // about a single document earlier in the list.
+                    documentIds: filteredDocuments.map((document) => document.id),
+                    oldestCreatedAt: filteredDocuments.length > 0
+                        ? getDocumentCreatedTimestamp(
+                            filteredDocuments[filteredDocuments.length - 1]!,
+                        )
+                        : undefined,
                 },
             );
         }

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -39,6 +39,7 @@ import {
     filterDocumentsByStatusCategory,
     filterDocumentsByTemplate,
     filterOutDeletedDocuments,
+    getDocumentStatusCategory,
     matchesKoreanSearch,
     sortDocumentsByCreatedDate,
     type DocumentStatusCategory,
@@ -55,12 +56,46 @@ import { EformsignApiError } from "infrastructure/api/eformsign-api.error";
  * What a local list would select for each tab, standing in for "whichever vendor inbox the
  * document sits in" — the mirror does not record that. The merged list has no entry here
  * because it does not filter by inbox at all.
+ *
+ * Applied to both sides of the comparison, because a vendor inbox is not the tab: type 04
+ * is eformsign's document-management inbox and carries in-progress and completed documents
+ * too, which the client filters out by status before rendering. Comparing the raw inbox
+ * against a status-selected mirror would report every one of those as missing.
  */
 const SHADOW_SCOPE_CATEGORIES: Partial<Record<string, DocumentStatusCategory[]>> = {
     "in-progress": ["drafting", "in-progress"],
     completed: ["completed"],
     rejected: ["expired"],
 };
+
+/**
+ * The served side of a shadow comparison: the whole filtered set rather than the page, so
+ * a single disagreement early in the list is not re-reported at every later page boundary.
+ */
+function buildShadowServed(
+    filteredDocuments: EformsignListDoc[],
+    scannedDocuments: EformsignListDoc[],
+    scopeCategories: DocumentStatusCategory[] | undefined,
+) {
+    const comparable = scopeCategories === undefined
+        ? filteredDocuments
+        : filteredDocuments.filter((document) =>
+            scopeCategories.includes(getDocumentStatusCategory(document)));
+
+    return {
+        documentIds: comparable.map((document) => document.id),
+        fieldsById: new Map(
+            comparable.map((document) => [
+                document.id,
+                eformsignListCompareFields(document),
+            ] as const),
+        ),
+        // From the unfiltered scan, not the filtered result: a template or status filter
+        // can drop every old document and would otherwise make the vendor's range look far
+        // newer than it was, hiding real extras.
+        oldestScannedAt: oldestScannedTimestamp(scannedDocuments),
+    };
+}
 
 /** Oldest document the vendor scan produced, before any per-request filter. */
 function oldestScannedTimestamp(documents: EformsignListDoc[]): number | undefined {
@@ -537,22 +572,7 @@ export class EformsignController {
                     search,
                     excludeDeleted,
                 },
-                {
-                    // The whole filtered set, not the page: comparing pages would report
-                    // a pagination boundary as a difference every time the two disagree
-                    // about a single document earlier in the list.
-                    documentIds: filteredDocuments.map((document) => document.id),
-                    fieldsById: new Map(
-                        filteredDocuments.map((document) => [
-                            document.id,
-                            eformsignListCompareFields(document),
-                        ] as const),
-                    ),
-                    // From the unfiltered scan, not the filtered result: a template or
-                    // status filter can drop every old document and would otherwise make
-                    // the vendor's range look far newer than it was, hiding real extras.
-                    oldestScannedAt: oldestScannedTimestamp(documents),
-                },
+                buildShadowServed(filteredDocuments, documents, shadow.scopeCategories),
             );
         }
         return {

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -65,7 +65,10 @@ import { EformsignApiError } from "infrastructure/api/eformsign-api.error";
 const SHADOW_SCOPE_CATEGORIES: Partial<Record<string, DocumentStatusCategory[]>> = {
     "in-progress": ["drafting", "in-progress"],
     completed: ["completed"],
-    rejected: ["expired"],
+    // "unknown" is here because getDocumentStatusCategory puts the deleted codes 047 and
+    // 049 there, while the desktop's expired set counts them as expired and does not ask
+    // for excludeDeleted — so users do see them in this tab.
+    rejected: ["expired", "unknown"],
 };
 
 /**
@@ -76,6 +79,7 @@ function buildShadowServed(
     filteredDocuments: EformsignListDoc[],
     scannedDocuments: EformsignListDoc[],
     scopeCategories: DocumentStatusCategory[] | undefined,
+    scanCapped: boolean,
 ) {
     const comparable = scopeCategories === undefined
         ? filteredDocuments
@@ -94,6 +98,7 @@ function buildShadowServed(
         // can drop every old document and would otherwise make the vendor's range look far
         // newer than it was, hiding real extras.
         oldestScannedAt: oldestScannedTimestamp(scannedDocuments),
+        scanCapped,
     };
 }
 
@@ -333,6 +338,23 @@ export class EformsignController {
     ) { }
 
     /**
+     * Whether the last vendor scan for a scope stopped at the page cap. Kept here rather
+     * than in the snapshot because the snapshot's cached shape is shared with three other
+     * endpoints and serialised; this is written whenever a scan actually runs, so a cache
+     * hit reuses the value from the scan that produced the very snapshot being served.
+     * Bounded by branches × scopes, and only ever read by the shadow comparison.
+     */
+    private readonly lastScanCapped = new Map<string, boolean>();
+
+    private rememberScan(
+        scanKey: string,
+        scan: { documents: EformsignListDoc[]; capped: boolean },
+    ): EformsignListDoc[] {
+        this.lastScanCapped.set(scanKey, scan.capped);
+        return scan.documents;
+    }
+
+    /**
      * 인천점(staff slug=incheon)은 본사 성격이라 지점에 매여 있지 않은 문서까지 본다:
      * 자기가 만든 문서 + 지점 매핑이 없는(branchId 미지정) 문서. 단, 다른 지점이
      * 소유한 문서는 제외한다. 그 외 지점은 자기 지점이 만든(=로컬에 적재된) 문서만 본다.
@@ -385,7 +407,7 @@ export class EformsignController {
         branchId: string,
         fetchPage: (limit: number, skip: number) => Promise<{ documents?: EformsignListDoc[] }> =
             (limit, skip) => this.eformsignService.getAllDocuments(accessToken, limit, skip),
-    ): Promise<EformsignListDoc[]> {
+    ): Promise<{ documents: EformsignListDoc[]; capped: boolean }> {
         const PAGE_SIZE = 100;
         const MAX_PAGES = 10;
         const scanStartedAt = Date.now();
@@ -422,14 +444,21 @@ export class EformsignController {
         this.logger.log(
             `scanCompanyDocuments branch=${branchId} pages=${pagesFetched} matched=${collected.size} tookMs=${Date.now() - scanStartedAt}`,
         );
-        return sortDocumentsByCreatedDate(Array.from(collected.values()));
+        // `capped` says the vendor has more we never looked at. Without it, a scan that
+        // simply ran out of documents is indistinguishable from one that stopped at the
+        // page limit — and the shadow comparison would have to treat a genuinely stale
+        // mirror row and an unreachable old one the same way.
+        return {
+            documents: sortDocumentsByCreatedDate(Array.from(collected.values())),
+            capped: !exhausted,
+        };
     }
 
     private async collectBranchScopedDocuments(
         accessToken: string,
         branchId: string,
         fetchPage: (limit: number, skip: number) => Promise<{ documents?: EformsignListDoc[] }>,
-    ): Promise<EformsignListDoc[]> {
+    ): Promise<{ documents: EformsignListDoc[]; capped: boolean }> {
         if (await this.isHeadquartersBranch(branchId)) {
             const otherBranchIds = new Set(
                 await this.eformsignDocService.findDocumentIdsForOtherBranches(branchId),
@@ -446,7 +475,8 @@ export class EformsignController {
         const localDocs = await this.eformsignDocService.findAll(branchId);
         const allowedIds = new Set(localDocs.map((doc) => doc.documentId));
         if (allowedIds.size === 0) {
-            return [];
+            // Nothing local to look for, so nothing was left unscanned either.
+            return { documents: [], capped: false };
         }
         return this.scanCompanyDocuments(
             accessToken,
@@ -534,6 +564,7 @@ export class EformsignController {
         shadow?: {
             scope: string;
             isHeadquarters: boolean;
+            scanCapped: boolean;
             scopeCategories?: DocumentStatusCategory[];
         },
     ) {
@@ -572,7 +603,12 @@ export class EformsignController {
                     search,
                     excludeDeleted,
                 },
-                buildShadowServed(filteredDocuments, documents, shadow.scopeCategories),
+                buildShadowServed(
+                    filteredDocuments,
+                    documents,
+                    shadow.scopeCategories,
+                    shadow.scanCapped,
+                ),
             );
         }
         return {
@@ -602,10 +638,14 @@ export class EformsignController {
         search?: string,
     ) {
         const isHeadquarters = await this.isHeadquartersBranch(branchId);
+        const scanKey = `${scope}:${branchId}`;
         const snapshot = await this.documentSnapshotService.getOrBuild<EformsignListDoc>(
             { scope, branchId, accessToken, isHeadquarters },
             async () => this.toSnapshotEntries(
-                await this.collectBranchScopedDocuments(accessToken, branchId, fetchPage),
+                this.rememberScan(
+                    scanKey,
+                    await this.collectBranchScopedDocuments(accessToken, branchId, fetchPage),
+                ),
             ),
         );
         return this.paginateSnapshot(
@@ -622,6 +662,7 @@ export class EformsignController {
             {
                 scope,
                 isHeadquarters,
+                scanCapped: this.lastScanCapped.get(scanKey) ?? false,
                 ...(SHADOW_SCOPE_CATEGORIES[scope]
                     ? { scopeCategories: SHADOW_SCOPE_CATEGORIES[scope] }
                     : {}),
@@ -635,11 +676,15 @@ export class EformsignController {
      * 빈 페이지에서 무한스크롤이 멈춰 누락되므로, 회사 페이지를 훑어 지점 문서를 모은다.
      * 지점 보유 documentId 집합 크기를 기대 개수로 삼아 다 찾으면 조기 종료한다.
      */
-    private async collectBranchDocuments(accessToken: string, branchId: string): Promise<EformsignListDoc[]> {
+    private async collectBranchDocuments(
+        accessToken: string,
+        branchId: string,
+    ): Promise<{ documents: EformsignListDoc[]; capped: boolean }> {
         const localDocs = await this.eformsignDocService.findAll(branchId);
         const allowedIds = new Set(localDocs.map((doc) => doc.documentId));
         if (allowedIds.size === 0) {
-            return [];
+            // Nothing local to look for, so nothing was left unscanned either.
+            return { documents: [], capped: false };
         }
         return this.scanCompanyDocuments(
             accessToken,
@@ -654,7 +699,10 @@ export class EformsignController {
      * 즉 인천이 만든 문서 + 지점 매핑이 없는(branchId null/미적재) 문서를 본다. 제외할
      * 집합만 알 뿐 기대 개수를 알 수 없어, 페이지 상한까지 전수 스캔(targetCount=null)한다.
      */
-    private async collectHeadquartersDocuments(accessToken: string, incheonBranchId: string): Promise<EformsignListDoc[]> {
+    private async collectHeadquartersDocuments(
+        accessToken: string,
+        incheonBranchId: string,
+    ): Promise<{ documents: EformsignListDoc[]; capped: boolean }> {
         const otherBranchIds = new Set(
             await this.eformsignDocService.findDocumentIdsForOtherBranches(incheonBranchId),
         );
@@ -920,11 +968,15 @@ export class EformsignController {
 
             // 인천점(본사): 회사 전체에서 다른 지점 소유분만 빼고 모은 뒤 요청 구간만 잘라 반환.
             // (필터링 때문에 외부 페이지네이션을 그대로 흘리면 페이지 경계에 빈틈이 생긴다.)
+            const scanKey = `all:${branchId}`;
             if (await this.isHeadquartersBranch(branchId)) {
                 const hqSnapshot = await this.documentSnapshotService.getOrBuild<EformsignListDoc>(
                     { scope: "all", branchId, accessToken, isHeadquarters: true },
                     async () => this.toSnapshotEntries(
-                        await this.collectHeadquartersDocuments(accessToken, branchId),
+                        this.rememberScan(
+                            scanKey,
+                            await this.collectHeadquartersDocuments(accessToken, branchId),
+                        ),
                     ),
                 );
                 return this.paginateSnapshot(
@@ -938,7 +990,11 @@ export class EformsignController {
                     statusCategory,
                     search,
                     excludeDeleted,
-                    { scope: "all", isHeadquarters: true },
+                    {
+                        scope: "all",
+                        isHeadquarters: true,
+                        scanCapped: this.lastScanCapped.get(scanKey) ?? false,
+                    },
                 );
             }
 
@@ -948,7 +1004,10 @@ export class EformsignController {
             const branchSnapshot = await this.documentSnapshotService.getOrBuild<EformsignListDoc>(
                 { scope: "all", branchId, accessToken },
                 async () => this.toSnapshotEntries(
-                    await this.collectBranchDocuments(accessToken, branchId),
+                    this.rememberScan(
+                        scanKey,
+                        await this.collectBranchDocuments(accessToken, branchId),
+                    ),
                 ),
             );
             return this.paginateSnapshot(
@@ -962,7 +1021,11 @@ export class EformsignController {
                 statusCategory,
                 search,
                 excludeDeleted,
-                { scope: "all", isHeadquarters: false },
+                {
+                    scope: "all",
+                    isHeadquarters: false,
+                    scanCapped: this.lastScanCapped.get(scanKey) ?? false,
+                },
             );
         } catch (error) {
             throwHttpOrInternalError(error);
@@ -1000,9 +1063,12 @@ export class EformsignController {
             const snapshot = await this.documentSnapshotService.getOrBuild<EformsignListDoc>(
                 { scope: "all", branchId, accessToken, isHeadquarters },
                 async () => this.toSnapshotEntries(
-                    isHeadquarters
-                        ? await this.collectHeadquartersDocuments(accessToken, branchId)
-                        : await this.collectBranchDocuments(accessToken, branchId),
+                    this.rememberScan(
+                        `all:${branchId}`,
+                        isHeadquarters
+                            ? await this.collectHeadquartersDocuments(accessToken, branchId)
+                            : await this.collectBranchDocuments(accessToken, branchId),
+                    ),
                 ),
             );
             // 모바일 필터 pill 카운터용: 목록과 동일한 선(先)필터를 적용한 뒤 신호만 내려준다.

--- a/backend/test/controllers/eformsign.controller.enrichment.spec.ts
+++ b/backend/test/controllers/eformsign.controller.enrichment.spec.ts
@@ -41,6 +41,7 @@ describe("EformsignController display-field enrichment", () => {
             {} as never,
             {} as never,
             snapshotService,
+            { compareInBackground: jest.fn() } as never,
         ) as unknown as EnrichmentController;
         eformsignDocService.findDisplayFieldsByDocumentIds.mockResolvedValue([]);
     });

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -318,7 +318,8 @@ describe("EformsignController (Integration)", () => {
             expect.objectContaining({
                 // The whole filtered set, which for this request is also the page.
                 documentIds: response.body.documents.map((doc: { id: string }) => doc.id),
-                oldestCreatedAt: expect.any(Number),
+                fieldsById: expect.any(Map),
+                oldestScannedAt: expect.any(Number),
             }),
         );
     });

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -466,7 +466,9 @@ describe("EformsignController (Integration)", () => {
         expect(shadowCompareService.compareInBackground).toHaveBeenCalledWith(
             expect.objectContaining({
                 scope: "rejected",
-                scopeCategories: ["expired"],
+                // "unknown" carries the deleted codes 047/049, which the desktop's expired
+                // set counts as expired and shows without asking for excludeDeleted.
+                scopeCategories: ["expired", "unknown"],
             }),
             expect.objectContaining({ documentIds: ["expired-doc"] }),
         );

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -65,6 +65,7 @@ describe("EformsignController (Integration)", () => {
     const shadowCompareService = { compareInBackground: jest.fn() };
 
     beforeEach(async () => {
+        shadowCompareService.compareInBackground.mockClear();
         const moduleFixture: TestingModule = await Test.createTestingModule({
             controllers: [EformsignController],
             providers: [
@@ -303,19 +304,21 @@ describe("EformsignController (Integration)", () => {
         ] as any);
 
         const response = await request(app.getHttpServer())
-            .get("/api/documents?accessToken=access-token&search=%EA%B9%80");
+            .get("/api/documents?accessToken=access-token&search=branch");
 
         expect(response.status).toBe(200);
+        expect(response.body.documents).toHaveLength(1);
         expect(shadowCompareService.compareInBackground).toHaveBeenCalledWith(
             expect.objectContaining({
                 branchId: "branch-1",
                 scope: "all",
                 isHeadquarters: false,
-                search: "김",
+                search: "branch",
             }),
             expect.objectContaining({
+                // The whole filtered set, which for this request is also the page.
                 documentIds: response.body.documents.map((doc: { id: string }) => doc.id),
-                totalRows: response.body.total_rows,
+                oldestCreatedAt: expect.any(Number),
             }),
         );
     });

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -9,6 +9,7 @@ import { TenantGuard } from "infrastructure/tenant";
 import { EformsignController } from "interface/controllers/eformsign.controller";
 import { ContractClientAssignmentGuardService } from "application/services/contract-client-assignment-guard.service";
 import { EformsignDocumentSnapshotService } from "application/services/eformsign-document-snapshot.service";
+import { EformsignListShadowCompareService } from "application/services/eformsign-list-shadow-compare.service";
 import request from "supertest";
 
 // Known transport-level flake (~1/8 full-suite runs under parallel-worker
@@ -61,6 +62,8 @@ describe("EformsignController (Integration)", () => {
         },
     };
 
+    const shadowCompareService = { compareInBackground: jest.fn() };
+
     beforeEach(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
             controllers: [EformsignController],
@@ -109,6 +112,12 @@ describe("EformsignController (Integration)", () => {
                 // 실제 구현을 그대로 쓴다. VALKEY_URL이 없는 테스트 환경에서는 프로세스
                 // 로컬 in-memory 스토어로 동작하고, 인스턴스는 테스트마다 새로 만들어진다.
                 EformsignDocumentSnapshotService,
+                {
+                    // 그림자 비교는 서빙 결과에 영향을 주지 않아야 한다. 여기서 호출만
+                    // 기록하고 아무것도 하지 않게 두면, 응답 검증이 그 사실을 보증한다.
+                    provide: EformsignListShadowCompareService,
+                    useValue: shadowCompareService,
+                },
             ],
         })
             .overrideGuard(JwtGuard)
@@ -277,6 +286,37 @@ describe("EformsignController (Integration)", () => {
             "access-token",
             "unmapped-doc",
             "document",
+        );
+    });
+
+    it("hands the served page to the shadow comparison without changing it", async () => {
+        // D단계의 계약: 화면에 나가는 것은 여전히 외부 API 결과이고, 미러는 같은 질문에
+        // 따로 답해 차이만 로그로 남긴다. 비교가 응답을 건드리면 그 계약이 깨진다.
+        eformsignService.getAllDocuments.mockResolvedValue({
+            documents: [{ id: "branch-1-doc" }, { id: "other-branch-doc" }],
+            total_rows: 2,
+            limit: 100,
+            skip: 0,
+        });
+        eformsignDocService.findAll.mockResolvedValue([
+            { documentId: "branch-1-doc" },
+        ] as any);
+
+        const response = await request(app.getHttpServer())
+            .get("/api/documents?accessToken=access-token&search=%EA%B9%80");
+
+        expect(response.status).toBe(200);
+        expect(shadowCompareService.compareInBackground).toHaveBeenCalledWith(
+            expect.objectContaining({
+                branchId: "branch-1",
+                scope: "all",
+                isHeadquarters: false,
+                search: "김",
+            }),
+            expect.objectContaining({
+                documentIds: response.body.documents.map((doc: { id: string }) => doc.id),
+                totalRows: response.body.total_rows,
+            }),
         );
     });
 

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -321,7 +321,6 @@ describe("EformsignController (Integration)", () => {
                 // The whole filtered set, which for this request is also the page.
                 documentIds: response.body.documents.map((doc: { id: string }) => doc.id),
                 fieldsById: expect.any(Map),
-                oldestScannedAt: expect.any(Number),
             }),
         );
     });
@@ -464,12 +463,7 @@ describe("EformsignController (Integration)", () => {
         // narrowed, because that is what the tab actually shows.
         expect(response.body.documents).toHaveLength(2);
         expect(shadowCompareService.compareInBackground).toHaveBeenCalledWith(
-            expect.objectContaining({
-                scope: "rejected",
-                // "unknown" carries the deleted codes 047/049, which the desktop's expired
-                // set counts as expired and shows without asking for excludeDeleted.
-                scopeCategories: ["expired", "unknown"],
-            }),
+            expect.objectContaining({ scope: "rejected" }),
             expect.objectContaining({ documentIds: ["expired-doc"] }),
         );
     });

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -32,6 +32,7 @@ describe("EformsignController (Integration)", () => {
         | "downloadDocumentFile"
         | "getAllDocuments"
         | "getInProgressDocuments"
+        | "getRejectedDocuments"
         | "getCompletedDocuments"
         | "getDocumentById"
     >>;
@@ -80,6 +81,7 @@ describe("EformsignController (Integration)", () => {
                         downloadDocumentFile: jest.fn(),
                         getAllDocuments: jest.fn(),
                         getInProgressDocuments: jest.fn(),
+                        getRejectedDocuments: jest.fn(),
                         getCompletedDocuments: jest.fn(),
                         getDocumentById: jest.fn(),
                     },
@@ -436,6 +438,38 @@ describe("EformsignController (Integration)", () => {
         expect(response.status).toBe(200);
         expect(response.body.documents).toEqual([{ id: "branch-1-doc" }]);
         expect(eformsignDocService.findAll).toHaveBeenCalledWith("branch-1");
+    });
+
+    it("compares the rejected tab by status, not by which inbox the vendor used", async () => {
+        // Type 04 is eformsign's document-management inbox, not a rejected-only one: it
+        // carries in-progress and completed documents too, which the client filters out
+        // by status. Handing the raw inbox to the comparison would report every one of
+        // those as missing from a mirror that is in fact correct.
+        eformsignService.getRejectedDocuments.mockResolvedValue({
+            documents: [
+                { id: "expired-doc", current_status: { status_type: "080" } },
+                { id: "still-open-doc", current_status: { status_type: "060" } },
+            ],
+        });
+        eformsignDocService.findAll.mockResolvedValue([
+            { documentId: "expired-doc" },
+            { documentId: "still-open-doc" },
+        ] as any);
+
+        const response = await request(app.getHttpServer())
+            .get("/api/documents/rejected?accessToken=access-token");
+
+        expect(response.status).toBe(200);
+        // The endpoint itself still returns what the inbox held — only the comparison is
+        // narrowed, because that is what the tab actually shows.
+        expect(response.body.documents).toHaveLength(2);
+        expect(shadowCompareService.compareInBackground).toHaveBeenCalledWith(
+            expect.objectContaining({
+                scope: "rejected",
+                scopeCategories: ["expired"],
+            }),
+            expect.objectContaining({ documentIds: ["expired-doc"] }),
+        );
     });
 
     it("finds current-branch status documents after pages containing only other branches", async () => {

--- a/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
@@ -774,6 +774,26 @@ describe("SbEformsignDocRepository", () => {
             .not.toHaveProperty("createdDate");
     });
 
+    it("repairs createdDate even when the event is refused as stale", async () => {
+        // An adopted row stores the moment of adoption as both createdDate and
+        // updatedDate, so an unchanged older vendor document is always "stale" and the
+        // guarded update never runs — which is exactly the row whose sort key is wrong.
+        // update refused → create races → P2002 → same guarded update refused again.
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 0 });
+        eformsignDocModel.create.mockRejectedValue(
+            Object.assign(new Error("Unique constraint failed"), { code: "P2002" }),
+        );
+        eformsignDocModel.count.mockResolvedValue(1);
+
+        await expect(repository.upsertUnassignedByDocumentId(createEntity()))
+            .rejects.toBeInstanceOf(EformsignDocStaleUpdateError);
+
+        const repair = eformsignDocModel.updateMany.mock.calls.at(-1)![0];
+        expect(repair.data).toEqual({ createdDate: legacyRow.createdDate });
+        // Ownership still applies, and rows that already agree are left alone.
+        expect(JSON.stringify(repair.where)).toContain("createdDate");
+    });
+
     it("omits expiredDate from list-sourced updates so a real expiry survives", async () => {
         // The list carries no expired_date, so what the mirror computed is only its
         // fallback guess — writing it would overwrite a date the vendor actually gave us.

--- a/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
@@ -473,6 +473,7 @@ describe("SbEformsignDocRepository", () => {
             statusType: "050",
             statusDetail: "완료",
             expiredDate: new Date("2026-08-01T00:00:00.000Z"),
+            createdDate: new Date("2026-07-01T00:00:00.000Z"),
             stepType: "05",
             stepIndex: "1",
             stepName: "이용자",
@@ -732,6 +733,45 @@ describe("SbEformsignDocRepository", () => {
 
         expect(eformsignDocModel.updateMany.mock.calls[0][0].data)
             .not.toHaveProperty("expired");
+    });
+
+    it("repairs createdDate on update so the list sorts by when eformsign made the document", async () => {
+        // The create and adopt paths store the moment we wrote the row, so a contract
+        // adopted long after it was created sorts as if it were new. Creation time is the
+        // list's sort key, so reconciling from a response that carries it puts that right.
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 1 });
+        eformsignDocModel.findFirst.mockResolvedValue({
+            ...legacyRow,
+            branchId: null,
+            clientId: null,
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: null,
+        });
+
+        await repository.upsertUnassignedByDocumentId(createEntity());
+
+        expect(eformsignDocModel.updateMany.mock.calls[0][0].data.createdDate)
+            .toEqual(legacyRow.createdDate);
+    });
+
+    it("leaves createdDate alone when the caller had to invent one", async () => {
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 1 });
+        eformsignDocModel.findFirst.mockResolvedValue({
+            ...legacyRow,
+            branchId: null,
+            clientId: null,
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: null,
+        });
+
+        await repository.upsertUnassignedByDocumentId(createEntity(), {
+            updateCreatedDate: false,
+        });
+
+        expect(eformsignDocModel.updateMany.mock.calls[0][0].data)
+            .not.toHaveProperty("createdDate");
     });
 
     it("omits expiredDate from list-sourced updates so a real expiry survives", async () => {

--- a/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
+++ b/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
@@ -77,6 +77,9 @@ function servedFrom(
         oldestScannedAt: ordered.length > 0
             ? ordered[ordered.length - 1]!.createdDate.getTime()
             : undefined,
+        // Most tests are about a capped scan, where an old mirror-only row is expected;
+        // the exhaustive case is asserted on its own below.
+        scanCapped: true,
         ...overrides,
     };
 }
@@ -430,6 +433,35 @@ describe("EformsignListShadowCompareService", () => {
         const message = logger.warn.mock.calls[0]?.[0] ?? "";
         expect(message).toContain("localOnlyNoScanRange=doc-old");
         expect(message).not.toContain("extra=");
+        expect(message).not.toContain("olderThanScanned=");
+    });
+
+    it("calls an old mirror-only row a real extra when the scan was exhaustive", async () => {
+        // A scan that ran out of pages saw everything, so the vendor genuinely does not
+        // have this document — its age says nothing. Suppressing it would be the one way
+        // this comparison could bless a mirror that is wrong.
+        const recent = createMirrorDocument({
+            documentId: "doc-new",
+            createdDate: "2026-07-05T00:00:00.000Z",
+        });
+        repository.findAll.mockResolvedValue([
+            recent,
+            createMirrorDocument({
+                documentId: "doc-ancient",
+                createdDate: "2024-01-01T00:00:00.000Z",
+            }),
+        ]);
+        const service = createService("true");
+        const logger = spyOnLogger(service);
+
+        service.compareInBackground(
+            createQuery(),
+            servedFrom([recent], { scanCapped: false }),
+        );
+        await settle();
+
+        const message = logger.warn.mock.calls[0]?.[0] ?? "";
+        expect(message).toContain("extra=doc-ancient");
         expect(message).not.toContain("olderThanScanned=");
     });
 

--- a/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
+++ b/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
@@ -1,0 +1,251 @@
+import { ConfigService } from "@nestjs/config";
+
+import {
+    EformsignListShadowCompareService,
+    type ListShadowCompareQuery,
+} from "application/services/eformsign-list-shadow-compare.service";
+import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
+
+function createConfigService(enabled: string | undefined): ConfigService {
+    return {
+        get: jest.fn((key: string) =>
+            key === "EFORMSIGN_SHADOW_COMPARE_ENABLED" ? enabled : undefined),
+    } as unknown as ConfigService;
+}
+
+function createMirrorDocument(overrides: {
+    documentId: string;
+    createdDate?: string;
+    statusType?: string;
+    templateId?: string | null;
+    customerName?: string | null;
+    documentName?: string | null;
+    stepRecipientName?: string;
+}): EformsignDocEntity {
+    const createdDate = new Date(overrides.createdDate ?? "2026-07-01T00:00:00.000Z");
+    return EformsignDocEntity.reconstitute({
+        id: 1,
+        documentId: overrides.documentId,
+        documentName: overrides.documentName ?? `문서 ${overrides.documentId}`,
+        documentNumber: `NO-${overrides.documentId}`,
+        templateName: "표준 계약서",
+        customerName: overrides.customerName ?? "김고객",
+        creatorName: "생성자",
+        lastEditorName: "편집자",
+        stepRecipientTypes: ["05"],
+        createdDate,
+        updatedDate: createdDate,
+        statusType: overrides.statusType ?? "060",
+        statusDetail: "서명 요청됨",
+        stepType: "01",
+        stepIndex: "1",
+        stepName: "이용자 서명",
+        stepRecipientType: "05",
+        stepRecipientName: overrides.stepRecipientName ?? "송진호",
+        stepRecipientSms: "01012345678",
+        expiredDate: new Date("2026-08-01T00:00:00.000Z"),
+        expired: false,
+        clientId: null,
+        documentKind: null,
+        employeeScheduleId: null,
+        templateId: overrides.templateId === undefined ? "template-1" : overrides.templateId,
+    });
+}
+
+function createQuery(overrides: Partial<ListShadowCompareQuery> = {}): ListShadowCompareQuery {
+    return {
+        branchId: "branch-1",
+        isHeadquarters: false,
+        scope: "all",
+        limit: 100,
+        skip: 0,
+        templateMatch: "include",
+        ...overrides,
+    };
+}
+
+describe("EformsignListShadowCompareService", () => {
+    let repository: { findAll: jest.Mock; findAllForHeadquarters: jest.Mock };
+
+    beforeEach(() => {
+        repository = {
+            findAll: jest.fn().mockResolvedValue([]),
+            findAllForHeadquarters: jest.fn().mockResolvedValue([]),
+        };
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    function createService(enabled: string | undefined) {
+        return new EformsignListShadowCompareService(
+            createConfigService(enabled),
+            repository as never,
+        );
+    }
+
+    /** compareInBackground deliberately does not await; give the microtasks a turn. */
+    const settle = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+    it.each([undefined, "false", "1"])(
+        "does nothing with EFORMSIGN_SHADOW_COMPARE_ENABLED=%s",
+        async (value) => {
+            const service = createService(value);
+
+            service.compareInBackground(createQuery(), { documentIds: ["a"], totalRows: 1 });
+            await settle();
+
+            expect(repository.findAll).not.toHaveBeenCalled();
+        },
+    );
+
+    it("reports a match when the mirror produces the same page", async () => {
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
+            createMirrorDocument({ documentId: "doc-1", createdDate: "2026-07-01T00:00:00.000Z" }),
+        ]);
+        const service = createService("true");
+        const log = jest.spyOn(
+            (service as unknown as { logger: { log: (message: string) => void } }).logger,
+            "log",
+        ).mockImplementation(() => undefined);
+        const warn = jest.spyOn(
+            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
+            "warn",
+        ).mockImplementation(() => undefined);
+
+        // Newest first, which is the order the served path sorts into.
+        service.compareInBackground(createQuery(), {
+            documentIds: ["doc-2", "doc-1"],
+            totalRows: 2,
+        });
+        await settle();
+
+        expect(warn).not.toHaveBeenCalled();
+        expect(log.mock.calls[0]?.[0]).toContain("match");
+    });
+
+    it("names the documents each side is missing", async () => {
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-1" }),
+            createMirrorDocument({ documentId: "doc-3" }),
+        ]);
+        const service = createService("true");
+        const warn = jest.spyOn(
+            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
+            "warn",
+        ).mockImplementation(() => undefined);
+
+        service.compareInBackground(createQuery(), {
+            documentIds: ["doc-1", "doc-2"],
+            totalRows: 2,
+        });
+        await settle();
+
+        const message = warn.mock.calls[0]?.[0] ?? "";
+        expect(message).toContain("missing=doc-2");
+        expect(message).toContain("extra=doc-3");
+    });
+
+    it("reports an order difference only when both sides hold the same documents", async () => {
+        // Same two documents, but the mirror's created dates put them the other way round.
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-a", createdDate: "2026-07-01T00:00:00.000Z" }),
+            createMirrorDocument({ documentId: "doc-b", createdDate: "2026-07-02T00:00:00.000Z" }),
+        ]);
+        const service = createService("true");
+        const warn = jest.spyOn(
+            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
+            "warn",
+        ).mockImplementation(() => undefined);
+
+        service.compareInBackground(createQuery(), {
+            documentIds: ["doc-a", "doc-b"],
+            totalRows: 2,
+        });
+        await settle();
+
+        expect(warn.mock.calls[0]?.[0]).toContain("order differs");
+    });
+
+    it("applies the same template filter the served page did", async () => {
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-keep", templateId: "template-1" }),
+            createMirrorDocument({ documentId: "doc-drop", templateId: "template-9" }),
+        ]);
+        const service = createService("true");
+        const warn = jest.spyOn(
+            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
+            "warn",
+        ).mockImplementation(() => undefined);
+
+        service.compareInBackground(
+            createQuery({ templateId: "template-1", templateMatch: "include" }),
+            { documentIds: ["doc-keep"], totalRows: 1 },
+        );
+        await settle();
+
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("searches the mirror by customer name, recipient name and 초성", async () => {
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-kim", customerName: "김고객" }),
+            createMirrorDocument({ documentId: "doc-lee", customerName: "이고객" }),
+        ]);
+        const service = createService("true");
+        const warn = jest.spyOn(
+            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
+            "warn",
+        ).mockImplementation(() => undefined);
+
+        // 초성 검색은 startsWith 규칙이라 "ㄱㄱ"은 김고객만 집는다.
+        service.compareInBackground(
+            createQuery({ search: "ㄱㄱ" }),
+            { documentIds: ["doc-kim"], totalRows: 1 },
+        );
+        await settle();
+
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("reads the headquarters scope from the repository method that includes unclaimed rows", async () => {
+        repository.findAllForHeadquarters.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-hq" }),
+        ]);
+        const service = createService("true");
+        jest.spyOn(
+            (service as unknown as { logger: { log: (message: string) => void } }).logger,
+            "log",
+        ).mockImplementation(() => undefined);
+
+        service.compareInBackground(
+            createQuery({ isHeadquarters: true }),
+            { documentIds: ["doc-hq"], totalRows: 1 },
+        );
+        await settle();
+
+        expect(repository.findAllForHeadquarters).toHaveBeenCalledWith("branch-1");
+        expect(repository.findAll).not.toHaveBeenCalled();
+    });
+
+    it("never lets a comparison failure escape into the request", async () => {
+        // The response has already been sent by the time this runs; throwing here would
+        // become an unhandled rejection, not an error the caller could do anything with.
+        repository.findAll.mockRejectedValue(new Error("mirror unavailable"));
+        const service = createService("true");
+        const warn = jest.spyOn(
+            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
+            "warn",
+        ).mockImplementation(() => undefined);
+
+        expect(() => service.compareInBackground(createQuery(), {
+            documentIds: [],
+            totalRows: 0,
+        })).not.toThrow();
+        await settle();
+
+        expect(warn.mock.calls[0]?.[0]).toContain("comparison failed");
+    });
+});

--- a/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
+++ b/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
@@ -74,12 +74,6 @@ function servedFrom(
                 eformsignListCompareFields(eformsignListDocFromMirror(document)),
             ] as const),
         ),
-        oldestScannedAt: ordered.length > 0
-            ? ordered[ordered.length - 1]!.createdDate.getTime()
-            : undefined,
-        // Most tests are about a capped scan, where an old mirror-only row is expected;
-        // the exhaustive case is asserted on its own below.
-        scanCapped: true,
         ...overrides,
     };
 }
@@ -204,9 +198,7 @@ describe("EformsignListShadowCompareService", () => {
         expect(logger.warn.mock.calls[0]?.[0]).toContain("order differs");
     });
 
-    it("still checks order when an out-of-range document is present", async () => {
-        // Dropping the order check whenever anything sat outside the vendor's range would
-        // hide a reversal behind a single ancient row.
+    it("checks order over the documents both sides hold", async () => {
         const a = createMirrorDocument({
             documentId: "doc-a",
             createdDate: "2026-07-01T00:00:00.000Z",
@@ -215,14 +207,7 @@ describe("EformsignListShadowCompareService", () => {
             documentId: "doc-b",
             createdDate: "2026-07-02T00:00:00.000Z",
         });
-        repository.findAll.mockResolvedValue([
-            a,
-            b,
-            createMirrorDocument({
-                documentId: "doc-ancient",
-                createdDate: "2024-01-01T00:00:00.000Z",
-            }),
-        ]);
+        repository.findAll.mockResolvedValue([a, b]);
         const service = createService("true");
         const logger = spyOnLogger(service);
 
@@ -234,8 +219,6 @@ describe("EformsignListShadowCompareService", () => {
 
         const message = logger.warn.mock.calls[0]?.[0] ?? "";
         expect(message).toContain("order differs");
-        expect(message).toContain("olderThanScanned=1");
-        expect(message).not.toContain("extra=");
     });
 
     it("reports documents whose values differ even when the list itself matches", async () => {
@@ -254,31 +237,6 @@ describe("EformsignListShadowCompareService", () => {
         await settle();
 
         expect(logger.warn.mock.calls[0]?.[0]).toContain("fields=doc-1[statusType]");
-    });
-
-    it("attributes documents older than the vendor's scanned range separately", async () => {
-        // The served path scans at most 10 vendor pages of 100 and warns when it hits that
-        // cap. Counting those as disagreements would make the gate unreachable for any
-        // company past a thousand documents, while they are what the switch recovers.
-        const recent = createMirrorDocument({
-            documentId: "doc-new",
-            createdDate: "2026-07-05T00:00:00.000Z",
-        });
-        repository.findAll.mockResolvedValue([
-            recent,
-            createMirrorDocument({
-                documentId: "doc-ancient",
-                createdDate: "2024-01-01T00:00:00.000Z",
-            }),
-        ]);
-        const service = createService("true");
-        const logger = spyOnLogger(service);
-
-        service.compareInBackground(createQuery(), servedFrom([recent]));
-        await settle();
-
-        expect(logger.warn).not.toHaveBeenCalled();
-        expect(logger.log.mock.calls[0]?.[0]).toContain("olderThanScanned=1");
     });
 
     it("applies the same template filter the served list did", async () => {
@@ -392,7 +350,7 @@ describe("EformsignListShadowCompareService", () => {
         const logger = spyOnLogger(service);
 
         service.compareInBackground(
-            createQuery({ scope: "in-progress", scopeCategories: ["drafting", "in-progress"] }),
+            createQuery({ scope: "in-progress" }),
             servedFrom([drafting]),
         );
         await settle();
@@ -415,54 +373,6 @@ describe("EformsignListShadowCompareService", () => {
         await settle();
 
         expect(logger.warn.mock.calls[0]?.[0]).toContain("fields=doc-1[updatedAt]");
-    });
-
-    it("refuses to classify local rows when the vendor scan returned nothing", async () => {
-        // A branch whose documents all sit past the 10-page company scan cap looks exactly
-        // like a branch whose mirror is wrong. Picking either verdict would be inventing
-        // one; the operator can tell them apart from the scan's own cap warning.
-        repository.findAll.mockResolvedValue([
-            createMirrorDocument({ documentId: "doc-old" }),
-        ]);
-        const service = createService("true");
-        const logger = spyOnLogger(service);
-
-        service.compareInBackground(createQuery(), servedFrom([]));
-        await settle();
-
-        const message = logger.warn.mock.calls[0]?.[0] ?? "";
-        expect(message).toContain("localOnlyNoScanRange=doc-old");
-        expect(message).not.toContain("extra=");
-        expect(message).not.toContain("olderThanScanned=");
-    });
-
-    it("calls an old mirror-only row a real extra when the scan was exhaustive", async () => {
-        // A scan that ran out of pages saw everything, so the vendor genuinely does not
-        // have this document — its age says nothing. Suppressing it would be the one way
-        // this comparison could bless a mirror that is wrong.
-        const recent = createMirrorDocument({
-            documentId: "doc-new",
-            createdDate: "2026-07-05T00:00:00.000Z",
-        });
-        repository.findAll.mockResolvedValue([
-            recent,
-            createMirrorDocument({
-                documentId: "doc-ancient",
-                createdDate: "2024-01-01T00:00:00.000Z",
-            }),
-        ]);
-        const service = createService("true");
-        const logger = spyOnLogger(service);
-
-        service.compareInBackground(
-            createQuery(),
-            servedFrom([recent], { scanCapped: false }),
-        );
-        await settle();
-
-        const message = logger.warn.mock.calls[0]?.[0] ?? "";
-        expect(message).toContain("extra=doc-ancient");
-        expect(message).not.toContain("olderThanScanned=");
     });
 
     it("keeps the search term itself out of the log", async () => {

--- a/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
+++ b/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
@@ -1,9 +1,12 @@
 import { ConfigService } from "@nestjs/config";
 
 import {
+    eformsignListCompareFields,
     EformsignListShadowCompareService,
     type ListShadowCompareQuery,
+    type ListShadowCompareServed,
 } from "application/services/eformsign-list-shadow-compare.service";
+import { eformsignListDocFromMirror } from "application/utils/eformsign-list-doc-from-mirror";
 import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
 
 function createConfigService(enabled: string | undefined): ConfigService {
@@ -52,6 +55,32 @@ function createMirrorDocument(overrides: {
     });
 }
 
+/**
+ * The served payload for documents that agree with the mirror, in served order. A test
+ * that wants a difference overrides one piece, so what it is asserting stays visible.
+ */
+function servedFrom(
+    documents: EformsignDocEntity[],
+    overrides: Partial<ListShadowCompareServed> = {},
+): ListShadowCompareServed {
+    const ordered = [...documents].sort(
+        (a, b) => b.createdDate.getTime() - a.createdDate.getTime(),
+    );
+    return {
+        documentIds: ordered.map((document) => document.documentId),
+        fieldsById: new Map(
+            ordered.map((document) => [
+                document.documentId,
+                eformsignListCompareFields(eformsignListDocFromMirror(document)),
+            ] as const),
+        ),
+        oldestScannedAt: ordered.length > 0
+            ? ordered[ordered.length - 1]!.createdDate.getTime()
+            : undefined,
+        ...overrides,
+    };
+}
+
 function createQuery(overrides: Partial<ListShadowCompareQuery> = {}): ListShadowCompareQuery {
     return {
         branchId: "branch-1",
@@ -85,136 +114,208 @@ describe("EformsignListShadowCompareService", () => {
         );
     }
 
+    function spyOnLogger(service: EformsignListShadowCompareService) {
+        const logger = (service as unknown as {
+            logger: { log: (message: string) => void; warn: (message: string) => void };
+        }).logger;
+        return {
+            log: jest.spyOn(logger, "log").mockImplementation(() => undefined),
+            warn: jest.spyOn(logger, "warn").mockImplementation(() => undefined),
+        };
+    }
+
     /** compareInBackground deliberately does not await; give the microtasks a turn. */
-    const settle = () => new Promise<void>((resolve) => setImmediate(resolve));
+    const settle = async () => {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        await new Promise<void>((resolve) => setImmediate(resolve));
+    };
 
     it.each([undefined, "false", "1"])(
         "does nothing with EFORMSIGN_SHADOW_COMPARE_ENABLED=%s",
         async (value) => {
             const service = createService(value);
 
-            service.compareInBackground(createQuery(), { documentIds: ["a"], oldestCreatedAt: undefined });
+            service.compareInBackground(createQuery(), servedFrom([]));
             await settle();
 
             expect(repository.findAll).not.toHaveBeenCalled();
         },
     );
 
-    it("reports a match when the mirror produces the same page", async () => {
-        repository.findAll.mockResolvedValue([
+    it("reports a match when the mirror produces the same list", async () => {
+        const documents = [
             createMirrorDocument({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
             createMirrorDocument({ documentId: "doc-1", createdDate: "2026-07-01T00:00:00.000Z" }),
-        ]);
+        ];
+        repository.findAll.mockResolvedValue(documents);
         const service = createService("true");
-        const log = jest.spyOn(
-            (service as unknown as { logger: { log: (message: string) => void } }).logger,
-            "log",
-        ).mockImplementation(() => undefined);
-        const warn = jest.spyOn(
-            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
-            "warn",
-        ).mockImplementation(() => undefined);
+        const logger = spyOnLogger(service);
 
-        // Newest first, which is the order the served path sorts into.
-        service.compareInBackground(createQuery(), {
-            documentIds: ["doc-2", "doc-1"],
-            oldestCreatedAt: undefined,
-        });
+        service.compareInBackground(createQuery(), servedFrom(documents));
         await settle();
 
-        expect(warn).not.toHaveBeenCalled();
-        expect(log.mock.calls[0]?.[0]).toContain("match");
+        expect(logger.warn).not.toHaveBeenCalled();
+        expect(logger.log.mock.calls[0]?.[0]).toContain("match");
     });
 
     it("names the documents each side is missing", async () => {
+        const shared = createMirrorDocument({ documentId: "doc-1" });
         repository.findAll.mockResolvedValue([
-            createMirrorDocument({ documentId: "doc-1" }),
+            shared,
             createMirrorDocument({ documentId: "doc-3" }),
         ]);
         const service = createService("true");
-        const warn = jest.spyOn(
-            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
-            "warn",
-        ).mockImplementation(() => undefined);
+        const logger = spyOnLogger(service);
 
-        service.compareInBackground(createQuery(), {
-            documentIds: ["doc-1", "doc-2"],
-            oldestCreatedAt: undefined,
-        });
+        service.compareInBackground(createQuery(), servedFrom([
+            shared,
+            createMirrorDocument({ documentId: "doc-2" }),
+        ]));
         await settle();
 
-        const message = warn.mock.calls[0]?.[0] ?? "";
+        const message = logger.warn.mock.calls[0]?.[0] ?? "";
         expect(message).toContain("missing=doc-2");
         expect(message).toContain("extra=doc-3");
     });
 
-    it("reports an order difference only when both sides hold the same documents", async () => {
-        // Same two documents, but the mirror's created dates put them the other way round.
-        repository.findAll.mockResolvedValue([
-            createMirrorDocument({ documentId: "doc-a", createdDate: "2026-07-01T00:00:00.000Z" }),
-            createMirrorDocument({ documentId: "doc-b", createdDate: "2026-07-02T00:00:00.000Z" }),
-        ]);
-        const service = createService("true");
-        const warn = jest.spyOn(
-            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
-            "warn",
-        ).mockImplementation(() => undefined);
-
-        service.compareInBackground(createQuery(), {
-            documentIds: ["doc-a", "doc-b"],
-            oldestCreatedAt: undefined,
+    it("reports an order difference when the same documents come out the other way round", async () => {
+        const a = createMirrorDocument({
+            documentId: "doc-a",
+            createdDate: "2026-07-01T00:00:00.000Z",
         });
+        const b = createMirrorDocument({
+            documentId: "doc-b",
+            createdDate: "2026-07-02T00:00:00.000Z",
+        });
+        repository.findAll.mockResolvedValue([a, b]);
+        const service = createService("true");
+        const logger = spyOnLogger(service);
+
+        // The mirror sorts b first; the served list claims a first.
+        service.compareInBackground(
+            createQuery(),
+            servedFrom([a, b], { documentIds: ["doc-a", "doc-b"] }),
+        );
         await settle();
 
-        expect(warn.mock.calls[0]?.[0]).toContain("order differs");
+        expect(logger.warn.mock.calls[0]?.[0]).toContain("order differs");
     });
 
-    it("applies the same template filter the served page did", async () => {
+    it("still checks order when an out-of-range document is present", async () => {
+        // Dropping the order check whenever anything sat outside the vendor's range would
+        // hide a reversal behind a single ancient row.
+        const a = createMirrorDocument({
+            documentId: "doc-a",
+            createdDate: "2026-07-01T00:00:00.000Z",
+        });
+        const b = createMirrorDocument({
+            documentId: "doc-b",
+            createdDate: "2026-07-02T00:00:00.000Z",
+        });
         repository.findAll.mockResolvedValue([
-            createMirrorDocument({ documentId: "doc-keep", templateId: "template-1" }),
+            a,
+            b,
+            createMirrorDocument({
+                documentId: "doc-ancient",
+                createdDate: "2024-01-01T00:00:00.000Z",
+            }),
+        ]);
+        const service = createService("true");
+        const logger = spyOnLogger(service);
+
+        service.compareInBackground(
+            createQuery(),
+            servedFrom([a, b], { documentIds: ["doc-a", "doc-b"] }),
+        );
+        await settle();
+
+        const message = logger.warn.mock.calls[0]?.[0] ?? "";
+        expect(message).toContain("order differs");
+        expect(message).toContain("olderThanScanned=1");
+        expect(message).not.toContain("extra=");
+    });
+
+    it("reports documents whose values differ even when the list itself matches", async () => {
+        // Membership and order can agree while the row serves a different status, and the
+        // UI reads that directly — it drives the pill and which actions are offered.
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-1", statusType: "060" }),
+        ]);
+        const service = createService("true");
+        const logger = spyOnLogger(service);
+
+        service.compareInBackground(
+            createQuery(),
+            servedFrom([createMirrorDocument({ documentId: "doc-1", statusType: "050" })]),
+        );
+        await settle();
+
+        expect(logger.warn.mock.calls[0]?.[0]).toContain("fields=doc-1[statusType]");
+    });
+
+    it("attributes documents older than the vendor's scanned range separately", async () => {
+        // The served path scans at most 10 vendor pages of 100 and warns when it hits that
+        // cap. Counting those as disagreements would make the gate unreachable for any
+        // company past a thousand documents, while they are what the switch recovers.
+        const recent = createMirrorDocument({
+            documentId: "doc-new",
+            createdDate: "2026-07-05T00:00:00.000Z",
+        });
+        repository.findAll.mockResolvedValue([
+            recent,
+            createMirrorDocument({
+                documentId: "doc-ancient",
+                createdDate: "2024-01-01T00:00:00.000Z",
+            }),
+        ]);
+        const service = createService("true");
+        const logger = spyOnLogger(service);
+
+        service.compareInBackground(createQuery(), servedFrom([recent]));
+        await settle();
+
+        expect(logger.warn).not.toHaveBeenCalled();
+        expect(logger.log.mock.calls[0]?.[0]).toContain("olderThanScanned=1");
+    });
+
+    it("applies the same template filter the served list did", async () => {
+        const kept = createMirrorDocument({ documentId: "doc-keep", templateId: "template-1" });
+        repository.findAll.mockResolvedValue([
+            kept,
             createMirrorDocument({ documentId: "doc-drop", templateId: "template-9" }),
         ]);
         const service = createService("true");
-        const warn = jest.spyOn(
-            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
-            "warn",
-        ).mockImplementation(() => undefined);
+        const logger = spyOnLogger(service);
 
         service.compareInBackground(
             createQuery({ templateId: "template-1", templateMatch: "include" }),
-            { documentIds: ["doc-keep"], oldestCreatedAt: undefined },
+            servedFrom([kept]),
         );
         await settle();
 
-        expect(warn).not.toHaveBeenCalled();
+        expect(logger.warn).not.toHaveBeenCalled();
     });
 
     it("matches 초성 against the recipient name, the way the served search does", async () => {
+        const song = createMirrorDocument({ documentId: "doc-song", stepRecipientName: "송진호" });
         repository.findAll.mockResolvedValue([
-            createMirrorDocument({ documentId: "doc-song", stepRecipientName: "송진호" }),
+            song,
             createMirrorDocument({ documentId: "doc-park", stepRecipientName: "박수신" }),
         ]);
         const service = createService("true");
-        const warn = jest.spyOn(
-            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
-            "warn",
-        ).mockImplementation(() => undefined);
+        const logger = spyOnLogger(service);
 
         // 초성 검색은 startsWith 규칙이라 "ㅅㅈㅎ"는 송진호만 집는다.
-        service.compareInBackground(
-            createQuery({ search: "ㅅㅈㅎ" }),
-            { documentIds: ["doc-song"], oldestCreatedAt: undefined },
-        );
+        service.compareInBackground(createQuery({ search: "ㅅㅈㅎ" }), servedFrom([song]));
         await settle();
 
-        expect(warn).not.toHaveBeenCalled();
+        expect(logger.warn).not.toHaveBeenCalled();
     });
 
     it("does not search the stored customerName, because the served list cannot", async () => {
         // The vendor list is fetched without include_fields, so the served search never
         // sees a customer name on the document and matches the recipient name instead.
-        // Searching the mirror's own column would find documents the served path cannot,
-        // and every one of those would be reported as a difference we invented.
+        // Searching the mirror's own column would find documents the served path cannot.
         repository.findAll.mockResolvedValue([
             createMirrorDocument({
                 documentId: "doc-hidden",
@@ -224,23 +325,96 @@ describe("EformsignListShadowCompareService", () => {
             }),
         ]);
         const service = createService("true");
-        const log = jest.spyOn(
-            (service as unknown as { logger: { log: (message: string) => void } }).logger,
-            "log",
-        ).mockImplementation(() => undefined);
-        const warn = jest.spyOn(
-            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
-            "warn",
-        ).mockImplementation(() => undefined);
+        const logger = spyOnLogger(service);
+
+        service.compareInBackground(createQuery({ search: "최고객" }), servedFrom([]));
+        await settle();
+
+        expect(logger.warn).not.toHaveBeenCalled();
+        expect(logger.log.mock.calls[0]?.[0]).toContain("match");
+    });
+
+    it("searches headquarters recipient names from branch-owned rows only", async () => {
+        // The served path builds its recipient-name corpus from findAll(branchId), so an
+        // unassigned document's recipient name is not searchable there.
+        repository.findAllForHeadquarters.mockResolvedValue([
+            createMirrorDocument({
+                documentId: "doc-unassigned",
+                documentName: null,
+                stepRecipientName: "박수신",
+            }),
+        ]);
+        repository.findAll.mockResolvedValue([]);
+        const service = createService("true");
+        const logger = spyOnLogger(service);
 
         service.compareInBackground(
-            createQuery({ search: "최고객" }),
-            { documentIds: [], oldestCreatedAt: undefined },
+            createQuery({ isHeadquarters: true, search: "박수신" }),
+            servedFrom([]),
         );
         await settle();
 
-        expect(warn).not.toHaveBeenCalled();
-        expect(log.mock.calls[0]?.[0]).toContain("match");
+        expect(logger.warn).not.toHaveBeenCalled();
+        expect(logger.log.mock.calls[0]?.[0]).toContain("match");
+    });
+
+    it("reads the headquarters corpus from the method that includes unclaimed rows", async () => {
+        const hqDocument = createMirrorDocument({ documentId: "doc-hq" });
+        repository.findAllForHeadquarters.mockResolvedValue([hqDocument]);
+        const service = createService("true");
+        spyOnLogger(service);
+
+        service.compareInBackground(
+            createQuery({ isHeadquarters: true }),
+            servedFrom([hqDocument]),
+        );
+        await settle();
+
+        expect(repository.findAllForHeadquarters).toHaveBeenCalledWith("branch-1");
+        // findAll is still consulted, but only for the recipient-name search corpus the
+        // served path builds the same way — not for which documents the list contains.
+        expect(repository.findAll).toHaveBeenCalledWith("branch-1");
+    });
+
+    it("stands in for the vendor inbox with local status categories on the tab endpoints", async () => {
+        // The tabs are most of the traffic, and the mirror does not record which inbox a
+        // document sat in — the switch has to answer them from status codes. Comparing
+        // that substitution is the only way to learn whether it lands the same content.
+        const drafting = createMirrorDocument({ documentId: "doc-open", statusType: "060" });
+        repository.findAll.mockResolvedValue([
+            drafting,
+            createMirrorDocument({ documentId: "doc-done", statusType: "050" }),
+        ]);
+        const service = createService("true");
+        const logger = spyOnLogger(service);
+
+        service.compareInBackground(
+            createQuery({ scope: "in-progress", scopeCategories: ["drafting", "in-progress"] }),
+            servedFrom([drafting]),
+        );
+        await settle();
+
+        expect(logger.warn).not.toHaveBeenCalled();
+        expect(logger.log.mock.calls[0]?.[0]).toContain("scope=in-progress");
+    });
+
+    it("keeps the search term itself out of the log", async () => {
+        // Searches are customer names often enough that the term does not belong in a
+        // centralised log, and a raw value could break the log line apart.
+        repository.findAll.mockResolvedValue([]);
+        const service = createService("true");
+        const logger = spyOnLogger(service);
+
+        service.compareInBackground(
+            createQuery({ search: "김민수\n[Shadow] injected" }),
+            servedFrom([createMirrorDocument({ documentId: "doc-missing" })]),
+        );
+        await settle();
+
+        const message = logger.warn.mock.calls[0]?.[0] ?? "";
+        expect(message).toContain("search=present");
+        expect(message).not.toContain("김민수");
+        expect(message).not.toContain("injected");
     });
 
     it("runs one comparison at a time and says how many it skipped", async () => {
@@ -251,12 +425,9 @@ describe("EformsignListShadowCompareService", () => {
             release = () => resolve([]);
         }));
         const service = createService("true");
-        const log = jest.spyOn(
-            (service as unknown as { logger: { log: (message: string) => void } }).logger,
-            "log",
-        ).mockImplementation(() => undefined);
+        const logger = spyOnLogger(service);
+        const served = servedFrom([]);
 
-        const served = { documentIds: [], oldestCreatedAt: undefined };
         service.compareInBackground(createQuery(), served);
         service.compareInBackground(createQuery(), served);
         service.compareInBackground(createQuery(), served);
@@ -264,116 +435,10 @@ describe("EformsignListShadowCompareService", () => {
 
         release?.();
         await settle();
-        await settle();
 
         // The run that got through reports what it displaced, so the log says how much of
         // the traffic this evidence actually covers.
-        expect(log.mock.calls[0]?.[0]).toContain("skippedWhileBusy=2");
-    });
-
-    it("reads the headquarters scope from the repository method that includes unclaimed rows", async () => {
-        repository.findAllForHeadquarters.mockResolvedValue([
-            createMirrorDocument({ documentId: "doc-hq" }),
-        ]);
-        const service = createService("true");
-        jest.spyOn(
-            (service as unknown as { logger: { log: (message: string) => void } }).logger,
-            "log",
-        ).mockImplementation(() => undefined);
-
-        service.compareInBackground(
-            createQuery({ isHeadquarters: true }),
-            { documentIds: ["doc-hq"], oldestCreatedAt: undefined },
-        );
-        await settle();
-
-        expect(repository.findAllForHeadquarters).toHaveBeenCalledWith("branch-1");
-        // findAll is still consulted, but only for the recipient-name search corpus the
-        // served path builds the same way — not for which documents the list contains.
-        expect(repository.findAll).toHaveBeenCalledWith("branch-1");
-    });
-
-    it("attributes documents older than the served scan window separately", async () => {
-        // The served path scans at most 10 vendor pages of 100 and warns that older
-        // contracts fall outside it. Counting those as disagreements would make the
-        // zero-diff gate unreachable for any company past a thousand documents, while
-        // they are in fact what the switch recovers.
-        repository.findAll.mockResolvedValue([
-            createMirrorDocument({ documentId: "doc-new", createdDate: "2026-07-05T00:00:00.000Z" }),
-            createMirrorDocument({ documentId: "doc-ancient", createdDate: "2024-01-01T00:00:00.000Z" }),
-        ]);
-        const service = createService("true");
-        const log = jest.spyOn(
-            (service as unknown as { logger: { log: (message: string) => void } }).logger,
-            "log",
-        ).mockImplementation(() => undefined);
-        const warn = jest.spyOn(
-            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
-            "warn",
-        ).mockImplementation(() => undefined);
-
-        service.compareInBackground(createQuery(), {
-            documentIds: ["doc-new"],
-            oldestCreatedAt: Date.parse("2026-07-05T00:00:00.000Z"),
-        });
-        await settle();
-
-        expect(warn).not.toHaveBeenCalled();
-        expect(log.mock.calls[0]?.[0]).toContain("beyondScanWindow=1");
-    });
-
-    it("searches headquarters recipient names from branch-owned rows only", async () => {
-        // The served path builds its recipient-name corpus from findAll(branchId), so an
-        // unassigned document's recipient name is not searchable there. Searching it here
-        // would report a difference that is this comparison's, not the mirror's.
-        const unassigned = createMirrorDocument({
-            documentId: "doc-unassigned",
-            customerName: null,
-            documentName: null,
-            stepRecipientName: "박수신",
-        });
-        repository.findAllForHeadquarters.mockResolvedValue([unassigned]);
-        repository.findAll.mockResolvedValue([]);
-        const service = createService("true");
-        const log = jest.spyOn(
-            (service as unknown as { logger: { log: (message: string) => void } }).logger,
-            "log",
-        ).mockImplementation(() => undefined);
-        const warn = jest.spyOn(
-            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
-            "warn",
-        ).mockImplementation(() => undefined);
-
-        service.compareInBackground(
-            createQuery({ isHeadquarters: true, search: "박수신" }),
-            { documentIds: [], oldestCreatedAt: undefined },
-        );
-        await settle();
-
-        expect(warn).not.toHaveBeenCalled();
-        expect(log.mock.calls[0]?.[0]).toContain("match");
-    });
-
-    it("keeps the search term itself out of the log", async () => {
-        // Searches are customer names often enough that the term does not belong in a
-        // centralised log, and a raw value could break the log line apart.
-        repository.findAll.mockResolvedValue([]);
-        const service = createService("true");
-        const warn = jest.spyOn(
-            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
-            "warn",
-        ).mockImplementation(() => undefined);
-
-        service.compareInBackground(
-            createQuery({ search: "김민수\n[Shadow] injected" }),
-            { documentIds: ["doc-missing"], oldestCreatedAt: undefined },
-        );
-        await settle();
-
-        const message = warn.mock.calls[0]?.[0] ?? "";
-        expect(message).toContain("search=present");
-        expect(message).not.toContain("김민수");
-        expect(message).not.toContain("injected");
+        expect(logger.log.mock.calls[0]?.[0]).toContain("skippedWhileBusy=2");
     });
 
     it("never lets a comparison failure escape into the request", async () => {
@@ -381,17 +446,12 @@ describe("EformsignListShadowCompareService", () => {
         // become an unhandled rejection, not an error the caller could do anything with.
         repository.findAll.mockRejectedValue(new Error("mirror unavailable"));
         const service = createService("true");
-        const warn = jest.spyOn(
-            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
-            "warn",
-        ).mockImplementation(() => undefined);
+        const logger = spyOnLogger(service);
 
-        expect(() => service.compareInBackground(createQuery(), {
-            documentIds: [],
-            oldestCreatedAt: undefined,
-        })).not.toThrow();
+        expect(() => service.compareInBackground(createQuery(), servedFrom([])))
+            .not.toThrow();
         await settle();
 
-        expect(warn.mock.calls[0]?.[0]).toContain("comparison failed");
+        expect(logger.warn.mock.calls[0]?.[0]).toContain("comparison failed");
     });
 });

--- a/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
+++ b/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
@@ -398,6 +398,41 @@ describe("EformsignListShadowCompareService", () => {
         expect(logger.log.mock.calls[0]?.[0]).toContain("scope=in-progress");
     });
 
+    it("reports a stale completion date even when everything else agrees", async () => {
+        // The list renders updated_date as the signed date, so a mirror that is right
+        // about membership and status can still show users the wrong day.
+        const mirrored = createMirrorDocument({ documentId: "doc-1" });
+        repository.findAll.mockResolvedValue([mirrored]);
+        const service = createService("true");
+        const logger = spyOnLogger(service);
+
+        const served = servedFrom([mirrored]);
+        served.fieldsById.get("doc-1")!.updatedAt += 86_400_000;
+        service.compareInBackground(createQuery(), served);
+        await settle();
+
+        expect(logger.warn.mock.calls[0]?.[0]).toContain("fields=doc-1[updatedAt]");
+    });
+
+    it("refuses to classify local rows when the vendor scan returned nothing", async () => {
+        // A branch whose documents all sit past the 10-page company scan cap looks exactly
+        // like a branch whose mirror is wrong. Picking either verdict would be inventing
+        // one; the operator can tell them apart from the scan's own cap warning.
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-old" }),
+        ]);
+        const service = createService("true");
+        const logger = spyOnLogger(service);
+
+        service.compareInBackground(createQuery(), servedFrom([]));
+        await settle();
+
+        const message = logger.warn.mock.calls[0]?.[0] ?? "";
+        expect(message).toContain("localOnlyNoScanRange=doc-old");
+        expect(message).not.toContain("extra=");
+        expect(message).not.toContain("olderThanScanned=");
+    });
+
     it("keeps the search term itself out of the log", async () => {
         // Searches are customer names often enough that the term does not belong in a
         // centralised log, and a raw value could break the log line apart.

--- a/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
+++ b/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
@@ -93,7 +93,7 @@ describe("EformsignListShadowCompareService", () => {
         async (value) => {
             const service = createService(value);
 
-            service.compareInBackground(createQuery(), { documentIds: ["a"], totalRows: 1 });
+            service.compareInBackground(createQuery(), { documentIds: ["a"], oldestCreatedAt: undefined });
             await settle();
 
             expect(repository.findAll).not.toHaveBeenCalled();
@@ -118,7 +118,7 @@ describe("EformsignListShadowCompareService", () => {
         // Newest first, which is the order the served path sorts into.
         service.compareInBackground(createQuery(), {
             documentIds: ["doc-2", "doc-1"],
-            totalRows: 2,
+            oldestCreatedAt: undefined,
         });
         await settle();
 
@@ -139,7 +139,7 @@ describe("EformsignListShadowCompareService", () => {
 
         service.compareInBackground(createQuery(), {
             documentIds: ["doc-1", "doc-2"],
-            totalRows: 2,
+            oldestCreatedAt: undefined,
         });
         await settle();
 
@@ -162,7 +162,7 @@ describe("EformsignListShadowCompareService", () => {
 
         service.compareInBackground(createQuery(), {
             documentIds: ["doc-a", "doc-b"],
-            totalRows: 2,
+            oldestCreatedAt: undefined,
         });
         await settle();
 
@@ -182,17 +182,17 @@ describe("EformsignListShadowCompareService", () => {
 
         service.compareInBackground(
             createQuery({ templateId: "template-1", templateMatch: "include" }),
-            { documentIds: ["doc-keep"], totalRows: 1 },
+            { documentIds: ["doc-keep"], oldestCreatedAt: undefined },
         );
         await settle();
 
         expect(warn).not.toHaveBeenCalled();
     });
 
-    it("searches the mirror by customer name, recipient name and 초성", async () => {
+    it("matches 초성 against the recipient name, the way the served search does", async () => {
         repository.findAll.mockResolvedValue([
-            createMirrorDocument({ documentId: "doc-kim", customerName: "김고객" }),
-            createMirrorDocument({ documentId: "doc-lee", customerName: "이고객" }),
+            createMirrorDocument({ documentId: "doc-song", stepRecipientName: "송진호" }),
+            createMirrorDocument({ documentId: "doc-park", stepRecipientName: "박수신" }),
         ]);
         const service = createService("true");
         const warn = jest.spyOn(
@@ -200,14 +200,75 @@ describe("EformsignListShadowCompareService", () => {
             "warn",
         ).mockImplementation(() => undefined);
 
-        // 초성 검색은 startsWith 규칙이라 "ㄱㄱ"은 김고객만 집는다.
+        // 초성 검색은 startsWith 규칙이라 "ㅅㅈㅎ"는 송진호만 집는다.
         service.compareInBackground(
-            createQuery({ search: "ㄱㄱ" }),
-            { documentIds: ["doc-kim"], totalRows: 1 },
+            createQuery({ search: "ㅅㅈㅎ" }),
+            { documentIds: ["doc-song"], oldestCreatedAt: undefined },
         );
         await settle();
 
         expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("does not search the stored customerName, because the served list cannot", async () => {
+        // The vendor list is fetched without include_fields, so the served search never
+        // sees a customer name on the document and matches the recipient name instead.
+        // Searching the mirror's own column would find documents the served path cannot,
+        // and every one of those would be reported as a difference we invented.
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({
+                documentId: "doc-hidden",
+                customerName: "최고객",
+                documentName: "계약",
+                stepRecipientName: "송진호",
+            }),
+        ]);
+        const service = createService("true");
+        const log = jest.spyOn(
+            (service as unknown as { logger: { log: (message: string) => void } }).logger,
+            "log",
+        ).mockImplementation(() => undefined);
+        const warn = jest.spyOn(
+            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
+            "warn",
+        ).mockImplementation(() => undefined);
+
+        service.compareInBackground(
+            createQuery({ search: "최고객" }),
+            { documentIds: [], oldestCreatedAt: undefined },
+        );
+        await settle();
+
+        expect(warn).not.toHaveBeenCalled();
+        expect(log.mock.calls[0]?.[0]).toContain("match");
+    });
+
+    it("runs one comparison at a time and says how many it skipped", async () => {
+        // Every list request would otherwise load the whole branch mirror and sort it,
+        // competing with the served requests for the same connection pool.
+        let release: (() => void) | undefined;
+        repository.findAll.mockImplementation(() => new Promise((resolve) => {
+            release = () => resolve([]);
+        }));
+        const service = createService("true");
+        const log = jest.spyOn(
+            (service as unknown as { logger: { log: (message: string) => void } }).logger,
+            "log",
+        ).mockImplementation(() => undefined);
+
+        const served = { documentIds: [], oldestCreatedAt: undefined };
+        service.compareInBackground(createQuery(), served);
+        service.compareInBackground(createQuery(), served);
+        service.compareInBackground(createQuery(), served);
+        expect(repository.findAll).toHaveBeenCalledTimes(1);
+
+        release?.();
+        await settle();
+        await settle();
+
+        // The run that got through reports what it displaced, so the log says how much of
+        // the traffic this evidence actually covers.
+        expect(log.mock.calls[0]?.[0]).toContain("skippedWhileBusy=2");
     });
 
     it("reads the headquarters scope from the repository method that includes unclaimed rows", async () => {
@@ -222,12 +283,97 @@ describe("EformsignListShadowCompareService", () => {
 
         service.compareInBackground(
             createQuery({ isHeadquarters: true }),
-            { documentIds: ["doc-hq"], totalRows: 1 },
+            { documentIds: ["doc-hq"], oldestCreatedAt: undefined },
         );
         await settle();
 
         expect(repository.findAllForHeadquarters).toHaveBeenCalledWith("branch-1");
-        expect(repository.findAll).not.toHaveBeenCalled();
+        // findAll is still consulted, but only for the recipient-name search corpus the
+        // served path builds the same way — not for which documents the list contains.
+        expect(repository.findAll).toHaveBeenCalledWith("branch-1");
+    });
+
+    it("attributes documents older than the served scan window separately", async () => {
+        // The served path scans at most 10 vendor pages of 100 and warns that older
+        // contracts fall outside it. Counting those as disagreements would make the
+        // zero-diff gate unreachable for any company past a thousand documents, while
+        // they are in fact what the switch recovers.
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-new", createdDate: "2026-07-05T00:00:00.000Z" }),
+            createMirrorDocument({ documentId: "doc-ancient", createdDate: "2024-01-01T00:00:00.000Z" }),
+        ]);
+        const service = createService("true");
+        const log = jest.spyOn(
+            (service as unknown as { logger: { log: (message: string) => void } }).logger,
+            "log",
+        ).mockImplementation(() => undefined);
+        const warn = jest.spyOn(
+            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
+            "warn",
+        ).mockImplementation(() => undefined);
+
+        service.compareInBackground(createQuery(), {
+            documentIds: ["doc-new"],
+            oldestCreatedAt: Date.parse("2026-07-05T00:00:00.000Z"),
+        });
+        await settle();
+
+        expect(warn).not.toHaveBeenCalled();
+        expect(log.mock.calls[0]?.[0]).toContain("beyondScanWindow=1");
+    });
+
+    it("searches headquarters recipient names from branch-owned rows only", async () => {
+        // The served path builds its recipient-name corpus from findAll(branchId), so an
+        // unassigned document's recipient name is not searchable there. Searching it here
+        // would report a difference that is this comparison's, not the mirror's.
+        const unassigned = createMirrorDocument({
+            documentId: "doc-unassigned",
+            customerName: null,
+            documentName: null,
+            stepRecipientName: "박수신",
+        });
+        repository.findAllForHeadquarters.mockResolvedValue([unassigned]);
+        repository.findAll.mockResolvedValue([]);
+        const service = createService("true");
+        const log = jest.spyOn(
+            (service as unknown as { logger: { log: (message: string) => void } }).logger,
+            "log",
+        ).mockImplementation(() => undefined);
+        const warn = jest.spyOn(
+            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
+            "warn",
+        ).mockImplementation(() => undefined);
+
+        service.compareInBackground(
+            createQuery({ isHeadquarters: true, search: "박수신" }),
+            { documentIds: [], oldestCreatedAt: undefined },
+        );
+        await settle();
+
+        expect(warn).not.toHaveBeenCalled();
+        expect(log.mock.calls[0]?.[0]).toContain("match");
+    });
+
+    it("keeps the search term itself out of the log", async () => {
+        // Searches are customer names often enough that the term does not belong in a
+        // centralised log, and a raw value could break the log line apart.
+        repository.findAll.mockResolvedValue([]);
+        const service = createService("true");
+        const warn = jest.spyOn(
+            (service as unknown as { logger: { warn: (message: string) => void } }).logger,
+            "warn",
+        ).mockImplementation(() => undefined);
+
+        service.compareInBackground(
+            createQuery({ search: "김민수\n[Shadow] injected" }),
+            { documentIds: ["doc-missing"], oldestCreatedAt: undefined },
+        );
+        await settle();
+
+        const message = warn.mock.calls[0]?.[0] ?? "";
+        expect(message).toContain("search=present");
+        expect(message).not.toContain("김민수");
+        expect(message).not.toContain("injected");
     });
 
     it("never lets a comparison failure escape into the request", async () => {
@@ -242,7 +388,7 @@ describe("EformsignListShadowCompareService", () => {
 
         expect(() => service.compareInBackground(createQuery(), {
             documentIds: [],
-            totalRows: 0,
+            oldestCreatedAt: undefined,
         })).not.toThrow();
         await settle();
 

--- a/backend/test/services/eformsign-webhook.service.spec.ts
+++ b/backend/test/services/eformsign-webhook.service.spec.ts
@@ -308,6 +308,7 @@ describe("EformsignWebhookService", () => {
                 templateName: "template",
                 templateId: "template-1",
             }),
+            { updateCreatedDate: false },
         );
         expect(updateStatusUsecase.execute).not.toHaveBeenCalled();
         expect(linkDocumentUsecase.execute).not.toHaveBeenCalled();
@@ -333,6 +334,7 @@ describe("EformsignWebhookService", () => {
                 templateId: "template-1",
                 updatedDate: existing.updatedDate,
             }),
+            { updateCreatedDate: false },
         );
         expect(eformsignDocRepository.claimCompletionStatus).not.toHaveBeenCalled();
         expect(linkDocumentUsecase.execute).not.toHaveBeenCalled();
@@ -377,6 +379,7 @@ describe("EformsignWebhookService", () => {
                 statusType: "070",
                 expired: false,
             }),
+            { updateCreatedDate: false },
         );
     });
 
@@ -399,6 +402,7 @@ describe("EformsignWebhookService", () => {
 
         expect(eformsignDocRepository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
             expect.objectContaining({ statusType: "070" }),
+            { updateCreatedDate: false },
         );
     });
 
@@ -421,6 +425,7 @@ describe("EformsignWebhookService", () => {
 
         expect(eformsignDocRepository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
             expect.objectContaining({ statusType: "071", statusDetail: "검토 반려" }),
+            { updateCreatedDate: false },
         );
     });
 
@@ -460,6 +465,7 @@ describe("EformsignWebhookService", () => {
                 statusType: "072",
                 expired: false,
             }),
+            { updateCreatedDate: false },
         );
     });
 
@@ -536,6 +542,7 @@ describe("EformsignWebhookService", () => {
                 statusDetail: "만료",
                 expired: true,
             }),
+            { updateCreatedDate: false },
         );
     });
 
@@ -583,6 +590,7 @@ describe("EformsignWebhookService", () => {
 
         expect(eformsignDocRepository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
             expect.objectContaining({ statusType: "080" }),
+            { updateCreatedDate: false },
         );
     });
 
@@ -631,6 +639,7 @@ describe("EformsignWebhookService", () => {
 
         expect(eformsignDocRepository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
             expect.objectContaining({ documentName: null }),
+            { updateCreatedDate: false },
         );
     });
 
@@ -650,6 +659,7 @@ describe("EformsignWebhookService", () => {
                 lastEditorName: "기존 편집자",
                 stepRecipientTypes: ["05", "06"],
             }),
+            { updateCreatedDate: false },
         );
     });
 
@@ -668,6 +678,7 @@ describe("EformsignWebhookService", () => {
 
         expect(eformsignDocRepository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
             expect.objectContaining({ templateName: null }),
+            { updateCreatedDate: false },
         );
     });
 

--- a/backend/test/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.spec.ts
@@ -134,7 +134,9 @@ describe("MirrorUnassignedEformsignDocUsecase", () => {
                 createdDate: new Date(updatedDate),
                 updatedDate: new Date(updatedDate),
             }),
-            { updateListDisplayFields: true },
+            // The created date here is invented from updated_date, so it seeds a new row
+            // but must not replace one already stored.
+            { updateListDisplayFields: true, updateCreatedDate: false },
         );
         expect(warn).toHaveBeenCalledWith(
             expect.stringContaining("remote-doc"),


### PR DESCRIPTION
BJJ-288 D단계. 목록은 **여전히 외부 API로만 서빙**한다. 같은 질문을 미러에도 던져 두 답이 어긋나는 지점만 로그로 남긴다. 이 로그가 E단계 전환의 판단 근거다.

## 설계에서 가장 중요한 것

목록 규칙(템플릿 필터, 삭제 제외, 상태 분류, 한글 **초성 검색**, 정렬, 탭 선택)을 `application/utils/eformsign-document-list.ts` 로 옮겼고, **두 경로가 같은 함수를 쓴다.**

로컬 행용으로 규칙을 다시 구현했다면 모든 차이가 "미러 데이터가 낡음"인지 "두 경로가 규칙을 다르게 해석함"인지 구분 불가능해진다. 이 저장소는 같은 규칙을 두 곳에 둔 대가를 **이미 세 번** 치렀다. 규칙에 두 번째 형태를 가르치는 대신, **미러 행을 벤더 응답 형태로 렌더해** 같은 함수에 통과시킨다.

## 무엇을 비교하나

- **어떤 문서가** — 지점/본사 스코프, 필터, 검색까지 적용한 전체 집합. 페이지가 아니라 전체를 비교한다(앞쪽 불일치 하나가 뒤 페이지마다 재보고되지 않도록).
- **어떤 순서로** — 생성일 내림차순, 동률 시 문서 ID.
- **어떤 값으로** — 문서명·문서번호·템플릿·상태 코드·단계·생성일·**수정일**. UI가 직접 읽는 값들이다. 상태는 pill과 가능한 액션을 결정하고, 수정일은 서명 완료일로 렌더된다. 여기까지 봐야 "구성원은 같은데 내용이 다른" 전환을 막는다.

**탭 엔드포인트도 포함한다.** 벤더 문서함 정보는 미러에 없으므로, 전환 시 탭은 상태 코드로 답해야 한다. 그 치환을 양쪽에 똑같이 적용해 비교한다 — 차이는 "미러가 낡음" 또는 "벤더 문서함과 상태 코드가 서로 다른 곳을 가리킴"이고, 둘 다 전환 전에 알아야 한다.

## 추측하지 않는 것

서빙 경로는 벤더 목록을 **최대 10페이지×100건**만 훑고, 그 사실을 자기 로그로 남긴다. 미러에만 있는 오래된 문서 중 "스캔이 닿지 못한 것"을 추론해 면제하려 했으나, **세 번 연속으로 틀렸다** — 필터링된 결과에서 경계를 잡거나, 프로세스 로컬 맵에 상한 플래그를 두거나, 10페이지가 마지막인 스캔을 상한으로 기록하거나. 실패 형태는 매번 같았다: **틀린 미러가 match로 기록됨.**

그래서 추론을 없앴다. 미러에만 있는 문서는 전부 그대로 보고한다. 스캔의 상한 경고가 같은 로그에 있으니, **두 줄을 함께 보는 사람은** 닿지 못한 문서와 낡은 문서를 구분할 수 있다 — 이 비교가 가진 데이터로는 불가능한 일이다.

## 안전성

비교는 응답을 건드리지 않는다 — 페이지가 만들어진 뒤에 돌고, await 하지 않으며, 자기 실패를 로그로 삼킨다. **한 번에 하나만** 실행하고 건너뛴 횟수를 로그에 남긴다(요청마다 지점 전체 행을 정렬하므로 서빙 요청과 커넥션 풀을 다투지 않도록). 검색어 원문은 로그에 남기지 않는다 — 고객명인 경우가 잦고, 이스케이프되지 않은 값은 로그 줄을 쪼갤 수 있다.

`EFORMSIGN_SHADOW_COMPARE_ENABLED=true` 가 아니면 아무것도 하지 않는다.

## 함께 고친 것

- **`createdDate` 가 영구히 어긋나 있었다.** 목록의 정렬 키인데, create/adopt 경로가 "우리가 행을 쓴 시각"을 저장한다 — 오래된 계약서를 오늘 adopt하면 오늘 것처럼 정렬된다. 벤더 응답이 실제로 `created_date` 를 실어올 때 복구하되, **stale 거부 경로에서도** 적용한다(그 행이 바로 복구 대상인데 가드가 통째로 막고 있었다). 웹훅은 생성 시각을 실어오지 않으므로 옵트아웃한다.

## 검증

- `npx tsc --noEmit` 통과, `npx nest build` 통과
- **177 suites / 1884 passed / 8 skipped**
- ESLint 0 errors / 76 warnings(기준선 그대로)
- 규칙 추출은 **순수 이동**(리뷰가 문자 단위 동일 확인), 기존 통합 테스트가 서빙 경로 무회귀를 보증
- 로컬 Codex 리뷰 1회 + 봇 리뷰 6회, 지적 18건 반영 후 최종 clean
- DB 스키마 변경 없음

## 배포 후

`EFORMSIGN_SHADOW_COMPARE_ENABLED=true` 설정 후 `[Shadow] diff` 를 관찰한다. E단계 진입 조건은 `[Shadow] match` 가 며칠 이어지는 것 — 단, 회사 문서가 1000건을 넘으면 스캔 상한 때문에 `extra` 가 상시 나올 수 있으므로 같은 로그의 `scanCompanyDocuments hit MAX_PAGES` 경고와 함께 판단한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG