### PR TITLE
fix(frontend): 삭제 묘비 문서가 전체 탭에 다시 나타나지 않도록

### DIFF
--- a/frontend/src/hooks/__tests__/useInfiniteContracts.excludeDeleted.test.tsx
+++ b/frontend/src/hooks/__tests__/useInfiniteContracts.excludeDeleted.test.tsx
@@ -1,0 +1,59 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { eformsignApi } from "@/services/api";
+import { useInfiniteContracts } from "../useInfiniteContracts";
+
+jest.mock("@/services/api", () => ({
+  eformsignApi: {
+    getAllDocuments: jest.fn(),
+    getInProgressDocuments: jest.fn(),
+    getCompletedDocuments: jest.fn(),
+    getExpiredDocuments: jest.fn(),
+  },
+}));
+
+const mockedApi = eformsignApi as jest.Mocked<typeof eformsignApi>;
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function emptyPage() {
+  return { documents: [], total_rows: 0, limit: 20, skip: 0 };
+}
+
+describe("useInfiniteContracts — the All tab and deletion tombstones", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApi.getAllDocuments.mockResolvedValue(emptyPage() as never);
+    mockedApi.getExpiredDocuments.mockResolvedValue(emptyPage() as never);
+  });
+
+  it("asks the server to leave deleted contracts out of the All tab", async () => {
+    // A permanent delete scrubs the contract and leaves a 049 tombstone behind.
+    // Without this flag the All tab renders that emptied row straight back at the
+    // user after they deleted it. Mobile has always sent it; this is the desktop
+    // side of the same contract.
+    renderHook(() => useInfiniteContracts({ filterType: null }), { wrapper });
+
+    await waitFor(() => expect(mockedApi.getAllDocuments).toHaveBeenCalled());
+
+    expect(mockedApi.getAllDocuments).toHaveBeenCalledWith(
+      expect.objectContaining({ excludeDeleted: true }),
+    );
+  });
+
+  it("leaves the 기간 만료 tab alone, which is where deleted contracts belong", async () => {
+    renderHook(() => useInfiniteContracts({ filterType: "expired" }), { wrapper });
+
+    await waitFor(() => expect(mockedApi.getExpiredDocuments).toHaveBeenCalled());
+
+    expect(mockedApi.getExpiredDocuments).not.toHaveBeenCalledWith(
+      expect.objectContaining({ excludeDeleted: true }),
+    );
+  });
+});

--- a/frontend/src/hooks/useInfiniteContracts.ts
+++ b/frontend/src/hooks/useInfiniteContracts.ts
@@ -110,7 +110,15 @@ export function useInfiniteContracts({
           return await eformsignApi.getExpiredDocuments(params);
         case null:
         default:
-          return await eformsignApi.getAllDocuments({ ...params, type: null });
+          return await eformsignApi.getAllDocuments({
+            ...params,
+            type: null,
+            // A permanent delete scrubs the contract and leaves a 049 tombstone.
+            // Without this the All tab shows that emptied row back to the user
+            // right after they deleted it; the 기간 만료 tab is where deleted
+            // contracts are meant to appear. Mobile has always sent this.
+            excludeDeleted: true,
+          });
       }
     },
     getNextPageParam: getNextContractsPageParam,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -203,7 +203,7 @@ export const eformsignApi = {
     // Documents APIs - token is read from httpOnly cookie on server
     // Note: eformsign routes use /eformsign prefix to avoid conflict with file storage /documents
     // Unified endpoint - fetches all documents in single request (more efficient)
-    getAllDocuments: async (params?: { limit?: number; skip?: number; type?: string | null; templateId?: string; templateMatch?: "include" | "exclude" }): Promise<EformsignDocumentsResponse> => {
+    getAllDocuments: async (params?: { limit?: number; skip?: number; type?: string | null; templateId?: string; templateMatch?: "include" | "exclude"; excludeDeleted?: boolean }): Promise<EformsignDocumentsResponse> => {
         const { data } = await api.get('/eformsign/documents', { params });
         return data;
     },


### PR DESCRIPTION
릴리스 PR #427 리뷰에서 나온 P2를 고칩니다.

## 문제

영구 삭제는 계약 내용을 지우고 **049 묘비(tombstone)** 행을 남깁니다. 백엔드는 `excludeDeleted=true`를 받았을 때만 이를 걸러내는데, **데스크톱 전체 탭이 그 플래그를 보내지 않았습니다.**

결과: 사용자가 계약을 삭제한 직후, 내용이 비워진 그 행이 전체 탭에 그대로 다시 나타납니다.

모바일은 처음부터 이 플래그를 보내고 있었고(`mobile/src/hooks/useInfiniteContracts.ts:129`, 이유를 적은 주석까지 있음), 데스크톱만 빠져 있었습니다.

## 수정

데스크톱 전체 탭도 `excludeDeleted: true`를 보냅니다. **기간 만료 탭은 건드리지 않습니다** — 삭제된 계약이 보여야 하는 곳은 거기입니다.

백엔드 기본값을 바꾸지 않은 이유: 그 엔드포인트의 다른 소비자까지 동작이 바뀝니다. 프론트 한 줄이 더 수술적이고, 모바일이 이미 취한 방식과 같습니다.

Next.js 프록시(`src/app/api/eformsign/documents/route.ts:56`)는 이미 이 파라미터를 전달하고 있었습니다. API 클라이언트 시그니처에만 없었습니다.

## 검증

`tsc` 통과, eslint 클린, jest **141 suites / 636 passed**. 신규 테스트 2건이 전체 탭은 플래그를 보내고 기간 만료 탭은 안 보낸다는 것을 고정합니다.

## 함께 보고된, 이 PR에서 다루지 않은 것

리뷰가 지적한 P1 하나는 의도적으로 남겼습니다 — `eformsign-document-mirror.service.ts`에서 목록 투영(`mirrorRemoteDocument`)이 파일 동기화보다 **먼저** 실행되고, 완료 문서에 PDF가 없으면 그 뒤에 throw합니다. 투영은 이미 나간 뒤라 목록에는 완료로 보이는데 PDF는 503입니다.

지적은 정확하지만 ADR 004의 동기화 순서 설계에 해당하고, 릴리스 중에 임의로 재구성할 사안이 아니라고 판단했습니다. 별도로 논의가 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG