### PR TITLE
release: preview → main (2026-07-29 r2) — expired_date 수정 + 프로덕션 배포 바인딩 검증

### DIFF
--- a/backend/application/usecases/eformsign-doc/backfill-eformsign-docs.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/backfill-eformsign-docs.usecase.ts
@@ -463,10 +463,17 @@ export class BackfillEformsignDocsUsecase {
 
             summary.failed += 1;
             typeSummary.failed += 1;
+            // The status fields are here because every mirroring failure so far has been a
+            // value the vendor sent that our mapping did not expect. Without them the log
+            // says a document could not be mirrored and nothing about why, which costs a
+            // second full sweep to find out.
+            const status = document.current_status;
             this.logger.warn(
                 `Failed to mirror eformsign document ${document.id}: ${
                     error instanceof Error ? error.message : String(error)
-                }`,
+                } (status_type=${status?.status_type}`
+                + ` expired_date=${JSON.stringify(status?.expired_date)}`
+                + ` expired=${JSON.stringify(status?._expired)})`,
             );
         }
     }

--- a/backend/domain/utils/eformsign-expiry-date.ts
+++ b/backend/domain/utils/eformsign-expiry-date.ts
@@ -9,12 +9,52 @@ const DEFAULT_DOCUMENT_EXPIRY_DAYS = 30;
  */
 export const EFORMSIGN_NO_EXPIRY_DATE = "9999-12-31T23:59:59.999Z";
 
+/**
+ * Above this, the number is not a day count.
+ *
+ * eformsign sends `expired_date` two different ways, and nothing in the payload declares
+ * which: a small day count while the document can still be signed, and the actual expiry
+ * instant in epoch milliseconds once it has expired. Measured on the live company list
+ * (2026-07-29): 189 live documents sent `0`, and every one of the 18 that sent a value
+ * near 1.7e12 also carried `_expired: true`.
+ *
+ * Magnitude is the discriminator rather than `_expired`, because `_expired` is absent from
+ * some list responses while the ambiguity is not. 1e10 days is 27 million years and 1e10
+ * milliseconds is 1970-04-26, so no real value of either kind lands near the boundary.
+ */
+const EPOCH_MILLISECONDS_THRESHOLD = 1e10;
+
+/** The largest instant a JavaScript Date can hold; beyond it `new Date()` is invalid. */
+const MAX_TIME_VALUE = 8.64e15;
+
+/**
+ * The moment a document expires, from whichever form eformsign sent.
+ *
+ * Always returns a valid Date. It used to be possible for it not to: reading an epoch as a
+ * day count multiplies it past `MAX_TIME_VALUE`, and the resulting Invalid Date failed
+ * entity validation, which the backfill then reported as an unmirrorable document. Both
+ * halves of that history were half-right — reading every value as an epoch stored 1970 for
+ * live documents, reading every value as days broke the expired ones.
+ */
 export function eformsignExpiryDateFromRemainingDays(
     remainingDays: number | null | undefined,
     referenceTime: number,
 ): Date {
     if (remainingDays === 0) {
         return new Date(EFORMSIGN_NO_EXPIRY_DATE);
+    }
+
+    if (
+        typeof remainingDays === "number"
+        && Number.isFinite(remainingDays)
+        && remainingDays >= EPOCH_MILLISECONDS_THRESHOLD
+    ) {
+        // Already an instant. Anything a Date cannot hold is not one, so it falls through
+        // to the default rather than being stored as an invalid value.
+        if (remainingDays <= MAX_TIME_VALUE) {
+            return new Date(remainingDays);
+        }
+        return defaultExpiry(referenceTime);
     }
 
     const expiryDays = typeof remainingDays === "number"
@@ -24,4 +64,8 @@ export function eformsignExpiryDateFromRemainingDays(
         : DEFAULT_DOCUMENT_EXPIRY_DAYS;
 
     return new Date(referenceTime + expiryDays * MILLISECONDS_PER_DAY);
+}
+
+function defaultExpiry(referenceTime: number): Date {
+    return new Date(referenceTime + DEFAULT_DOCUMENT_EXPIRY_DAYS * MILLISECONDS_PER_DAY);
 }

--- a/backend/domain/utils/eformsign-expiry-date.ts
+++ b/backend/domain/utils/eformsign-expiry-date.ts
@@ -49,12 +49,8 @@ export function eformsignExpiryDateFromRemainingDays(
         && Number.isFinite(remainingDays)
         && remainingDays >= EPOCH_MILLISECONDS_THRESHOLD
     ) {
-        // Already an instant. Anything a Date cannot hold is not one, so it falls through
-        // to the default rather than being stored as an invalid value.
-        if (remainingDays <= MAX_TIME_VALUE) {
-            return new Date(remainingDays);
-        }
-        return defaultExpiry(referenceTime);
+        // Already an instant.
+        return boundedDate(remainingDays, referenceTime);
     }
 
     const expiryDays = typeof remainingDays === "number"
@@ -63,9 +59,24 @@ export function eformsignExpiryDateFromRemainingDays(
         ? remainingDays
         : DEFAULT_DOCUMENT_EXPIRY_DAYS;
 
-    return new Date(referenceTime + expiryDays * MILLISECONDS_PER_DAY);
+    // A day count under the epoch threshold can still overflow once multiplied — anything
+    // past 1e8 days does — so this branch needs the same bound as the instant one.
+    return boundedDate(referenceTime + expiryDays * MILLISECONDS_PER_DAY, referenceTime);
 }
 
-function defaultExpiry(referenceTime: number): Date {
-    return new Date(referenceTime + DEFAULT_DOCUMENT_EXPIRY_DAYS * MILLISECONDS_PER_DAY);
+/**
+ * The single place the "always a valid Date" guarantee is enforced, so neither branch above
+ * can quietly stop honouring it. A value a Date cannot hold is not a date at all; it falls
+ * back to the default window, and if even that is unusable the caller gets the no-expiry
+ * sentinel rather than a value that fails entity validation and drops the document.
+ */
+function boundedDate(timeValue: number, referenceTime: number): Date {
+    if (Number.isFinite(timeValue) && Math.abs(timeValue) <= MAX_TIME_VALUE) {
+        return new Date(timeValue);
+    }
+
+    const fallback = referenceTime + DEFAULT_DOCUMENT_EXPIRY_DAYS * MILLISECONDS_PER_DAY;
+    return Number.isFinite(fallback) && Math.abs(fallback) <= MAX_TIME_VALUE
+        ? new Date(fallback)
+        : new Date(EFORMSIGN_NO_EXPIRY_DATE);
 }

--- a/backend/scripts/backfill-eformsign-docs.ts
+++ b/backend/scripts/backfill-eformsign-docs.ts
@@ -28,6 +28,7 @@ import {
     resolveEformsignBackfillTarget,
 } from "application/utils/eformsign-backfill-safety";
 import { EformsignBackfillLockService } from "infrastructure/locking/eformsign-backfill-lock.service";
+import { TenantModule } from "infrastructure/tenant/tenant.module";
 import { EformsignDocModule } from "module/eformsign-doc.module";
 
 const ENV_FILE_PATHS = [
@@ -43,6 +44,13 @@ const ENV_FILE_PATHS = [
             isGlobal: true,
             envFilePath: ENV_FILE_PATHS,
         }),
+        // @Global() is global to a graph that imports it, not to the process. AppModule
+        // imports TenantModule; this one does not, and EformsignDocModule reaches
+        // AreaTemplateModule, whose controller carries @UseGuards(TenantGuard) — Nest
+        // instantiates that guard while building the graph and fails on TenantContext.
+        // Nothing here serves a request, so the guard is never used; it only has to
+        // resolve. Same fix, same reason, as bjj249-service-record-snapshot.live.e2e.spec.
+        TenantModule,
         EformsignDocModule,
     ],
 })

--- a/backend/test/domain/eformsign-expiry-date.spec.ts
+++ b/backend/test/domain/eformsign-expiry-date.spec.ts
@@ -31,10 +31,16 @@ describe("eformsignExpiryDateFromRemainingDays", () => {
         );
     });
 
-    it("falls back rather than returning a Date that cannot hold the value", () => {
-        // A caller storing this would fail entity validation, and the document would be
+    it.each([
+        ["an instant past the end of time", 1e17],
+        // Under the epoch threshold, so it takes the day-count branch — but 1e8 days is
+        // already past what a Date can hold once multiplied out. Both branches need the
+        // same bound; only the instant one had it at first.
+        ["a day count that overflows once multiplied", 100_000_000],
+    ])("falls back rather than returning a Date that cannot hold %s", (_label, value) => {
+        // A caller storing an invalid Date fails entity validation, and the document is
         // dropped from the mirror — the outcome this whole discrimination exists to avoid.
-        const result = eformsignExpiryDateFromRemainingDays(1e17, referenceTime);
+        const result = eformsignExpiryDateFromRemainingDays(value, referenceTime);
 
         expect(Number.isNaN(result.getTime())).toBe(false);
         expect(result).toEqual(new Date(referenceTime + 30 * 24 * 60 * 60 * 1000));

--- a/backend/test/domain/eformsign-expiry-date.spec.ts
+++ b/backend/test/domain/eformsign-expiry-date.spec.ts
@@ -20,4 +20,31 @@ describe("eformsignExpiryDateFromRemainingDays", () => {
             new Date(referenceTime + 3 * 24 * 60 * 60 * 1000),
         );
     });
+
+    it("reads an expired document's value as the instant it already is", () => {
+        // Measured on the live company list: every document eformsign reported as expired
+        // sent its expiry as epoch milliseconds instead of a day count, with nothing in the
+        // payload to say so. Multiplying one of these by a day overflowed Date, and the
+        // backfill reported those documents as unmirrorable.
+        expect(eformsignExpiryDateFromRemainingDays(1749524449968, referenceTime)).toEqual(
+            new Date(1749524449968),
+        );
+    });
+
+    it("falls back rather than returning a Date that cannot hold the value", () => {
+        // A caller storing this would fail entity validation, and the document would be
+        // dropped from the mirror — the outcome this whole discrimination exists to avoid.
+        const result = eformsignExpiryDateFromRemainingDays(1e17, referenceTime);
+
+        expect(Number.isNaN(result.getTime())).toBe(false);
+        expect(result).toEqual(new Date(referenceTime + 30 * 24 * 60 * 60 * 1000));
+    });
+
+    it("still treats a plausible day count as days, not as an instant", () => {
+        // 9999 days is ~27 years out; an epoch this small would be 1970-01-01T00:00:09Z.
+        // The boundary has to leave real day counts on the day-count side.
+        expect(eformsignExpiryDateFromRemainingDays(9999, referenceTime)).toEqual(
+            new Date(referenceTime + 9999 * 24 * 60 * 60 * 1000),
+        );
+    });
 });

--- a/frontend/src/components/app/clients/ClientDetailPanel.tsx
+++ b/frontend/src/components/app/clients/ClientDetailPanel.tsx
@@ -898,7 +898,7 @@ function ClientDetailPanelBody({
                                         />
                                     </InfoCard>
 
-                                    <InfoCard data-component={`${dataComponentPrefix}_content_basic_grid_service-card`} title="서비스 정보" className="col-start-2 row-start-1 row-end-5">
+                                    <InfoCard data-component={`${dataComponentPrefix}_content_basic_grid_service-card`} title="서비스 정보" className="col-start-2 row-start-1 row-end-5 content-start">
                                         <InfoRow
                                             label={t(locale, "clients.form.voucher-type")}
                                             value={client.type ? getClientDisplayLabel(client.type) : "-"}

--- a/mobile/src/app/(shell)/select-branch/actions.test.ts
+++ b/mobile/src/app/(shell)/select-branch/actions.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment node
+ */
+import { cookies } from "next/headers";
+
+import { serverAPIClient } from "@/lib/api/server";
+
+import { getUserBranches } from "./actions";
+
+jest.mock("next/headers", () => ({ cookies: jest.fn() }));
+jest.mock("@/lib/api/server", () => ({
+  serverAPIClient: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+const mockCookies = jest.mocked(cookies);
+const mockGet = jest.mocked(serverAPIClient.get);
+
+describe("mobile getUserBranches", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the most recently selected branch first", async () => {
+    mockCookies.mockResolvedValue({
+      get: jest.fn((name: string) => {
+        if (name === "auth_token") return { value: "auth-token" };
+        if (name === "selected_branch_id") return { value: "branch-c" };
+        return undefined;
+      }),
+    } as never);
+    mockGet.mockResolvedValue({
+      data: {
+        branches: [
+          { id: "branch-a", name: "가 지점" },
+          { id: "branch-b", name: "나 지점" },
+          { id: "branch-c", name: "다 지점" },
+        ],
+      },
+    });
+
+    await expect(getUserBranches()).resolves.toEqual({
+      success: true,
+      branches: [
+        { id: "branch-c", name: "다 지점" },
+        { id: "branch-a", name: "가 지점" },
+        { id: "branch-b", name: "나 지점" },
+      ],
+    });
+    expect(mockGet).toHaveBeenCalledWith("/auth/branches", {
+      headers: { Authorization: "Bearer auth-token" },
+    });
+  });
+});

--- a/mobile/src/app/(shell)/select-branch/actions.ts
+++ b/mobile/src/app/(shell)/select-branch/actions.ts
@@ -11,6 +11,8 @@ import {
   getRefreshSessionMaxAgeSeconds,
 } from "@/lib/auth/session-policy";
 
+import { prioritizeRecentBranch } from "./branch-order";
+
 interface Branch {
   id: string;
   name: string;
@@ -37,6 +39,7 @@ export async function getUserBranches(): Promise<{
   try {
     const cookieStore = await cookies();
     const token = cookieStore.get("auth_token")?.value || null;
+    const recentBranchId = cookieStore.get("selected_branch_id")?.value;
 
     const { data } = await serverAPIClient.get("/auth/branches", {
       headers: getAuthHeaders(token),
@@ -44,7 +47,7 @@ export async function getUserBranches(): Promise<{
 
     return {
       success: true,
-      branches: data.branches,
+      branches: prioritizeRecentBranch(data.branches ?? [], recentBranchId),
     };
   } catch (error) {
     console.error("[Server Action] Error fetching branches:", error);

--- a/mobile/src/app/(shell)/select-branch/branch-order.test.ts
+++ b/mobile/src/app/(shell)/select-branch/branch-order.test.ts
@@ -1,0 +1,21 @@
+import { prioritizeRecentBranch } from "./branch-order";
+
+describe("prioritizeRecentBranch", () => {
+  const branches = [
+    { id: "branch-a", name: "가 지점" },
+    { id: "branch-b", name: "나 지점" },
+    { id: "branch-c", name: "다 지점" },
+  ];
+
+  it("moves the most recently selected branch to the front while preserving the remaining order", () => {
+    expect(prioritizeRecentBranch(branches, "branch-c")).toEqual([
+      branches[2],
+      branches[0],
+      branches[1],
+    ]);
+  });
+
+  it("preserves the original order when the recent branch is unavailable", () => {
+    expect(prioritizeRecentBranch(branches, "branch-missing")).toEqual(branches);
+  });
+});

--- a/mobile/src/app/(shell)/select-branch/branch-order.ts
+++ b/mobile/src/app/(shell)/select-branch/branch-order.ts
@@ -1,0 +1,26 @@
+interface BranchIdentifier {
+  id: string;
+}
+
+export function prioritizeRecentBranch<TBranch extends BranchIdentifier>(
+  branches: TBranch[],
+  recentBranchId?: string,
+): TBranch[] {
+  if (!recentBranchId) {
+    return branches;
+  }
+
+  const recentBranchIndex = branches.findIndex(
+    (branch) => branch.id === recentBranchId,
+  );
+
+  if (recentBranchIndex <= 0) {
+    return branches;
+  }
+
+  return [
+    branches[recentBranchIndex],
+    ...branches.slice(0, recentBranchIndex),
+    ...branches.slice(recentBranchIndex + 1),
+  ];
+}


### PR DESCRIPTION
`preview` → `main` 7커밋.

## 왜 지금 올리는가

**프로덕션에 살아 있는 버그가 있습니다.** 오늘 PR #419에서 고친 `expired_date` 판별이 프로덕션 코드에 없습니다.

eformsign은 `expired_date`를 두 형식으로 보냅니다 — 서명 가능한 문서에는 남은 일수, **이미 만료된 문서에는 만료 시각(ms epoch)**. 페이로드에 어느 쪽인지 표시가 없습니다. epoch를 일수로 읽으면:

```
webhook → mirror-unassigned-eformsign-doc.usecase
  → eformsignExpiryDateFromRemainingDays(1749524449968)
  → referenceTime + 1749524449968 × 86400000  > Date 최대치
  → Invalid Date → 엔티티 검증 throw → 503 → eformsign 무한 재시도
```

미러에 아직 없는 문서가 만료될 때 발생합니다. 회사 코퍼스 실측에서 그런 문서가 18건 확인됐고, 외부 생성 문서의 웹훅 미러링은 2026-07-28부터 라이브입니다.

## 담기는 것

- **PR #419** — 백필 CLI 부팅 실패(`TenantModule` 누락)와 `expired_date` 두 형식 처리. 크기로 판별하며(1e10 경계), 두 분기 모두 같은 경계 검사를 지나 invalid Date를 반환하지 않습니다.
- 모바일: 최근 선택한 지점 우선 표시
- 프론트엔드: 대시보드 서비스 카드 상단 정렬

DB 마이그레이션은 없습니다. 프로덕션 스키마는 오늘 11:52에 이미 최신화했습니다(run 30449116829).

## 이 병합이 검증하는 것

오늘 Railway 배포 트리거를 교정했습니다 — 그전까지 **세 환경이 전부 `dev`를 보고 있었고**, `main` 병합은 Vercel 프론트엔드만 배포했습니다. 교정 후 dev·preview 방향은 실제로 확인됐습니다:

```
14:32:46  Babyjamjam Server / preview  ref=8128de30   ← preview 병합 → preview만
14:26:35  Babyjamjam Server / dev      ref=baf7ffb9   ← dev 병합 → dev만
```

**`main` 방향은 아직 발동한 적이 없습니다.** 이 병합 후 `Babyjamjam Server / production` 배포 기록이 생기는지가 확인 포인트입니다. 안 생기면 트리거를 update가 아니라 새로 create해야 합니다.

## 검증

`tsc` 통과, eslint 0 errors / 76 warnings(기준선), jest 179 suites / 1916 passed / 8 skipped. PR #419는 Codex 리뷰 클린(`d2f0f21193`), PR #420은 17/17 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG