### PR TITLE
fix(backend): compat read가 살릴 수 있는 컬럼을 살리도록 + Dependabot 타깃을 dev로

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,15 @@
+# target-branch is dev on every ecosystem, and has to stay that way.
+#
+# Without it Dependabot opens against the default branch, main — and main is what the
+# production Railway backend deploys from, with no watch patterns, so every push to it
+# rebuilds and ships the service. A bump merged there would reach production without ever
+# having run in preview. Pointing at dev puts these through dev -> preview -> main like
+# every other change.
 version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
@@ -13,5 +21,6 @@ updates:
           - "@types/nodemailer"
   - package-ecosystem: github-actions
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@
 # rebuilds and ships the service. A bump merged there would reach production without ever
 # having run in preview. Pointing at dev puts these through dev -> preview -> main like
 # every other change.
+#
+# This covers version updates only. GitHub applies target-branch to those alone; Dependabot
+# *security* updates keep opening against the default branch and ignore this file, so the
+# direct-to-production path is narrowed here, not closed. Closing it needs branch
+# protection on main, which is a repository setting rather than anything expressible here.
 version: 2
 updates:
   - package-ecosystem: npm

--- a/backend/infrastructure/database/eformsign-doc-compat.ts
+++ b/backend/infrastructure/database/eformsign-doc-compat.ts
@@ -1,5 +1,9 @@
 import { Prisma } from "@prisma/client";
 
+/**
+ * The columns that predate every pending migration. Always present, whatever the database
+ * is missing — the floor a compatibility read can never fall below.
+ */
 export const EFORMSIGN_DOC_COMPAT_READ_SELECT = {
     id: true,
     documentId: true,
@@ -96,8 +100,12 @@ export const isPendingEformsignDocColumnError = (error: unknown): boolean => {
     return PENDING_EFORMSIGN_DOC_COLUMN_NAMES.some((columnName) => haystack.includes(columnName));
 };
 
-export const toCompatDomainRow = (row: EformsignDocCompatReadRow) => ({
-    ...row,
+/** The pending columns as the database actually types them, not as `unknown`. */
+type EformsignDocPendingReadRow = Prisma.eformsign_docGetPayload<{
+    select: { [K in keyof PendingEformsignDocData]: true };
+}>;
+
+const PENDING_EFORMSIGN_DOC_NULLS = {
     documentKind: null,
     employeeScheduleId: null,
     templateId: null,
@@ -108,6 +116,47 @@ export const toCompatDomainRow = (row: EformsignDocCompatReadRow) => ({
     creatorName: null,
     lastEditorName: null,
     stepRecipientTypes: null,
+} as const satisfies Record<keyof PendingEformsignDocData, null>;
+
+/**
+ * The columns to read once a missing-column error says which migration the database has
+ * not had yet: the floor, plus every pending group that shipped *before* the missing one.
+ *
+ * Reads used to drop all pending columns at the first sign of any missing one. That threw
+ * away `templateId`, which shipped three migrations earlier and was still there — and the
+ * ten-minute duplicate-send guard decides by comparing it, so with every stored document
+ * reading null it stopped matching and stopped suppressing anything. A branch could be sent
+ * a second contract for the duration of a deploy window. Writes already narrowed to the
+ * missing group; reads now do the same.
+ */
+export const eformsignDocCompatReadSelect = (
+    error: unknown,
+): Prisma.eformsign_docSelect => {
+    // Prisma sometimes raises P2022 with no column metadata and nothing nameable in the
+    // message. That says a pending column is missing without saying which, so a read drops
+    // to the floor — the assumption that cannot be wrong. Writes throw in the same
+    // situation instead, because silently dropping data a caller asked to store is worse
+    // than failing; a read losing columns it could have kept is recoverable.
+    const keptGroupCount = Math.max(findEformsignDocGroupIndex(error), 0);
+    const select: Prisma.eformsign_docSelect = { ...EFORMSIGN_DOC_COMPAT_READ_SELECT };
+    for (const group of PENDING_EFORMSIGN_DOC_COLUMN_GROUPS.slice(0, keptGroupCount)) {
+        for (const column of group.columns) {
+            select[column.prismaName] = true;
+        }
+    }
+    return select;
+};
+
+/**
+ * Nulls first, row second: a column the select managed to keep wins over its placeholder.
+ * The previous order spread the row first and then overwrote every pending column with
+ * null, which made the narrowed select above pointless.
+ */
+export const toCompatDomainRow = (
+    row: EformsignDocCompatReadRow & Partial<EformsignDocPendingReadRow>,
+) => ({
+    ...PENDING_EFORMSIGN_DOC_NULLS,
+    ...row,
 });
 
 const getMissingEformsignDocColumnName = (error: unknown): string | null => {
@@ -140,19 +189,25 @@ const getMissingEformsignDocColumnName = (error: unknown): string | null => {
     return null;
 };
 
-export const omitPendingEformsignDocColumns = <T extends PendingEformsignDocData>(
-    data: T,
-    error: unknown,
-) => {
+/** Which migration group the error names, or -1 when it names none. */
+const findEformsignDocGroupIndex = (error: unknown): number => {
     const missingColumnName = getMissingEformsignDocColumnName(error);
-    const missingGroupIndex = PENDING_EFORMSIGN_DOC_COLUMN_GROUPS.findIndex(
+    return PENDING_EFORMSIGN_DOC_COLUMN_GROUPS.findIndex(
         (group) => group.columns.some(
             (column) =>
                 column.databaseName === missingColumnName
                 || column.prismaName === missingColumnName,
         ),
     );
+};
 
+export const omitPendingEformsignDocColumns = <T extends PendingEformsignDocData>(
+    data: T,
+    error: unknown,
+) => {
+    const missingGroupIndex = findEformsignDocGroupIndex(error);
+    // Unlike a read, a write cannot guess. Dropping the wrong columns here stores a row
+    // that is silently missing values the caller supplied.
     if (missingGroupIndex < 0) {
         throw error;
     }

--- a/backend/infrastructure/database/eformsign-doc-compat.ts
+++ b/backend/infrastructure/database/eformsign-doc-compat.ts
@@ -129,6 +129,31 @@ const PENDING_EFORMSIGN_DOC_NULLS = {
  * a second contract for the duration of a deploy window. Writes already narrowed to the
  * missing group; reads now do the same.
  */
+/**
+ * Runs a compatibility read, narrowed by what the error named, and drops to the floor if
+ * that narrowed read still hits a missing column.
+ *
+ * The second attempt is not belt-and-braces. A P2022 names *a* missing column, not the
+ * earliest one — Postgres reports whichever it resolved first, and `eformsign_doc` lists
+ * `document_name` ahead of `template_id` in the schema. So a database missing three
+ * migrations can report the second group's column, and keeping the first group would then
+ * select columns that are equally absent. The floor predates every pending migration and
+ * cannot fail, which is what makes one retry enough for any number of missing groups.
+ */
+export const readWithEformsignDocCompat = async <TRow>(
+    error: unknown,
+    read: (select: Prisma.eformsign_docSelect) => Promise<TRow>,
+): Promise<TRow> => {
+    try {
+        return await read(eformsignDocCompatReadSelect(error));
+    } catch (narrowedError) {
+        if (!isPendingEformsignDocColumnError(narrowedError)) {
+            throw narrowedError;
+        }
+        return read({ ...EFORMSIGN_DOC_COMPAT_READ_SELECT });
+    }
+};
+
 export const eformsignDocCompatReadSelect = (
     error: unknown,
 ): Prisma.eformsign_docSelect => {

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -19,7 +19,7 @@ import {
     UpsertUnassignedEformsignDocOptions,
 } from "domain/repositories/eformsign-doc.repository.interface";
 import {
-    eformsignDocCompatReadSelect,
+    readWithEformsignDocCompat,
     isPendingEformsignDocColumnError,
     omitPendingEformsignDocColumns,
     toCompatDomainRow,
@@ -73,13 +73,11 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                 throw error;
             }
 
-            const doc = await this.prismaService.eformsign_doc.findUnique({
-                where: { documentId },
-                select: {
-                    ...eformsignDocCompatReadSelect(error),
-                    branchId: true,
-                },
-            });
+            const doc = await readWithEformsignDocCompat(error, (select) =>
+                this.prismaService.eformsign_doc.findUnique({
+                    where: { documentId },
+                    select: { ...select, branchId: true },
+                }));
             return doc
                 ? toUnscopedResult(documentId, {
                     ...toCompatDomainRow(doc),
@@ -315,10 +313,11 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                 throw error;
             }
 
-            const created = await this.prismaService.eformsign_doc.create({
-                data: omitPendingEformsignDocColumns(data, error),
-                select: eformsignDocCompatReadSelect(error),
-            });
+            const created = await readWithEformsignDocCompat(error, (select) =>
+                this.prismaService.eformsign_doc.create({
+                    data: omitPendingEformsignDocColumns(data, error),
+                    select,
+                }));
             return EformsignDocMapper.toDomain(toCompatDomainRow(created));
         }
     }
@@ -564,10 +563,12 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
         if (updated.count === 0) {
             try {
                 if (compatibilityError !== undefined) {
-                    const created = await this.prismaService.eformsign_doc.create({
-                        data: params.create,
-                        select: eformsignDocCompatReadSelect(compatibilityError),
-                    });
+                    const created = await readWithEformsignDocCompat(
+                        compatibilityError,
+                        (select) => this.prismaService.eformsign_doc.create({
+                            data: params.create,
+                            select,
+                        }));
                     return EformsignDocMapper.toDomain(toCompatDomainRow(created));
                 }
 
@@ -615,10 +616,8 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                 throw error;
             }
 
-            const doc = await this.prismaService.eformsign_doc.findFirst({
-                where,
-                select: eformsignDocCompatReadSelect(error),
-            });
+            const doc = await readWithEformsignDocCompat(error, (select) =>
+                this.prismaService.eformsign_doc.findFirst({ where, select }));
             return doc ? EformsignDocMapper.toDomain(toCompatDomainRow(doc)) : null;
         }
     }
@@ -632,10 +631,8 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                 throw error;
             }
 
-            const docs = await this.prismaService.eformsign_doc.findMany({
-                where,
-                select: eformsignDocCompatReadSelect(error),
-            });
+            const docs = await readWithEformsignDocCompat(error, (select) =>
+                this.prismaService.eformsign_doc.findMany({ where, select }));
             return docs.map((doc) => EformsignDocMapper.toDomain(toCompatDomainRow(doc)));
         }
     }

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -19,7 +19,7 @@ import {
     UpsertUnassignedEformsignDocOptions,
 } from "domain/repositories/eformsign-doc.repository.interface";
 import {
-    EFORMSIGN_DOC_COMPAT_READ_SELECT,
+    eformsignDocCompatReadSelect,
     isPendingEformsignDocColumnError,
     omitPendingEformsignDocColumns,
     toCompatDomainRow,
@@ -76,7 +76,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
             const doc = await this.prismaService.eformsign_doc.findUnique({
                 where: { documentId },
                 select: {
-                    ...EFORMSIGN_DOC_COMPAT_READ_SELECT,
+                    ...eformsignDocCompatReadSelect(error),
                     branchId: true,
                 },
             });
@@ -317,7 +317,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
 
             const created = await this.prismaService.eformsign_doc.create({
                 data: omitPendingEformsignDocColumns(data, error),
-                select: EFORMSIGN_DOC_COMPAT_READ_SELECT,
+                select: eformsignDocCompatReadSelect(error),
             });
             return EformsignDocMapper.toDomain(toCompatDomainRow(created));
         }
@@ -490,7 +490,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
         repairCreatedDateWhenStale?: Date;
     }): Promise<EformsignDocEntity> {
         try {
-            return await this.attemptConditionalUpsertByDocumentId(params, false);
+            return await this.attemptConditionalUpsertByDocumentId(params);
         } catch (error) {
             if (!isPendingEformsignDocColumnError(error)) {
                 throw error;
@@ -500,7 +500,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                 ...params,
                 create: omitPendingEformsignDocColumns(params.create, error),
                 update: omitPendingEformsignDocColumns(params.update, error),
-            }, true);
+            }, error);
         }
     }
 
@@ -513,7 +513,9 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
             staleGuard?: Prisma.eformsign_docWhereInput;
             repairCreatedDateWhenStale?: Date;
         },
-        compatibilityMode: boolean,
+        // The original missing-column error, not just a flag: the read select below has to
+        // know which migration is absent so it keeps the columns that are not.
+        compatibilityError?: unknown,
     ): Promise<EformsignDocEntity> {
         // Ownership is enforced by the UPDATE predicate itself. If no row matches,
         // create under the unique documentId constraint; a racing create surfaces as
@@ -561,10 +563,10 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
         let updated = await updateExisting();
         if (updated.count === 0) {
             try {
-                if (compatibilityMode) {
+                if (compatibilityError !== undefined) {
                     const created = await this.prismaService.eformsign_doc.create({
                         data: params.create,
-                        select: EFORMSIGN_DOC_COMPAT_READ_SELECT,
+                        select: eformsignDocCompatReadSelect(compatibilityError),
                     });
                     return EformsignDocMapper.toDomain(toCompatDomainRow(created));
                 }
@@ -615,7 +617,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
 
             const doc = await this.prismaService.eformsign_doc.findFirst({
                 where,
-                select: EFORMSIGN_DOC_COMPAT_READ_SELECT,
+                select: eformsignDocCompatReadSelect(error),
             });
             return doc ? EformsignDocMapper.toDomain(toCompatDomainRow(doc)) : null;
         }
@@ -632,7 +634,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
 
             const docs = await this.prismaService.eformsign_doc.findMany({
                 where,
-                select: EFORMSIGN_DOC_COMPAT_READ_SELECT,
+                select: eformsignDocCompatReadSelect(error),
             });
             return docs.map((doc) => EformsignDocMapper.toDomain(toCompatDomainRow(doc)));
         }

--- a/backend/test/infrastructure/eformsign-doc-compat.spec.ts
+++ b/backend/test/infrastructure/eformsign-doc-compat.spec.ts
@@ -2,6 +2,7 @@ import {
     EFORMSIGN_DOC_COMPAT_READ_SELECT,
     eformsignDocCompatReadSelect,
     omitPendingEformsignDocColumns,
+    readWithEformsignDocCompat,
     toCompatDomainRow,
 } from "infrastructure/database/eformsign-doc-compat";
 
@@ -66,6 +67,46 @@ describe("eformsignDocCompatReadSelect", () => {
         );
 
         expect(select).toEqual(EFORMSIGN_DOC_COMPAT_READ_SELECT);
+    });
+});
+
+describe("readWithEformsignDocCompat", () => {
+    it("drops to the floor when the narrowed read still hits a missing column", async () => {
+        // A P2022 names *a* missing column, not the earliest one, and eformsign_doc lists
+        // document_name ahead of template_id in the schema. So a database missing three
+        // migrations can report the second group's column, and keeping the first group
+        // would select columns that are equally absent. Without this second attempt the
+        // narrowed read fails outright — a regression against always using the floor.
+        const read = jest.fn()
+            .mockRejectedValueOnce(missingColumnError("template_id"))
+            .mockResolvedValueOnce({ documentId: "doc-1" });
+
+        const result = await readWithEformsignDocCompat(
+            missingColumnError("document_name"),
+            read,
+        );
+
+        expect(result).toEqual({ documentId: "doc-1" });
+        expect(read).toHaveBeenCalledTimes(2);
+        expect(read.mock.calls[0]![0]).toMatchObject({ templateId: true });
+        expect(read.mock.calls[1]![0]).toEqual(EFORMSIGN_DOC_COMPAT_READ_SELECT);
+    });
+
+    it("does not retry an error that is not about a missing column", async () => {
+        const other = new Error("connection reset");
+        const read = jest.fn().mockRejectedValue(other);
+
+        await expect(readWithEformsignDocCompat(missingColumnError("customer_name"), read))
+            .rejects.toThrow(other);
+        expect(read).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not read twice when the narrowed select works", async () => {
+        const read = jest.fn().mockResolvedValue({ documentId: "doc-1" });
+
+        await readWithEformsignDocCompat(missingColumnError("customer_name"), read);
+
+        expect(read).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/backend/test/infrastructure/eformsign-doc-compat.spec.ts
+++ b/backend/test/infrastructure/eformsign-doc-compat.spec.ts
@@ -1,0 +1,135 @@
+import {
+    EFORMSIGN_DOC_COMPAT_READ_SELECT,
+    eformsignDocCompatReadSelect,
+    omitPendingEformsignDocColumns,
+    toCompatDomainRow,
+} from "infrastructure/database/eformsign-doc-compat";
+
+/** What Prisma raises when a column the client knows about is not in the database. */
+function missingColumnError(column: string): unknown {
+    return Object.assign(
+        new Error(`The column \`${column}\` does not exist in the current database.`),
+        { code: "P2022", meta: { column } },
+    );
+}
+
+describe("eformsignDocCompatReadSelect", () => {
+    it("keeps the columns from migrations that did ship", () => {
+        // The defect this exists for: a deploy that runs ahead of the newest patch used to
+        // drop every pending column, templateId included — and templateId shipped three
+        // migrations earlier. The ten-minute duplicate-send guard decides by comparing it,
+        // so a null read there means no duplicate is ever detected and a branch can be sent
+        // a second contract for the whole window.
+        const select = eformsignDocCompatReadSelect(missingColumnError("customer_name"));
+
+        expect(select).toMatchObject({
+            templateId: true,
+            documentKind: true,
+            employeeScheduleId: true,
+            documentName: true,
+            documentNumber: true,
+        });
+    });
+
+    it("omits the missing migration's columns and every later one", () => {
+        const select = eformsignDocCompatReadSelect(missingColumnError("document_name"));
+
+        expect(select).toMatchObject({ templateId: true });
+        for (const column of [
+            "documentName",
+            "documentNumber",
+            "templateName",
+            "customerName",
+            "creatorName",
+            "lastEditorName",
+            "stepRecipientTypes",
+        ]) {
+            expect(select[column as keyof typeof select]).toBeUndefined();
+        }
+    });
+
+    it("falls back to the floor when the oldest migration is the missing one", () => {
+        const select = eformsignDocCompatReadSelect(missingColumnError("template_id"));
+
+        expect(select).toEqual(EFORMSIGN_DOC_COMPAT_READ_SELECT);
+    });
+
+    it("drops to the floor when Prisma does not say which column is missing", () => {
+        // Prisma raises P2022 with no meta.column and nothing nameable in the message. The
+        // read knows a pending column is gone but not which, so it assumes the worst —
+        // the one assumption that cannot be wrong. Throwing here would take down reads
+        // that used to work.
+        const select = eformsignDocCompatReadSelect(
+            Object.assign(new Error("[PrismaException] Code: P2022, Field: N/A"), {
+                code: "P2022",
+            }),
+        );
+
+        expect(select).toEqual(EFORMSIGN_DOC_COMPAT_READ_SELECT);
+    });
+});
+
+describe("toCompatDomainRow", () => {
+    const baseRow = {
+        id: 1,
+        documentId: "doc-1",
+        createdDate: new Date("2026-07-01T00:00:00.000Z"),
+        updatedDate: new Date("2026-07-02T00:00:00.000Z"),
+        statusType: "060",
+        statusDetail: "서명 요청됨",
+        stepType: "01",
+        stepIndex: "1",
+        stepName: "이용자 서명",
+        stepRecipientType: "05",
+        stepRecipientName: "송진호",
+        stepRecipientSms: "01012345678",
+        expiredDate: new Date("2026-08-01T00:00:00.000Z"),
+        expired: false,
+        clientId: null,
+    };
+
+    it("keeps a column the select managed to read", () => {
+        // Nulls are placeholders for what could not be read, not overrides. Filling them in
+        // after the row is what made the narrowed select above pointless.
+        const row = toCompatDomainRow({ ...baseRow, templateId: "template-1" });
+
+        expect(row.templateId).toBe("template-1");
+    });
+
+    it("supplies null only for the columns that were left out", () => {
+        const row = toCompatDomainRow({ ...baseRow, templateId: "template-1" });
+
+        expect(row).toMatchObject({
+            templateId: "template-1",
+            customerName: null,
+            documentName: null,
+            stepRecipientTypes: null,
+        });
+    });
+});
+
+describe("omitPendingEformsignDocColumns", () => {
+    it("still narrows writes to the missing migration and later ones", () => {
+        // Unchanged behaviour, asserted here because reads now share its group logic.
+        const data = {
+            templateId: "template-1",
+            documentName: "계약서",
+            customerName: "김고객",
+        };
+
+        expect(omitPendingEformsignDocColumns(data, missingColumnError("customer_name")))
+            .toEqual({ templateId: "template-1", documentName: "계약서" });
+    });
+
+    it("still throws where a read would drop to the floor", () => {
+        // The asymmetry is deliberate: a read that loses columns it could have kept is
+        // recoverable, a write that silently drops values the caller supplied is not.
+        const error = Object.assign(
+            new Error("[PrismaException] Code: P2022, Field: N/A"),
+            { code: "P2022" },
+        );
+
+        expect(() => omitPendingEformsignDocColumns({ templateId: "t-1" }, error))
+            .toThrow(error);
+    });
+});


### PR DESCRIPTION
관련 없어 보이지만 둘 다 **오늘 프로덕션에서 실제로 겪은 일**의 후속입니다.

## 1. compat read가 templateId를 잃던 문제

컬럼이 없다는 에러를 만나면 읽기가 **대기 중인 컬럼 전부**를 버렸습니다. 없는 것만이 아니라요. 그 바람에 `templateId`도 같이 날아갔는데, 이 컬럼은 배포 창에서 실제로 없는 컬럼들보다 **세 마이그레이션 먼저** 들어온 것입니다.

이게 문제인 이유:

```
dispatch-document-headless.usecase.ts:109
  document.templateId === (templateId ?? null)
```

10분 중복 발송 가드가 이 동등 비교로 판정합니다. 저장된 문서가 전부 null로 읽히면 비교가 영영 일치하지 않고, 중복이 한 건도 검출되지 않으며, **앱 배포와 `database-patches` 사이 구간 내내 지점에 계약서가 한 번 더 발송될 수 있습니다.** 2026-07-28~29 프로덕션에서 실제로 열려 있던 창입니다.

쓰기(`omitPendingEformsignDocColumns`)는 이미 없는 마이그레이션의 그룹과 그 이후만 정밀하게 뺐습니다. 읽기도 같은 그룹 로직을 쓰게 했습니다 — 최신 패치 하나만 없는 DB는 그 이전 마이그레이션이 추가한 컬럼을 전부 그대로 돌려받습니다.

`toCompatDomainRow`의 null 채우기도 순서를 뒤집었습니다. row를 먼저 펼치고 null로 덮어쓰고 있었는데, 그러면 좁힌 select가 애써 살려온 컬럼을 다시 지웁니다.

### 읽기와 쓰기의 기본값이 다릅니다 (의도적)

Prisma는 컬럼 이름 없이 P2022만 던지기도 합니다. 그때:

- **읽기 → 최소 집합으로 내려감.** 뭔가 없다는 건 알지만 무엇인지 모르므로, 틀릴 수 없는 가정을 택합니다. 여기서 예외를 던지면 **되던 읽기가 죽습니다**(실제로 `sb.eformsign-doc.repository.spec.ts`의 기존 테스트가 이 회귀를 잡아냈습니다)
- **쓰기 → 그대로 예외.** 호출자가 넘긴 값을 조용히 버리는 것이 실패보다 나쁩니다

`attemptConditionalUpsertByDocumentId`는 boolean 대신 원본 에러를 받습니다 — select가 어느 마이그레이션이 없는지 알아야 하기 때문입니다.

## 2. Dependabot 타깃을 dev로

`target-branch`가 없어서 전부 기본 브랜치인 `main`을 향하고 있었습니다. 오늘 아침까지는 안전했습니다 — main 병합은 Vercel 프론트엔드만 배포했으니까요.

**오늘 Railway 배포 트리거를 교정하면서 main 병합이 프로덕션 백엔드 배포가 됐습니다.** `watchPatterns=[]`라 경로와 무관하게 매 푸시마다 재빌드·재배포합니다. 지금 열려 있는 14건을 병합하면 preview에서 한 번도 안 돌려본 의존성 변경으로 프로덕션을 14번 배포하게 됩니다.

`dev`로 돌리면 dev → preview → main 경로를 타게 됩니다.

기존 14건은 **닫지 않았습니다.** Dependabot은 닫힌 PR의 버전을 "원치 않음"으로 기억해 재생성을 막습니다. 다음 주간 실행에서 dev 대상으로 새로 열리며 자연히 대체됩니다.

## 검증

`tsc` 통과, eslint 0 errors / 76 warnings(기준선 유지), jest **180 suites / 1924 passed / 8 skipped**. 신규 `test/infrastructure/eformsign-doc-compat.spec.ts` 8건이 그룹 경계·null 순서·읽기·쓰기 비대칭을 고정합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG