### PR TITLE
feat(backend): serve the contract list from the mirror behind a switch (BJJ-288 E)

### DIFF
--- a/backend/app.module.ts
+++ b/backend/app.module.ts
@@ -6,6 +6,7 @@ import { JwtStrategy } from "./infrastructure/auth/jwt.strategy";
 import { EformsignController } from "interface/controllers/eformsign.controller";
 import { EformsignService } from "application/services/eformsign.service";
 import { EformsignListShadowCompareService } from "application/services/eformsign-list-shadow-compare.service";
+import { EformsignMirrorListService } from "application/services/eformsign-mirror-list.service";
 import { ConfigModule } from "@nestjs/config";
 import { PassportModule } from "@nestjs/passport";
 import { ScheduleModule } from "@nestjs/schedule";
@@ -89,6 +90,7 @@ const ENV_FILE_PATHS = [
         JwtStrategy,
         ContractClientAssignmentGuardService,
         EformsignListShadowCompareService,
+        EformsignMirrorListService,
     ],
 })
 export class AppModule {}

--- a/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
+++ b/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
@@ -6,6 +6,7 @@ import Redis from "ioredis";
 import {
     DocumentSnapshotEntry,
     DocumentSnapshotKeyParams,
+    DocumentSnapshotScope,
     EformsignDocumentSnapshotService,
 } from "application/services/eformsign-document-snapshot.service";
 
@@ -54,11 +55,29 @@ function createEntry(id: string): DocumentSnapshotEntry<TestDocument> {
     };
 }
 
-function createParams(overrides: Partial<DocumentSnapshotKeyParams> = {}): DocumentSnapshotKeyParams {
+interface TenantOverrides {
+    scope?: DocumentSnapshotScope;
+    branchId?: string;
+    isHeadquarters?: boolean;
+}
+
+function createParams(
+    overrides: TenantOverrides & { accessToken?: string } = {},
+): DocumentSnapshotKeyParams {
     return {
         branchId: "branch-a",
         scope: "all",
         accessToken: "access-token",
+        ...overrides,
+    };
+}
+
+/** The mirror variant takes no credential at all — that is the point of the union. */
+function createMirrorParams(overrides: TenantOverrides = {}): DocumentSnapshotKeyParams {
+    return {
+        branchId: "branch-a",
+        scope: "all",
+        source: "mirror",
         ...overrides,
     };
 }
@@ -355,6 +374,26 @@ describe("EformsignDocumentSnapshotService", () => {
         expect(storedKey).not.toContain(accessToken);
         expect(storedValue.payload).not.toContain(accessToken);
         expect(loggedOutput).not.toContain(accessToken);
+    });
+
+    it("should key a mirror snapshot by tenant alone, with no credential in it", async () => {
+        // The mirror never calls the vendor, so nothing validates the token and nothing in
+        // the result depends on it. Keying by it would only let one authenticated caller
+        // store a fresh copy of the whole branch corpus per token string they invent.
+        const service = new EformsignDocumentSnapshotService();
+        const internals = service as unknown as SnapshotServiceInternals;
+        const build = jest.fn().mockResolvedValue([createEntry("document-1")]);
+
+        await service.getOrBuild(createMirrorParams(), build);
+        await service.getOrBuild(createMirrorParams(), build);
+
+        const storedKeys = Array.from(internals.memoryStore.keys());
+
+        expect(storedKeys).toEqual(["eformsign:doclist:v1:mirror:branch-a:all:0"]);
+        expect(build).toHaveBeenCalledTimes(1);
+        // And still distinct from the vendor snapshot of the same scope, so flipping the
+        // switch back does not keep serving the source it was flipped away from.
+        expect(internals.snapshotKey(createParams(), 0)).not.toBe(storedKeys[0]);
     });
 
     it("should bypass the cache and omit snapshotVersion when Valkey lookup fails", async () => {

--- a/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
+++ b/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
@@ -326,7 +326,10 @@ describe("EformsignDocumentSnapshotService", () => {
         const accessToken = "raw-secret-access-token";
         const params = createParams({ accessToken });
         const tokenHash = createHash("sha256").update(accessToken).digest("hex");
-        const expectedKey = `eformsign:doclist:v1:branch-a:all:${tokenHash}:0`;
+        // The data source is part of the key: a vendor snapshot and a mirror snapshot of
+        // the same scope must never be served for one another, or flipping the switch back
+        // would keep serving the source it was flipped away from.
+        const expectedKey = `eformsign:doclist:v1:api:branch-a:all:${tokenHash}:0`;
         const logSpy = jest.spyOn(Logger.prototype, "log").mockImplementation(() => undefined);
         const warnSpy = jest.spyOn(Logger.prototype, "warn").mockImplementation(() => undefined);
         const service = new EformsignDocumentSnapshotService();

--- a/backend/application/services/eformsign-document-snapshot.service.ts
+++ b/backend/application/services/eformsign-document-snapshot.service.ts
@@ -29,19 +29,36 @@ export interface DocumentSnapshotResult<TDoc> {
     cached: boolean;
 }
 
-export interface DocumentSnapshotKeyParams {
+interface DocumentSnapshotTenantParams {
     scope: DocumentSnapshotScope;
     branchId: string;
-    accessToken: string;
     /** 본사(HQ) 뷰 여부 — true면 키에 회사 epoch가 포함돼 타 지점 변이로도 무효화된다. */
     isHeadquarters?: boolean;
-    /**
-     * 이 스냅샷을 만든 데이터 출처. 벤더 스캔 결과와 로컬 미러 결과가 같은 키를 쓰면,
-     * 전환 스위치를 되돌려도 최대 5분간 이전 출처의 스냅샷이 계속 나간다 — 긴급 롤백이
-     * 즉시 듣지 않는다는 뜻이라 스위치를 두는 이유 자체가 사라진다.
-     */
-    source?: "api" | "mirror";
 }
+
+/**
+ * 스냅샷 키를 결정하는 값들. `source`로 갈라진 이유는 두 가지다.
+ *
+ * 첫째, 벤더 스캔 결과와 로컬 미러 결과가 같은 키를 쓰면 전환 스위치를 되돌려도 최대
+ * 5분간 이전 출처의 스냅샷이 계속 나간다 — 긴급 롤백이 즉시 듣지 않는다는 뜻이라
+ * 스위치를 두는 이유 자체가 사라진다.
+ *
+ * 둘째, 미러 경로는 자격증명을 아예 받지 않는다. 스캔 결과는 accessToken에 따라 달라지고
+ * 잘못된 토큰은 벤더에서 먼저 거부돼 스냅샷이 만들어지지 않지만, 미러는 토큰을 검증하지도
+ * 사용하지도 않는다. 그런 값을 키에 넣으면 구분되는 것은 없고, 인증된 호출자 한 명이
+ * 서로 다른 토큰 문자열을 계속 보내는 것만으로 지점 전체 목록을 5분짜리로 무한히 쌓을 수
+ * 있다. 타입으로 막아 실수로도 넘기지 못하게 한다.
+ */
+export type DocumentSnapshotKeyParams =
+    | (DocumentSnapshotTenantParams & {
+        source?: "api";
+        /** 스캔이 사용한 자격증명. 결과가 이 값에 따라 달라지므로 키에 들어간다. */
+        accessToken: string;
+    })
+    | (DocumentSnapshotTenantParams & {
+        source: "mirror";
+        accessToken?: never;
+    });
 
 export interface DocumentDisplayFieldEnrichment {
     fields?: unknown;
@@ -467,9 +484,14 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
     }
 
     private snapshotKey(params: DocumentSnapshotKeyParams, version: string): string {
-        const tokenHash = this.tokenHash(params.accessToken);
         const source = params.source ?? "api";
-        return `${SNAPSHOT_KEY_PREFIX}:v${SNAPSHOT_SCHEMA_VERSION}:${source}:${params.branchId}:${params.scope}:${tokenHash}:${version}`;
+        const tenant = `${SNAPSHOT_KEY_PREFIX}:v${SNAPSHOT_SCHEMA_VERSION}:${source}`
+            + `:${params.branchId}:${params.scope}`;
+        // A mirror snapshot is decided entirely by the tenant and the generation, so there
+        // is no credential in its key — see DocumentSnapshotKeyParams for why that matters.
+        return params.source === "mirror"
+            ? `${tenant}:${version}`
+            : `${tenant}:${this.tokenHash(params.accessToken)}:${version}`;
     }
 
     private versionKey(branchId: string): string {

--- a/backend/application/services/eformsign-document-snapshot.service.ts
+++ b/backend/application/services/eformsign-document-snapshot.service.ts
@@ -35,6 +35,12 @@ export interface DocumentSnapshotKeyParams {
     accessToken: string;
     /** 본사(HQ) 뷰 여부 — true면 키에 회사 epoch가 포함돼 타 지점 변이로도 무효화된다. */
     isHeadquarters?: boolean;
+    /**
+     * 이 스냅샷을 만든 데이터 출처. 벤더 스캔 결과와 로컬 미러 결과가 같은 키를 쓰면,
+     * 전환 스위치를 되돌려도 최대 5분간 이전 출처의 스냅샷이 계속 나간다 — 긴급 롤백이
+     * 즉시 듣지 않는다는 뜻이라 스위치를 두는 이유 자체가 사라진다.
+     */
+    source?: "api" | "mirror";
 }
 
 export interface DocumentDisplayFieldEnrichment {
@@ -462,7 +468,8 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
 
     private snapshotKey(params: DocumentSnapshotKeyParams, version: string): string {
         const tokenHash = this.tokenHash(params.accessToken);
-        return `${SNAPSHOT_KEY_PREFIX}:v${SNAPSHOT_SCHEMA_VERSION}:${params.branchId}:${params.scope}:${tokenHash}:${version}`;
+        const source = params.source ?? "api";
+        return `${SNAPSHOT_KEY_PREFIX}:v${SNAPSHOT_SCHEMA_VERSION}:${source}:${params.branchId}:${params.scope}:${tokenHash}:${version}`;
     }
 
     private versionKey(branchId: string): string {

--- a/backend/application/services/eformsign-list-shadow-compare.service.ts
+++ b/backend/application/services/eformsign-list-shadow-compare.service.ts
@@ -1,14 +1,7 @@
-import { Inject, Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 
 import {
-    documentSearchValues,
-    filterDocumentsByStatusCategory,
-    filterDocumentsByTemplate,
-    eformsignListScopeSelector,
-    filterOutDeletedDocuments,
-    matchesKoreanSearch,
-    sortDocumentsByCreatedDate,
     type DocumentStatusCategory,
     type EformsignListDoc,
     type TemplateMatch,
@@ -18,16 +11,12 @@ import {
     stringFromUnknown,
 } from "application/utils/eformsign-document-customer-name";
 import { eformsignDocumentTemplateId } from "application/utils/eformsign-document-template-id";
-import { eformsignListDocFromMirror } from "application/utils/eformsign-list-doc-from-mirror";
+import { EformsignMirrorListService } from "application/services/eformsign-mirror-list.service";
 import { getDocumentCreatedTimestamp } from "application/services/eformsign.service";
 import {
     normalizeEformsignStatusCode,
     normalizeEformsignStepType,
 } from "domain/utils/eformsign-status-code";
-import {
-    EFORMSIGN_DOC_REPOSITORY,
-    IEformsignDocRepository,
-} from "domain/repositories/eformsign-doc.repository.interface";
 
 export interface ListShadowCompareQuery {
     branchId: string;
@@ -97,8 +86,7 @@ export class EformsignListShadowCompareService {
 
     constructor(
         private readonly configService: ConfigService,
-        @Inject(EFORMSIGN_DOC_REPOSITORY)
-        private readonly eformsignDocRepository: IEformsignDocRepository,
+        private readonly mirrorListService: EformsignMirrorListService,
     ) {}
 
     isEnabled(): boolean {
@@ -201,74 +189,18 @@ export class EformsignListShadowCompareService {
     private async buildLocalList(
         query: ListShadowCompareQuery,
     ): Promise<{ documentIds: string[]; fieldsById: Map<string, ListShadowCompareFields> }> {
-        // For a regular branch the corpus and the search rows are the same query, so it
-        // is read once; only headquarters needs the wider set as well.
-        const branchOwned = await this.eformsignDocRepository.findAll(query.branchId);
-        const mirrored = query.isHeadquarters
-            ? await this.eformsignDocRepository.findAllForHeadquarters(query.branchId)
-            : branchOwned;
-        // Deliberately the branch-owned rows only, even for headquarters. The served path
-        // builds its recipient-name search corpus from findAll(branchId), so an unassigned
-        // document's recipient name is not searchable there — reproducing that is the
-        // point, and "fixing" it here would report a difference that is ours, not the
-        // mirror's.
-        const localSearchValues = new Map(
-            branchOwned.map((document) => [
-                document.documentId,
-                [document.stepRecipientName].filter((value) => Boolean(value)),
-            ] as const),
-        );
-        const documents = mirrored.map(eformsignListDocFromMirror);
-        const fieldsById = new Map(
-            documents.map((document) => [
-                document.id,
-                eformsignListCompareFields(document),
-            ] as const),
-        );
-
-        const templateFiltered = filterDocumentsByTemplate(
-            documents,
-            query.templateId,
-            query.templateMatch,
-        );
-        const deletionFiltered = filterOutDeletedDocuments(
-            templateFiltered,
-            query.excludeDeleted ?? false,
-        );
-        const scopeSelector = eformsignListScopeSelector(query.scope);
-        const scopeFiltered = scopeSelector === undefined
-            ? deletionFiltered
-            : deletionFiltered.filter(scopeSelector);
-        const statusFiltered = filterDocumentsByStatusCategory(
-            scopeFiltered,
-            query.statusCategory,
-        );
-        const searchFiltered = this.filterBySearch(statusFiltered, localSearchValues, query.search);
-        const sorted = sortDocumentsByCreatedDate(searchFiltered);
-
+        // Delegated rather than reimplemented: what this measures has to be the same
+        // computation the switch would serve, or the evidence describes nothing.
+        const { documents } = await this.mirrorListService.buildList(query);
         return {
-            documentIds: sorted.map((document) => document.id),
-            fieldsById,
+            documentIds: documents.map((document) => document.id),
+            fieldsById: new Map(
+                documents.map((document) => [
+                    document.id,
+                    eformsignListCompareFields(document),
+                ] as const),
+            ),
         };
-    }
-
-    private filterBySearch(
-        documents: EformsignListDoc[],
-        localSearchValues: Map<string, string[]>,
-        search: string | undefined,
-    ): EformsignListDoc[] {
-        const query = search?.trim() ?? "";
-        if (!query) {
-            return documents;
-        }
-
-        return documents.filter((document) => {
-            const values = documentSearchValues(
-                document,
-                localSearchValues.get(document.id) ?? [],
-            );
-            return values.some((value) => matchesKoreanSearch(value, query));
-        });
     }
 }
 

--- a/backend/application/services/eformsign-mirror-list.service.ts
+++ b/backend/application/services/eformsign-mirror-list.service.ts
@@ -1,0 +1,177 @@
+import { Inject, Injectable } from "@nestjs/common";
+
+import {
+    documentSearchValues,
+    eformsignListScopeSelector,
+    filterDocumentsByStatusCategory,
+    filterDocumentsByTemplate,
+    filterOutDeletedDocuments,
+    matchesKoreanSearch,
+    sortDocumentsByCreatedDate,
+    type DocumentStatusCategory,
+    type EformsignListDoc,
+    type TemplateMatch,
+} from "application/utils/eformsign-document-list";
+import { eformsignListDocFromMirror } from "application/utils/eformsign-list-doc-from-mirror";
+import { stringFromUnknown } from "application/utils/eformsign-document-customer-name";
+import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
+import {
+    EFORMSIGN_DOC_REPOSITORY,
+    IEformsignDocRepository,
+} from "domain/repositories/eformsign-doc.repository.interface";
+
+export interface MirrorListQuery {
+    branchId: string;
+    isHeadquarters: boolean;
+    /** "all" for the merged list, or a tab name the scope selector understands. */
+    scope: string;
+    templateId?: string;
+    templateMatch: TemplateMatch;
+    statusCategory?: DocumentStatusCategory;
+    search?: string;
+    excludeDeleted?: boolean;
+}
+
+export interface MirrorListResult {
+    /** Filtered and sorted, but not paginated — the caller slices what it needs. */
+    documents: EformsignListDoc[];
+    /** The rows behind those documents, for filling in display values on a page. */
+    entityById: Map<string, EformsignDocEntity>;
+}
+
+/**
+ * Answers the contract list from the local mirror.
+ *
+ * This is the same computation the shadow comparison measures and the same one the switch
+ * serves — deliberately one implementation, because evidence gathered from a second one
+ * would say nothing about what production would do.
+ *
+ * It runs the shared list rules over mirror rows rendered into the vendor's list shape,
+ * rather than teaching those rules a second shape. Keeping one set of rules is not tidiness
+ * here: a divergence between them is exactly the class of defect this codebase has paid for
+ * three times, and it would be invisible to a comparison that used them both.
+ */
+@Injectable()
+export class EformsignMirrorListService {
+    constructor(
+        @Inject(EFORMSIGN_DOC_REPOSITORY)
+        private readonly eformsignDocRepository: IEformsignDocRepository,
+    ) {}
+
+    async buildList(query: MirrorListQuery): Promise<MirrorListResult> {
+        // For a regular branch the list rows and the search rows are the same query, so it
+        // is read once; only headquarters needs the wider set as well.
+        const branchOwned = await this.eformsignDocRepository.findAll(query.branchId);
+        const mirrored = query.isHeadquarters
+            ? await this.eformsignDocRepository.findAllForHeadquarters(query.branchId)
+            : branchOwned;
+
+        // Branch-owned rows only, even for headquarters: the API path builds its
+        // recipient-name search corpus from findAll(branchId), so an unassigned document's
+        // recipient name is not searchable there either.
+        const searchValuesById = new Map(
+            branchOwned.map((document) => [
+                document.documentId,
+                [document.stepRecipientName].filter((value) => Boolean(value)),
+            ] as const),
+        );
+        const entityById = new Map(
+            mirrored.map((document) => [document.documentId, document] as const),
+        );
+        const documents = mirrored.map(eformsignListDocFromMirror);
+
+        const templateFiltered = filterDocumentsByTemplate(
+            documents,
+            query.templateId,
+            query.templateMatch,
+        );
+        const deletionFiltered = filterOutDeletedDocuments(
+            templateFiltered,
+            query.excludeDeleted ?? false,
+        );
+        const scopeSelector = eformsignListScopeSelector(query.scope);
+        const scopeFiltered = scopeSelector === undefined
+            ? deletionFiltered
+            : deletionFiltered.filter(scopeSelector);
+        const statusFiltered = filterDocumentsByStatusCategory(
+            scopeFiltered,
+            query.statusCategory,
+        );
+        const searchFiltered = filterBySearch(statusFiltered, searchValuesById, query.search);
+
+        return {
+            documents: sortDocumentsByCreatedDate(searchFiltered),
+            entityById,
+        };
+    }
+}
+
+function filterBySearch(
+    documents: EformsignListDoc[],
+    searchValuesById: Map<string, string[]>,
+    search: string | undefined,
+): EformsignListDoc[] {
+    const query = search?.trim() ?? "";
+    if (!query) {
+        return documents;
+    }
+
+    return documents.filter((document) => {
+        const values = documentSearchValues(
+            document,
+            searchValuesById.get(document.id) ?? [],
+        );
+        return values.some((value) => matchesKoreanSearch(value, query));
+    });
+}
+
+/**
+ * Fills in the customer name the list renders, the way the API path's enrichment does —
+ * except that the mirror already holds the answer, so no document is ever re-fetched.
+ *
+ * Applied to a page rather than the whole list, and deliberately after filtering: the API
+ * path enriches only what it is about to return, so its search never sees these values.
+ * Adding them earlier here would quietly make the list searchable by customer name.
+ */
+export function enrichMirrorPage(
+    documents: EformsignListDoc[],
+    entityById: Map<string, EformsignDocEntity>,
+): EformsignListDoc[] {
+    return documents.map((document) => {
+        const entity = entityById.get(document.id);
+        if (!entity) {
+            return document;
+        }
+
+        const customerName = entity.customerName
+            ?? recipientNameAsCustomerName(entity, document);
+        if (!customerName) {
+            return document;
+        }
+
+        return {
+            ...document,
+            fields: [
+                ...(Array.isArray(document.fields) ? document.fields : []),
+                { id: "이용자 성명", value: customerName },
+            ],
+        };
+    });
+}
+
+/**
+ * Adoption can fall back to the document title for the recipient name, and a title is not
+ * a customer name. The API path skips those for the same reason.
+ */
+function recipientNameAsCustomerName(
+    entity: EformsignDocEntity,
+    document: EformsignListDoc,
+): string | null {
+    const recipientName = entity.stepRecipientName?.trim();
+    if (!recipientName) {
+        return null;
+    }
+
+    const documentTitle = (stringFromUnknown(document["document_name"]) ?? "").trim();
+    return recipientName === documentTitle ? null : recipientName;
+}

--- a/backend/application/services/eformsign-mirror-list.service.ts
+++ b/backend/application/services/eformsign-mirror-list.service.ts
@@ -15,6 +15,7 @@ import {
 import {
     eformsignListDocFromMirror,
     MIRROR_CUSTOMER_NAME_KEY,
+    MIRROR_DISPLAY_RECIPIENT_NAME_KEY,
     MIRROR_RECIPIENT_NAME_KEY,
 } from "application/utils/eformsign-list-doc-from-mirror";
 import { stringFromUnknown } from "application/utils/eformsign-document-customer-name";
@@ -174,7 +175,7 @@ export function enrichMirrorPage(documents: EformsignListDoc[]): EformsignListDo
  * a customer name. The API path skips those for the same reason.
  */
 function recipientNameAsCustomerName(document: EformsignListDoc): string | null {
-    const recipientName = stringFromUnknown(document[MIRROR_RECIPIENT_NAME_KEY]);
+    const recipientName = stringFromUnknown(document[MIRROR_DISPLAY_RECIPIENT_NAME_KEY]);
     if (!recipientName) {
         return null;
     }

--- a/backend/application/services/eformsign-mirror-list.service.ts
+++ b/backend/application/services/eformsign-mirror-list.service.ts
@@ -12,9 +12,12 @@ import {
     type EformsignListDoc,
     type TemplateMatch,
 } from "application/utils/eformsign-document-list";
-import { eformsignListDocFromMirror } from "application/utils/eformsign-list-doc-from-mirror";
+import {
+    eformsignListDocFromMirror,
+    MIRROR_CUSTOMER_NAME_KEY,
+    MIRROR_RECIPIENT_NAME_KEY,
+} from "application/utils/eformsign-list-doc-from-mirror";
 import { stringFromUnknown } from "application/utils/eformsign-document-customer-name";
-import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
 import {
     EFORMSIGN_DOC_REPOSITORY,
     IEformsignDocRepository,
@@ -35,8 +38,6 @@ export interface MirrorListQuery {
 export interface MirrorListResult {
     /** Filtered and sorted, but not paginated — the caller slices what it needs. */
     documents: EformsignListDoc[];
-    /** The rows behind those documents, for filling in display values on a page. */
-    entityById: Map<string, EformsignDocEntity>;
 }
 
 /**
@@ -58,7 +59,16 @@ export class EformsignMirrorListService {
         private readonly eformsignDocRepository: IEformsignDocRepository,
     ) {}
 
-    async buildList(query: MirrorListQuery): Promise<MirrorListResult> {
+    /**
+     * Every mirrored document for a scope, in list order and before any per-request
+     * filter. Separate from `buildList` so a caller can cache this — the list has to be
+     * paginated over one generation, or a document that leaves the set between two pages
+     * shifts the rest up and is never shown.
+     */
+    async loadScopeDocuments(query: {
+        branchId: string;
+        isHeadquarters: boolean;
+    }): Promise<EformsignListDoc[]> {
         // For a regular branch the list rows and the search rows are the same query, so it
         // is read once; only headquarters needs the wider set as well.
         const branchOwned = await this.eformsignDocRepository.findAll(query.branchId);
@@ -68,18 +78,25 @@ export class EformsignMirrorListService {
 
         // Branch-owned rows only, even for headquarters: the API path builds its
         // recipient-name search corpus from findAll(branchId), so an unassigned document's
-        // recipient name is not searchable there either.
-        const searchValuesById = new Map(
+        // recipient name is not searchable there either. Carried on the document so a
+        // cached generation keeps it without a second read.
+        const recipientNameById = new Map(
             branchOwned.map((document) => [
                 document.documentId,
-                [document.stepRecipientName].filter((value) => Boolean(value)),
+                document.stepRecipientName,
             ] as const),
         );
-        const entityById = new Map(
-            mirrored.map((document) => [document.documentId, document] as const),
-        );
-        const documents = mirrored.map(eformsignListDocFromMirror);
+        return mirrored.map((document) => {
+            const listDoc = eformsignListDocFromMirror(document);
+            const recipientName = recipientNameById.get(document.documentId);
+            return recipientName
+                ? { ...listDoc, [MIRROR_RECIPIENT_NAME_KEY]: recipientName }
+                : listDoc;
+        });
+    }
 
+    /** Applies the per-request filters to an already-loaded scope. */
+    filterScope(documents: EformsignListDoc[], query: MirrorListQuery): MirrorListResult {
         const templateFiltered = filterDocumentsByTemplate(
             documents,
             query.templateId,
@@ -97,18 +114,18 @@ export class EformsignMirrorListService {
             scopeFiltered,
             query.statusCategory,
         );
-        const searchFiltered = filterBySearch(statusFiltered, searchValuesById, query.search);
+        const searchFiltered = filterBySearch(statusFiltered, query.search);
 
-        return {
-            documents: sortDocumentsByCreatedDate(searchFiltered),
-            entityById,
-        };
+        return { documents: sortDocumentsByCreatedDate(searchFiltered) };
+    }
+
+    async buildList(query: MirrorListQuery): Promise<MirrorListResult> {
+        return this.filterScope(await this.loadScopeDocuments(query), query);
     }
 }
 
 function filterBySearch(
     documents: EformsignListDoc[],
-    searchValuesById: Map<string, string[]>,
     search: string | undefined,
 ): EformsignListDoc[] {
     const query = search?.trim() ?? "";
@@ -117,9 +134,10 @@ function filterBySearch(
     }
 
     return documents.filter((document) => {
+        const recipientName = document[MIRROR_RECIPIENT_NAME_KEY];
         const values = documentSearchValues(
             document,
-            searchValuesById.get(document.id) ?? [],
+            typeof recipientName === "string" ? [recipientName] : [],
         );
         return values.some((value) => matchesKoreanSearch(value, query));
     });
@@ -133,18 +151,10 @@ function filterBySearch(
  * path enriches only what it is about to return, so its search never sees these values.
  * Adding them earlier here would quietly make the list searchable by customer name.
  */
-export function enrichMirrorPage(
-    documents: EformsignListDoc[],
-    entityById: Map<string, EformsignDocEntity>,
-): EformsignListDoc[] {
+export function enrichMirrorPage(documents: EformsignListDoc[]): EformsignListDoc[] {
     return documents.map((document) => {
-        const entity = entityById.get(document.id);
-        if (!entity) {
-            return document;
-        }
-
-        const customerName = entity.customerName
-            ?? recipientNameAsCustomerName(entity, document);
+        const customerName = stringFromUnknown(document[MIRROR_CUSTOMER_NAME_KEY])
+            ?? recipientNameAsCustomerName(document);
         if (!customerName) {
             return document;
         }
@@ -163,11 +173,8 @@ export function enrichMirrorPage(
  * Adoption can fall back to the document title for the recipient name, and a title is not
  * a customer name. The API path skips those for the same reason.
  */
-function recipientNameAsCustomerName(
-    entity: EformsignDocEntity,
-    document: EformsignListDoc,
-): string | null {
-    const recipientName = entity.stepRecipientName?.trim();
+function recipientNameAsCustomerName(document: EformsignListDoc): string | null {
+    const recipientName = stringFromUnknown(document[MIRROR_RECIPIENT_NAME_KEY]);
     if (!recipientName) {
         return null;
     }

--- a/backend/application/services/eformsign-mirror-list.service.ts
+++ b/backend/application/services/eformsign-mirror-list.service.ts
@@ -15,7 +15,6 @@ import {
 import {
     eformsignListDocFromMirror,
     MIRROR_CUSTOMER_NAME_KEY,
-    MIRROR_DISPLAY_RECIPIENT_NAME_KEY,
     MIRROR_RECIPIENT_NAME_KEY,
 } from "application/utils/eformsign-list-doc-from-mirror";
 import { stringFromUnknown } from "application/utils/eformsign-document-customer-name";
@@ -171,11 +170,22 @@ export function enrichMirrorPage(documents: EformsignListDoc[]): EformsignListDo
 }
 
 /**
- * Adoption can fall back to the document title for the recipient name, and a title is not
- * a customer name. The API path skips those for the same reason.
+ * The branch's own recipient name, used the way the API path uses it — and only where it
+ * does. That path reads this from a branch-scoped lookup, so an unclaimed document never
+ * gets one; it falls through to a document-detail fetch instead.
+ *
+ * Which is why this must not reach for the recipient name of an unclaimed row even though
+ * the mirror has it: `stepRecipientName` is whoever the *current* step is waiting on, and
+ * when that step is the provider review it is the provider. Showing the wrong person's
+ * name is worse than showing none, so those rows read 고객 미지정 until the mirror learns
+ * a real customer name — which it does the moment any webhook touches the document, since
+ * that path mirrors from a detail response.
+ *
+ * Adoption can also put the document title here, and a title is not a customer name. The
+ * API path skips those for the same reason.
  */
 function recipientNameAsCustomerName(document: EformsignListDoc): string | null {
-    const recipientName = stringFromUnknown(document[MIRROR_DISPLAY_RECIPIENT_NAME_KEY]);
+    const recipientName = stringFromUnknown(document[MIRROR_RECIPIENT_NAME_KEY]);
     if (!recipientName) {
         return null;
     }

--- a/backend/application/services/eformsign-mirror-list.service.ts
+++ b/backend/application/services/eformsign-mirror-list.service.ts
@@ -16,6 +16,7 @@ import {
     eformsignListDocFromMirror,
     MIRROR_CUSTOMER_NAME_KEY,
     MIRROR_RECIPIENT_NAME_KEY,
+    MIRROR_UNKNOWN_RECIPIENT_NAME,
 } from "application/utils/eformsign-list-doc-from-mirror";
 import { stringFromUnknown } from "application/utils/eformsign-document-customer-name";
 import {
@@ -181,12 +182,17 @@ export function enrichMirrorPage(documents: EformsignListDoc[]): EformsignListDo
  * a real customer name — which it does the moment any webhook touches the document, since
  * that path mirrors from a detail response.
  *
- * Adoption can also put the document title here, and a title is not a customer name. The
- * API path skips those for the same reason.
+ * Adoption can also put the document title here, or — when it had neither a name nor a
+ * title — the literal word 수신자. Neither is a customer name, and the API path rejects
+ * both: `findDisplayFieldsByDocumentIds` nulls the sentinel out before enrichment sees it,
+ * and enrichment itself drops a title match. Both then fall through to a detail fetch. This
+ * path has no detail fetch to fall through to, so it returns nothing and the row reads
+ * 고객 미지정 — which is what the UI's own missing-name fallback is for, and what it would
+ * stop doing if we handed it the sentinel as a name.
  */
 function recipientNameAsCustomerName(document: EformsignListDoc): string | null {
     const recipientName = stringFromUnknown(document[MIRROR_RECIPIENT_NAME_KEY]);
-    if (!recipientName) {
+    if (!recipientName || recipientName === MIRROR_UNKNOWN_RECIPIENT_NAME) {
         return null;
     }
 

--- a/backend/application/utils/eformsign-list-doc-from-mirror.ts
+++ b/backend/application/utils/eformsign-list-doc-from-mirror.ts
@@ -30,6 +30,16 @@ export const MIRROR_CUSTOMER_NAME_KEY = "_mirror_customer_name";
  */
 export const MIRROR_RECIPIENT_NAME_KEY = "_mirror_recipient_name";
 
+/**
+ * The recipient name for *display*, carried for every mirrored row rather than only the
+ * branch's own. The two are separate on purpose: search parity requires headquarters not
+ * to match on an unclaimed document's recipient name, but the list still has to show one.
+ * Without this, an unclaimed document — whose customerName is usually null, because the
+ * reconciliation sweep reads list responses and those carry no fields — would render as
+ * 고객 미지정 where the API path used to fetch the detail and find the name.
+ */
+export const MIRROR_DISPLAY_RECIPIENT_NAME_KEY = "_mirror_display_recipient_name";
+
 export function eformsignListDocFromMirror(document: EformsignDocEntity): EformsignListDoc {
     return {
         id: document.documentId,
@@ -57,6 +67,9 @@ export function eformsignListDocFromMirror(document: EformsignDocEntity): Eforms
         ...(document.customerName === null
             ? {}
             : { [MIRROR_CUSTOMER_NAME_KEY]: document.customerName }),
+        ...(document.stepRecipientName
+            ? { [MIRROR_DISPLAY_RECIPIENT_NAME_KEY]: document.stepRecipientName }
+            : {}),
         // No `fields`, deliberately, even though the mirror holds a customerName. The
         // vendor's list endpoint is fetched without include_fields — only the
         // single-document fetch asks for them — so the served search never sees a customer

--- a/backend/application/utils/eformsign-list-doc-from-mirror.ts
+++ b/backend/application/utils/eformsign-list-doc-from-mirror.ts
@@ -23,6 +23,10 @@ import type { EformsignListDoc } from "./eformsign-document-list";
  */
 export const MIRROR_CUSTOMER_NAME_KEY = "_mirror_customer_name";
 
+/** What the mirror stores when eformsign gave it no recipient contact at all. */
+const UNKNOWN_RECIPIENT_CONTACT = "미확인";
+const UNKNOWN_RECIPIENT_NAME = "수신자";
+
 /**
  * The branch's own recipient name for a document, carried the same way and for the same
  * reason: the search reads it, headquarters must not see it for unclaimed documents, and
@@ -50,9 +54,7 @@ export function eformsignListDocFromMirror(document: EformsignDocEntity): Eforms
             step_type: document.stepType,
             step_index: document.stepIndex,
             step_name: document.stepName,
-            step_recipients: (document.stepRecipientTypes ?? []).map((recipientType) => ({
-                recipient_type: recipientType,
-            })),
+            step_recipients: buildStepRecipients(document),
             _expired: document.expired,
         },
         ...(document.customerName === null
@@ -68,4 +70,37 @@ export function eformsignListDocFromMirror(document: EformsignDocEntity): Eforms
         // Phase E may well decide the list should search customerName. That is a change in
         // what the feature does and belongs in that decision, not inherited by accident.
     };
+}
+
+/**
+ * The recipient list, with the current step's own name and contact on the entry it belongs
+ * to. The mirror stores those three singular fields from `step_recipients[0]`, and the
+ * type list is mapped from the same array in order, so the first entry is the one they
+ * describe — the equality check is there to say so rather than to guess.
+ *
+ * They matter because the mobile detail sheet renders and enables actions from the list
+ * row while the detail request is still in flight: dropping them would offer to send to a
+ * contract whose recipient it could not name.
+ */
+function buildStepRecipients(
+    document: EformsignDocEntity,
+): Array<Record<string, unknown>> {
+    const recipientTypes = document.stepRecipientTypes ?? [];
+    // The placeholders the mirror writes when eformsign gave it nothing are not contacts.
+    const name = document.stepRecipientName === UNKNOWN_RECIPIENT_NAME
+        ? null
+        : document.stepRecipientName?.trim() || null;
+    const contact = document.stepRecipientSms === UNKNOWN_RECIPIENT_CONTACT
+        ? null
+        : document.stepRecipientSms?.trim() || null;
+
+    return recipientTypes.map((recipientType, index) => ({
+        recipient_type: recipientType,
+        ...(index === 0 && recipientType === document.stepRecipientType
+            ? {
+                ...(name === null ? {} : { name }),
+                ...(contact === null ? {} : { id: contact }),
+            }
+            : {}),
+    }));
 }

--- a/backend/application/utils/eformsign-list-doc-from-mirror.ts
+++ b/backend/application/utils/eformsign-list-doc-from-mirror.ts
@@ -30,15 +30,6 @@ export const MIRROR_CUSTOMER_NAME_KEY = "_mirror_customer_name";
  */
 export const MIRROR_RECIPIENT_NAME_KEY = "_mirror_recipient_name";
 
-/**
- * The recipient name for *display*, carried for every mirrored row rather than only the
- * branch's own. The two are separate on purpose: search parity requires headquarters not
- * to match on an unclaimed document's recipient name, but the list still has to show one.
- * Without this, an unclaimed document — whose customerName is usually null, because the
- * reconciliation sweep reads list responses and those carry no fields — would render as
- * 고객 미지정 where the API path used to fetch the detail and find the name.
- */
-export const MIRROR_DISPLAY_RECIPIENT_NAME_KEY = "_mirror_display_recipient_name";
 
 export function eformsignListDocFromMirror(document: EformsignDocEntity): EformsignListDoc {
     return {
@@ -67,9 +58,6 @@ export function eformsignListDocFromMirror(document: EformsignDocEntity): Eforms
         ...(document.customerName === null
             ? {}
             : { [MIRROR_CUSTOMER_NAME_KEY]: document.customerName }),
-        ...(document.stepRecipientName
-            ? { [MIRROR_DISPLAY_RECIPIENT_NAME_KEY]: document.stepRecipientName }
-            : {}),
         // No `fields`, deliberately, even though the mirror holds a customerName. The
         // vendor's list endpoint is fetched without include_fields — only the
         // single-document fetch asks for them — so the served search never sees a customer

--- a/backend/application/utils/eformsign-list-doc-from-mirror.ts
+++ b/backend/application/utils/eformsign-list-doc-from-mirror.ts
@@ -15,6 +15,21 @@ import type { EformsignListDoc } from "./eformsign-document-list";
  * deliberately absent rather than invented. A caller that needs them is not looking at a
  * list and should fetch the document.
  */
+/**
+ * Where the mirror's own customer name rides along. Not a vendor field, and deliberately
+ * not one the list rules read: filtering and searching must not see it, because the API
+ * path's search index is built before enrichment and never sees a customer name either.
+ * The page enrichment lifts it into `fields`, which is where the UI looks.
+ */
+export const MIRROR_CUSTOMER_NAME_KEY = "_mirror_customer_name";
+
+/**
+ * The branch's own recipient name for a document, carried the same way and for the same
+ * reason: the search reads it, headquarters must not see it for unclaimed documents, and
+ * a cached generation has to keep it without going back to the database.
+ */
+export const MIRROR_RECIPIENT_NAME_KEY = "_mirror_recipient_name";
+
 export function eformsignListDocFromMirror(document: EformsignDocEntity): EformsignListDoc {
     return {
         id: document.documentId,
@@ -39,6 +54,9 @@ export function eformsignListDocFromMirror(document: EformsignDocEntity): Eforms
             })),
             _expired: document.expired,
         },
+        ...(document.customerName === null
+            ? {}
+            : { [MIRROR_CUSTOMER_NAME_KEY]: document.customerName }),
         // No `fields`, deliberately, even though the mirror holds a customerName. The
         // vendor's list endpoint is fetched without include_fields — only the
         // single-document fetch asks for them — so the served search never sees a customer

--- a/backend/application/utils/eformsign-list-doc-from-mirror.ts
+++ b/backend/application/utils/eformsign-list-doc-from-mirror.ts
@@ -23,9 +23,8 @@ import type { EformsignListDoc } from "./eformsign-document-list";
  */
 export const MIRROR_CUSTOMER_NAME_KEY = "_mirror_customer_name";
 
-/** What the mirror stores when eformsign gave it no recipient contact at all. */
-const UNKNOWN_RECIPIENT_CONTACT = "미확인";
-const UNKNOWN_RECIPIENT_NAME = "수신자";
+/** What the mirror stores when eformsign gave it no recipient name at all. */
+export const MIRROR_UNKNOWN_RECIPIENT_NAME = "수신자";
 
 /**
  * The branch's own recipient name for a document, carried the same way and for the same
@@ -73,34 +72,24 @@ export function eformsignListDocFromMirror(document: EformsignDocEntity): Eforms
 }
 
 /**
- * The recipient list, with the current step's own name and contact on the entry it belongs
- * to. The mirror stores those three singular fields from `step_recipients[0]`, and the
- * type list is mapped from the same array in order, so the first entry is the one they
- * describe — the equality check is there to say so rather than to guess.
+ * Recipient types only — deliberately without the stored name and contact.
  *
- * They matter because the mobile detail sheet renders and enables actions from the list
- * row while the detail request is still in flight: dropping them would offer to send to a
- * contract whose recipient it could not name.
+ * A webhook that advances a document updates its step type, index and name but copies the
+ * recipient fields forward unchanged, and the reconciliation sweep cannot refresh them
+ * either: it reads list responses, which carry no recipients. So what the mirror holds may
+ * describe the step *before* the current one. Emitting a name and phone number under
+ * `current_status` would present that as the person to contact, and the mobile sheet acts
+ * on it — it offers edit-and-send from the list row before the detail request returns.
+ *
+ * The list itself does not render these; the detail fetch that does is where accurate
+ * recipients come from. The types are here because the status counters fold them, and the
+ * shadow comparison checks them so a mirror whose recipients have gone stale shows up as a
+ * difference rather than being discovered after the switch.
  */
 function buildStepRecipients(
     document: EformsignDocEntity,
 ): Array<Record<string, unknown>> {
-    const recipientTypes = document.stepRecipientTypes ?? [];
-    // The placeholders the mirror writes when eformsign gave it nothing are not contacts.
-    const name = document.stepRecipientName === UNKNOWN_RECIPIENT_NAME
-        ? null
-        : document.stepRecipientName?.trim() || null;
-    const contact = document.stepRecipientSms === UNKNOWN_RECIPIENT_CONTACT
-        ? null
-        : document.stepRecipientSms?.trim() || null;
-
-    return recipientTypes.map((recipientType, index) => ({
+    return (document.stepRecipientTypes ?? []).map((recipientType) => ({
         recipient_type: recipientType,
-        ...(index === 0 && recipientType === document.stepRecipientType
-            ? {
-                ...(name === null ? {} : { name }),
-                ...(contact === null ? {} : { id: contact }),
-            }
-            : {}),
     }));
 }

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -319,11 +319,13 @@ export class EformsignController {
     }
 
     /**
-     * The list, answered locally. No snapshot cache: it exists to make a 30-call vendor
-     * scan bearable, and there is no scan here to amortise.
+     * The list, answered locally.
+     *
+     * No access token: this path never calls the vendor, so it has no credential to spend
+     * and nothing that varies by one. The endpoint still requires callers to send it —
+     * that check is unchanged — it just does not reach the cache or the query.
      */
     private async listFromMirror(params: {
-        accessToken: string;
         branchId: string;
         isHeadquarters: boolean;
         scope: string;
@@ -343,7 +345,6 @@ export class EformsignController {
             {
                 scope: params.scope as DocumentSnapshotScope,
                 branchId: params.branchId,
-                accessToken: params.accessToken,
                 isHeadquarters: params.isHeadquarters,
                 source: "mirror",
             },
@@ -639,7 +640,6 @@ export class EformsignController {
             // document sat in — the mirror does not record that, and the shadow comparison
             // has been measuring exactly this substitution.
             return await this.listFromMirror({
-                accessToken,
                 branchId,
                 isHeadquarters,
                 scope,
@@ -971,7 +971,6 @@ export class EformsignController {
             const isHeadquarters = await this.isHeadquartersBranch(branchId);
             if (this.servesFromMirror()) {
                 return await this.listFromMirror({
-                    accessToken,
                     branchId,
                     isHeadquarters,
                     scope: "all",
@@ -1078,7 +1077,7 @@ export class EformsignController {
                 // the list can never describe different moments.
                 const countSnapshot = await this.documentSnapshotService
                     .getOrBuild<EformsignListDoc>(
-                        { scope: "all", branchId, accessToken, isHeadquarters, source: "mirror" },
+                        { scope: "all", branchId, isHeadquarters, source: "mirror" },
                         async () => this.toSnapshotEntries(
                             await this.mirrorListService.loadScopeDocuments({
                                 branchId,

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -345,6 +345,7 @@ export class EformsignController {
                 branchId: params.branchId,
                 accessToken: params.accessToken,
                 isHeadquarters: params.isHeadquarters,
+                source: "mirror",
             },
             async () => this.toSnapshotEntries(
                 await this.mirrorListService.loadScopeDocuments(params),
@@ -1073,7 +1074,7 @@ export class EformsignController {
                 // the list can never describe different moments.
                 const countSnapshot = await this.documentSnapshotService
                     .getOrBuild<EformsignListDoc>(
-                        { scope: "all", branchId, accessToken, isHeadquarters },
+                        { scope: "all", branchId, accessToken, isHeadquarters, source: "mirror" },
                         async () => this.toSnapshotEntries(
                             await this.mirrorListService.loadScopeDocuments({
                                 branchId,

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -323,6 +323,7 @@ export class EformsignController {
      * scan bearable, and there is no scan here to amortise.
      */
     private async listFromMirror(params: {
+        accessToken: string;
         branchId: string;
         isHeadquarters: boolean;
         scope: string;
@@ -334,11 +335,29 @@ export class EformsignController {
         search?: string;
         excludeDeleted?: boolean;
     }) {
-        const { documents, entityById } = await this.mirrorListService.buildList(params);
+        // Through the same snapshot the API path uses. Not for the vendor calls it saves —
+        // there are none here — but because pagination has to walk one generation: a
+        // document leaving the set between two pages shifts the rest up, and the page the
+        // client asks for next then skips one it never saw.
+        const snapshot = await this.documentSnapshotService.getOrBuild<EformsignListDoc>(
+            {
+                scope: params.scope as DocumentSnapshotScope,
+                branchId: params.branchId,
+                accessToken: params.accessToken,
+                isHeadquarters: params.isHeadquarters,
+            },
+            async () => this.toSnapshotEntries(
+                await this.mirrorListService.loadScopeDocuments(params),
+            ),
+        );
+        const { documents } = this.mirrorListService.filterScope(
+            snapshot.entries.map((entry) => entry.document),
+            params,
+        );
         const page = documents.slice(params.skip, params.skip + params.limit);
 
         return {
-            documents: enrichMirrorPage(page, entityById),
+            documents: enrichMirrorPage(page),
             total_rows: documents.length,
             limit: params.limit,
             skip: params.skip,
@@ -615,6 +634,7 @@ export class EformsignController {
             // document sat in — the mirror does not record that, and the shadow comparison
             // has been measuring exactly this substitution.
             return await this.listFromMirror({
+                accessToken,
                 branchId,
                 isHeadquarters,
                 scope,
@@ -946,6 +966,7 @@ export class EformsignController {
             const isHeadquarters = await this.isHeadquartersBranch(branchId);
             if (this.servesFromMirror()) {
                 return await this.listFromMirror({
+                    accessToken,
                     branchId,
                     isHeadquarters,
                     scope: "all",
@@ -1048,15 +1069,30 @@ export class EformsignController {
                 // Same filters as the list, and the same source — the counters and the
                 // list have to agree, which is why they shared a snapshot generation
                 // before and share a query now.
-                const { documents } = await this.mirrorListService.buildList({
-                    branchId,
-                    isHeadquarters,
-                    scope: "all",
-                    templateId,
-                    templateMatch,
-                    search,
-                    excludeDeleted,
-                });
+                // The same snapshot generation the list is paginating, so the counters and
+                // the list can never describe different moments.
+                const countSnapshot = await this.documentSnapshotService
+                    .getOrBuild<EformsignListDoc>(
+                        { scope: "all", branchId, accessToken, isHeadquarters },
+                        async () => this.toSnapshotEntries(
+                            await this.mirrorListService.loadScopeDocuments({
+                                branchId,
+                                isHeadquarters,
+                            }),
+                        ),
+                    );
+                const { documents } = this.mirrorListService.filterScope(
+                    countSnapshot.entries.map((entry) => entry.document),
+                    {
+                        branchId,
+                        isHeadquarters,
+                        scope: "all",
+                        templateId,
+                        templateMatch,
+                        search,
+                        excludeDeleted,
+                    },
+                );
                 return { documents: documents.map((doc) => toStatusSignal(doc)) };
             }
 

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -363,6 +363,10 @@ export class EformsignController {
             limit: params.limit,
             skip: params.skip,
             has_more: params.skip + params.limit < documents.length,
+            // The client resets its pagination when a later page reports a different
+            // generation. Without this it has no way to notice that the list moved under
+            // it, and would quietly skip whatever the shift displaced.
+            ...(snapshot.snapshotVersion ? { snapshot_version: snapshot.snapshotVersion } : {}),
         };
     }
 

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -33,6 +33,11 @@ import {
     eformsignListCompareFields,
     EformsignListShadowCompareService,
 } from "application/services/eformsign-list-shadow-compare.service";
+import { ConfigService } from "@nestjs/config";
+import {
+    EformsignMirrorListService,
+    enrichMirrorPage,
+} from "application/services/eformsign-mirror-list.service";
 import {
     documentSearchIndex,
     documentSearchValues,
@@ -298,7 +303,48 @@ export class EformsignController {
         private readonly assignmentGuard: ContractClientAssignmentGuardService,
         private readonly documentSnapshotService: EformsignDocumentSnapshotService,
         private readonly listShadowCompareService: EformsignListShadowCompareService,
+        private readonly mirrorListService: EformsignMirrorListService,
+        private readonly configService: ConfigService,
     ) { }
+
+    /**
+     * Whether the list is answered from the local mirror instead of scanning eformsign.
+     *
+     * The switch stays until the shadow log has read clean for long enough that nobody
+     * wants it back — reverting has to be a config change, not a deploy, because the whole
+     * point of the staged rollout is that this step is the reversible one.
+     */
+    private servesFromMirror(): boolean {
+        return this.configService.get<string>("EFORMSIGN_LIST_FROM_MIRROR") === "true";
+    }
+
+    /**
+     * The list, answered locally. No snapshot cache: it exists to make a 30-call vendor
+     * scan bearable, and there is no scan here to amortise.
+     */
+    private async listFromMirror(params: {
+        branchId: string;
+        isHeadquarters: boolean;
+        scope: string;
+        limit: number;
+        skip: number;
+        templateId?: string;
+        templateMatch: TemplateMatch;
+        statusCategory?: DocumentStatusCategory;
+        search?: string;
+        excludeDeleted?: boolean;
+    }) {
+        const { documents, entityById } = await this.mirrorListService.buildList(params);
+        const page = documents.slice(params.skip, params.skip + params.limit);
+
+        return {
+            documents: enrichMirrorPage(page, entityById),
+            total_rows: documents.length,
+            limit: params.limit,
+            skip: params.skip,
+            has_more: params.skip + params.limit < documents.length,
+        };
+    }
 
 
     /**
@@ -564,6 +610,23 @@ export class EformsignController {
         search?: string,
     ) {
         const isHeadquarters = await this.isHeadquartersBranch(branchId);
+        if (this.servesFromMirror()) {
+            // The tab is answered from status codes, not from which vendor inbox the
+            // document sat in — the mirror does not record that, and the shadow comparison
+            // has been measuring exactly this substitution.
+            return await this.listFromMirror({
+                branchId,
+                isHeadquarters,
+                scope,
+                limit,
+                skip,
+                templateId,
+                templateMatch,
+                statusCategory,
+                search,
+            });
+        }
+
         const snapshot = await this.documentSnapshotService.getOrBuild<EformsignListDoc>(
             { scope, branchId, accessToken, isHeadquarters },
             async () => this.toSnapshotEntries(
@@ -880,9 +943,25 @@ export class EformsignController {
             const excludeDeleted = excludeDeletedValue === "true";
             const branchId = tenant.branchId ?? "";
 
+            const isHeadquarters = await this.isHeadquartersBranch(branchId);
+            if (this.servesFromMirror()) {
+                return await this.listFromMirror({
+                    branchId,
+                    isHeadquarters,
+                    scope: "all",
+                    limit: parsedLimit,
+                    skip: parsedSkip,
+                    templateId,
+                    templateMatch,
+                    statusCategory,
+                    search,
+                    excludeDeleted,
+                });
+            }
+
             // 인천점(본사): 회사 전체에서 다른 지점 소유분만 빼고 모은 뒤 요청 구간만 잘라 반환.
             // (필터링 때문에 외부 페이지네이션을 그대로 흘리면 페이지 경계에 빈틈이 생긴다.)
-            if (await this.isHeadquartersBranch(branchId)) {
+            if (isHeadquarters) {
                 const hqSnapshot = await this.documentSnapshotService.getOrBuild<EformsignListDoc>(
                     { scope: "all", branchId, accessToken, isHeadquarters: true },
                     async () => this.toSnapshotEntries(
@@ -965,6 +1044,22 @@ export class EformsignController {
             // 인천점(본사)은 다른 지점 소유분 제외 전체, 그 외 지점은 보유 문서 전체를 모은다.
             // 목록과 같은 "all" 스냅샷을 공유해 StatsBar 카운터와 목록이 항상 같은 세대를 본다.
             const isHeadquarters = await this.isHeadquartersBranch(branchId);
+            if (this.servesFromMirror()) {
+                // Same filters as the list, and the same source — the counters and the
+                // list have to agree, which is why they shared a snapshot generation
+                // before and share a query now.
+                const { documents } = await this.mirrorListService.buildList({
+                    branchId,
+                    isHeadquarters,
+                    scope: "all",
+                    templateId,
+                    templateMatch,
+                    search,
+                    excludeDeleted,
+                });
+                return { documents: documents.map((doc) => toStatusSignal(doc)) };
+            }
+
             const snapshot = await this.documentSnapshotService.getOrBuild<EformsignListDoc>(
                 { scope: "all", branchId, accessToken, isHeadquarters },
                 async () => this.toSnapshotEntries(

--- a/backend/test/controllers/eformsign.controller.enrichment.spec.ts
+++ b/backend/test/controllers/eformsign.controller.enrichment.spec.ts
@@ -42,6 +42,9 @@ describe("EformsignController display-field enrichment", () => {
             {} as never,
             snapshotService,
             { compareInBackground: jest.fn() } as never,
+            { buildList: jest.fn() } as never,
+            // Serving from the mirror is off, so this suite still exercises the API path.
+            { get: jest.fn().mockReturnValue(undefined) } as never,
         ) as unknown as EnrichmentController;
         eformsignDocService.findDisplayFieldsByDocumentIds.mockResolvedValue([]);
     });

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -495,6 +495,39 @@ describe("EformsignController (Integration)", () => {
             expect(response.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-unclaimed"]);
         });
 
+        it("shows a name for an unclaimed headquarters document", async () => {
+            // 미러의 customerName은 목록 응답에서 채워지는데 목록에는 fields가 없어 보통
+            // null이다. 그때 수신자명으로 채우지 않으면 본사 화면에서 "고객 미지정"이 된다 —
+            // 기존 API 경로는 단건 조회로 이름을 찾아왔다.
+            branchFindUnique.mockResolvedValue({ slug: "incheon" });
+            mirrorRepository.findAllForHeadquarters.mockResolvedValue([
+                createMirrorRow({ documentId: "doc-unclaimed", customerName: null }),
+            ]);
+            mirrorRepository.findAll.mockResolvedValue([]);
+
+            const response = await request(mirrorApp.getHttpServer())
+                .get("/api/documents?accessToken=access-token");
+
+            expect(response.body.documents[0].fields).toEqual([
+                { id: "이용자 성명", value: "송진호" },
+            ]);
+        });
+
+        it("does not let that name widen headquarters search", async () => {
+            // 표시용과 검색용은 분리돼 있다. 서빙 경로는 findAll(branchId)로 검색 코퍼스를
+            // 만들어 미배정 문서의 수신자명을 찾지 못하므로, 여기서도 찾으면 안 된다.
+            branchFindUnique.mockResolvedValue({ slug: "incheon" });
+            mirrorRepository.findAllForHeadquarters.mockResolvedValue([
+                createMirrorRow({ documentId: "doc-unclaimed", customerName: null }),
+            ]);
+            mirrorRepository.findAll.mockResolvedValue([]);
+
+            const response = await request(mirrorApp.getHttpServer())
+                .get("/api/documents?accessToken=access-token&search=%EC%86%A1%EC%A7%84%ED%98%B8");
+
+            expect(response.body.documents).toEqual([]);
+        });
+
         it("counts statuses from the same generation the list pages over", async () => {
             mirrorRepository.findAll.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-1", statusType: "060" }),

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -446,6 +446,19 @@ describe("EformsignController (Integration)", () => {
             expect(second.body.has_more).toBe(false);
         });
 
+        it("reports the generation so the client can notice the list moved", async () => {
+            // 클라이언트는 뒤 페이지의 snapshot_version이 다르면 페이지네이션을 리셋한다.
+            // 이 값을 빼면 목록이 아래에서 밀려도 신호가 없어 문서를 조용히 건너뛴다.
+            mirrorRepository.findAll.mockResolvedValue([
+                createMirrorRow({ documentId: "doc-1" }),
+            ]);
+
+            const response = await request(mirrorApp.getHttpServer())
+                .get("/api/documents?accessToken=access-token");
+
+            expect(typeof response.body.snapshot_version).toBe("string");
+        });
+
         it("answers each tab from status codes", async () => {
             mirrorRepository.findAll.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-open", statusType: "060" }),
@@ -495,15 +508,27 @@ describe("EformsignController (Integration)", () => {
             expect(response.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-unclaimed"]);
         });
 
-        it("shows a name for an unclaimed headquarters document", async () => {
-            // 미러의 customerName은 목록 응답에서 채워지는데 목록에는 fields가 없어 보통
-            // null이다. 그때 수신자명으로 채우지 않으면 본사 화면에서 "고객 미지정"이 된다 —
-            // 기존 API 경로는 단건 조회로 이름을 찾아왔다.
+        it("leaves an unclaimed document unnamed rather than naming the wrong person", async () => {
+            // stepRecipientName은 *현재 단계*가 기다리는 사람이라, 그 단계가 제공기관 검토면
+            // 제공기관 이름이다. 미배정 문서에는 지점 스코프 조회가 걸리지 않아 API 경로도
+            // 이 값을 쓰지 않는다(단건 조회로 넘어간다). 틀린 이름을 보여주는 것보다
+            // 비워 두는 편이 낫고, 웹훅이 한 번이라도 닿으면 진짜 고객명이 채워진다.
             branchFindUnique.mockResolvedValue({ slug: "incheon" });
             mirrorRepository.findAllForHeadquarters.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-unclaimed", customerName: null }),
             ]);
             mirrorRepository.findAll.mockResolvedValue([]);
+
+            const response = await request(mirrorApp.getHttpServer())
+                .get("/api/documents?accessToken=access-token");
+
+            expect(response.body.documents[0].fields).toBeUndefined();
+        });
+
+        it("still names a branch-owned document from its recipient", async () => {
+            mirrorRepository.findAll.mockResolvedValue([
+                createMirrorRow({ documentId: "doc-owned", customerName: null }),
+            ]);
 
             const response = await request(mirrorApp.getHttpServer())
                 .get("/api/documents?accessToken=access-token");

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -12,6 +12,8 @@ import { EformsignDocumentSnapshotService } from "application/services/eformsign
 import { ConfigService } from "@nestjs/config";
 import { EformsignListShadowCompareService } from "application/services/eformsign-list-shadow-compare.service";
 import { EformsignMirrorListService } from "application/services/eformsign-mirror-list.service";
+import { EFORMSIGN_DOC_REPOSITORY } from "domain/repositories/eformsign-doc.repository.interface";
+import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
 import request from "supertest";
 
 // Known transport-level flake (~1/8 full-suite runs under parallel-worker
@@ -309,8 +311,52 @@ describe("EformsignController (Integration)", () => {
         // E단계의 계약: 목록이 로컬 미러에서 나오고 eformsign을 전혀 호출하지 않는다.
         // 되돌리기는 배포가 아니라 설정 한 줄이어야 한다.
         let mirrorApp: INestApplication;
+        const mirrorRepository = {
+            findAll: jest.fn().mockResolvedValue([]),
+            findAllForHeadquarters: jest.fn().mockResolvedValue([]),
+        };
+
+        const createMirrorRow = (overrides: {
+            documentId: string;
+            createdDate?: string;
+            statusType?: string;
+            customerName?: string | null;
+        }) => {
+            const createdDate = new Date(overrides.createdDate ?? "2026-07-01T00:00:00.000Z");
+            return EformsignDocEntity.reconstitute({
+                id: 1,
+                documentId: overrides.documentId,
+                documentName: `문서 ${overrides.documentId}`,
+                documentNumber: `NO-${overrides.documentId}`,
+                templateName: "표준 계약서",
+                customerName: overrides.customerName === undefined
+                    ? "김고객"
+                    : overrides.customerName,
+                creatorName: "생성자",
+                lastEditorName: "편집자",
+                stepRecipientTypes: ["05"],
+                createdDate,
+                updatedDate: createdDate,
+                statusType: overrides.statusType ?? "060",
+                statusDetail: "서명 요청됨",
+                stepType: "01",
+                stepIndex: "1",
+                stepName: "이용자 서명",
+                stepRecipientType: "05",
+                stepRecipientName: "송진호",
+                stepRecipientSms: "01012345678",
+                expiredDate: new Date("2026-08-01T00:00:00.000Z"),
+                expired: false,
+                clientId: null,
+                documentKind: null,
+                employeeScheduleId: null,
+                templateId: "template-1",
+            });
+        };
 
         beforeEach(async () => {
+            mirrorRepository.findAll.mockResolvedValue([]);
+            mirrorRepository.findAllForHeadquarters.mockResolvedValue([]);
             const fixture = await Test.createTestingModule({
                 controllers: [EformsignController],
                 providers: [
@@ -327,7 +373,10 @@ describe("EformsignController (Integration)", () => {
                     },
                     EformsignDocumentSnapshotService,
                     { provide: EformsignListShadowCompareService, useValue: shadowCompareService },
-                    { provide: EformsignMirrorListService, useValue: mirrorListService },
+                    // 실제 미러 서비스를 쓴다. 스텁을 두면 이 스위트가 검증하는 것이
+                    // "컨트롤러가 스텁을 호출한다" 뿐이 되어, 정작 목록이 맞는지는 못 본다.
+                    { provide: EFORMSIGN_DOC_REPOSITORY, useValue: mirrorRepository },
+                    EformsignMirrorListService,
                     {
                         provide: ConfigService,
                         useValue: {
@@ -352,57 +401,114 @@ describe("EformsignController (Integration)", () => {
             await mirrorApp.close();
         });
 
-        it("serves the list from the mirror without calling eformsign", async () => {
-            mirrorListService.buildList.mockResolvedValue({
-                documents: [
-                    { id: "doc-1", document_name: "문서 1" },
-                    { id: "doc-2", document_name: "문서 2" },
-                ],
-                entityById: new Map(),
-            });
+        it("paginates the mirror without calling eformsign", async () => {
+            mirrorRepository.findAll.mockResolvedValue([
+                createMirrorRow({ documentId: "doc-old", createdDate: "2026-07-01T00:00:00.000Z" }),
+                createMirrorRow({ documentId: "doc-new", createdDate: "2026-07-02T00:00:00.000Z" }),
+            ]);
 
-            const response = await request(mirrorApp.getHttpServer())
+            const first = await request(mirrorApp.getHttpServer())
                 .get("/api/documents?accessToken=access-token&limit=1&skip=0");
 
-            expect(response.status).toBe(200);
-            expect(response.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-1"]);
-            expect(response.body.total_rows).toBe(2);
-            expect(response.body.has_more).toBe(true);
+            expect(first.status).toBe(200);
+            expect(first.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-new"]);
+            expect(first.body).toMatchObject({
+                total_rows: 2,
+                limit: 1,
+                skip: 0,
+                has_more: true,
+            });
             expect(eformsignService.getAllDocuments).not.toHaveBeenCalled();
-            // Nothing to compare against: the mirror is now the thing being served.
+            // 미러가 서빙 중이면 비교할 상대가 없다.
             expect(shadowCompareService.compareInBackground).not.toHaveBeenCalled();
         });
 
-        it("answers a tab from the mirror using its scope", async () => {
-            mirrorListService.buildList.mockResolvedValue({
-                documents: [{ id: "doc-open" }],
-                entityById: new Map(),
-            });
+        it("keeps paging over one generation when the list changes underneath", async () => {
+            // 페이지 사이에 문서가 목록에서 빠지면, 매 요청 새로 만들던 시절에는 나머지가
+            // 한 칸씩 당겨져 마지막 문서를 영영 못 보게 된다. 스냅샷 세대가 그걸 막는다.
+            mirrorRepository.findAll.mockResolvedValue([
+                createMirrorRow({ documentId: "doc-1", createdDate: "2026-07-03T00:00:00.000Z" }),
+                createMirrorRow({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
+            ]);
 
-            const response = await request(mirrorApp.getHttpServer())
-                .get("/api/documents/in-progress?accessToken=access-token");
+            const first = await request(mirrorApp.getHttpServer())
+                .get("/api/documents?accessToken=access-token&limit=1&skip=0");
+            expect(first.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-1"]);
 
-            expect(response.status).toBe(200);
-            expect(response.body.documents).toEqual([{ id: "doc-open" }]);
-            expect(eformsignService.getInProgressDocuments).not.toHaveBeenCalled();
-            expect(mirrorListService.buildList).toHaveBeenCalledWith(
-                expect.objectContaining({ scope: "in-progress", branchId: "branch-1" }),
-            );
+            // 첫 페이지의 문서가 사라져도 두 번째 페이지는 같은 세대에서 잘린다.
+            mirrorRepository.findAll.mockResolvedValue([
+                createMirrorRow({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
+            ]);
+            const second = await request(mirrorApp.getHttpServer())
+                .get("/api/documents?accessToken=access-token&limit=1&skip=1");
+
+            expect(second.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-2"]);
+            expect(second.body.has_more).toBe(false);
         });
 
-        it("counts statuses from the same query the list uses", async () => {
-            mirrorListService.buildList.mockResolvedValue({
-                documents: [
-                    { id: "doc-1", current_status: { status_type: "060", step_name: "이용자" } },
-                ],
-                entityById: new Map(),
-            });
+        it("answers each tab from status codes", async () => {
+            mirrorRepository.findAll.mockResolvedValue([
+                createMirrorRow({ documentId: "doc-open", statusType: "060" }),
+                createMirrorRow({ documentId: "doc-done", statusType: "050" }),
+                createMirrorRow({ documentId: "doc-gone", statusType: "080" }),
+            ]);
+
+            const inProgress = await request(mirrorApp.getHttpServer())
+                .get("/api/documents/in-progress?accessToken=access-token");
+            const completed = await request(mirrorApp.getHttpServer())
+                .get("/api/documents/completed?accessToken=access-token");
+            const rejected = await request(mirrorApp.getHttpServer())
+                .get("/api/documents/rejected?accessToken=access-token");
+
+            expect(inProgress.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-open"]);
+            expect(completed.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-done"]);
+            expect(rejected.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-gone"]);
+            expect(eformsignService.getInProgressDocuments).not.toHaveBeenCalled();
+            expect(eformsignService.getCompletedDocuments).not.toHaveBeenCalled();
+            expect(eformsignService.getRejectedDocuments).not.toHaveBeenCalled();
+        });
+
+        it("shows the customer name on the page it returns", async () => {
+            mirrorRepository.findAll.mockResolvedValue([
+                createMirrorRow({ documentId: "doc-1", customerName: "최고객" }),
+            ]);
+
+            const response = await request(mirrorApp.getHttpServer())
+                .get("/api/documents?accessToken=access-token");
+
+            expect(response.body.documents[0].fields).toEqual([
+                { id: "이용자 성명", value: "최고객" },
+            ]);
+        });
+
+        it("reads the headquarters scope, including unclaimed documents", async () => {
+            branchFindUnique.mockResolvedValue({ slug: "incheon" });
+            mirrorRepository.findAllForHeadquarters.mockResolvedValue([
+                createMirrorRow({ documentId: "doc-unclaimed" }),
+            ]);
+
+            const response = await request(mirrorApp.getHttpServer())
+                .get("/api/documents?accessToken=access-token");
+
+            expect(response.status).toBe(200);
+            expect(mirrorRepository.findAllForHeadquarters).toHaveBeenCalledWith("branch-1");
+            expect(response.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-unclaimed"]);
+        });
+
+        it("counts statuses from the same generation the list pages over", async () => {
+            mirrorRepository.findAll.mockResolvedValue([
+                createMirrorRow({ documentId: "doc-1", statusType: "060" }),
+                createMirrorRow({ documentId: "doc-2", statusType: "050" }),
+            ]);
 
             const response = await request(mirrorApp.getHttpServer())
                 .get("/api/documents/status-counts?accessToken=access-token");
 
             expect(response.status).toBe(200);
-            expect(response.body.documents).toHaveLength(1);
+            expect(response.body.documents).toHaveLength(2);
+            expect(response.body.documents[0]).toEqual(
+                expect.objectContaining({ status_type: expect.any(String) }),
+            );
             expect(eformsignService.getAllDocuments).not.toHaveBeenCalled();
         });
     });

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -9,7 +9,9 @@ import { TenantGuard } from "infrastructure/tenant";
 import { EformsignController } from "interface/controllers/eformsign.controller";
 import { ContractClientAssignmentGuardService } from "application/services/contract-client-assignment-guard.service";
 import { EformsignDocumentSnapshotService } from "application/services/eformsign-document-snapshot.service";
+import { ConfigService } from "@nestjs/config";
 import { EformsignListShadowCompareService } from "application/services/eformsign-list-shadow-compare.service";
+import { EformsignMirrorListService } from "application/services/eformsign-mirror-list.service";
 import request from "supertest";
 
 // Known transport-level flake (~1/8 full-suite runs under parallel-worker
@@ -64,6 +66,7 @@ describe("EformsignController (Integration)", () => {
     };
 
     const shadowCompareService = { compareInBackground: jest.fn() };
+    const mirrorListService = { buildList: jest.fn() };
 
     beforeEach(async () => {
         shadowCompareService.compareInBackground.mockClear();
@@ -120,6 +123,16 @@ describe("EformsignController (Integration)", () => {
                     // 기록하고 아무것도 하지 않게 두면, 응답 검증이 그 사실을 보증한다.
                     provide: EformsignListShadowCompareService,
                     useValue: shadowCompareService,
+                },
+                {
+                    provide: EformsignMirrorListService,
+                    useValue: mirrorListService,
+                },
+                {
+                    // EFORMSIGN_LIST_FROM_MIRROR 미설정 = 기존 API 경로. 이 스위트 전체가
+                    // 그 경로의 무회귀를 검증한다.
+                    provide: ConfigService,
+                    useValue: { get: jest.fn(() => undefined) },
                 },
             ],
         })
@@ -290,6 +303,108 @@ describe("EformsignController (Integration)", () => {
             "unmapped-doc",
             "document",
         );
+    });
+
+    describe("when EFORMSIGN_LIST_FROM_MIRROR is on", () => {
+        // E단계의 계약: 목록이 로컬 미러에서 나오고 eformsign을 전혀 호출하지 않는다.
+        // 되돌리기는 배포가 아니라 설정 한 줄이어야 한다.
+        let mirrorApp: INestApplication;
+
+        beforeEach(async () => {
+            const fixture = await Test.createTestingModule({
+                controllers: [EformsignController],
+                providers: [
+                    { provide: EformsignService, useValue: eformsignService },
+                    { provide: AreaTemplateService, useValue: { findByArea: jest.fn() } },
+                    { provide: EformsignDocService, useValue: eformsignDocService },
+                    {
+                        provide: PrismaService,
+                        useValue: { branch: { findUnique: branchFindUnique } },
+                    },
+                    {
+                        provide: ContractClientAssignmentGuardService,
+                        useValue: { assertAssignedProvider: jest.fn() },
+                    },
+                    EformsignDocumentSnapshotService,
+                    { provide: EformsignListShadowCompareService, useValue: shadowCompareService },
+                    { provide: EformsignMirrorListService, useValue: mirrorListService },
+                    {
+                        provide: ConfigService,
+                        useValue: {
+                            get: jest.fn((key: string) =>
+                                key === "EFORMSIGN_LIST_FROM_MIRROR" ? "true" : undefined),
+                        },
+                    },
+                ],
+            })
+                .overrideGuard(JwtGuard)
+                .useValue(authGuard)
+                .overrideGuard(TenantGuard)
+                .useValue(authGuard)
+                .compile();
+
+            mirrorApp = fixture.createNestApplication();
+            mirrorApp.useGlobalPipes(new ValidationPipe({ transform: true }));
+            await mirrorApp.init();
+        });
+
+        afterEach(async () => {
+            await mirrorApp.close();
+        });
+
+        it("serves the list from the mirror without calling eformsign", async () => {
+            mirrorListService.buildList.mockResolvedValue({
+                documents: [
+                    { id: "doc-1", document_name: "문서 1" },
+                    { id: "doc-2", document_name: "문서 2" },
+                ],
+                entityById: new Map(),
+            });
+
+            const response = await request(mirrorApp.getHttpServer())
+                .get("/api/documents?accessToken=access-token&limit=1&skip=0");
+
+            expect(response.status).toBe(200);
+            expect(response.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-1"]);
+            expect(response.body.total_rows).toBe(2);
+            expect(response.body.has_more).toBe(true);
+            expect(eformsignService.getAllDocuments).not.toHaveBeenCalled();
+            // Nothing to compare against: the mirror is now the thing being served.
+            expect(shadowCompareService.compareInBackground).not.toHaveBeenCalled();
+        });
+
+        it("answers a tab from the mirror using its scope", async () => {
+            mirrorListService.buildList.mockResolvedValue({
+                documents: [{ id: "doc-open" }],
+                entityById: new Map(),
+            });
+
+            const response = await request(mirrorApp.getHttpServer())
+                .get("/api/documents/in-progress?accessToken=access-token");
+
+            expect(response.status).toBe(200);
+            expect(response.body.documents).toEqual([{ id: "doc-open" }]);
+            expect(eformsignService.getInProgressDocuments).not.toHaveBeenCalled();
+            expect(mirrorListService.buildList).toHaveBeenCalledWith(
+                expect.objectContaining({ scope: "in-progress", branchId: "branch-1" }),
+            );
+        });
+
+        it("counts statuses from the same query the list uses", async () => {
+            mirrorListService.buildList.mockResolvedValue({
+                documents: [
+                    { id: "doc-1", current_status: { status_type: "060", step_name: "이용자" } },
+                ],
+                entityById: new Map(),
+            });
+
+            const response = await request(mirrorApp.getHttpServer())
+                .get("/api/documents/status-counts?accessToken=access-token");
+
+            expect(response.status).toBe(200);
+            expect(response.body.documents).toHaveLength(1);
+            expect(eformsignService.getAllDocuments).not.toHaveBeenCalled();
+        });
     });
 
     it("hands the served page to the shadow comparison without changing it", async () => {

--- a/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
+++ b/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
@@ -379,6 +379,33 @@ describe("EformsignListShadowCompareService", () => {
         expect(logger.warn.mock.calls[0]?.[0]).toContain("fields=doc-1[updatedAt]");
     });
 
+    it("catches a mirrored row whose stored creation time sorts it wrong", async () => {
+        // Rows written by create and adopt carry the moment we wrote them, so a contract
+        // adopted long after it was made sorts as if it were new. The nightly sweep repairs
+        // those from the vendor, and until it has, this is what keeps the switch shut:
+        // the two sides hold the same documents but disagree about the order.
+        const older = createMirrorDocument({
+            documentId: "doc-2025",
+            // The vendor knows it as a 2025 contract; the mirror still has adoption day.
+            createdDate: "2026-07-29T00:00:00.000Z",
+        });
+        const newer = createMirrorDocument({
+            documentId: "doc-2026",
+            createdDate: "2026-07-20T00:00:00.000Z",
+        });
+        repository.findAll.mockResolvedValue([older, newer]);
+        const service = createService("true");
+        const logger = spyOnLogger(service);
+
+        service.compareInBackground(createQuery(), servedFrom([older, newer], {
+            documentIds: ["doc-2026", "doc-2025"],
+        }));
+        await settle();
+
+        expect(logger.log).not.toHaveBeenCalled();
+        expect(logger.warn.mock.calls[0]?.[0]).toContain("order differs");
+    });
+
     it("keeps the search term itself out of the log", async () => {
         // Searches are customer names often enough that the term does not belong in a
         // centralised log, and a raw value could break the log line apart.

--- a/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
+++ b/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
@@ -6,6 +6,7 @@ import {
     type ListShadowCompareQuery,
     type ListShadowCompareServed,
 } from "application/services/eformsign-list-shadow-compare.service";
+import { EformsignMirrorListService } from "application/services/eformsign-mirror-list.service";
 import { eformsignListDocFromMirror } from "application/utils/eformsign-list-doc-from-mirror";
 import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
 
@@ -105,9 +106,12 @@ describe("EformsignListShadowCompareService", () => {
     });
 
     function createService(enabled: string | undefined) {
+        // The real mirror list service, not a stub: the filtering, searching and scope
+        // rules these tests assert on live there, and it is the same instance the switch
+        // serves from. Stubbing it would leave them asserting on nothing.
         return new EformsignListShadowCompareService(
             createConfigService(enabled),
-            repository as never,
+            new EformsignMirrorListService(repository as never),
         );
     }
 

--- a/backend/test/services/eformsign-mirror-list.service.spec.ts
+++ b/backend/test/services/eformsign-mirror-list.service.spec.ts
@@ -1,0 +1,249 @@
+import {
+    EformsignMirrorListService,
+    enrichMirrorPage,
+    type MirrorListQuery,
+} from "application/services/eformsign-mirror-list.service";
+import { documentCustomerNameValue } from "application/utils/eformsign-document-customer-name";
+import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
+
+function createMirrorDocument(overrides: {
+    documentId: string;
+    createdDate?: string;
+    statusType?: string;
+    stepType?: string;
+    stepName?: string;
+    templateId?: string | null;
+    customerName?: string | null;
+    documentName?: string | null;
+    stepRecipientName?: string;
+}): EformsignDocEntity {
+    const createdDate = new Date(overrides.createdDate ?? "2026-07-01T00:00:00.000Z");
+    return EformsignDocEntity.reconstitute({
+        id: 1,
+        documentId: overrides.documentId,
+        documentName: overrides.documentName ?? `문서 ${overrides.documentId}`,
+        documentNumber: `NO-${overrides.documentId}`,
+        templateName: "표준 계약서",
+        customerName: overrides.customerName === undefined ? "김고객" : overrides.customerName,
+        creatorName: "생성자",
+        lastEditorName: "편집자",
+        stepRecipientTypes: ["05"],
+        createdDate,
+        updatedDate: createdDate,
+        statusType: overrides.statusType ?? "060",
+        statusDetail: "서명 요청됨",
+        stepType: overrides.stepType ?? "01",
+        stepIndex: "1",
+        stepName: overrides.stepName ?? "이용자 서명",
+        stepRecipientType: "05",
+        stepRecipientName: overrides.stepRecipientName ?? "송진호",
+        stepRecipientSms: "01012345678",
+        expiredDate: new Date("2026-08-01T00:00:00.000Z"),
+        expired: false,
+        clientId: null,
+        documentKind: null,
+        employeeScheduleId: null,
+        templateId: overrides.templateId === undefined ? "template-1" : overrides.templateId,
+    });
+}
+
+function createQuery(overrides: Partial<MirrorListQuery> = {}): MirrorListQuery {
+    return {
+        branchId: "branch-1",
+        isHeadquarters: false,
+        scope: "all",
+        templateMatch: "include",
+        ...overrides,
+    };
+}
+
+describe("EformsignMirrorListService", () => {
+    let repository: { findAll: jest.Mock; findAllForHeadquarters: jest.Mock };
+    let service: EformsignMirrorListService;
+
+    beforeEach(() => {
+        repository = {
+            findAll: jest.fn().mockResolvedValue([]),
+            findAllForHeadquarters: jest.fn().mockResolvedValue([]),
+        };
+        service = new EformsignMirrorListService(repository as never);
+    });
+
+    it("returns documents newest first, tie-broken by id", async () => {
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-b", createdDate: "2026-07-01T00:00:00.000Z" }),
+            createMirrorDocument({ documentId: "doc-c", createdDate: "2026-07-02T00:00:00.000Z" }),
+            createMirrorDocument({ documentId: "doc-a", createdDate: "2026-07-01T00:00:00.000Z" }),
+        ]);
+
+        const { documents } = await service.buildList(createQuery());
+
+        expect(documents.map((document) => document.id)).toEqual(["doc-c", "doc-a", "doc-b"]);
+    });
+
+    it("reads the headquarters scope from the method that includes unclaimed rows", async () => {
+        repository.findAllForHeadquarters.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-hq" }),
+        ]);
+
+        const { documents } = await service.buildList(createQuery({ isHeadquarters: true }));
+
+        expect(repository.findAllForHeadquarters).toHaveBeenCalledWith("branch-1");
+        expect(documents.map((document) => document.id)).toEqual(["doc-hq"]);
+    });
+
+    it("selects a tab by status rather than by vendor inbox", async () => {
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-open", statusType: "060" }),
+            createMirrorDocument({ documentId: "doc-done", statusType: "050" }),
+            createMirrorDocument({ documentId: "doc-gone", statusType: "080" }),
+        ]);
+
+        const inProgress = await service.buildList(createQuery({ scope: "in-progress" }));
+        const completed = await service.buildList(createQuery({ scope: "completed" }));
+        const rejected = await service.buildList(createQuery({ scope: "rejected" }));
+
+        expect(inProgress.documents.map((d) => d.id)).toEqual(["doc-open"]);
+        expect(completed.documents.map((d) => d.id)).toEqual(["doc-done"]);
+        expect(rejected.documents.map((d) => d.id)).toEqual(["doc-gone"]);
+    });
+
+    it("puts a deleted document in the rejected tab, where the desktop shows it", async () => {
+        // 047/049 land in the "unknown" category, which also holds every unrecognised
+        // status — those belong in 진행 중, and only the deleted ones in 기간 만료.
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-deleted", statusType: "049" }),
+            createMirrorDocument({ documentId: "doc-strange", statusType: "999" }),
+        ]);
+
+        const rejected = await service.buildList(createQuery({ scope: "rejected" }));
+        const inProgress = await service.buildList(createQuery({ scope: "in-progress" }));
+
+        expect(rejected.documents.map((d) => d.id)).toEqual(["doc-deleted"]);
+        expect(inProgress.documents.map((d) => d.id)).toEqual(["doc-strange"]);
+    });
+
+    it("applies template include and exclude across a comma-separated list", async () => {
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-1", templateId: "t-1" }),
+            createMirrorDocument({ documentId: "doc-2", templateId: "t-2" }),
+            createMirrorDocument({ documentId: "doc-3", templateId: "t-9" }),
+        ]);
+
+        const included = await service.buildList(
+            createQuery({ templateId: "t-1, t-2", templateMatch: "include" }),
+        );
+        const excluded = await service.buildList(
+            createQuery({ templateId: "t-1, t-2", templateMatch: "exclude" }),
+        );
+
+        expect(included.documents.map((d) => d.id).sort()).toEqual(["doc-1", "doc-2"]);
+        expect(excluded.documents.map((d) => d.id)).toEqual(["doc-3"]);
+    });
+
+    it("excludes deleted documents only when asked", async () => {
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-live", statusType: "060" }),
+            createMirrorDocument({ documentId: "doc-deleted", statusType: "047" }),
+        ]);
+
+        const kept = await service.buildList(createQuery());
+        const dropped = await service.buildList(createQuery({ excludeDeleted: true }));
+
+        expect(kept.documents).toHaveLength(2);
+        expect(dropped.documents.map((d) => d.id)).toEqual(["doc-live"]);
+    });
+
+    it("searches the recipient name, including by 초성", async () => {
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({ documentId: "doc-song", stepRecipientName: "송진호" }),
+            createMirrorDocument({ documentId: "doc-park", stepRecipientName: "박수신" }),
+        ]);
+
+        const exact = await service.buildList(createQuery({ search: "송진" }));
+        const chosung = await service.buildList(createQuery({ search: "ㅅㅈㅎ" }));
+
+        expect(exact.documents.map((d) => d.id)).toEqual(["doc-song"]);
+        expect(chosung.documents.map((d) => d.id)).toEqual(["doc-song"]);
+    });
+
+    it("does not let the stored customerName widen the search", async () => {
+        // The API path's search index is built before enrichment, so a customer name never
+        // reaches it. Matching one here would change what the search finds the moment the
+        // source switches — a feature change smuggled in as a migration.
+        repository.findAll.mockResolvedValue([
+            createMirrorDocument({
+                documentId: "doc-1",
+                customerName: "최고객",
+                documentName: "계약",
+                stepRecipientName: "송진호",
+            }),
+        ]);
+
+        const { documents } = await service.buildList(createQuery({ search: "최고객" }));
+
+        expect(documents).toHaveLength(0);
+    });
+
+    it("only searches recipient names the branch owns", async () => {
+        // Headquarters sees unclaimed documents, but the API path builds its recipient-name
+        // corpus from findAll(branchId), so their names are not searchable there.
+        repository.findAllForHeadquarters.mockResolvedValue([
+            createMirrorDocument({
+                documentId: "doc-unassigned",
+                documentName: "무관한 제목",
+                stepRecipientName: "박수신",
+            }),
+        ]);
+        repository.findAll.mockResolvedValue([]);
+
+        const { documents } = await service.buildList(
+            createQuery({ isHeadquarters: true, search: "박수신" }),
+        );
+
+        expect(documents).toHaveLength(0);
+    });
+});
+
+describe("enrichMirrorPage", () => {
+    const entity = createMirrorDocument({ documentId: "doc-1", customerName: "최고객" });
+
+    it("fills in the customer name the list renders", async () => {
+        const service = new EformsignMirrorListService({
+            findAll: jest.fn().mockResolvedValue([entity]),
+            findAllForHeadquarters: jest.fn(),
+        } as never);
+        const { documents, entityById } = await service.buildList(createQuery());
+
+        const [enriched] = enrichMirrorPage(documents, entityById);
+
+        expect(documentCustomerNameValue(enriched!)).toBe("최고객");
+    });
+
+    it("falls back to the recipient name, but not when it is just the document title", async () => {
+        // Adoption can put the document title in stepRecipientName; a title is not a
+        // customer name, and the API path skips those for the same reason.
+        const titled = createMirrorDocument({
+            documentId: "doc-titled",
+            customerName: null,
+            documentName: "산모 계약서",
+            stepRecipientName: "산모 계약서",
+        });
+        const named = createMirrorDocument({
+            documentId: "doc-named",
+            customerName: null,
+            stepRecipientName: "송진호",
+        });
+        const service = new EformsignMirrorListService({
+            findAll: jest.fn().mockResolvedValue([titled, named]),
+            findAllForHeadquarters: jest.fn(),
+        } as never);
+        const { documents, entityById } = await service.buildList(createQuery());
+
+        const enriched = enrichMirrorPage(documents, entityById);
+        const byId = new Map(enriched.map((document) => [document.id, document] as const));
+
+        expect(documentCustomerNameValue(byId.get("doc-named")!)).toBe("송진호");
+        expect(documentCustomerNameValue(byId.get("doc-titled")!)).toBeNull();
+    });
+});

--- a/backend/test/services/eformsign-mirror-list.service.spec.ts
+++ b/backend/test/services/eformsign-mirror-list.service.spec.ts
@@ -246,4 +246,23 @@ describe("enrichMirrorPage", () => {
         expect(documentCustomerNameValue(byId.get("doc-named")!)).toBe("송진호");
         expect(documentCustomerNameValue(byId.get("doc-titled")!)).toBeNull();
     });
+
+    it("does not pass off the adoption sentinel as a customer name", async () => {
+        // Adoption stores the literal word 수신자 when it had neither a recipient name nor
+        // a document title. The API path's own lookup nulls it out before enrichment sees
+        // it; emitting it here would put it on screen and stop the UI falling back to
+        // 고객 미지정, which is the only signal that the name is still unknown.
+        const sentinel = createMirrorDocument({
+            documentId: "doc-sentinel",
+            customerName: null,
+            stepRecipientName: "수신자",
+        });
+        const service = new EformsignMirrorListService({
+            findAll: jest.fn().mockResolvedValue([sentinel]),
+            findAllForHeadquarters: jest.fn(),
+        } as never);
+        const { documents } = await service.buildList(createQuery());
+
+        expect(documentCustomerNameValue(enrichMirrorPage(documents)[0]!)).toBeNull();
+    });
 });

--- a/backend/test/services/eformsign-mirror-list.service.spec.ts
+++ b/backend/test/services/eformsign-mirror-list.service.spec.ts
@@ -213,9 +213,9 @@ describe("enrichMirrorPage", () => {
             findAll: jest.fn().mockResolvedValue([entity]),
             findAllForHeadquarters: jest.fn(),
         } as never);
-        const { documents, entityById } = await service.buildList(createQuery());
+        const { documents } = await service.buildList(createQuery());
 
-        const [enriched] = enrichMirrorPage(documents, entityById);
+        const [enriched] = enrichMirrorPage(documents);
 
         expect(documentCustomerNameValue(enriched!)).toBe("최고객");
     });
@@ -238,9 +238,9 @@ describe("enrichMirrorPage", () => {
             findAll: jest.fn().mockResolvedValue([titled, named]),
             findAllForHeadquarters: jest.fn(),
         } as never);
-        const { documents, entityById } = await service.buildList(createQuery());
+        const { documents } = await service.buildList(createQuery());
 
-        const enriched = enrichMirrorPage(documents, entityById);
+        const enriched = enrichMirrorPage(documents);
         const byId = new Map(enriched.map((document) => [document.id, document] as const));
 
         expect(documentCustomerNameValue(byId.get("doc-named")!)).toBe("송진호");

--- a/backend/test/utils/eformsign-list-doc-from-mirror.spec.ts
+++ b/backend/test/utils/eformsign-list-doc-from-mirror.spec.ts
@@ -98,12 +98,9 @@ describe("eformsignListDocFromMirror", () => {
         // Filtering and searching happen before enrichment on the API path, so a customer
         // name must not be visible to them here either — otherwise switching the source
         // would silently change what a search finds.
-        const entity = createMirrorDocument();
-        const document = eformsignListDocFromMirror(entity);
+        const document = eformsignListDocFromMirror(createMirrorDocument());
 
         expect(documentCustomerNameValue(document)).toBeNull();
-        expect(documentCustomerNameValue(
-            enrichMirrorPage([document], new Map([[entity.documentId, entity]]))[0]!,
-        )).toBe("김고객");
+        expect(documentCustomerNameValue(enrichMirrorPage([document])[0]!)).toBe("김고객");
     });
 });

--- a/backend/test/utils/eformsign-list-doc-from-mirror.spec.ts
+++ b/backend/test/utils/eformsign-list-doc-from-mirror.spec.ts
@@ -1,0 +1,109 @@
+import { enrichMirrorPage } from "application/services/eformsign-mirror-list.service";
+import { documentCustomerNameValue } from "application/utils/eformsign-document-customer-name";
+import { eformsignListDocFromMirror } from "application/utils/eformsign-list-doc-from-mirror";
+import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
+
+function createMirrorDocument(): EformsignDocEntity {
+    return EformsignDocEntity.reconstitute({
+        id: 1,
+        documentId: "doc-1",
+        documentName: "산모신생아건강관리서비스 계약서",
+        documentNumber: "NO-0001",
+        templateName: "표준 계약서",
+        customerName: "김고객",
+        creatorName: "생성자",
+        lastEditorName: "편집자",
+        stepRecipientTypes: ["05", "06"],
+        createdDate: new Date("2026-07-01T00:00:00.000Z"),
+        updatedDate: new Date("2026-07-02T00:00:00.000Z"),
+        statusType: "060",
+        statusDetail: "서명 요청됨",
+        stepType: "01",
+        stepIndex: "2",
+        stepName: "이용자 서명",
+        stepRecipientType: "05",
+        stepRecipientName: "송진호",
+        stepRecipientSms: "01012345678",
+        expiredDate: new Date("2026-08-01T00:00:00.000Z"),
+        expired: false,
+        clientId: null,
+        documentKind: null,
+        employeeScheduleId: null,
+        templateId: "template-1",
+    });
+}
+
+/**
+ * Every property the contract list actually reads off a document, gathered from the
+ * desktop row, the mobile row, the hooks that sort and dedupe, and the status-count
+ * signal. Anything the *detail* panel needs is absent on purpose: it refetches by id and
+ * uses the list item only as placeholder data, exactly as it does against the vendor list.
+ */
+const LIST_UI_PROPERTY_PATHS = [
+    "id",
+    "document_name",
+    "document_number",
+    "created_date",
+    "updated_date",
+    "template.name",
+    "current_status.status_type",
+    "current_status.step_type",
+    "current_status.step_name",
+    "current_status.step_recipients",
+] as const;
+
+function readPath(document: unknown, path: string): unknown {
+    return path.split(".").reduce<unknown>(
+        (value, key) => (value as Record<string, unknown> | undefined)?.[key],
+        document,
+    );
+}
+
+describe("eformsignListDocFromMirror", () => {
+    it("carries every property the contract list reads", () => {
+        // The switch is only safe if a mirrored row can answer everything the list asks
+        // of a document. When a new field starts being rendered, this list grows and this
+        // test is what says whether the mirror can supply it.
+        const document = eformsignListDocFromMirror(createMirrorDocument());
+
+        for (const path of LIST_UI_PROPERTY_PATHS) {
+            expect({ path, value: readPath(document, path) }).toEqual({
+                path,
+                value: expect.anything(),
+            });
+        }
+    });
+
+    it("carries the recipient types the status counters fold", () => {
+        const document = eformsignListDocFromMirror(createMirrorDocument());
+
+        expect(document["current_status"]).toEqual(
+            expect.objectContaining({
+                step_recipients: [
+                    { recipient_type: "05" },
+                    { recipient_type: "06" },
+                ],
+            }),
+        );
+    });
+
+    it("emits timestamps as epoch milliseconds, the way the list sorts and formats them", () => {
+        const document = eformsignListDocFromMirror(createMirrorDocument());
+
+        expect(document.created_date).toBe(Date.parse("2026-07-01T00:00:00.000Z"));
+        expect(document["updated_date"]).toBe(Date.parse("2026-07-02T00:00:00.000Z"));
+    });
+
+    it("leaves the customer name out until the page is enriched", () => {
+        // Filtering and searching happen before enrichment on the API path, so a customer
+        // name must not be visible to them here either — otherwise switching the source
+        // would silently change what a search finds.
+        const entity = createMirrorDocument();
+        const document = eformsignListDocFromMirror(entity);
+
+        expect(documentCustomerNameValue(document)).toBeNull();
+        expect(documentCustomerNameValue(
+            enrichMirrorPage([document], new Map([[entity.documentId, entity]]))[0]!,
+        )).toBe("김고객");
+    });
+});

--- a/backend/test/utils/eformsign-list-doc-from-mirror.spec.ts
+++ b/backend/test/utils/eformsign-list-doc-from-mirror.spec.ts
@@ -3,8 +3,8 @@ import { documentCustomerNameValue } from "application/utils/eformsign-document-
 import { eformsignListDocFromMirror } from "application/utils/eformsign-list-doc-from-mirror";
 import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
 
-function createMirrorDocument(): EformsignDocEntity {
-    return EformsignDocEntity.reconstitute({
+function persistedMirrorRow() {
+    return {
         id: 1,
         documentId: "doc-1",
         documentName: "산모신생아건강관리서비스 계약서",
@@ -30,7 +30,11 @@ function createMirrorDocument(): EformsignDocEntity {
         documentKind: null,
         employeeScheduleId: null,
         templateId: "template-1",
-    });
+    };
+}
+
+function createMirrorDocument(): EformsignDocEntity {
+    return EformsignDocEntity.reconstitute(persistedMirrorRow());
 }
 
 /**
@@ -74,8 +78,29 @@ describe("eformsignListDocFromMirror", () => {
         }
     });
 
-    it("carries the recipient types the status counters fold", () => {
+    it("carries the recipient types the status counters fold, and the current step's contact", () => {
+        // The mobile detail sheet renders and enables actions from the list row while the
+        // detail request is in flight, and reads the name and contact from here.
         const document = eformsignListDocFromMirror(createMirrorDocument());
+
+        expect(document["current_status"]).toEqual(
+            expect.objectContaining({
+                step_recipients: [
+                    { recipient_type: "05", name: "송진호", id: "01012345678" },
+                    { recipient_type: "06" },
+                ],
+            }),
+        );
+    });
+
+    it("does not present the mirror's own placeholders as a contact", () => {
+        // "수신자"/"미확인" are what the mirror writes when eformsign gave it nothing.
+        // Passing those on would look like a name and a phone number to the UI.
+        const document = eformsignListDocFromMirror(EformsignDocEntity.reconstitute({
+            ...persistedMirrorRow(),
+            stepRecipientName: "수신자",
+            stepRecipientSms: "미확인",
+        }));
 
         expect(document["current_status"]).toEqual(
             expect.objectContaining({

--- a/backend/test/utils/eformsign-list-doc-from-mirror.spec.ts
+++ b/backend/test/utils/eformsign-list-doc-from-mirror.spec.ts
@@ -78,29 +78,12 @@ describe("eformsignListDocFromMirror", () => {
         }
     });
 
-    it("carries the recipient types the status counters fold, and the current step's contact", () => {
-        // The mobile detail sheet renders and enables actions from the list row while the
-        // detail request is in flight, and reads the name and contact from here.
+    it("carries the recipient types the status counters fold, and nothing else about them", () => {
+        // A webhook advancing a document copies the stored recipient name and contact
+        // forward unchanged, so they can describe the step before the current one. The
+        // mobile sheet offers edit-and-send off the list row before its detail request
+        // returns, so a stale contact here is one someone acts on.
         const document = eformsignListDocFromMirror(createMirrorDocument());
-
-        expect(document["current_status"]).toEqual(
-            expect.objectContaining({
-                step_recipients: [
-                    { recipient_type: "05", name: "송진호", id: "01012345678" },
-                    { recipient_type: "06" },
-                ],
-            }),
-        );
-    });
-
-    it("does not present the mirror's own placeholders as a contact", () => {
-        // "수신자"/"미확인" are what the mirror writes when eformsign gave it nothing.
-        // Passing those on would look like a name and a phone number to the UI.
-        const document = eformsignListDocFromMirror(EformsignDocEntity.reconstitute({
-            ...persistedMirrorRow(),
-            stepRecipientName: "수신자",
-            stepRecipientSms: "미확인",
-        }));
 
         expect(document["current_status"]).toEqual(
             expect.objectContaining({


### PR DESCRIPTION
BJJ-288 E단계(마지막). `EFORMSIGN_LIST_FROM_MIRROR=true` 가 아니면 **아무것도 바뀌지 않는다.** 스위치로 두는 이유는 되돌리기가 배포가 아니라 설정 한 줄이어야 하기 때문이다 — 단계를 나눈 목적 자체가 그것이다.

## 측정한 것이 곧 서빙하는 것

로컬 목록 구축을 D단계의 그림자 비교에서 **전용 서비스로 뽑아, 둘이 같은 인스턴스를 쓴다.**

단정함의 문제가 아니다. 한 구현으로 모은 증거는 다른 구현에 대해 아무것도 말해 주지 않는다. D단계가 실 트래픽에 대고 측정해 온 계산이 **말 그대로** 이 PR이 서빙하는 계산이어야, 그림자 로그가 전환 판단의 근거가 된다.

## 대체하는 경로와 달라지는 것 — 그리고 그게 이 마이그레이션의 이유

- **벤더 스캔이 없다.** API 경로는 지점 문서를 찾으려고 회사 전체를 최대 10페이지×100건 훑고, "오래된 계약서는 누락될 수 있다"고 자기 로그에 남긴다. 로컬 쿼리에는 그 지평선이 없다.
- **이 경로엔 스냅샷 캐시가 없다.** 캐시는 벤더 호출 30번을 견디게 하려고 있는 것이다. 여기엔 분할상환할 대상이 없고, 그 대가로 감수하던 5분 staleness도 함께 사라진다.
- **고객명 채우려고 단건 재조회를 하지 않는다.** enrichment가 찾아 나서는 값을 미러가 이미 갖고 있다. 지금 로그에 `apiFallbacks=` 로 찍히는 그 호출이 발생할 수 없다.

## 바뀌지 않는 것

탭은 같은 문서를 보여주고, 검색은 같은 문서를 찾는다.

**enrichment는 페이지에, 그리고 필터링 이후에** 적용한다 — API 경로와 정확히 같다. 고객명을 더 일찍 넣으면 목록이 조용히 고객명으로 검색 가능해지는데, 그건 **데이터 출처가 아니라 기능이 바뀌는 것**이라 마이그레이션에 섞일 일이 아니다. 테스트로 고정했다.

## 유일하게 새로운 것

탭은 **상태 코드로** 답한다. 미러에는 문서가 어느 벤더 문서함에 있었는지가 없기 때문이다. 이 치환이 여기서 유일하게 새로운 부분이고, D단계의 그림자 비교가 상태별 엔드포인트에서 내내 측정해 온 것이 바로 이것이다.

## 검증

- `npx tsc --noEmit` 통과, `npx nest build` 통과
- **178 suites / 1898 passed / 8 skipped**
- ESLint 0 errors / 76 warnings(기준선 그대로)
- 스위치 OFF 상태의 기존 통합 테스트 38건이 API 경로 무회귀를 보증
- 스위치 ON 경로는 별도 테스트 모듈로 검증: 미러에서 서빙하고 **eformsign을 호출하지 않는다**
- DB 스키마 변경 없음

## 켜기 전 조건 (코드로 앞당길 수 없음)

1. C단계 대조(`EFORMSIGN_RECONCILE_ENABLED`)가 돌아 미러가 채워져 있을 것
2. D단계 그림자 로그(`EFORMSIGN_SHADOW_COMPARE_ENABLED`)가 **며칠간 `[Shadow] match`** 일 것
   - 회사 문서가 1000건을 넘으면 스캔 상한 때문에 `extra` 가 상시 나올 수 있다. 같은 로그의 `scanCompanyDocuments hit MAX_PAGES` 경고와 함께 판단한다
3. 그 다음에야 `EFORMSIGN_LIST_FROM_MIRROR=true`

전환 후에도 스위치는 한동안 유지한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG