### PR TITLE
release: dev → preview (2026-07-29 r2) — 백필 CLI/expired_date 수정

### DIFF
--- a/backend/application/usecases/eformsign-doc/backfill-eformsign-docs.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/backfill-eformsign-docs.usecase.ts
@@ -463,10 +463,17 @@ export class BackfillEformsignDocsUsecase {
 
             summary.failed += 1;
             typeSummary.failed += 1;
+            // The status fields are here because every mirroring failure so far has been a
+            // value the vendor sent that our mapping did not expect. Without them the log
+            // says a document could not be mirrored and nothing about why, which costs a
+            // second full sweep to find out.
+            const status = document.current_status;
             this.logger.warn(
                 `Failed to mirror eformsign document ${document.id}: ${
                     error instanceof Error ? error.message : String(error)
-                }`,
+                } (status_type=${status?.status_type}`
+                + ` expired_date=${JSON.stringify(status?.expired_date)}`
+                + ` expired=${JSON.stringify(status?._expired)})`,
             );
         }
     }

--- a/backend/domain/utils/eformsign-expiry-date.ts
+++ b/backend/domain/utils/eformsign-expiry-date.ts
@@ -9,12 +9,52 @@ const DEFAULT_DOCUMENT_EXPIRY_DAYS = 30;
  */
 export const EFORMSIGN_NO_EXPIRY_DATE = "9999-12-31T23:59:59.999Z";
 
+/**
+ * Above this, the number is not a day count.
+ *
+ * eformsign sends `expired_date` two different ways, and nothing in the payload declares
+ * which: a small day count while the document can still be signed, and the actual expiry
+ * instant in epoch milliseconds once it has expired. Measured on the live company list
+ * (2026-07-29): 189 live documents sent `0`, and every one of the 18 that sent a value
+ * near 1.7e12 also carried `_expired: true`.
+ *
+ * Magnitude is the discriminator rather than `_expired`, because `_expired` is absent from
+ * some list responses while the ambiguity is not. 1e10 days is 27 million years and 1e10
+ * milliseconds is 1970-04-26, so no real value of either kind lands near the boundary.
+ */
+const EPOCH_MILLISECONDS_THRESHOLD = 1e10;
+
+/** The largest instant a JavaScript Date can hold; beyond it `new Date()` is invalid. */
+const MAX_TIME_VALUE = 8.64e15;
+
+/**
+ * The moment a document expires, from whichever form eformsign sent.
+ *
+ * Always returns a valid Date. It used to be possible for it not to: reading an epoch as a
+ * day count multiplies it past `MAX_TIME_VALUE`, and the resulting Invalid Date failed
+ * entity validation, which the backfill then reported as an unmirrorable document. Both
+ * halves of that history were half-right — reading every value as an epoch stored 1970 for
+ * live documents, reading every value as days broke the expired ones.
+ */
 export function eformsignExpiryDateFromRemainingDays(
     remainingDays: number | null | undefined,
     referenceTime: number,
 ): Date {
     if (remainingDays === 0) {
         return new Date(EFORMSIGN_NO_EXPIRY_DATE);
+    }
+
+    if (
+        typeof remainingDays === "number"
+        && Number.isFinite(remainingDays)
+        && remainingDays >= EPOCH_MILLISECONDS_THRESHOLD
+    ) {
+        // Already an instant. Anything a Date cannot hold is not one, so it falls through
+        // to the default rather than being stored as an invalid value.
+        if (remainingDays <= MAX_TIME_VALUE) {
+            return new Date(remainingDays);
+        }
+        return defaultExpiry(referenceTime);
     }
 
     const expiryDays = typeof remainingDays === "number"
@@ -24,4 +64,8 @@ export function eformsignExpiryDateFromRemainingDays(
         : DEFAULT_DOCUMENT_EXPIRY_DAYS;
 
     return new Date(referenceTime + expiryDays * MILLISECONDS_PER_DAY);
+}
+
+function defaultExpiry(referenceTime: number): Date {
+    return new Date(referenceTime + DEFAULT_DOCUMENT_EXPIRY_DAYS * MILLISECONDS_PER_DAY);
 }

--- a/backend/domain/utils/eformsign-expiry-date.ts
+++ b/backend/domain/utils/eformsign-expiry-date.ts
@@ -49,12 +49,8 @@ export function eformsignExpiryDateFromRemainingDays(
         && Number.isFinite(remainingDays)
         && remainingDays >= EPOCH_MILLISECONDS_THRESHOLD
     ) {
-        // Already an instant. Anything a Date cannot hold is not one, so it falls through
-        // to the default rather than being stored as an invalid value.
-        if (remainingDays <= MAX_TIME_VALUE) {
-            return new Date(remainingDays);
-        }
-        return defaultExpiry(referenceTime);
+        // Already an instant.
+        return boundedDate(remainingDays, referenceTime);
     }
 
     const expiryDays = typeof remainingDays === "number"
@@ -63,9 +59,24 @@ export function eformsignExpiryDateFromRemainingDays(
         ? remainingDays
         : DEFAULT_DOCUMENT_EXPIRY_DAYS;
 
-    return new Date(referenceTime + expiryDays * MILLISECONDS_PER_DAY);
+    // A day count under the epoch threshold can still overflow once multiplied — anything
+    // past 1e8 days does — so this branch needs the same bound as the instant one.
+    return boundedDate(referenceTime + expiryDays * MILLISECONDS_PER_DAY, referenceTime);
 }
 
-function defaultExpiry(referenceTime: number): Date {
-    return new Date(referenceTime + DEFAULT_DOCUMENT_EXPIRY_DAYS * MILLISECONDS_PER_DAY);
+/**
+ * The single place the "always a valid Date" guarantee is enforced, so neither branch above
+ * can quietly stop honouring it. A value a Date cannot hold is not a date at all; it falls
+ * back to the default window, and if even that is unusable the caller gets the no-expiry
+ * sentinel rather than a value that fails entity validation and drops the document.
+ */
+function boundedDate(timeValue: number, referenceTime: number): Date {
+    if (Number.isFinite(timeValue) && Math.abs(timeValue) <= MAX_TIME_VALUE) {
+        return new Date(timeValue);
+    }
+
+    const fallback = referenceTime + DEFAULT_DOCUMENT_EXPIRY_DAYS * MILLISECONDS_PER_DAY;
+    return Number.isFinite(fallback) && Math.abs(fallback) <= MAX_TIME_VALUE
+        ? new Date(fallback)
+        : new Date(EFORMSIGN_NO_EXPIRY_DATE);
 }

--- a/backend/scripts/backfill-eformsign-docs.ts
+++ b/backend/scripts/backfill-eformsign-docs.ts
@@ -28,6 +28,7 @@ import {
     resolveEformsignBackfillTarget,
 } from "application/utils/eformsign-backfill-safety";
 import { EformsignBackfillLockService } from "infrastructure/locking/eformsign-backfill-lock.service";
+import { TenantModule } from "infrastructure/tenant/tenant.module";
 import { EformsignDocModule } from "module/eformsign-doc.module";
 
 const ENV_FILE_PATHS = [
@@ -43,6 +44,13 @@ const ENV_FILE_PATHS = [
             isGlobal: true,
             envFilePath: ENV_FILE_PATHS,
         }),
+        // @Global() is global to a graph that imports it, not to the process. AppModule
+        // imports TenantModule; this one does not, and EformsignDocModule reaches
+        // AreaTemplateModule, whose controller carries @UseGuards(TenantGuard) — Nest
+        // instantiates that guard while building the graph and fails on TenantContext.
+        // Nothing here serves a request, so the guard is never used; it only has to
+        // resolve. Same fix, same reason, as bjj249-service-record-snapshot.live.e2e.spec.
+        TenantModule,
         EformsignDocModule,
     ],
 })

--- a/backend/test/domain/eformsign-expiry-date.spec.ts
+++ b/backend/test/domain/eformsign-expiry-date.spec.ts
@@ -31,10 +31,16 @@ describe("eformsignExpiryDateFromRemainingDays", () => {
         );
     });
 
-    it("falls back rather than returning a Date that cannot hold the value", () => {
-        // A caller storing this would fail entity validation, and the document would be
+    it.each([
+        ["an instant past the end of time", 1e17],
+        // Under the epoch threshold, so it takes the day-count branch — but 1e8 days is
+        // already past what a Date can hold once multiplied out. Both branches need the
+        // same bound; only the instant one had it at first.
+        ["a day count that overflows once multiplied", 100_000_000],
+    ])("falls back rather than returning a Date that cannot hold %s", (_label, value) => {
+        // A caller storing an invalid Date fails entity validation, and the document is
         // dropped from the mirror — the outcome this whole discrimination exists to avoid.
-        const result = eformsignExpiryDateFromRemainingDays(1e17, referenceTime);
+        const result = eformsignExpiryDateFromRemainingDays(value, referenceTime);
 
         expect(Number.isNaN(result.getTime())).toBe(false);
         expect(result).toEqual(new Date(referenceTime + 30 * 24 * 60 * 60 * 1000));

--- a/backend/test/domain/eformsign-expiry-date.spec.ts
+++ b/backend/test/domain/eformsign-expiry-date.spec.ts
@@ -20,4 +20,31 @@ describe("eformsignExpiryDateFromRemainingDays", () => {
             new Date(referenceTime + 3 * 24 * 60 * 60 * 1000),
         );
     });
+
+    it("reads an expired document's value as the instant it already is", () => {
+        // Measured on the live company list: every document eformsign reported as expired
+        // sent its expiry as epoch milliseconds instead of a day count, with nothing in the
+        // payload to say so. Multiplying one of these by a day overflowed Date, and the
+        // backfill reported those documents as unmirrorable.
+        expect(eformsignExpiryDateFromRemainingDays(1749524449968, referenceTime)).toEqual(
+            new Date(1749524449968),
+        );
+    });
+
+    it("falls back rather than returning a Date that cannot hold the value", () => {
+        // A caller storing this would fail entity validation, and the document would be
+        // dropped from the mirror — the outcome this whole discrimination exists to avoid.
+        const result = eformsignExpiryDateFromRemainingDays(1e17, referenceTime);
+
+        expect(Number.isNaN(result.getTime())).toBe(false);
+        expect(result).toEqual(new Date(referenceTime + 30 * 24 * 60 * 60 * 1000));
+    });
+
+    it("still treats a plausible day count as days, not as an instant", () => {
+        // 9999 days is ~27 years out; an epoch this small would be 1970-01-01T00:00:09Z.
+        // The boundary has to leave real day counts on the day-count side.
+        expect(eformsignExpiryDateFromRemainingDays(9999, referenceTime)).toEqual(
+            new Date(referenceTime + 9999 * 24 * 60 * 60 * 1000),
+        );
+    });
 });

--- a/frontend/src/components/app/clients/ClientDetailPanel.tsx
+++ b/frontend/src/components/app/clients/ClientDetailPanel.tsx
@@ -898,7 +898,7 @@ function ClientDetailPanelBody({
                                         />
                                     </InfoCard>
 
-                                    <InfoCard data-component={`${dataComponentPrefix}_content_basic_grid_service-card`} title="서비스 정보" className="col-start-2 row-start-1 row-end-5">
+                                    <InfoCard data-component={`${dataComponentPrefix}_content_basic_grid_service-card`} title="서비스 정보" className="col-start-2 row-start-1 row-end-5 content-start">
                                         <InfoRow
                                             label={t(locale, "clients.form.voucher-type")}
                                             value={client.type ? getClientDisplayLabel(client.type) : "-"}

--- a/mobile/src/app/(shell)/select-branch/actions.test.ts
+++ b/mobile/src/app/(shell)/select-branch/actions.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment node
+ */
+import { cookies } from "next/headers";
+
+import { serverAPIClient } from "@/lib/api/server";
+
+import { getUserBranches } from "./actions";
+
+jest.mock("next/headers", () => ({ cookies: jest.fn() }));
+jest.mock("@/lib/api/server", () => ({
+  serverAPIClient: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+const mockCookies = jest.mocked(cookies);
+const mockGet = jest.mocked(serverAPIClient.get);
+
+describe("mobile getUserBranches", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the most recently selected branch first", async () => {
+    mockCookies.mockResolvedValue({
+      get: jest.fn((name: string) => {
+        if (name === "auth_token") return { value: "auth-token" };
+        if (name === "selected_branch_id") return { value: "branch-c" };
+        return undefined;
+      }),
+    } as never);
+    mockGet.mockResolvedValue({
+      data: {
+        branches: [
+          { id: "branch-a", name: "가 지점" },
+          { id: "branch-b", name: "나 지점" },
+          { id: "branch-c", name: "다 지점" },
+        ],
+      },
+    });
+
+    await expect(getUserBranches()).resolves.toEqual({
+      success: true,
+      branches: [
+        { id: "branch-c", name: "다 지점" },
+        { id: "branch-a", name: "가 지점" },
+        { id: "branch-b", name: "나 지점" },
+      ],
+    });
+    expect(mockGet).toHaveBeenCalledWith("/auth/branches", {
+      headers: { Authorization: "Bearer auth-token" },
+    });
+  });
+});

--- a/mobile/src/app/(shell)/select-branch/actions.ts
+++ b/mobile/src/app/(shell)/select-branch/actions.ts
@@ -11,6 +11,8 @@ import {
   getRefreshSessionMaxAgeSeconds,
 } from "@/lib/auth/session-policy";
 
+import { prioritizeRecentBranch } from "./branch-order";
+
 interface Branch {
   id: string;
   name: string;
@@ -37,6 +39,7 @@ export async function getUserBranches(): Promise<{
   try {
     const cookieStore = await cookies();
     const token = cookieStore.get("auth_token")?.value || null;
+    const recentBranchId = cookieStore.get("selected_branch_id")?.value;
 
     const { data } = await serverAPIClient.get("/auth/branches", {
       headers: getAuthHeaders(token),
@@ -44,7 +47,7 @@ export async function getUserBranches(): Promise<{
 
     return {
       success: true,
-      branches: data.branches,
+      branches: prioritizeRecentBranch(data.branches ?? [], recentBranchId),
     };
   } catch (error) {
     console.error("[Server Action] Error fetching branches:", error);

--- a/mobile/src/app/(shell)/select-branch/branch-order.test.ts
+++ b/mobile/src/app/(shell)/select-branch/branch-order.test.ts
@@ -1,0 +1,21 @@
+import { prioritizeRecentBranch } from "./branch-order";
+
+describe("prioritizeRecentBranch", () => {
+  const branches = [
+    { id: "branch-a", name: "가 지점" },
+    { id: "branch-b", name: "나 지점" },
+    { id: "branch-c", name: "다 지점" },
+  ];
+
+  it("moves the most recently selected branch to the front while preserving the remaining order", () => {
+    expect(prioritizeRecentBranch(branches, "branch-c")).toEqual([
+      branches[2],
+      branches[0],
+      branches[1],
+    ]);
+  });
+
+  it("preserves the original order when the recent branch is unavailable", () => {
+    expect(prioritizeRecentBranch(branches, "branch-missing")).toEqual(branches);
+  });
+});

--- a/mobile/src/app/(shell)/select-branch/branch-order.ts
+++ b/mobile/src/app/(shell)/select-branch/branch-order.ts
@@ -1,0 +1,26 @@
+interface BranchIdentifier {
+  id: string;
+}
+
+export function prioritizeRecentBranch<TBranch extends BranchIdentifier>(
+  branches: TBranch[],
+  recentBranchId?: string,
+): TBranch[] {
+  if (!recentBranchId) {
+    return branches;
+  }
+
+  const recentBranchIndex = branches.findIndex(
+    (branch) => branch.id === recentBranchId,
+  );
+
+  if (recentBranchIndex <= 0) {
+    return branches;
+  }
+
+  return [
+    branches[recentBranchIndex],
+    ...branches.slice(0, recentBranchIndex),
+    ...branches.slice(recentBranchIndex + 1),
+  ];
+}


### PR DESCRIPTION
## 담기는 것

**PR #419 — 백필 CLI 부팅 실패와 `expired_date` 두 형식 처리 (핵심)**

preview에 실제로 스윕을 돌려 발견한 결함 두 개입니다.

1. **운영자 백필 CLI가 부팅조차 못 했습니다.** `EformsignBackfillCliModule` → `EformsignDocModule` → `AreaTemplateModule`에 `@UseGuards(TenantGuard)`가 붙은 컨트롤러가 있고, Nest가 그래프를 만들며 그 가드를 인스턴스화하다 `TenantContext`를 못 찾습니다. `TenantModule`은 `@Global()`이지만 그건 임포트한 그래프 안에서만 전역입니다. 야간 크론은 전체 앱 안에서 돌아 멀쩡했고 — 그래서 아무도 몰랐습니다.

2. **`expired_date`가 두 가지 형식으로 옵니다.** 라이브 회사 목록 실측: `0`(만료 없음) 189건, 작은 정수(남은 일수) 8건, `1.7e12`급(**이미 만료된 시각, ms epoch**) 18건 — 마지막 18건은 전부 `_expired: true`. epoch를 일수로 읽으면 Date 최대치를 넘어 Invalid Date가 되고 엔티티 검증에 걸려 미러에서 통째로 탈락합니다. 크기로 구분하며(`_expired`는 일부 응답에서 생략됨), 두 분기 모두 같은 경계 검사를 지나 invalid Date를 절대 반환하지 않습니다.

미러링 실패 로그에 벤더가 보낸 값(`status_type`/`expired_date`/`_expired`)을 남깁니다.

**함께 담기는 다른 작업**
- 모바일: 최근 선택한 지점 우선 표시
- 프론트엔드: 대시보드 서비스 카드 상단 정렬

## 검증

preview 실측 — 스윕이 `outcome: completed`, `failed=0`으로 완료되고 미러가 **8행 → 215행**(207행이 표시 컬럼 보유, 2025-01-15까지). Codex 리뷰 클린(`d2f0f21193`), `tsc` 통과, eslint 0 errors / 76 warnings(기준선), jest 179 suites / 1916 passed / 8 skipped.

마이그레이션이 없으므로 `database-patches`는 이 푸시에 걸리지 않습니다.

## 배포 경로 참고

오늘 Railway 배포 트리거를 교정해서(production→`main`, preview→`preview`, dev→`dev`) **이 병합이 preview 백엔드를 실제로 배포합니다.** 이전에는 세 환경이 전부 `dev`를 보고 있었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG