### PR TITLE
fix(clients): make empty updates relink-only

### DIFF
--- a/backend/application/services/client.service.ts
+++ b/backend/application/services/client.service.ts
@@ -1135,8 +1135,18 @@ export class ClientService {
         // Get existing client
         const existingClient = await this.findClientByIdUsecase.execute(branchid, id);
         if (!existingClient) {
-            throw new Error(`Client with id ${id} not found`);
+            throw new NotFoundException(`Client with id ${id} not found`);
         }
+
+        const hasRequestedUpdate = Object.values(params).some((value) => value !== undefined);
+        if (!hasRequestedUpdate) {
+            const existingPhone = normalizePhone(existingClient.phone);
+            if (existingPhone) {
+                await this.linkContractDocumentsByPhone(branchid, existingClient, existingPhone);
+            }
+            return existingClient;
+        }
+
         const hasPricingUpdate = params.voucherClient !== undefined
             || params.type !== undefined
             || params.duration !== undefined

--- a/backend/test/integration/client.controller.integration.spec.ts
+++ b/backend/test/integration/client.controller.integration.spec.ts
@@ -497,6 +497,45 @@ describe("ClientController (Integration)", () => {
                 );
             });
         });
+
+        describe("given an empty update", () => {
+            it("should preserve the relink-only wire contract", async () => {
+                const existingClient = createMockClient({ id: 5 });
+                clientService.update.mockResolvedValue(existingClient);
+
+                const response = await request(app.getHttpServer())
+                    .patch("/clients/5")
+                    .send({});
+
+                expect(response.status).toBe(200);
+                expect(clientService.update).toHaveBeenCalledWith(
+                    expect.any(String),
+                    5,
+                    {
+                        name: undefined,
+                        primaryEmployeeId: undefined,
+                        secondaryEmployeeId: undefined,
+                        address: undefined,
+                        phone: undefined,
+                        type: undefined,
+                        duration: undefined,
+                        fullPrice: undefined,
+                        grant: undefined,
+                        actualPrice: undefined,
+                        startDate: undefined,
+                        endDate: undefined,
+                        careCenter: undefined,
+                        voucherClient: undefined,
+                        birthday: undefined,
+                        dueDate: undefined,
+                        serviceStatus: undefined,
+                        breastPump: undefined,
+                        eDocId: undefined,
+                        areaId: undefined,
+                    },
+                );
+            });
+        });
     });
 
     // ============================================

--- a/backend/test/services/client.service.spec.ts
+++ b/backend/test/services/client.service.spec.ts
@@ -1,7 +1,8 @@
-import { Logger } from "@nestjs/common";
+import { Logger, NotFoundException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 
 import { ClientService } from "../../application/services/client.service";
+import { ServiceRecordLifecycleService } from "../../application/services/service-record-lifecycle.service";
 import {
     CreateClientUsecase,
     DeleteClientUsecase,
@@ -109,6 +110,12 @@ describe("ClientService", () => {
         revoke: jest.fn().mockResolvedValue(undefined),
     });
 
+    const createMockServiceRecordLifecycleService = () => ({
+        validatePeriodChange: jest.fn().mockResolvedValue(undefined),
+        ensureForClient: jest.fn().mockResolvedValue(undefined),
+        markTerminated: jest.fn().mockResolvedValue(undefined),
+    });
+
     const createMockSystemSettingService = () => ({
         getClientAutoRegistrationEnabled: jest.fn().mockResolvedValue(true),
         getGreetingOnAutoRegistrationEnabled: jest.fn().mockResolvedValue(false),
@@ -173,6 +180,7 @@ describe("ClientService", () => {
     let prismaService: ReturnType<typeof createMockPrismaService>;
     let triggerService: ReturnType<typeof createMockTriggerService>;
     let serviceRecordLinkService: ReturnType<typeof createMockServiceRecordLinkService>;
+    let serviceRecordLifecycleService: ReturnType<typeof createMockServiceRecordLifecycleService>;
     let clientRepository: ReturnType<typeof createMockClientRepository>;
     let systemSettingService: ReturnType<typeof createMockSystemSettingService>;
     let configService: ReturnType<typeof createMockConfigService>;
@@ -188,6 +196,7 @@ describe("ClientService", () => {
         prismaService = createMockPrismaService();
         triggerService = createMockTriggerService();
         serviceRecordLinkService = createMockServiceRecordLinkService();
+        serviceRecordLifecycleService = createMockServiceRecordLifecycleService();
         clientRepository = createMockClientRepository();
         systemSettingService = createMockSystemSettingService();
         configService = createMockConfigService();
@@ -206,7 +215,7 @@ describe("ClientService", () => {
             documentSnapshotService as unknown as EformsignDocumentSnapshotService,
             triggerService as unknown as MessageTriggerService,
             serviceRecordLinkService as unknown as ServiceRecordLinkService,
-            undefined,
+            serviceRecordLifecycleService as unknown as ServiceRecordLifecycleService,
             configService as unknown as ConfigService,
         );
     });
@@ -1151,6 +1160,10 @@ describe("ClientService", () => {
                 // A no-op save is an explicit, targeted local-DB reconciliation.
                 const result = await service.update(branchId, existingClient.id, {});
 
+                expect(prismaService.$transaction).toHaveBeenCalledTimes(1);
+                expect(serviceRecordLifecycleService.validatePeriodChange).not.toHaveBeenCalled();
+                expect(serviceRecordLifecycleService.ensureForClient).not.toHaveBeenCalled();
+                expect(triggerService.syncClientRulesForClient).not.toHaveBeenCalled();
                 expect(prismaService.eformsign_doc.findMany).toHaveBeenCalledWith(
                     expect.objectContaining({
                         where: expect.objectContaining({
@@ -1199,6 +1212,7 @@ describe("ClientService", () => {
                     },
                     data: { eDocId: "DOC-AFTER-UPDATE" },
                 });
+                expect(prismaService.client.updateMany).toHaveBeenCalledTimes(1);
                 expect(result.eDocId).toBe("DOC-AFTER-UPDATE");
                 expect(documentSnapshotService.bumpVersion).toHaveBeenCalledWith(branchId);
                 expect(documentSnapshotService.bumpCompanyEpoch).toHaveBeenCalledTimes(1);
@@ -1234,13 +1248,34 @@ describe("ClientService", () => {
                 const result = await service.update(branchId, existingClient.id, {});
 
                 expect(prismaService.eformsign_doc.updateMany).not.toHaveBeenCalled();
-                expect(prismaService.client.updateMany).toHaveBeenCalledTimes(1);
-                expect(prismaService.client.updateMany).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        where: { id: existingClient.id, branchId },
-                    }),
-                );
+                expect(prismaService.client.updateMany).not.toHaveBeenCalled();
+                expect(prismaService.$transaction).not.toHaveBeenCalled();
                 expect(result.eDocId).toBeNull();
+            });
+
+            it("treats an empty update as relink-only even when lifecycle reconciliation would fail", async () => {
+                const existingClient = createClientEntity();
+                findClientByIdUsecase.execute.mockResolvedValue(existingClient);
+                serviceRecordLifecycleService.ensureForClient.mockRejectedValue(
+                    new NotFoundException("Client not found"),
+                );
+
+                await expect(service.update(branchId, existingClient.id, {})).resolves.toBe(existingClient);
+
+                expect(prismaService.eformsign_doc.findMany).toHaveBeenCalled();
+                expect(prismaService.$transaction).not.toHaveBeenCalled();
+                expect(serviceRecordLifecycleService.validatePeriodChange).not.toHaveBeenCalled();
+                expect(serviceRecordLifecycleService.ensureForClient).not.toHaveBeenCalled();
+                expect(triggerService.syncClientRulesForClient).not.toHaveBeenCalled();
+            });
+
+            it("returns a semantic not-found error when the scoped client does not exist", async () => {
+                findClientByIdUsecase.execute.mockResolvedValue(null);
+
+                await expect(service.update(branchId, 999, {})).rejects.toBeInstanceOf(NotFoundException);
+
+                expect(prismaService.eformsign_doc.findMany).not.toHaveBeenCalled();
+                expect(prismaService.$transaction).not.toHaveBeenCalled();
             });
 
             it("does not resolve a service date update before scheduled jobs are recalculated", async () => {

--- a/frontend/src/app/api/clients/[id]/route.test.ts
+++ b/frontend/src/app/api/clients/[id]/route.test.ts
@@ -4,22 +4,127 @@
 import { NextRequest } from "next/server";
 
 import { serverAPIClient } from "@/lib/api/server";
-import { DELETE } from "./route";
+import { DELETE, GET, PATCH } from "./route";
 
 jest.mock("@/lib/api/server", () => ({
     serverAPIClient: {
+        get: jest.fn(),
+        patch: jest.fn(),
         delete: jest.fn(),
     },
 }));
 
+const mockGet = serverAPIClient.get as jest.Mock;
+const mockPatch = serverAPIClient.patch as jest.Mock;
 const mockDelete = serverAPIClient.delete as jest.Mock;
 
-function createRequest(): NextRequest {
+function createRequest(method = "DELETE", body?: object): NextRequest {
     return new NextRequest("http://localhost/api/clients/75", {
-        method: "DELETE",
-        headers: { cookie: "auth_token=access-token" },
+        method,
+        headers: {
+            cookie: "auth_token=access-token",
+            ...(body ? { "content-type": "application/json" } : {}),
+        },
+        ...(body ? { body: JSON.stringify(body) } : {}),
     });
 }
+
+describe("PATCH /api/clients/[id]", () => {
+    beforeEach(() => {
+        mockPatch.mockReset();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("forwards an empty relink-only update", async () => {
+        mockPatch.mockResolvedValue({ data: { id: 75 } });
+
+        const response = await PATCH(createRequest("PATCH", {}), {
+            params: Promise.resolve({ id: "75" }),
+        });
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({ id: 75 });
+        expect(mockPatch).toHaveBeenCalledWith(
+            "/clients/75",
+            {},
+            { headers: { Authorization: "Bearer access-token" } },
+        );
+    });
+
+    it("preserves the upstream status without logging or returning private details", async () => {
+        const privateMessage = "private customer details";
+        const privateToken = "Bearer private-token";
+        const consoleError = jest.spyOn(console, "error").mockImplementation(() => undefined);
+        mockPatch.mockRejectedValue({
+            response: {
+                status: 404,
+                data: {
+                    code: "CLIENT_NOT_FOUND",
+                    message: privateMessage,
+                },
+            },
+            config: {
+                headers: { Authorization: privateToken },
+                data: privateMessage,
+            },
+        });
+
+        const response = await PATCH(createRequest("PATCH", {}), {
+            params: Promise.resolve({ id: "75" }),
+        });
+
+        expect(response.status).toBe(404);
+        await expect(response.json()).resolves.toEqual({
+            error: "Failed to update client",
+            code: "CLIENT_NOT_FOUND",
+        });
+        const logged = JSON.stringify(consoleError.mock.calls);
+        expect(logged).not.toContain(privateMessage);
+        expect(logged).not.toContain(privateToken);
+    });
+});
+
+describe("GET /api/clients/[id]", () => {
+    beforeEach(() => {
+        mockGet.mockReset();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("preserves a sanitized upstream not-found response", async () => {
+        const privateMessage = "private database details";
+        const consoleError = jest.spyOn(console, "error").mockImplementation(() => undefined);
+        mockGet.mockRejectedValue({
+            response: {
+                status: 404,
+                data: {
+                    code: "CLIENT_NOT_FOUND",
+                    message: privateMessage,
+                },
+            },
+            config: {
+                headers: { Authorization: "Bearer private-token" },
+            },
+        });
+
+        const response = await GET(createRequest("GET"), {
+            params: Promise.resolve({ id: "75" }),
+        });
+
+        expect(response.status).toBe(404);
+        await expect(response.json()).resolves.toEqual({
+            error: "Failed to fetch client",
+            code: "CLIENT_NOT_FOUND",
+        });
+        expect(JSON.stringify(consoleError.mock.calls)).not.toContain(privateMessage);
+        expect(JSON.stringify(consoleError.mock.calls)).not.toContain("private-token");
+    });
+});
 
 describe("DELETE /api/clients/[id]", () => {
     beforeEach(() => {

--- a/frontend/src/app/api/clients/[id]/route.ts
+++ b/frontend/src/app/api/clients/[id]/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { serverAPIClient } from "@/lib/api/server";
-import { errorResponse, getUpstreamErrorStatus, logUpstreamError } from "@/lib/api/route-utils";
+import {
+    errorResponse,
+    getUpstreamErrorStatus,
+    logUpstreamError,
+    sanitizeUpstreamClientError,
+} from "@/lib/api/route-utils";
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -10,11 +15,16 @@ const CLIENT_DELETE_CONFLICT_MESSAGE =
 const CLIENT_DELETE_CONFLICT_FALLBACK =
     "연결된 정보 때문에 고객을 삭제할 수 없습니다. 잠시 후 다시 시도해 주세요.";
 
-function getUpstreamErrorCode(error: unknown): unknown {
+function getUpstreamErrorData(error: unknown): unknown {
     if (!error || typeof error !== "object" || !("response" in error)) return undefined;
     const response = (error as { response?: { data?: unknown } }).response;
-    if (!response?.data || typeof response.data !== "object") return undefined;
-    return (response.data as { code?: unknown }).code;
+    return response?.data;
+}
+
+function getUpstreamErrorCode(error: unknown): unknown {
+    const data = getUpstreamErrorData(error);
+    if (!data || typeof data !== "object") return undefined;
+    return (data as { code?: unknown }).code;
 }
 
 // Helper to get auth token from request
@@ -41,10 +51,13 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         });
         return NextResponse.json(response.data);
     } catch (error) {
-        console.error("[API] Error fetching client:", error);
+        logUpstreamError("fetch client", error);
         return NextResponse.json(
-            { error: "Failed to fetch client" },
-            { status: 500 }
+            sanitizeUpstreamClientError(
+                getUpstreamErrorData(error),
+                "Failed to fetch client",
+            ),
+            { status: getUpstreamErrorStatus(error) },
         );
     }
 }
@@ -64,10 +77,13 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
         });
         return NextResponse.json(response.data);
     } catch (error) {
-        console.error("[API] Error updating client:", error);
+        logUpstreamError("update client", error);
         return NextResponse.json(
-            { error: "Failed to update client" },
-            { status: 500 }
+            sanitizeUpstreamClientError(
+                getUpstreamErrorData(error),
+                "Failed to update client",
+            ),
+            { status: getUpstreamErrorStatus(error) },
         );
     }
 }


### PR DESCRIPTION
## Summary
- Treat an all-undefined client update as an explicit local eformsign relink request.
- Keep the branch-scoped client lookup before relinking and return a semantic 404 when the scoped client is absent.
- Preserve upstream GET/PATCH status codes in the frontend BFF while logging and returning only sanitized fields.

## Root cause
An unchanged legacy-client save reaches the backend as an all-undefined update. Prisma `updateMany` reports `count: 0` for that empty mutation, which the service interpreted as not found; the BFF then converted the upstream 404 to 500.

## Validation
- Backend: 187 suites passed; 2,132 tests passed, 37 skipped.
- Frontend: 140 suites / 637 tests passed.
- Focused regression tests: backend 101 passed; BFF route 5 passed.
- Backend/frontend typecheck, lint, and production builds passed.
- Prisma schema validation and UI architecture gate passed.
- `git diff --check` passed.
- Independent P0-P2 review: APPROVE.

## Security
- Tenant/branch-scoped lookup remains before the relink-only branch.
- Null remains an intentional mutation; only all-undefined updates bypass normal lifecycle mutation work.
- Raw Axios errors are no longer logged for client GET/PATCH.
- No schema, dependency, environment, auth core, or secret changes.
- Existing transitive `brace-expansion` advisory is unchanged and tracked separately.

## Database / deployment
- No database patch or backfill is required for this code-only fix.
- Expected rollback: revert the squash merge; mirror tables and backfilled document data are unaffected.