### PR TITLE
fix(backend): 백필 CLI 부팅 실패와 expired_date 두 형식 처리

### DIFF
--- a/backend/application/usecases/eformsign-doc/backfill-eformsign-docs.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/backfill-eformsign-docs.usecase.ts
@@ -463,10 +463,17 @@ export class BackfillEformsignDocsUsecase {
 
             summary.failed += 1;
             typeSummary.failed += 1;
+            // The status fields are here because every mirroring failure so far has been a
+            // value the vendor sent that our mapping did not expect. Without them the log
+            // says a document could not be mirrored and nothing about why, which costs a
+            // second full sweep to find out.
+            const status = document.current_status;
             this.logger.warn(
                 `Failed to mirror eformsign document ${document.id}: ${
                     error instanceof Error ? error.message : String(error)
-                }`,
+                } (status_type=${status?.status_type}`
+                + ` expired_date=${JSON.stringify(status?.expired_date)}`
+                + ` expired=${JSON.stringify(status?._expired)})`,
             );
         }
     }

--- a/backend/domain/utils/eformsign-expiry-date.ts
+++ b/backend/domain/utils/eformsign-expiry-date.ts
@@ -9,12 +9,52 @@ const DEFAULT_DOCUMENT_EXPIRY_DAYS = 30;
  */
 export const EFORMSIGN_NO_EXPIRY_DATE = "9999-12-31T23:59:59.999Z";
 
+/**
+ * Above this, the number is not a day count.
+ *
+ * eformsign sends `expired_date` two different ways, and nothing in the payload declares
+ * which: a small day count while the document can still be signed, and the actual expiry
+ * instant in epoch milliseconds once it has expired. Measured on the live company list
+ * (2026-07-29): 189 live documents sent `0`, and every one of the 18 that sent a value
+ * near 1.7e12 also carried `_expired: true`.
+ *
+ * Magnitude is the discriminator rather than `_expired`, because `_expired` is absent from
+ * some list responses while the ambiguity is not. 1e10 days is 27 million years and 1e10
+ * milliseconds is 1970-04-26, so no real value of either kind lands near the boundary.
+ */
+const EPOCH_MILLISECONDS_THRESHOLD = 1e10;
+
+/** The largest instant a JavaScript Date can hold; beyond it `new Date()` is invalid. */
+const MAX_TIME_VALUE = 8.64e15;
+
+/**
+ * The moment a document expires, from whichever form eformsign sent.
+ *
+ * Always returns a valid Date. It used to be possible for it not to: reading an epoch as a
+ * day count multiplies it past `MAX_TIME_VALUE`, and the resulting Invalid Date failed
+ * entity validation, which the backfill then reported as an unmirrorable document. Both
+ * halves of that history were half-right — reading every value as an epoch stored 1970 for
+ * live documents, reading every value as days broke the expired ones.
+ */
 export function eformsignExpiryDateFromRemainingDays(
     remainingDays: number | null | undefined,
     referenceTime: number,
 ): Date {
     if (remainingDays === 0) {
         return new Date(EFORMSIGN_NO_EXPIRY_DATE);
+    }
+
+    if (
+        typeof remainingDays === "number"
+        && Number.isFinite(remainingDays)
+        && remainingDays >= EPOCH_MILLISECONDS_THRESHOLD
+    ) {
+        // Already an instant. Anything a Date cannot hold is not one, so it falls through
+        // to the default rather than being stored as an invalid value.
+        if (remainingDays <= MAX_TIME_VALUE) {
+            return new Date(remainingDays);
+        }
+        return defaultExpiry(referenceTime);
     }
 
     const expiryDays = typeof remainingDays === "number"
@@ -24,4 +64,8 @@ export function eformsignExpiryDateFromRemainingDays(
         : DEFAULT_DOCUMENT_EXPIRY_DAYS;
 
     return new Date(referenceTime + expiryDays * MILLISECONDS_PER_DAY);
+}
+
+function defaultExpiry(referenceTime: number): Date {
+    return new Date(referenceTime + DEFAULT_DOCUMENT_EXPIRY_DAYS * MILLISECONDS_PER_DAY);
 }

--- a/backend/domain/utils/eformsign-expiry-date.ts
+++ b/backend/domain/utils/eformsign-expiry-date.ts
@@ -49,12 +49,8 @@ export function eformsignExpiryDateFromRemainingDays(
         && Number.isFinite(remainingDays)
         && remainingDays >= EPOCH_MILLISECONDS_THRESHOLD
     ) {
-        // Already an instant. Anything a Date cannot hold is not one, so it falls through
-        // to the default rather than being stored as an invalid value.
-        if (remainingDays <= MAX_TIME_VALUE) {
-            return new Date(remainingDays);
-        }
-        return defaultExpiry(referenceTime);
+        // Already an instant.
+        return boundedDate(remainingDays, referenceTime);
     }
 
     const expiryDays = typeof remainingDays === "number"
@@ -63,9 +59,24 @@ export function eformsignExpiryDateFromRemainingDays(
         ? remainingDays
         : DEFAULT_DOCUMENT_EXPIRY_DAYS;
 
-    return new Date(referenceTime + expiryDays * MILLISECONDS_PER_DAY);
+    // A day count under the epoch threshold can still overflow once multiplied — anything
+    // past 1e8 days does — so this branch needs the same bound as the instant one.
+    return boundedDate(referenceTime + expiryDays * MILLISECONDS_PER_DAY, referenceTime);
 }
 
-function defaultExpiry(referenceTime: number): Date {
-    return new Date(referenceTime + DEFAULT_DOCUMENT_EXPIRY_DAYS * MILLISECONDS_PER_DAY);
+/**
+ * The single place the "always a valid Date" guarantee is enforced, so neither branch above
+ * can quietly stop honouring it. A value a Date cannot hold is not a date at all; it falls
+ * back to the default window, and if even that is unusable the caller gets the no-expiry
+ * sentinel rather than a value that fails entity validation and drops the document.
+ */
+function boundedDate(timeValue: number, referenceTime: number): Date {
+    if (Number.isFinite(timeValue) && Math.abs(timeValue) <= MAX_TIME_VALUE) {
+        return new Date(timeValue);
+    }
+
+    const fallback = referenceTime + DEFAULT_DOCUMENT_EXPIRY_DAYS * MILLISECONDS_PER_DAY;
+    return Number.isFinite(fallback) && Math.abs(fallback) <= MAX_TIME_VALUE
+        ? new Date(fallback)
+        : new Date(EFORMSIGN_NO_EXPIRY_DATE);
 }

--- a/backend/scripts/backfill-eformsign-docs.ts
+++ b/backend/scripts/backfill-eformsign-docs.ts
@@ -28,6 +28,7 @@ import {
     resolveEformsignBackfillTarget,
 } from "application/utils/eformsign-backfill-safety";
 import { EformsignBackfillLockService } from "infrastructure/locking/eformsign-backfill-lock.service";
+import { TenantModule } from "infrastructure/tenant/tenant.module";
 import { EformsignDocModule } from "module/eformsign-doc.module";
 
 const ENV_FILE_PATHS = [
@@ -43,6 +44,13 @@ const ENV_FILE_PATHS = [
             isGlobal: true,
             envFilePath: ENV_FILE_PATHS,
         }),
+        // @Global() is global to a graph that imports it, not to the process. AppModule
+        // imports TenantModule; this one does not, and EformsignDocModule reaches
+        // AreaTemplateModule, whose controller carries @UseGuards(TenantGuard) — Nest
+        // instantiates that guard while building the graph and fails on TenantContext.
+        // Nothing here serves a request, so the guard is never used; it only has to
+        // resolve. Same fix, same reason, as bjj249-service-record-snapshot.live.e2e.spec.
+        TenantModule,
         EformsignDocModule,
     ],
 })

--- a/backend/test/domain/eformsign-expiry-date.spec.ts
+++ b/backend/test/domain/eformsign-expiry-date.spec.ts
@@ -31,10 +31,16 @@ describe("eformsignExpiryDateFromRemainingDays", () => {
         );
     });
 
-    it("falls back rather than returning a Date that cannot hold the value", () => {
-        // A caller storing this would fail entity validation, and the document would be
+    it.each([
+        ["an instant past the end of time", 1e17],
+        // Under the epoch threshold, so it takes the day-count branch — but 1e8 days is
+        // already past what a Date can hold once multiplied out. Both branches need the
+        // same bound; only the instant one had it at first.
+        ["a day count that overflows once multiplied", 100_000_000],
+    ])("falls back rather than returning a Date that cannot hold %s", (_label, value) => {
+        // A caller storing an invalid Date fails entity validation, and the document is
         // dropped from the mirror — the outcome this whole discrimination exists to avoid.
-        const result = eformsignExpiryDateFromRemainingDays(1e17, referenceTime);
+        const result = eformsignExpiryDateFromRemainingDays(value, referenceTime);
 
         expect(Number.isNaN(result.getTime())).toBe(false);
         expect(result).toEqual(new Date(referenceTime + 30 * 24 * 60 * 60 * 1000));

--- a/backend/test/domain/eformsign-expiry-date.spec.ts
+++ b/backend/test/domain/eformsign-expiry-date.spec.ts
@@ -20,4 +20,31 @@ describe("eformsignExpiryDateFromRemainingDays", () => {
             new Date(referenceTime + 3 * 24 * 60 * 60 * 1000),
         );
     });
+
+    it("reads an expired document's value as the instant it already is", () => {
+        // Measured on the live company list: every document eformsign reported as expired
+        // sent its expiry as epoch milliseconds instead of a day count, with nothing in the
+        // payload to say so. Multiplying one of these by a day overflowed Date, and the
+        // backfill reported those documents as unmirrorable.
+        expect(eformsignExpiryDateFromRemainingDays(1749524449968, referenceTime)).toEqual(
+            new Date(1749524449968),
+        );
+    });
+
+    it("falls back rather than returning a Date that cannot hold the value", () => {
+        // A caller storing this would fail entity validation, and the document would be
+        // dropped from the mirror — the outcome this whole discrimination exists to avoid.
+        const result = eformsignExpiryDateFromRemainingDays(1e17, referenceTime);
+
+        expect(Number.isNaN(result.getTime())).toBe(false);
+        expect(result).toEqual(new Date(referenceTime + 30 * 24 * 60 * 60 * 1000));
+    });
+
+    it("still treats a plausible day count as days, not as an instant", () => {
+        // 9999 days is ~27 years out; an epoch this small would be 1970-01-01T00:00:09Z.
+        // The boundary has to leave real day counts on the day-count side.
+        expect(eformsignExpiryDateFromRemainingDays(9999, referenceTime)).toEqual(
+            new Date(referenceTime + 9999 * 24 * 60 * 60 * 1000),
+        );
+    });
 });


### PR DESCRIPTION
preview에 실제로 스윕을 돌려 발견한 결함 두 개입니다. 야간 크론을 기다렸으면 내일 아침에 알았을 것들입니다.

## 1. 운영자 백필 CLI가 부팅조차 못 함

`EformsignBackfillCliModule` → `EformsignDocModule` → `AreaTemplateModule`에 `@UseGuards(TenantGuard)`가 붙은 컨트롤러가 있고, Nest가 그래프를 만들며 그 가드를 인스턴스화하다 `TenantContext`를 못 찾습니다.

`TenantModule`은 `@Global()`이지만 **그건 그 모듈을 임포트한 그래프 안에서만 전역**입니다. `AppModule`은 명시적으로 임포트하고, `bjj249-service-record-snapshot.live.e2e.spec.ts:67`도 같은 이유로 임포트하며 주석까지 남겨 뒀습니다. 이제 이 모듈도 임포트합니다. 여기서는 요청을 처리하지 않으므로 가드가 쓰이지는 않고, 해석만 되면 됩니다.

야간 크론은 전체 앱 안에서 돌아 영향이 없었습니다 — 그래서 아무도 몰랐습니다.

## 2. `expired_date`가 두 가지 형식으로 온다

라이브 회사 목록에서 실측했습니다:

| 값 | 의미 | 건수 |
|---|---|---|
| `0` | 만료 없음 | 189 |
| 작은 정수 | 남은 일수 | 기존 8 |
| `1.7e12` 급 | **이미 만료된 시각(ms epoch)** | 18, **전부 `_expired: true`** |

epoch를 일수로 읽으면 `referenceTime + 1.7e12 × 86400000`이 Date 최대치를 넘어 Invalid Date가 되고, 엔티티 검증에 걸려 18건이 통째로 미러에서 탈락했습니다.

이 파일의 이력은 **양쪽 다 절반만 맞았습니다.** 전부 epoch로 읽던 시절엔 라이브 문서에 1970년이 저장됐고(메모리에 남은 `expiredDate` 오염 사건), PR #414에서 전부 일수로 뒤집으니 만료 문서가 깨졌습니다.

`_expired`가 아니라 **크기로** 구분합니다 — 일부 목록 응답은 `_expired`를 생략하지만 모호함은 그대로이기 때문입니다. 1e10일은 2700만 년, 1e10밀리초는 1970-04-26이라 실제 값이 경계 근처에 오지 않습니다. 범위를 벗어나는 값은 invalid Date 대신 기본값으로 떨어집니다.

## 부수 변경

미러링 실패 로그에 `status_type` / `expired_date` / `_expired`를 남깁니다. 지금까지 모든 실패가 "벤더가 보낸 예상 밖 값"이었는데, 로그에는 "미러링 실패"만 있고 이유가 없어 원인을 알아내는 데 전체 스윕을 한 번 더 돌려야 했습니다.

## 검증

preview 실측 — 스윕이 `outcome: completed`, `failed=0`으로 끝나고 미러가 **8행 → 215행**(207행이 표시 컬럼 보유, 2025-01-15까지). 만료된 18건은 실제 만료 시각으로 저장됩니다.

`tsc` 통과, eslint 0 errors / 76 warnings(기준선 유지), jest 179 suites / 1915 passed / 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG