### PR TITLE
fix: allow legacy no-op client relink

### DIFF
--- a/frontend/src/components/app/clients/ClientFormDialog.tsx
+++ b/frontend/src/components/app/clients/ClientFormDialog.tsx
@@ -70,6 +70,22 @@ export interface ClientFormPanelProps extends Omit<ClientFormDialogProps, "open"
 
 type ClientFormData = Omit<CreateClientDto, "primaryEmployeeId"> & { primaryEmployeeId: number | null };
 
+interface InitialEditFormSnapshot {
+    clientId: number;
+    formData: ClientFormData;
+}
+
+const isSameClientFormData = (
+    left: ClientFormData,
+    right: ClientFormData,
+): boolean => {
+    const leftKeys = Object.keys(left) as Array<keyof ClientFormData>;
+    const rightKeys = Object.keys(right) as Array<keyof ClientFormData>;
+
+    return leftKeys.length === rightKeys.length
+        && leftKeys.every((key) => left[key] === right[key]);
+};
+
 const PANEL_STEP_CONTENT_CLASS_NAME =
     "grid w-full grid-cols-1 gap-[calc(16px*var(--glint-ui-scale,1))] pb-[calc(24px*var(--glint-ui-scale,1))] md:grid-cols-2";
 const PANEL_FULL_FIELD_CLASS_NAME = "md:col-span-2";
@@ -320,6 +336,7 @@ function ClientFormContent({
     const [isEmployeeDialogOpen, setIsEmployeeDialogOpen] = useState(false);
     const [employeeDialogTarget, setEmployeeDialogTarget] = useState<"primary" | "secondary" | null>(null);
     const contentRef = useRef<HTMLDivElement>(null);
+    const [initialEditFormSnapshot, setInitialEditFormSnapshot] = useState<InitialEditFormSnapshot | null>(null);
     const [internalActiveStep, setInternalActiveStep] = useState(0);
     const activeStep = controlledActiveStep ?? internalActiveStep;
     const setActiveStep = useCallback(
@@ -583,15 +600,27 @@ function ClientFormContent({
                 startDate: normalizeDateForCompactState(nextFormData.startDate),
                 endDate: normalizeDateForCompactState(nextFormData.endDate),
             };
+            const nextInitialEditFormSnapshot = client
+                ? { clientId: client.id, formData: { ...nextFormData } }
+                : null;
 
             queueMicrotask(() => {
                 setFormData(nextFormData);
+                setInitialEditFormSnapshot(nextInitialEditFormSnapshot);
                 setPricesManuallyEdited(nextPricesManuallyEdited);
                 setVoucherYear(null); // Reset to default (current year, falling back to latest available)
                 setError(null);
             });
         }
     }, [clearPrefillName, client, open, prefillName]);
+
+    const isLegacyNoopEdit = Boolean(
+        isEditMode
+        && client
+        && !client.dueDate
+        && initialEditFormSnapshot?.clientId === client.id
+        && isSameClientFormData(formData, initialEditFormSnapshot.formData),
+    );
 
     const handleChange = (field: keyof CreateClientDto, value: unknown) => {
         setFormData(prev => ({ ...prev, [field]: value }));
@@ -654,13 +683,15 @@ function ClientFormContent({
             setErrorAndScroll(t(locale, "clients.form.error-birthday-required"));
             return;
         }
-        if (!formData.dueDate?.trim()) {
-            setErrorAndScroll(t(locale, "clients.form.error-due-date-required"));
-            return;
-        }
-        if (!isValidCompactDateInput(formData.dueDate)) {
-            setErrorAndScroll(t(locale, "clients.form.error-due-date-invalid"));
-            return;
+        if (!isLegacyNoopEdit) {
+            if (!formData.dueDate?.trim()) {
+                setErrorAndScroll(t(locale, "clients.form.error-due-date-required"));
+                return;
+            }
+            if (!isValidCompactDateInput(formData.dueDate)) {
+                setErrorAndScroll(t(locale, "clients.form.error-due-date-invalid"));
+                return;
+            }
         }
         if (!formData.address?.trim()) {
             setErrorAndScroll(t(locale, "clients.form.error-address-required"));
@@ -689,7 +720,18 @@ function ClientFormContent({
             }
         }
         try {
-            const normalizedDueDate = normalizeCompactDateForSubmit(formData.dueDate);
+            if (isLegacyNoopEdit && client) {
+                // Some legacy customers predate the current required due-date field. An empty
+                // update preserves that record exactly while still invoking the backend's
+                // phone-based document relink. Any form edit exits this narrow compatibility
+                // path and must satisfy the normal validation below.
+                const updatedClient = await updateClient.mutateAsync({ id: client.id, dto: {} });
+                onSuccess?.(updatedClient);
+                onClose();
+                return;
+            }
+
+            const normalizedDueDate = normalizeCompactDateForSubmit(formData.dueDate ?? "");
             const normalizedStartDate = normalizeCompactDateForSubmit(formData.startDate ?? "");
             const normalizedEndDate = normalizeCompactDateForSubmit(formData.endDate ?? "");
 
@@ -756,7 +798,7 @@ function ClientFormContent({
     const isBasicStepValid = Boolean(
         formData.name.trim() &&
         formData.birthday?.trim() &&
-        isValidCompactDateInput(formData.dueDate ?? "") &&
+        (isLegacyNoopEdit || isValidCompactDateInput(formData.dueDate ?? "")) &&
         formData.address?.trim() &&
         isPhoneCheckReady
     );

--- a/frontend/src/components/app/clients/ClientFormDialog.tsx
+++ b/frontend/src/components/app/clients/ClientFormDialog.tsx
@@ -70,22 +70,6 @@ export interface ClientFormPanelProps extends Omit<ClientFormDialogProps, "open"
 
 type ClientFormData = Omit<CreateClientDto, "primaryEmployeeId"> & { primaryEmployeeId: number | null };
 
-interface InitialEditFormSnapshot {
-    clientId: number;
-    formData: ClientFormData;
-}
-
-const isSameClientFormData = (
-    left: ClientFormData,
-    right: ClientFormData,
-): boolean => {
-    const leftKeys = Object.keys(left) as Array<keyof ClientFormData>;
-    const rightKeys = Object.keys(right) as Array<keyof ClientFormData>;
-
-    return leftKeys.length === rightKeys.length
-        && leftKeys.every((key) => left[key] === right[key]);
-};
-
 const PANEL_STEP_CONTENT_CLASS_NAME =
     "grid w-full grid-cols-1 gap-[calc(16px*var(--glint-ui-scale,1))] pb-[calc(24px*var(--glint-ui-scale,1))] md:grid-cols-2";
 const PANEL_FULL_FIELD_CLASS_NAME = "md:col-span-2";
@@ -336,7 +320,8 @@ function ClientFormContent({
     const [isEmployeeDialogOpen, setIsEmployeeDialogOpen] = useState(false);
     const [employeeDialogTarget, setEmployeeDialogTarget] = useState<"primary" | "secondary" | null>(null);
     const contentRef = useRef<HTMLDivElement>(null);
-    const [initialEditFormSnapshot, setInitialEditFormSnapshot] = useState<InitialEditFormSnapshot | null>(null);
+    const [initializedEditClientId, setInitializedEditClientId] = useState<number | null>(null);
+    const [hasUserEditedSinceOpen, setHasUserEditedSinceOpen] = useState(false);
     const [internalActiveStep, setInternalActiveStep] = useState(0);
     const activeStep = controlledActiveStep ?? internalActiveStep;
     const setActiveStep = useCallback(
@@ -495,6 +480,7 @@ function ClientFormContent({
 
     // Reset duration/prices when the voucher year changes (same semantics as handleTypeChange)
     const handleVoucherYearChange = (newYear: string) => {
+        setHasUserEditedSinceOpen(true);
         const parsedYear = Number(newYear);
         setVoucherYear(Number.isNaN(parsedYear) ? null : parsedYear);
         setFormData(prev => ({
@@ -511,6 +497,7 @@ function ClientFormContent({
 
     // Reset duration when type changes
     const handleTypeChange = (newType: string) => {
+        setHasUserEditedSinceOpen(true);
         setFormData(prev => ({
             ...prev,
             type: newType,
@@ -525,6 +512,7 @@ function ClientFormContent({
     };
 
     const handleVoucherClientChange = (voucherClient: boolean) => {
+        setHasUserEditedSinceOpen(true);
         setPricesManuallyEdited(false);
         setFormData(prev => ({
             ...prev,
@@ -600,13 +588,10 @@ function ClientFormContent({
                 startDate: normalizeDateForCompactState(nextFormData.startDate),
                 endDate: normalizeDateForCompactState(nextFormData.endDate),
             };
-            const nextInitialEditFormSnapshot = client
-                ? { clientId: client.id, formData: { ...nextFormData } }
-                : null;
-
             queueMicrotask(() => {
                 setFormData(nextFormData);
-                setInitialEditFormSnapshot(nextInitialEditFormSnapshot);
+                setInitializedEditClientId(client?.id ?? null);
+                setHasUserEditedSinceOpen(false);
                 setPricesManuallyEdited(nextPricesManuallyEdited);
                 setVoucherYear(null); // Reset to default (current year, falling back to latest available)
                 setError(null);
@@ -618,11 +603,12 @@ function ClientFormContent({
         isEditMode
         && client
         && !client.dueDate
-        && initialEditFormSnapshot?.clientId === client.id
-        && isSameClientFormData(formData, initialEditFormSnapshot.formData),
+        && initializedEditClientId === client.id
+        && !hasUserEditedSinceOpen,
     );
 
     const handleChange = (field: keyof CreateClientDto, value: unknown) => {
+        setHasUserEditedSinceOpen(true);
         setFormData(prev => ({ ...prev, [field]: value }));
     };
 
@@ -637,6 +623,7 @@ function ClientFormContent({
     };
 
     const handleEmployeeCreated = (newEmployee: Employee) => {
+        setHasUserEditedSinceOpen(true);
         setFormData(prev => {
             if (employeeDialogTarget === "primary") {
                 return { ...prev, primaryEmployeeId: newEmployee.id };
@@ -673,6 +660,22 @@ function ClientFormContent({
 
     const handleSubmit = async () => {
         setError(null);
+
+        if (isLegacyNoopEdit && client) {
+            try {
+                // Some legacy customers predate the current required form fields. An empty
+                // update preserves that record exactly while still invoking the backend's
+                // phone-based document relink. Automatic form hydration is not considered an
+                // edit; any user interaction exits this narrow compatibility path.
+                const updatedClient = await updateClient.mutateAsync({ id: client.id, dto: {} });
+                onSuccess?.(updatedClient);
+                onClose();
+            } catch (error: unknown) {
+                console.error("Failed to save client:", error);
+                setErrorAndScroll(getErrorMessage(error, locale, "clients.form.error-save-failed"));
+            }
+            return;
+        }
 
         // 고객 기본 정보만 필수이며 서비스 정보는 상담 단계에서 비워둘 수 있다.
         if (!formData.name.trim()) {
@@ -720,17 +723,6 @@ function ClientFormContent({
             }
         }
         try {
-            if (isLegacyNoopEdit && client) {
-                // Some legacy customers predate the current required due-date field. An empty
-                // update preserves that record exactly while still invoking the backend's
-                // phone-based document relink. Any form edit exits this narrow compatibility
-                // path and must satisfy the normal validation below.
-                const updatedClient = await updateClient.mutateAsync({ id: client.id, dto: {} });
-                onSuccess?.(updatedClient);
-                onClose();
-                return;
-            }
-
             const normalizedDueDate = normalizeCompactDateForSubmit(formData.dueDate ?? "");
             const normalizedStartDate = normalizeCompactDateForSubmit(formData.startDate ?? "");
             const normalizedEndDate = normalizeCompactDateForSubmit(formData.endDate ?? "");
@@ -795,12 +787,12 @@ function ClientFormContent({
 
     const isSubmitting = createClient.isPending || updateClient.isPending;
 
-    const isBasicStepValid = Boolean(
-        formData.name.trim() &&
-        formData.birthday?.trim() &&
-        (isLegacyNoopEdit || isValidCompactDateInput(formData.dueDate ?? "")) &&
-        formData.address?.trim() &&
-        isPhoneCheckReady
+    const isBasicStepValid = isLegacyNoopEdit || Boolean(
+        formData.name.trim()
+        && formData.birthday?.trim()
+        && isValidCompactDateInput(formData.dueDate ?? "")
+        && formData.address?.trim()
+        && isPhoneCheckReady
     );
     const isEmployeeStepValid = true;
     const isVoucherStepValid = true;
@@ -850,7 +842,7 @@ function ClientFormContent({
                 variant="positive"
                 size="sm"
                 onClick={handleSubmit}
-                disabled={isSubmitting || isPhoneCheckBlockingSubmit}
+                disabled={isSubmitting || (!isLegacyNoopEdit && isPhoneCheckBlockingSubmit)}
                 data-component={`${base}_submit`}
                 className="w-full sm:flex-1"
             >

--- a/frontend/src/components/app/clients/__tests__/ClientFormDialog.legacy-noop-relink.test.tsx
+++ b/frontend/src/components/app/clients/__tests__/ClientFormDialog.legacy-noop-relink.test.tsx
@@ -6,6 +6,11 @@ import type { Client } from "@/lib/client/types";
 import { ClientFormPanel } from "../ClientFormDialog";
 
 const mockUpdateClient = jest.fn();
+let mockOutOfPocketPriceInfos: Array<{
+  id: number;
+  duration: number;
+  fullPrice: string;
+}> = [];
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ replace: jest.fn() }),
@@ -18,7 +23,11 @@ jest.mock("@/hooks/useClients", () => ({
 }));
 
 jest.mock("@/hooks/useVoucherData", () => ({
-  useOutOfPocketPriceInfos: () => ({ data: [], isError: false, isLoading: false }),
+  useOutOfPocketPriceInfos: () => ({
+    data: mockOutOfPocketPriceInfos,
+    isError: false,
+    isLoading: false,
+  }),
   useVoucherPriceInfos: () => ({ data: [], isLoading: false }),
   useVoucherYears: () => ({ data: [], isLoading: false }),
 }));
@@ -84,6 +93,7 @@ describe("ClientForm legacy no-op relink", () => {
     mockApiGet.mockResolvedValue({ data: { exists: false } });
     mockUpdateClient.mockReset();
     mockUpdateClient.mockResolvedValue(legacyClient);
+    mockOutOfPocketPriceInfos = [];
   });
 
   it("sends an empty update for an unchanged legacy client with no due date", async () => {
@@ -187,6 +197,123 @@ describe("ClientForm legacy no-op relink", () => {
 
     await act(async () => {
       await Promise.resolve();
+    });
+  });
+
+  it("keeps no-op relink available after automatic price hydration", async () => {
+    mockOutOfPocketPriceInfos = [
+      { id: 1, duration: 5, fullPrice: "815000" },
+    ];
+    const clientWithAutoPrice = {
+      ...legacyClient,
+      duration: 5,
+      fullPrice: null,
+      grant: null,
+      actualPrice: null,
+    };
+    const onClose = jest.fn();
+    const { rerender } = render(
+      <ClientFormPanel
+        open
+        activeStep={2}
+        client={clientWithAutoPrice}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("총 서비스 금액")).toHaveValue("815,000");
+    });
+
+    rerender(
+      <ClientFormPanel
+        open
+        activeStep={3}
+        client={clientWithAutoPrice}
+        onClose={onClose}
+      />,
+    );
+
+    const saveButton = screen.getByRole("button", { name: "저장" });
+    expect(saveButton).toBeEnabled();
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockUpdateClient).toHaveBeenCalledWith({
+        id: clientWithAutoPrice.id,
+        dto: {},
+      });
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires normal validation after a user edits an automatically hydrated price", async () => {
+    mockOutOfPocketPriceInfos = [
+      { id: 1, duration: 5, fullPrice: "815000" },
+    ];
+    const clientWithAutoPrice = {
+      ...legacyClient,
+      duration: 5,
+      fullPrice: null,
+      grant: null,
+      actualPrice: null,
+    };
+    const { rerender } = render(
+      <ClientFormPanel
+        open
+        activeStep={2}
+        client={clientWithAutoPrice}
+        onClose={jest.fn()}
+      />,
+    );
+
+    const priceInput = await screen.findByLabelText("총 서비스 금액");
+    await waitFor(() => expect(priceInput).toHaveValue("815,000"));
+    fireEvent.change(priceInput, { target: { value: "820000" } });
+
+    rerender(
+      <ClientFormPanel
+        open
+        activeStep={3}
+        client={clientWithAutoPrice}
+        onClose={jest.fn()}
+      />,
+    );
+
+    const saveButton = screen.getByRole("button", { name: "저장" });
+    expect(saveButton).toBeDisabled();
+    fireEvent.click(saveButton);
+    expect(mockUpdateClient).not.toHaveBeenCalled();
+  });
+
+  it("allows an unchanged international-format phone to reach the backend relink", async () => {
+    const internationalPhoneClient = {
+      ...legacyClient,
+      phone: "+82 10-1111-2222",
+    };
+
+    render(
+      <ClientFormPanel
+        open
+        activeStep={3}
+        client={internationalPhoneClient}
+        onClose={jest.fn()}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const saveButton = screen.getByRole("button", { name: "저장" });
+    expect(saveButton).toBeEnabled();
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockUpdateClient).toHaveBeenCalledWith({
+        id: internationalPhoneClient.id,
+        dto: {},
+      });
     });
   });
 

--- a/frontend/src/components/app/clients/__tests__/ClientFormDialog.legacy-noop-relink.test.tsx
+++ b/frontend/src/components/app/clients/__tests__/ClientFormDialog.legacy-noop-relink.test.tsx
@@ -1,0 +1,214 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { api } from "@/lib/api/client";
+import type { Client } from "@/lib/client/types";
+
+import { ClientFormPanel } from "../ClientFormDialog";
+
+const mockUpdateClient = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock("@/hooks/useClients", () => ({
+  useCreateClient: () => ({ isPending: false, mutateAsync: jest.fn() }),
+  useUpdateClient: () => ({ isPending: false, mutateAsync: mockUpdateClient }),
+}));
+
+jest.mock("@/hooks/useVoucherData", () => ({
+  useOutOfPocketPriceInfos: () => ({ data: [], isError: false, isLoading: false }),
+  useVoucherPriceInfos: () => ({ data: [], isLoading: false }),
+  useVoucherYears: () => ({ data: [], isLoading: false }),
+}));
+
+jest.mock("@/stores/client-dialog-store", () => {
+  const state = { prefillName: "", clearPrefillName: jest.fn() };
+
+  return {
+    useClientDialogStore: (selector: (value: typeof state) => unknown) => selector(state),
+  };
+});
+
+jest.mock("@/providers/LocaleProvider", () => ({
+  useLocale: () => "ko",
+}));
+
+jest.mock("../EmployeeAutocomplete", () => ({
+  EmployeeAutocomplete: () => <div data-testid="employee-autocomplete" />,
+}));
+
+jest.mock("@/components/app/employees/EmployeeFormDialog", () => ({
+  EmployeeFormDialog: () => null,
+}));
+
+jest.mock("@/lib/api/client", () => ({
+  api: {
+    get: jest.fn(),
+  },
+}));
+
+const mockApiGet = api.get as jest.MockedFunction<typeof api.get>;
+
+const legacyClient: Client = {
+  id: 82,
+  name: "레거시 고객",
+  createdAt: "2026-01-01",
+  birthday: "900101",
+  dueDate: null,
+  address: "인천시 남동구",
+  phone: "010-1111-2222",
+  primaryEmployee: null,
+  secondaryEmployee: null,
+  type: null,
+  duration: null,
+  fullPrice: null,
+  grant: null,
+  actualPrice: null,
+  startDate: null,
+  endDate: null,
+  careCenter: false,
+  voucherClient: false,
+  breastPump: false,
+  serviceStatus: "completed",
+  eDocId: null,
+  hasSigned: false,
+  documentStatus: null,
+};
+
+describe("ClientForm legacy no-op relink", () => {
+  beforeEach(() => {
+    HTMLElement.prototype.scrollTo = jest.fn();
+    mockApiGet.mockReset();
+    mockApiGet.mockResolvedValue({ data: { exists: false } });
+    mockUpdateClient.mockReset();
+    mockUpdateClient.mockResolvedValue(legacyClient);
+  });
+
+  it("sends an empty update for an unchanged legacy client with no due date", async () => {
+    const onClose = jest.fn();
+
+    render(
+      <ClientFormPanel
+        open
+        activeStep={3}
+        client={legacyClient}
+        onClose={onClose}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const saveButton = screen.getByRole("button", { name: "저장" });
+    await waitFor(() => expect(saveButton).toBeEnabled());
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockUpdateClient).toHaveBeenCalledWith({
+        id: legacyClient.id,
+        dto: {},
+      });
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps due-date validation when any legacy client field changes", async () => {
+    const { rerender } = render(
+      <ClientFormPanel
+        open
+        activeStep={0}
+        client={legacyClient}
+        onClose={jest.fn()}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const nextButton = screen.getByRole("button", { name: "다음" });
+    await waitFor(() => expect(nextButton).toBeEnabled());
+    fireEvent.change(screen.getByLabelText(/이름/), {
+      target: { value: "변경된 고객" },
+    });
+
+    rerender(
+      <ClientFormPanel
+        open
+        activeStep={3}
+        client={legacyClient}
+        onClose={jest.fn()}
+      />,
+    );
+
+    const saveButton = screen.getByRole("button", { name: "저장" });
+    expect(saveButton).toBeDisabled();
+    fireEvent.click(saveButton);
+    expect(mockUpdateClient).not.toHaveBeenCalled();
+  });
+
+  it("does not reuse another legacy client's no-op snapshot during a client switch", async () => {
+    const { rerender } = render(
+      <ClientFormPanel
+        open
+        activeStep={3}
+        client={legacyClient}
+        onClose={jest.fn()}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const nextLegacyClient = {
+      ...legacyClient,
+      id: legacyClient.id + 1,
+      name: "다른 레거시 고객",
+      phone: "010-3333-4444",
+    };
+
+    rerender(
+      <ClientFormPanel
+        open
+        activeStep={3}
+        client={nextLegacyClient}
+        onClose={jest.fn()}
+      />,
+    );
+
+    const saveButton = screen.getByRole("button", { name: "저장" });
+    expect(saveButton).toBeDisabled();
+    fireEvent.click(saveButton);
+    expect(mockUpdateClient).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+  });
+
+  it("does not treat clearing an existing due date as a no-op", async () => {
+    render(
+      <ClientFormPanel
+        open
+        activeStep={0}
+        client={{ ...legacyClient, dueDate: "2026-08-01" }}
+        onClose={jest.fn()}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.change(screen.getByLabelText(/출산 예정일/), {
+      target: { value: "" },
+    });
+
+    expect(screen.getByRole("button", { name: "다음" })).toBeDisabled();
+    expect(mockUpdateClient).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changed
- permits an unchanged save for legacy clients whose `dueDate` predates the current required-field rule
- sends an empty update DTO only for the exact unchanged client snapshot, so the backend can rerun phone-based eformsign relinking without rewriting legacy data
- binds the snapshot to the client ID to prevent cross-client races
- keeps normal due-date validation for every edited client and for cleared existing due dates

## Root cause
The backend relink path already runs on an empty client update, but the frontend required `dueDate` before issuing PATCH. Legacy clients with a null due date therefore could not reach the relink path through an unchanged Save.

## Validation
- targeted Jest: 4/4
- frontend Jest: 140 suites / 631 tests
- frontend TypeScript: passed
- changed-file ESLint and full ESLint errors-only: passed
- UI architecture gate: passed
- frontend production build: passed
- `git diff --check`: passed
- independent P0-P2 review: approved

## Security and data impact
No auth, schema, database, or vendor API changes. The compatibility path sends `{}` only for the currently displayed client's exact unchanged snapshot; any edit re-enables the existing validation. The backend remains tenant-scoped and relinks against the persisted phone number.

## Rollback
Revert this commit. Legacy clients with missing due dates will again be blocked from unchanged Save; no data migration or cleanup is required.