### PR TITLE
fix(eformsign): publish completed mirrors only when ready

### DIFF
--- a/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
+++ b/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
@@ -220,7 +220,7 @@ describe("EformsignDocumentSnapshotService", () => {
             { excludeTombstones: true },
         );
 
-        expect(build).toHaveBeenCalledTimes(1);
+        expect(build).toHaveBeenCalledTimes(3);
         expect(defaultResult).toEqual({
             entries: [
                 createEntry("safe-document"),
@@ -272,7 +272,7 @@ describe("EformsignDocumentSnapshotService", () => {
 
         const result = await service.getOrBuild(createMirrorParams(), build);
 
-        expect(build).toHaveBeenCalledTimes(1);
+        expect(build).toHaveBeenCalledTimes(2);
         expect(result).toEqual({
             entries: [createEntry("safe-document")],
             snapshotVersion: expect.stringMatching(/^0:\d+:f[0-9a-f]{12}$/),
@@ -290,6 +290,50 @@ describe("EformsignDocumentSnapshotService", () => {
             createEntry("completed-syncing-document"),
         ]);
         expect(restored.snapshotVersion).toBe(initialResult.snapshotVersion);
+    });
+
+    it("should add a newly ready row even when its version bump failed", async () => {
+        const exclusionLookup = createSnapshotExclusionLookup();
+        const redis = createRedisStub();
+        let snapshotPayload: string | null = null;
+        redis.get.mockImplementation(async (key) => {
+            if (key === "eformsign:doclist-version:branch-a") {
+                return "0";
+            }
+            return snapshotPayload;
+        });
+        redis.set.mockImplementation(async (key, value) => {
+            if (key.startsWith("eformsign:doclist:")) {
+                snapshotPayload = value;
+            }
+            return "OK";
+        });
+        useRedisStub(redis);
+        const service = new EformsignDocumentSnapshotService(exclusionLookup);
+        let liveEntries = [createEntry("safe-document")];
+        const build = jest.fn(async () => liveEntries);
+
+        const initial = await service.getOrBuild(createMirrorParams(), build);
+        redis.incr.mockRejectedValueOnce(
+            new Error("Valkey unavailable during ready publication"),
+        );
+        await expect(service.bumpVersion("branch-a")).resolves.toBeNull();
+        liveEntries = [
+            createEntry("safe-document"),
+            createEntry("newly-ready-document"),
+        ];
+
+        const recovered = await service.getOrBuild(createMirrorParams(), build);
+
+        expect(build).toHaveBeenCalledTimes(2);
+        expect(recovered.entries).toEqual(liveEntries);
+        expect(recovered.snapshotVersion).toMatch(/^0:\d+:f[0-9a-f]{12}$/);
+        expect(recovered.snapshotVersion).not.toBe(initial.snapshotVersion);
+
+        const stable = await service.getOrBuild(createMirrorParams(), build);
+        expect(build).toHaveBeenCalledTimes(3);
+        expect(stable.entries).toEqual(liveEntries);
+        expect(stable.snapshotVersion).toBe(recovered.snapshotVersion);
     });
 
     it("should apply the readiness fence only to mirror snapshots", async () => {
@@ -376,7 +420,7 @@ describe("EformsignDocumentSnapshotService", () => {
             { excludeTombstones: true },
         );
 
-        expect(build).toHaveBeenCalledTimes(1);
+        expect(build).toHaveBeenCalledTimes(2);
         expect(result).toEqual({
             entries: [createEntry("hq-safe-document")],
             snapshotVersion: expect.stringMatching(/^0:\d+:f[0-9a-f]{12}$/),
@@ -670,7 +714,7 @@ describe("EformsignDocumentSnapshotService", () => {
         const storedKeys = Array.from(internals.memoryStore.keys());
 
         expect(storedKeys).toEqual(["eformsign:doclist:v1:mirror:branch-a:all:0"]);
-        expect(build).toHaveBeenCalledTimes(1);
+        expect(build).toHaveBeenCalledTimes(2);
         // And still distinct from the vendor snapshot of the same scope, so flipping the
         // switch back does not keep serving the source it was flipped away from.
         expect(internals.snapshotKey(createParams(), 0)).not.toBe(storedKeys[0]);

--- a/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
+++ b/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
@@ -202,7 +202,7 @@ describe("EformsignDocumentSnapshotService", () => {
         ];
         const build = jest.fn().mockResolvedValue(staleEntries);
 
-        await service.getOrBuild(createMirrorParams(), build);
+        const initialResult = await service.getOrBuild(createMirrorParams(), build);
         redis.incr.mockRejectedValueOnce(new Error("Valkey unavailable during purge invalidation"));
         await expect(service.bumpVersion("branch-a")).resolves.toBeNull();
         exclusionLookup.findPermanentPurgeRequestedDocumentIds.mockResolvedValue([
@@ -226,14 +226,16 @@ describe("EformsignDocumentSnapshotService", () => {
                 createEntry("safe-document"),
                 createEntry("tombstoned-document"),
             ],
-            snapshotVersion: expect.stringMatching(/^0:\d+$/),
+            snapshotVersion: expect.stringMatching(/^0:\d+:f[0-9a-f]{12}$/),
             cached: true,
         });
         expect(deletionFilteredResult).toEqual({
             entries: [createEntry("safe-document")],
-            snapshotVersion: expect.stringMatching(/^0:\d+$/),
+            snapshotVersion: expect.stringMatching(/^0:\d+:f[0-9a-f]{12}$/),
             cached: true,
         });
+        expect(defaultResult.snapshotVersion).not.toBe(initialResult.snapshotVersion);
+        expect(deletionFilteredResult.snapshotVersion).not.toBe(defaultResult.snapshotVersion);
     });
 
     it("should fence an unready completed row from a stale mirror snapshot after a version bump fails", async () => {
@@ -259,7 +261,7 @@ describe("EformsignDocumentSnapshotService", () => {
             createEntry("completed-syncing-document"),
         ]);
 
-        await service.getOrBuild(createMirrorParams(), build);
+        const initialResult = await service.getOrBuild(createMirrorParams(), build);
         redis.incr.mockRejectedValueOnce(
             new Error("Valkey unavailable during completed mirror invalidation"),
         );
@@ -273,9 +275,21 @@ describe("EformsignDocumentSnapshotService", () => {
         expect(build).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
             entries: [createEntry("safe-document")],
-            snapshotVersion: expect.stringMatching(/^0:\d+$/),
+            snapshotVersion: expect.stringMatching(/^0:\d+:f[0-9a-f]{12}$/),
             cached: true,
         });
+        expect(result.snapshotVersion).not.toBe(initialResult.snapshotVersion);
+
+        const sameFence = await service.getOrBuild(createMirrorParams(), build);
+        expect(sameFence.snapshotVersion).toBe(result.snapshotVersion);
+
+        exclusionLookup.findUnreadyCompletedDocumentIds.mockResolvedValue([]);
+        const restored = await service.getOrBuild(createMirrorParams(), build);
+        expect(restored.entries).toEqual([
+            createEntry("safe-document"),
+            createEntry("completed-syncing-document"),
+        ]);
+        expect(restored.snapshotVersion).toBe(initialResult.snapshotVersion);
     });
 
     it("should apply the readiness fence only to mirror snapshots", async () => {
@@ -291,6 +305,21 @@ describe("EformsignDocumentSnapshotService", () => {
 
         expect(result.entries).toEqual([entry]);
         expect(exclusionLookup.findUnreadyCompletedDocumentIds).not.toHaveBeenCalled();
+    });
+
+    it("should keep the base generation when live exclusions do not affect membership", async () => {
+        const exclusionLookup = createSnapshotExclusionLookup();
+        const service = new EformsignDocumentSnapshotService(exclusionLookup);
+        const build = jest.fn().mockResolvedValue([createEntry("document-1")]);
+
+        const initial = await service.getOrBuild(createMirrorParams(), build);
+        exclusionLookup.findUnreadyCompletedDocumentIds.mockResolvedValue([
+            "not-in-this-snapshot",
+        ]);
+        const cached = await service.getOrBuild(createMirrorParams(), build);
+
+        expect(cached.entries).toEqual(initial.entries);
+        expect(cached.snapshotVersion).toBe(initial.snapshotVersion);
     });
 
     it("should fail closed when the mirror readiness fence is unavailable", async () => {
@@ -350,7 +379,7 @@ describe("EformsignDocumentSnapshotService", () => {
         expect(build).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
             entries: [createEntry("hq-safe-document")],
-            snapshotVersion: expect.stringMatching(/^0:\d+$/),
+            snapshotVersion: expect.stringMatching(/^0:\d+:f[0-9a-f]{12}$/),
             cached: true,
         });
     });

--- a/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
+++ b/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
@@ -12,6 +12,7 @@ import {
 
 interface SnapshotExclusionLookup {
     findListExcludedDocumentIds: jest.Mock<Promise<string[]>, []>;
+    findUnreadyCompletedDocumentIds: jest.Mock<Promise<string[]>, []>;
     findPermanentPurgeRequestedDocumentIds: jest.Mock<Promise<string[]>, []>;
 }
 
@@ -128,6 +129,7 @@ function createSnapshotExclusionLookup(
         findListExcludedDocumentIds: jest.fn().mockResolvedValue(
             excludedDocumentIds,
         ),
+        findUnreadyCompletedDocumentIds: jest.fn().mockResolvedValue([]),
         findPermanentPurgeRequestedDocumentIds: jest.fn().mockResolvedValue([]),
     };
 }
@@ -232,6 +234,75 @@ describe("EformsignDocumentSnapshotService", () => {
             snapshotVersion: expect.stringMatching(/^0:\d+$/),
             cached: true,
         });
+    });
+
+    it("should fence an unready completed row from a stale mirror snapshot after a version bump fails", async () => {
+        const exclusionLookup = createSnapshotExclusionLookup();
+        const redis = createRedisStub();
+        let snapshotPayload: string | null = null;
+        redis.get.mockImplementation(async (key) => {
+            if (key === "eformsign:doclist-version:branch-a") {
+                return "0";
+            }
+            return snapshotPayload;
+        });
+        redis.set.mockImplementation(async (key, value) => {
+            if (key.startsWith("eformsign:doclist:")) {
+                snapshotPayload = value;
+            }
+            return "OK";
+        });
+        useRedisStub(redis);
+        const service = new EformsignDocumentSnapshotService(exclusionLookup);
+        const build = jest.fn().mockResolvedValue([
+            createEntry("safe-document"),
+            createEntry("completed-syncing-document"),
+        ]);
+
+        await service.getOrBuild(createMirrorParams(), build);
+        redis.incr.mockRejectedValueOnce(
+            new Error("Valkey unavailable during completed mirror invalidation"),
+        );
+        await expect(service.bumpVersion("branch-a")).resolves.toBeNull();
+        exclusionLookup.findUnreadyCompletedDocumentIds.mockResolvedValue([
+            "completed-syncing-document",
+        ]);
+
+        const result = await service.getOrBuild(createMirrorParams(), build);
+
+        expect(build).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({
+            entries: [createEntry("safe-document")],
+            snapshotVersion: expect.stringMatching(/^0:\d+$/),
+            cached: true,
+        });
+    });
+
+    it("should apply the readiness fence only to mirror snapshots", async () => {
+        const exclusionLookup = createSnapshotExclusionLookup();
+        exclusionLookup.findUnreadyCompletedDocumentIds.mockResolvedValue(["document-1"]);
+        const service = new EformsignDocumentSnapshotService(exclusionLookup);
+        const entry = createEntry("document-1");
+
+        const result = await service.getOrBuild(
+            createParams(),
+            jest.fn().mockResolvedValue([entry]),
+        );
+
+        expect(result.entries).toEqual([entry]);
+        expect(exclusionLookup.findUnreadyCompletedDocumentIds).not.toHaveBeenCalled();
+    });
+
+    it("should fail closed when the mirror readiness fence is unavailable", async () => {
+        const exclusionLookup = createSnapshotExclusionLookup();
+        const service = new EformsignDocumentSnapshotService(exclusionLookup);
+        const fenceError = new Error("mirror readiness lookup unavailable");
+        exclusionLookup.findUnreadyCompletedDocumentIds.mockRejectedValue(fenceError);
+
+        await expect(service.getOrBuild(
+            createMirrorParams(),
+            jest.fn().mockResolvedValue([createEntry("document-1")]),
+        )).rejects.toBe(fenceError);
     });
 
     it("should exclude a tombstoned unassigned document from a stale headquarters snapshot after its epoch bump fails", async () => {

--- a/backend/application/services/eformsign-document-mirror.service.ts
+++ b/backend/application/services/eformsign-document-mirror.service.ts
@@ -269,6 +269,10 @@ export class EformsignDocumentMirrorService {
         try {
             const remote = await this.eformsignClient.getDocument(accessToken, documentId);
             const sourceUpdatedDate = validSourceDate(remote.updated_date);
+            const statusType = normalizeEformsignStatusCode(
+                remote.current_status.status_type,
+            );
+            const isCompletedDocument = EFORMSIGN_COMPLETED_STATUS_CODES.has(statusType);
             attemptedSourceUpdatedDate = sourceUpdatedDate;
             try {
                 await this.mirrorDocumentUsecase.mirrorRemoteDocument(
@@ -331,6 +335,13 @@ export class EformsignDocumentMirrorService {
                 };
             }
 
+            if (isCompletedDocument) {
+                // saveDetail moves this generation to syncing. Invalidate the prior
+                // snapshot now so a completed row cannot stay published while either
+                // required PDF is missing or being replaced.
+                await this.invalidateDocumentSnapshots([documentId]);
+            }
+
             const storedFileTypes: EformsignDocumentFileType[] = [];
             const missingFileTypes: EformsignDocumentFileType[] = [];
             const shouldRepairFiles = !options.skipHealthySameVersionFileRepair
@@ -353,11 +364,8 @@ export class EformsignDocumentMirrorService {
                 storedFileTypes.push(...FILE_TYPES);
             }
 
-            const statusType = normalizeEformsignStatusCode(
-                remote.current_status.status_type,
-            );
             if (
-                EFORMSIGN_COMPLETED_STATUS_CODES.has(statusType)
+                isCompletedDocument
                 && missingFileTypes.length > 0
             ) {
                 throw new Error(
@@ -375,6 +383,11 @@ export class EformsignDocumentMirrorService {
                 partialMessage ? "partial" : "ready",
                 partialMessage,
             );
+            if (finishApplied && isCompletedDocument) {
+                // The list repository admits completed rows only at ready. Publish the
+                // successfully stored detail/PDF generation immediately.
+                await this.invalidateDocumentSnapshots([documentId]);
+            }
             let ownershipChanged = false;
             if (!finishApplied) {
                 // A newer attempt owns the terminal state. Reconcile only if that

--- a/backend/application/services/eformsign-document-snapshot.service.ts
+++ b/backend/application/services/eformsign-document-snapshot.service.ts
@@ -418,19 +418,53 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
             };
         }
         if (read.status === "hit") {
-            const visible = await this.excludeSnapshotEntries(
+            const cachedVisible = await this.excludeSnapshotEntries(
                 read.snapshot.entries,
                 returnOptions,
                 params.source,
             );
+            if (params.source === "mirror") {
+                // Mirror snapshots are an optimization over local DB reads, not an
+                // authority boundary. A failed Valkey generation bump can leave an
+                // old snapshot that a subtractive readiness fence cannot repair when
+                // a newly-ready row was absent. Rebuild the exact local scope and use
+                // a stable content fence whenever it diverges. This keeps reads
+                // vendor-free while making cache invalidation failure fail closed.
+                const liveVisible = await this.excludeSnapshotEntries(
+                    await this.buildSafeEntries(build),
+                    returnOptions,
+                    params.source,
+                );
+                const contentFence = snapshotEntriesEqual(
+                    cachedVisible.entries,
+                    liveVisible.entries,
+                )
+                    ? (
+                        cachedVisible.visibilityFence
+                        ?? liveVisible.visibilityFence
+                    )
+                    : snapshotEntriesFence(liveVisible.entries);
+                this.logger.log(
+                    `documentSnapshot hit branch=${params.branchId} scope=${params.scope}`
+                    + ` docs=${liveVisible.entries.length}`,
+                );
+                return {
+                    entries: liveVisible.entries,
+                    snapshotVersion: formatSnapshotVersion(
+                        read.snapshot,
+                        contentFence,
+                    ),
+                    cached: true,
+                };
+            }
             this.logger.log(
-                `documentSnapshot hit branch=${params.branchId} scope=${params.scope} docs=${visible.entries.length}`,
+                `documentSnapshot hit branch=${params.branchId} scope=${params.scope} docs=${cachedVisible.entries.length}`,
             );
             return {
-                entries: visible.entries,
+                entries: cachedVisible.entries,
                 snapshotVersion: formatSnapshotVersion(
                     read.snapshot,
-                    visible.visibilityFence,
+                    cachedVisible.visibilityFence,
                 ),
                 cached: true,
             };
@@ -714,6 +748,22 @@ function formatSnapshotVersion(
 ): string {
     const baseVersion = `${snapshot.version}:${snapshot.builtAt}`;
     return visibilityFence ? `${baseVersion}:f${visibilityFence}` : baseVersion;
+}
+
+function snapshotEntriesEqual<TDoc>(
+    left: DocumentSnapshotEntry<TDoc>[],
+    right: DocumentSnapshotEntry<TDoc>[],
+): boolean {
+    return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function snapshotEntriesFence<TDoc>(
+    entries: DocumentSnapshotEntry<TDoc>[],
+): string {
+    return createHash("sha256")
+        .update(JSON.stringify(entries))
+        .digest("hex")
+        .slice(0, 12);
 }
 
 function describeError(error: unknown): string {

--- a/backend/application/services/eformsign-document-snapshot.service.ts
+++ b/backend/application/services/eformsign-document-snapshot.service.ts
@@ -110,12 +110,14 @@ const DISPLAY_FIELD_MEMORY_STORE_MAX_ENTRIES = 512;
 type SnapshotExclusionLookup = Pick<
     IEformsignDocumentMirrorRepository,
     | "findListExcludedDocumentIds"
+    | "findUnreadyCompletedDocumentIds"
     | "findPermanentPurgeRequestedDocumentIds"
 >;
 
 /** Direct unit construction has no Nest container; production DI must provide the repository token. */
 const NO_SNAPSHOT_EXCLUSIONS: SnapshotExclusionLookup = {
     findListExcludedDocumentIds: async () => [],
+    findUnreadyCompletedDocumentIds: async () => [],
     findPermanentPurgeRequestedDocumentIds: async () => [],
 };
 
@@ -371,8 +373,9 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
         if (version === null) {
             return {
                 entries: await this.excludeSnapshotEntries(
-                    await this.buildSafeEntries(build),
+                    await this.buildSafeEntries(build, params.source),
                     returnOptions,
+                    params.source,
                 ),
                 cached: false,
             };
@@ -383,8 +386,9 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
             if (epoch === null) {
                 return {
                     entries: await this.excludeSnapshotEntries(
-                        await this.buildSafeEntries(build),
+                        await this.buildSafeEntries(build, params.source),
                         returnOptions,
+                        params.source,
                     ),
                     cached: false,
                 };
@@ -397,8 +401,9 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
         if (read.status === "error") {
             return {
                 entries: await this.excludeSnapshotEntries(
-                    await this.buildSafeEntries(build),
+                    await this.buildSafeEntries(build, params.source),
                     returnOptions,
+                    params.source,
                 ),
                 cached: false,
             };
@@ -407,6 +412,7 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
             const entries = await this.excludeSnapshotEntries(
                 read.snapshot.entries,
                 returnOptions,
+                params.source,
             );
             this.logger.log(
                 `documentSnapshot hit branch=${params.branchId} scope=${params.scope} docs=${entries.length}`,
@@ -425,6 +431,7 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
                 entries: await this.excludeSnapshotEntries(
                     shared.snapshot.entries,
                     returnOptions,
+                    params.source,
                 ),
                 ...(shared.stored ? { snapshotVersion: formatSnapshotVersion(shared.snapshot) } : {}),
                 cached: true,
@@ -441,6 +448,7 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
             entries: await this.excludeSnapshotEntries(
                 outcome.snapshot.entries,
                 returnOptions,
+                params.source,
             ),
             ...(outcome.stored ? { snapshotVersion: formatSnapshotVersion(outcome.snapshot) } : {}),
             cached: false,
@@ -453,7 +461,7 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
         params: DocumentSnapshotKeyParams,
         build: () => Promise<DocumentSnapshotEntry<TDoc>[]>,
     ): Promise<BuildOutcome<TDoc>> {
-        const entries = await this.buildSafeEntries(build);
+        const entries = await this.buildSafeEntries(build, params.source);
         const snapshot: StoredSnapshot<TDoc> = { version, builtAt: Date.now(), entries };
         const stored = await this.writeSnapshot(key, snapshot, params);
         return { snapshot, stored };
@@ -461,8 +469,9 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
 
     private async buildSafeEntries<TDoc>(
         build: () => Promise<DocumentSnapshotEntry<TDoc>[]>,
+        source: DocumentSnapshotKeyParams["source"],
     ): Promise<DocumentSnapshotEntry<TDoc>[]> {
-        return this.excludePermanentPurgeEntries(await build());
+        return this.excludeSnapshotEntries(await build(), {}, source);
     }
 
     /**
@@ -474,21 +483,17 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
     private async excludeSnapshotEntries<TDoc>(
         entries: DocumentSnapshotEntry<TDoc>[],
         options: DocumentSnapshotReturnOptions,
+        source: DocumentSnapshotKeyParams["source"],
     ): Promise<DocumentSnapshotEntry<TDoc>[]> {
-        const excludedIds = new Set(
-            options.excludeTombstones
-                ? await this.snapshotExclusionLookup.findListExcludedDocumentIds()
-                : await this.snapshotExclusionLookup.findPermanentPurgeRequestedDocumentIds(),
-        );
-        return this.filterExcludedSnapshotEntries(entries, excludedIds);
-    }
-
-    private async excludePermanentPurgeEntries<TDoc>(
-        entries: DocumentSnapshotEntry<TDoc>[],
-    ): Promise<DocumentSnapshotEntry<TDoc>[]> {
-        const excludedIds = new Set(
-            await this.snapshotExclusionLookup.findPermanentPurgeRequestedDocumentIds(),
-        );
+        const excludedIds = new Set(options.excludeTombstones
+            ? await this.snapshotExclusionLookup.findListExcludedDocumentIds()
+            : await this.snapshotExclusionLookup.findPermanentPurgeRequestedDocumentIds());
+        if (source === "mirror") {
+            for (const documentId of await this.snapshotExclusionLookup
+                .findUnreadyCompletedDocumentIds()) {
+                excludedIds.add(documentId);
+            }
+        }
         return this.filterExcludedSnapshotEntries(entries, excludedIds);
     }
 

--- a/backend/application/services/eformsign-document-snapshot.service.ts
+++ b/backend/application/services/eformsign-document-snapshot.service.ts
@@ -82,6 +82,15 @@ interface BuildOutcome<TDoc> {
     stored: boolean;
 }
 
+interface SnapshotExclusionResult<TDoc> {
+    entries: DocumentSnapshotEntry<TDoc>[];
+    /**
+     * Stable hash of live exclusions that actually changed this stored snapshot's
+     * membership. It becomes part of snapshotVersion so offset clients reset.
+     */
+    visibilityFence?: string;
+}
+
 interface MemoryEntry {
     expiresAt: number;
     payload: string;
@@ -372,11 +381,11 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
         const version = await this.getVersion(params.branchId);
         if (version === null) {
             return {
-                entries: await this.excludeSnapshotEntries(
-                    await this.buildSafeEntries(build, params.source),
+                entries: (await this.excludeSnapshotEntries(
+                    await this.buildSafeEntries(build),
                     returnOptions,
                     params.source,
-                ),
+                )).entries,
                 cached: false,
             };
         }
@@ -385,11 +394,11 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
             const epoch = await this.getCompanyEpoch();
             if (epoch === null) {
                 return {
-                    entries: await this.excludeSnapshotEntries(
-                        await this.buildSafeEntries(build, params.source),
+                    entries: (await this.excludeSnapshotEntries(
+                        await this.buildSafeEntries(build),
                         returnOptions,
                         params.source,
-                    ),
+                    )).entries,
                     cached: false,
                 };
             }
@@ -400,26 +409,29 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
         const read = await this.readSnapshot<TDoc>(key);
         if (read.status === "error") {
             return {
-                entries: await this.excludeSnapshotEntries(
-                    await this.buildSafeEntries(build, params.source),
+                entries: (await this.excludeSnapshotEntries(
+                    await this.buildSafeEntries(build),
                     returnOptions,
                     params.source,
-                ),
+                )).entries,
                 cached: false,
             };
         }
         if (read.status === "hit") {
-            const entries = await this.excludeSnapshotEntries(
+            const visible = await this.excludeSnapshotEntries(
                 read.snapshot.entries,
                 returnOptions,
                 params.source,
             );
             this.logger.log(
-                `documentSnapshot hit branch=${params.branchId} scope=${params.scope} docs=${entries.length}`,
+                `documentSnapshot hit branch=${params.branchId} scope=${params.scope} docs=${visible.entries.length}`,
             );
             return {
-                entries,
-                snapshotVersion: formatSnapshotVersion(read.snapshot),
+                entries: visible.entries,
+                snapshotVersion: formatSnapshotVersion(
+                    read.snapshot,
+                    visible.visibilityFence,
+                ),
                 cached: true,
             };
         }
@@ -427,13 +439,21 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
         const inFlight = this.inFlight.get(key);
         if (inFlight) {
             const shared = (await inFlight) as BuildOutcome<TDoc>;
+            const visible = await this.excludeSnapshotEntries(
+                shared.snapshot.entries,
+                returnOptions,
+                params.source,
+            );
             return {
-                entries: await this.excludeSnapshotEntries(
-                    shared.snapshot.entries,
-                    returnOptions,
-                    params.source,
-                ),
-                ...(shared.stored ? { snapshotVersion: formatSnapshotVersion(shared.snapshot) } : {}),
+                entries: visible.entries,
+                ...(shared.stored
+                    ? {
+                        snapshotVersion: formatSnapshotVersion(
+                            shared.snapshot,
+                            visible.visibilityFence,
+                        ),
+                    }
+                    : {}),
                 cached: true,
             };
         }
@@ -444,13 +464,21 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
         void pending.catch(() => undefined).finally(() => this.inFlight.delete(key));
 
         const outcome = await pending;
+        const visible = await this.excludeSnapshotEntries(
+            outcome.snapshot.entries,
+            returnOptions,
+            params.source,
+        );
         return {
-            entries: await this.excludeSnapshotEntries(
-                outcome.snapshot.entries,
-                returnOptions,
-                params.source,
-            ),
-            ...(outcome.stored ? { snapshotVersion: formatSnapshotVersion(outcome.snapshot) } : {}),
+            entries: visible.entries,
+            ...(outcome.stored
+                ? {
+                    snapshotVersion: formatSnapshotVersion(
+                        outcome.snapshot,
+                        visible.visibilityFence,
+                    ),
+                }
+                : {}),
             cached: false,
         };
     }
@@ -461,7 +489,7 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
         params: DocumentSnapshotKeyParams,
         build: () => Promise<DocumentSnapshotEntry<TDoc>[]>,
     ): Promise<BuildOutcome<TDoc>> {
-        const entries = await this.buildSafeEntries(build, params.source);
+        const entries = await this.buildSafeEntries(build);
         const snapshot: StoredSnapshot<TDoc> = { version, builtAt: Date.now(), entries };
         const stored = await this.writeSnapshot(key, snapshot, params);
         return { snapshot, stored };
@@ -469,9 +497,11 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
 
     private async buildSafeEntries<TDoc>(
         build: () => Promise<DocumentSnapshotEntry<TDoc>[]>,
-        source: DocumentSnapshotKeyParams["source"],
     ): Promise<DocumentSnapshotEntry<TDoc>[]> {
-        return this.excludeSnapshotEntries(await build(), {}, source);
+        const excludedIds = new Set(
+            await this.snapshotExclusionLookup.findPermanentPurgeRequestedDocumentIds(),
+        );
+        return this.filterExcludedSnapshotEntries(await build(), excludedIds);
     }
 
     /**
@@ -484,7 +514,7 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
         entries: DocumentSnapshotEntry<TDoc>[],
         options: DocumentSnapshotReturnOptions,
         source: DocumentSnapshotKeyParams["source"],
-    ): Promise<DocumentSnapshotEntry<TDoc>[]> {
+    ): Promise<SnapshotExclusionResult<TDoc>> {
         const excludedIds = new Set(options.excludeTombstones
             ? await this.snapshotExclusionLookup.findListExcludedDocumentIds()
             : await this.snapshotExclusionLookup.findPermanentPurgeRequestedDocumentIds());
@@ -494,7 +524,33 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
                 excludedIds.add(documentId);
             }
         }
-        return this.filterExcludedSnapshotEntries(entries, excludedIds);
+        const effectiveExcludedIds = entries
+            .map((entry) => this.snapshotEntryDocumentId(entry))
+            .filter((documentId): documentId is string =>
+                documentId !== null && excludedIds.has(documentId))
+            .sort();
+        const filteredEntries = this.filterExcludedSnapshotEntries(entries, excludedIds);
+        if (effectiveExcludedIds.length === 0) {
+            return { entries: filteredEntries };
+        }
+        return {
+            entries: filteredEntries,
+            visibilityFence: createHash("sha256")
+                .update(effectiveExcludedIds.join("\0"))
+                .digest("hex")
+                .slice(0, 12),
+        };
+    }
+
+    private snapshotEntryDocumentId<TDoc>(
+        entry: DocumentSnapshotEntry<TDoc>,
+    ): string | null {
+        const document = entry.document;
+        if (typeof document !== "object" || document === null || !("id" in document)) {
+            return null;
+        }
+        const documentId = (document as { id?: unknown }).id;
+        return typeof documentId === "string" ? documentId : null;
     }
 
     private filterExcludedSnapshotEntries<TDoc>(
@@ -506,12 +562,8 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
         }
 
         return entries.filter((entry) => {
-            const document = entry.document;
-            if (typeof document !== "object" || document === null || !("id" in document)) {
-                return true;
-            }
-            const documentId = (document as { id?: unknown }).id;
-            return typeof documentId !== "string" || !excludedIds.has(documentId);
+            const documentId = this.snapshotEntryDocumentId(entry);
+            return documentId === null || !excludedIds.has(documentId);
         });
     }
 
@@ -656,8 +708,12 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
     }
 }
 
-function formatSnapshotVersion(snapshot: { version: number; builtAt: number }): string {
-    return `${snapshot.version}:${snapshot.builtAt}`;
+function formatSnapshotVersion(
+    snapshot: { version: number; builtAt: number },
+    visibilityFence?: string,
+): string {
+    const baseVersion = `${snapshot.version}:${snapshot.builtAt}`;
+    return visibilityFence ? `${baseVersion}:f${visibilityFence}` : baseVersion;
 }
 
 function describeError(error: unknown): string {

--- a/backend/application/services/eformsign-mirror-list.service.ts
+++ b/backend/application/services/eformsign-mirror-list.service.ts
@@ -72,15 +72,19 @@ export class EformsignMirrorListService {
     }): Promise<EformsignListDoc[]> {
         // For a regular branch the list rows and the search rows are the same query, so it
         // is read once; only headquarters needs the wider set as well.
-        const branchOwned = await this.eformsignDocRepository.findAll(query.branchId);
+        const branchOwned = await this.eformsignDocRepository.findAllVisibleInMirror(
+            query.branchId,
+        );
         const mirrored = query.isHeadquarters
-            ? await this.eformsignDocRepository.findAllForHeadquarters(query.branchId)
+            ? await this.eformsignDocRepository.findAllVisibleInMirrorForHeadquarters(
+                query.branchId,
+            )
             : branchOwned;
 
         // Branch-owned rows only, even for headquarters: the API path builds its
-        // recipient-name search corpus from findAll(branchId), so an unassigned document's
-        // recipient name is not searchable there either. Carried on the document so a
-        // cached generation keeps it without a second read.
+        // recipient-name search corpus from the branch-visible query, so an unassigned
+        // document's recipient name is not searchable there either. Carried on the
+        // document so a cached generation keeps it without a second read.
         const recipientNameById = new Map(
             branchOwned.map((document) => [
                 document.documentId,

--- a/backend/application/usecases/eformsign-doc/adopt-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/adopt-eformsign-doc.usecase.ts
@@ -4,6 +4,7 @@ import { documentCustomerNameValue } from "application/utils/eformsign-document-
 import { EFORMSIGN_DOCUMENT_KIND } from "domain/entities/eformsign-doc.entity";
 import { CLIENT_REPOSITORY, IClientRepository } from "domain/repositories/client.repository.interface";
 import { eformsignExpiryDateFromRemainingDays } from "domain/utils/eformsign-expiry-date";
+import { normalizeEformsignStatusCode } from "domain/utils/eformsign-status-code";
 
 import { CreateEformsignDocResult, CreateEformsignDocUsecase } from "./create-eformsign-doc.usecase";
 import { FetchEformsignDocFromApiUsecase } from "./fetch-eformsign-doc-from-api.usecase";
@@ -41,7 +42,7 @@ export class AdoptEformsignDocUsecase {
         return this.createEformsignDocUsecase.execute(branchId, {
             documentId: remote.id || params.documentId,
             clientId,
-            statusType: remote.current_status.status_type || "000",
+            statusType: normalizeEformsignStatusCode(remote.current_status.status_type),
             statusDetail: remote.current_status.status_doc_detail || remote.current_status.step_name || "진행중",
             stepType: remote.current_status.step_type || "01",
             stepIndex: remote.current_status.step_index || "1",

--- a/backend/application/usecases/eformsign-doc/adopt-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/adopt-eformsign-doc.usecase.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from "@nestjs/common";
 
+import { EformsignDocumentMirrorService } from "application/services/eformsign-document-mirror.service";
 import { documentCustomerNameValue } from "application/utils/eformsign-document-customer-name";
 import { EFORMSIGN_DOCUMENT_KIND } from "domain/entities/eformsign-doc.entity";
 import { CLIENT_REPOSITORY, IClientRepository } from "domain/repositories/client.repository.interface";
@@ -22,6 +23,7 @@ export class AdoptEformsignDocUsecase {
         private readonly fetchEformsignDocFromApiUsecase: FetchEformsignDocFromApiUsecase,
         private readonly createEformsignDocUsecase: CreateEformsignDocUsecase,
         @Inject(CLIENT_REPOSITORY) private readonly clientRepository: IClientRepository,
+        private readonly documentMirrorService: EformsignDocumentMirrorService,
     ) {}
 
     async execute(branchId: string, params: AdoptEformsignDocParams): Promise<CreateEformsignDocResult> {
@@ -39,7 +41,7 @@ export class AdoptEformsignDocUsecase {
             throw new Error("clientId가 필요합니다.");
         }
 
-        return this.createEformsignDocUsecase.execute(branchId, {
+        const result = await this.createEformsignDocUsecase.execute(branchId, {
             documentId: remote.id || params.documentId,
             clientId,
             statusType: normalizeEformsignStatusCode(remote.current_status.status_type),
@@ -66,5 +68,13 @@ export class AdoptEformsignDocUsecase {
                 ?.map((item) => item.recipient_type)
                 ?? null,
         });
+
+        await this.documentMirrorService.syncDocumentWithToken(
+            token.oauth_token.access_token,
+            remote.id || params.documentId,
+            { expectedUpdatedDate: remote.updated_date },
+        );
+
+        return result;
     }
 }

--- a/backend/application/usecases/eformsign-doc/adopt-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/adopt-eformsign-doc.usecase.ts
@@ -57,6 +57,10 @@ export class AdoptEformsignDocUsecase {
                 Date.now(),
             ),
             linkToClient: true,
+            // Existing ready detail/PDFs describe the stored projection. Assign
+            // ownership first, but let the fenced mirror sync below publish the
+            // newly fetched vendor projection only after its artifacts are ready.
+            preserveExistingMirrorProjection: true,
             documentKind: EFORMSIGN_DOCUMENT_KIND.CONTRACT,
             templateId: remote.template?.id ?? null,
             documentName: remote.document_name,

--- a/backend/application/usecases/eformsign-doc/create-and-send-service-record-snapshot.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/create-and-send-service-record-snapshot.usecase.ts
@@ -18,6 +18,7 @@ import {
 } from "infrastructure/database/eformsign-doc-compat";
 import { PrismaService } from "infrastructure/database/prisma.service";
 import { eformsignExpiryDateFromRemainingDays } from "domain/utils/eformsign-expiry-date";
+import { normalizeEformsignStatusCode } from "domain/utils/eformsign-status-code";
 import { captureServiceRecordError } from "infrastructure/observability/service-record-sentry";
 import { GetEformsignAccessTokenUsecase } from "./get-eformsign-access-token.usecase";
 import {
@@ -786,7 +787,7 @@ export class CreateAndSendServiceRecordSnapshotUsecase {
             stepRecipientTypes,
             createdDate,
             updatedDate,
-            statusType: remoteStatus?.status_type ?? "070",
+            statusType: normalizeEformsignStatusCode(remoteStatus?.status_type ?? "070"),
             statusDetail: remoteStatus?.status_doc_detail ?? "검토 요청",
             stepType: remoteStatus?.step_type ?? "06",
             stepIndex: remoteStatus?.step_index ?? "2",
@@ -814,7 +815,7 @@ export class CreateAndSendServiceRecordSnapshotUsecase {
             ...(stepRecipientTypes ? { stepRecipientTypes } : {}),
             ...(remoteStatus ? {
                 updatedDate,
-                statusType: remoteStatus.status_type,
+                statusType: normalizeEformsignStatusCode(remoteStatus.status_type),
                 // Only detail responses carry this. Omit rather than pass undefined so
                 // the intent is the code's, not Prisma's coincidental skip semantics.
                 ...(remoteStatus.status_doc_detail === undefined

--- a/backend/application/usecases/eformsign-doc/create-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/create-eformsign-doc.usecase.ts
@@ -31,6 +31,8 @@ export interface CreateEformsignDocParams {
     documentKind?: EformsignDocumentKind | null;
     employeeScheduleId?: number | null;
     templateId?: string | null;
+    /** Internal adopt-path fence; ordinary document creation must leave this unset. */
+    preserveExistingMirrorProjection?: boolean;
 }
 
 export type CreateEformsignDocResult = EformsignDocEntity & {
@@ -88,7 +90,13 @@ export class CreateEformsignDocUsecase {
             employeeScheduleId: params.employeeScheduleId ?? null,
             templateId: params.templateId ?? null,
         });
-        const createdDoc = await this.eformsignDocRepository.upsertByDocumentId(branchid, entity);
+        const createdDoc = params.preserveExistingMirrorProjection
+            ? await this.eformsignDocRepository.upsertByDocumentId(
+                branchid,
+                entity,
+                { preserveExistingMirrorProjection: true },
+            )
+            : await this.eformsignDocRepository.upsertByDocumentId(branchid, entity);
         const warnings: Array<"client_link_failed"> = [];
 
         // If linkToClient is true, also update client.e_doc_id to track this document

--- a/backend/application/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.ts
@@ -4,6 +4,7 @@ import { EformsignDocumentSnapshotService } from "application/services/eformsign
 import { documentCustomerNameValue } from "application/utils/eformsign-document-customer-name";
 import { eformsignDocumentTemplateId } from "application/utils/eformsign-document-template-id";
 import {
+    EFORMSIGN_COMPLETED_STATUS_CODES,
     EFORMSIGN_EXPIRED_STATUS_CODE,
     EFORMSIGN_TERMINAL_STATUS_DETAILS,
     TERMINAL_STATUS_CODES,
@@ -150,6 +151,9 @@ export class MirrorUnassignedEformsignDocUsecase {
         const mirrored = await this.eformsignDocRepository.upsertUnassignedByDocumentId(doc, {
             ...(options.allowAssignedUpdate ? { allowAssignedUpdate: true } : {}),
             updateListDisplayFields: true,
+            ...(EFORMSIGN_COMPLETED_STATUS_CODES.has(statusType)
+                ? { markMirrorPending: true }
+                : {}),
             ...(knowsExpiredState ? {} : { updateExpired: false }),
             // A detail derived from the step name must not replace one a webhook wrote —
             // but one derived from a terminal status code must, because the stored detail

--- a/backend/domain/constants/eformsign-doc-status.constants.ts
+++ b/backend/domain/constants/eformsign-doc-status.constants.ts
@@ -65,6 +65,21 @@ export const TERMINAL_STATUS_CODES = new Set<string>([
  */
 export const UNASSIGNED_REVIEW_STAGE_STATUS_CODES = new Set<string>(["062", "071"]);
 
+/**
+ * Canonical review-stage codes plus raw values written by older vendor-ingestion paths.
+ * The repository normally receives normalized codes now, but an equal-generation forward
+ * transition must also be able to replace a legacy row without broadly reopening every
+ * completed status.
+ */
+export const UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES = [
+    "062",
+    "071",
+    "62",
+    "71",
+    "doc_accept_participant",
+    "doc_reject_reviewer",
+] as const;
+
 export const UNASSIGNED_TERMINAL_STATUS_CODES = new Set<string>(
     [...TERMINAL_STATUS_CODES].filter(
         (statusCode) => !UNASSIGNED_REVIEW_STAGE_STATUS_CODES.has(statusCode),

--- a/backend/domain/constants/eformsign-doc-status.constants.ts
+++ b/backend/domain/constants/eformsign-doc-status.constants.ts
@@ -9,6 +9,31 @@ export const EFORMSIGN_COMPLETED_STATUS_CODES: ReadonlySet<string> = new Set([
     "092",
 ]);
 
+/**
+ * Completed values that may already exist in storage from legacy/raw vendor writes.
+ * New writes are normalized, but publication queries must also fence old aliases and
+ * unpadded numeric forms until a normal sync rewrites them canonically.
+ */
+export const EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES: readonly string[] = [
+    ...EFORMSIGN_COMPLETED_STATUS_CODES,
+    "3",
+    "03",
+    "12",
+    "22",
+    "32",
+    "50",
+    "62",
+    "72",
+    "92",
+    "doc_complete",
+    "doc_accept_approval",
+    "doc_accept_reception",
+    "doc_accept_outsider",
+    "doc_accept_participant",
+    "doc_accept_reviewer",
+    "face_signature_complete",
+];
+
 const REJECTED_STATUS_CODES = [
     "011",
     "021",

--- a/backend/domain/repositories/eformsign-doc.repository.interface.ts
+++ b/backend/domain/repositories/eformsign-doc.repository.interface.ts
@@ -70,6 +70,11 @@ export interface EformsignDocConditionalUpdateResult {
 export interface UpsertUnassignedEformsignDocOptions {
     allowAssignedUpdate?: boolean;
     updateListDisplayFields?: boolean;
+    /**
+     * Atomically withdraw a completed list projection before detail/PDF mirroring starts.
+     * The mirror service republishes it only after both required PDFs reach ready.
+     */
+    markMirrorPending?: boolean;
     updateExpired?: boolean;
     /**
      * The list endpoint carries no status detail, so a caller working from it only has a
@@ -110,11 +115,21 @@ export interface IEformsignDocRepository {
     findByClientId(branchid: string, clientId: number): Promise<EformsignDocEntity[]>;
     findAll(branchid: string): Promise<EformsignDocEntity[]>;
     /**
+     * Rows safe to expose through the local-only mirror list. Completed documents stay
+     * hidden until their detail and required PDFs reach the ready generation.
+     */
+    findAllVisibleInMirror(branchid: string): Promise<EformsignDocEntity[]>;
+    /**
      * Every document the headquarters list may show: ours plus the ones no branch has
      * claimed. Deliberately not "all rows minus other branches" done in memory — that is
      * the same rule, but expressed where the database can apply it.
      */
     findAllForHeadquarters(branchid: string): Promise<EformsignDocEntity[]>;
+    /**
+     * Headquarters equivalent of `findAllVisibleInMirror`, including unclaimed rows but
+     * applying the same completed-ready publication gate.
+     */
+    findAllVisibleInMirrorForHeadquarters(branchid: string): Promise<EformsignDocEntity[]>;
     findDocumentIdsForOtherBranches(branchid: string): Promise<string[]>;
     findDisplayFieldsByDocumentIds(
         branchid: string,

--- a/backend/domain/repositories/eformsign-doc.repository.interface.ts
+++ b/backend/domain/repositories/eformsign-doc.repository.interface.ts
@@ -98,6 +98,16 @@ export interface UpsertUnassignedEformsignDocOptions {
     updateCreatedDate?: boolean;
 }
 
+export interface UpsertEformsignDocByDocumentIdOptions {
+    /**
+     * Adoption may assign branch/client ownership to a row whose detail/PDF
+     * generation is already ready. Keep that existing vendor projection intact
+     * until the mirror service has fetched and fenced the replacement generation.
+     * A newly inserted row still receives the complete projection and starts pending.
+     */
+    preserveExistingMirrorProjection?: boolean;
+}
+
 export interface IEformsignDocRepository {
     findById(branchid: string, id: number): Promise<EformsignDocEntity | null>;
     findByDocumentId(branchid: string, documentId: string): Promise<EformsignDocEntity | null>;
@@ -156,7 +166,11 @@ export interface IEformsignDocRepository {
         documentId: string,
         clientId: number,
     ): Promise<boolean>;
-    upsertByDocumentId(branchid: string, doc: EformsignDocEntity): Promise<EformsignDocEntity>;
+    upsertByDocumentId(
+        branchid: string,
+        doc: EformsignDocEntity,
+        options?: UpsertEformsignDocByDocumentIdOptions,
+    ): Promise<EformsignDocEntity>;
     upsertUnassignedByDocumentId(
         doc: EformsignDocEntity,
         options?: UpsertUnassignedEformsignDocOptions,

--- a/backend/domain/repositories/eformsign-document-mirror.repository.interface.ts
+++ b/backend/domain/repositories/eformsign-document-mirror.repository.interface.ts
@@ -113,6 +113,11 @@ export interface IEformsignDocumentMirrorRepository {
      * cached HQ snapshots can contain both branch-owned and unassigned rows.
      */
     findListExcludedDocumentIds(): Promise<string[]>;
+    /**
+     * Completed rows that are not safe to publish from a cached mirror generation.
+     * Global by document id so the same fence protects branch and headquarters caches.
+     */
+    findUnreadyCompletedDocumentIds(): Promise<string[]>;
     findPermanentPurgeRequestedDocumentIds(): Promise<string[]>;
     requestPermanentPurge(documentIds: string[]): Promise<EformsignPermanentPurgeRequest[]>;
     /** Returns only requests whose exact generation was still pending. */

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
 import {
+    EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES,
     UNASSIGNED_FORWARD_STATUS_CODES_AFTER_REVIEW_STAGE,
     UNASSIGNED_REVIEW_STAGE_STATUS_CODES,
     UNASSIGNED_TERMINAL_STATUS_CODES,
@@ -35,6 +36,19 @@ const isUniqueConstraintError = (error: unknown): boolean =>
     && (error as { code?: unknown }).code === "P2002";
 
 const DELETED_EFORMSIGN_STATUS_TYPES = ["047", "049", "099"];
+const COMPLETED_EFORMSIGN_STATUS_TYPES = [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES];
+const MIRROR_LIST_NON_COMPLETED_WHERE: Prisma.eformsign_docWhereInput = {
+    statusType: { notIn: COMPLETED_EFORMSIGN_STATUS_TYPES },
+};
+const MIRROR_LIST_VISIBILITY_WHERE: Prisma.eformsign_docWhereInput = {
+    OR: [
+        MIRROR_LIST_NON_COMPLETED_WHERE,
+        {
+            statusType: { in: COMPLETED_EFORMSIGN_STATUS_TYPES },
+            syncStatus: "ready",
+        },
+    ],
+};
 
 const toUnscopedResult = (
     documentId: string,
@@ -242,11 +256,26 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
         });
     }
 
+    async findAllVisibleInMirror(branchid: string): Promise<EformsignDocEntity[]> {
+        return this.findManyVisibleInMirror({ branchId: branchid });
+    }
+
     async findAllForHeadquarters(branchid: string): Promise<EformsignDocEntity[]> {
         // Mirrors the scan filter the API path uses: headquarters keeps everything except
         // what another branch owns, so an unclaimed document (branchId null) stays in.
         return this.findManyDomain({
             permanentPurgeRequestedAt: null,
+            OR: [
+                { branchId: branchid },
+                { branchId: null },
+            ],
+        });
+    }
+
+    async findAllVisibleInMirrorForHeadquarters(
+        branchid: string,
+    ): Promise<EformsignDocEntity[]> {
+        return this.findManyVisibleInMirror({
             OR: [
                 { branchId: branchid },
                 { branchId: null },
@@ -591,6 +620,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
         };
         const update = {
             statusType: doc.statusType,
+            ...(options?.markMirrorPending ? { syncStatus: "pending" as const } : {}),
             ...(options?.updateStatusDetail === false ? {} : { statusDetail: doc.statusDetail }),
             stepType: doc.stepType,
             stepIndex: doc.stepIndex,
@@ -829,6 +859,34 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
             const docs = await readWithEformsignDocCompat(error, (select) =>
                 this.prismaService.eformsign_doc.findMany({ where, select }));
             return docs.map((doc) => EformsignDocMapper.toDomain(toCompatDomainRow(doc)));
+        }
+    }
+
+    private async findManyVisibleInMirror(
+        scopeWhere: Prisma.eformsign_docWhereInput,
+    ): Promise<EformsignDocEntity[]> {
+        try {
+            return await this.findManyDomain({
+                permanentPurgeRequestedAt: null,
+                AND: [
+                    scopeWhere,
+                    MIRROR_LIST_VISIBILITY_WHERE,
+                ],
+            });
+        } catch (error) {
+            if (!isPendingEformsignDocColumnError(error)) {
+                throw error;
+            }
+
+            // During a code-first rollout sync_status may not exist yet. Without it,
+            // no completed document can be proven to contain both required PDFs.
+            return this.findManyDomain({
+                permanentPurgeRequestedAt: null,
+                AND: [
+                    scopeWhere,
+                    MIRROR_LIST_NON_COMPLETED_WHERE,
+                ],
+            });
         }
     }
 }

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -52,6 +52,15 @@ const MIRROR_LIST_VISIBILITY_WHERE: Prisma.eformsign_docWhereInput = {
 };
 const RETRYABLE_MIRROR_SYNC_STATUSES = ["pending", "partial", "failed"] as const;
 
+const combineStatusGuards = (
+    guards: Prisma.eformsign_docWhereInput[],
+): Prisma.eformsign_docWhereInput => {
+    if (guards.length === 1) {
+        return guards[0] ?? {};
+    }
+    return guards.length > 1 ? { AND: guards } : {};
+};
+
 const toUnscopedResult = (
     documentId: string,
     row: Parameters<typeof EformsignDocMapper.toDomain>[0] & { branchId: string | null },
@@ -652,7 +661,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                 : {}),
         };
 
-        const statusGuards: Prisma.eformsign_docWhereInput[] = [
+        const baseStatusGuards: Prisma.eformsign_docWhereInput[] = [
             ...(UNASSIGNED_TERMINAL_STATUS_CODES.has(doc.statusType)
                 ? []
                 : [{
@@ -672,6 +681,9 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                         { statusType: doc.statusType },
                     ],
                 }]),
+        ];
+        const statusGuards: Prisma.eformsign_docWhereInput[] = [
+            ...baseStatusGuards,
             ...(options?.markMirrorPending
                 ? [{
                     // The detail attempt is the publication owner. A list status can
@@ -713,12 +725,8 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                 }]
                 : []),
         ];
-        let statusGuard: Prisma.eformsign_docWhereInput = {};
-        if (statusGuards.length === 1) {
-            statusGuard = statusGuards[0] ?? {};
-        } else if (statusGuards.length > 1) {
-            statusGuard = { AND: statusGuards };
-        }
+        const statusGuard = combineStatusGuards(statusGuards);
+        const compatibilityStatusGuard = combineStatusGuards(baseStatusGuards);
 
         return this.conditionalUpsertByDocumentId({
             documentId: doc.documentId,
@@ -740,6 +748,19 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                 statusType: { notIn: DELETED_EFORMSIGN_STATUS_TYPES },
                 ...statusGuard,
             },
+            ...(options?.markMirrorPending
+                ? {
+                    // Before the mirror migration there is no detail generation or
+                    // syncStatus to fence. Keep the pre-mirror ordering/status guards
+                    // so a P2022 retry never references columns that do not exist.
+                    compatibilityStaleGuard: {
+                        updatedDate: { lte: doc.updatedDate },
+                        permanentPurgeRequestedAt: null,
+                        statusType: { notIn: DELETED_EFORMSIGN_STATUS_TYPES },
+                        ...compatibilityStatusGuard,
+                    },
+                }
+                : {}),
             // Creation time is not state, so a refusal on ordering grounds must not take
             // it down with the rest. It has to be that way: a row written by create or
             // adopt carries the moment we wrote it, which is *newer* than the vendor's own
@@ -757,19 +778,25 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
         update: Prisma.eformsign_docUpdateManyMutationInput;
         allowedWhere: Prisma.eformsign_docWhereInput;
         staleGuard?: Prisma.eformsign_docWhereInput;
+        compatibilityStaleGuard?: Prisma.eformsign_docWhereInput;
         repairCreatedDateWhenStale?: Date;
     }): Promise<EformsignDocEntity> {
+        const {
+            compatibilityStaleGuard,
+            ...attemptParams
+        } = params;
         try {
-            return await this.attemptConditionalUpsertByDocumentId(params);
+            return await this.attemptConditionalUpsertByDocumentId(attemptParams);
         } catch (error) {
             if (!isPendingEformsignDocColumnError(error)) {
                 throw error;
             }
 
             return this.attemptConditionalUpsertByDocumentId({
-                ...params,
-                create: omitPendingEformsignDocColumns(params.create, error),
-                update: omitPendingEformsignDocColumns(params.update, error),
+                ...attemptParams,
+                create: omitPendingEformsignDocColumns(attemptParams.create, error),
+                update: omitPendingEformsignDocColumns(attemptParams.update, error),
+                staleGuard: compatibilityStaleGuard ?? attemptParams.staleGuard,
             }, error);
         }
     }

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -3,7 +3,7 @@ import { Prisma } from "@prisma/client";
 import {
     EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES,
     UNASSIGNED_FORWARD_STATUS_CODES_AFTER_REVIEW_STAGE,
-    UNASSIGNED_REVIEW_STAGE_STATUS_CODES,
+    UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES,
     UNASSIGNED_TERMINAL_STATUS_CODES,
 } from "domain/constants/eformsign-doc-status.constants";
 import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
@@ -655,12 +655,35 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                     OR: [
                         {
                             statusType: {
-                                notIn: [...UNASSIGNED_REVIEW_STAGE_STATUS_CODES],
+                                notIn: [...UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES],
                             },
                         },
                         { statusType: doc.statusType },
                     ],
                 }]),
+            ...(options?.markMirrorPending
+                ? [{
+                    // A completed projection owns a mirror attempt only if it advances
+                    // the vendor generation or changes an open row into a completion.
+                    // Equal-version completed retries must not downgrade a newer
+                    // syncing/ready attempt back to pending.
+                    OR: [
+                        { updatedDate: { lt: doc.updatedDate } },
+                        {
+                            statusType: {
+                                notIn: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES],
+                            },
+                        },
+                        ...(UNASSIGNED_TERMINAL_STATUS_CODES.has(doc.statusType)
+                            ? [{
+                                statusType: {
+                                    in: [...UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES],
+                                },
+                            }]
+                            : []),
+                    ],
+                }]
+                : []),
         ];
         let statusGuard: Prisma.eformsign_docWhereInput = {};
         if (statusGuards.length === 1) {

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -17,6 +17,7 @@ import {
     EformsignDocStaleUpdateError,
     EformsignDocUnscopedResult,
     IEformsignDocRepository,
+    UpsertEformsignDocByDocumentIdOptions,
     UpsertUnassignedEformsignDocOptions,
 } from "domain/repositories/eformsign-doc.repository.interface";
 import {
@@ -49,6 +50,7 @@ const MIRROR_LIST_VISIBILITY_WHERE: Prisma.eformsign_docWhereInput = {
         },
     ],
 };
+const RETRYABLE_MIRROR_SYNC_STATUSES = ["pending", "partial", "failed"] as const;
 
 const toUnscopedResult = (
     documentId: string,
@@ -572,17 +574,26 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
         return { document: updated, applied: true };
     }
 
-    async upsertByDocumentId(branchid: string, doc: EformsignDocEntity): Promise<EformsignDocEntity> {
+    async upsertByDocumentId(
+        branchid: string,
+        doc: EformsignDocEntity,
+        options?: UpsertEformsignDocByDocumentIdOptions,
+    ): Promise<EformsignDocEntity> {
         const create = {
             ...EformsignDocMapper.toPrismaCreate(doc),
             branchId: branchid,
         };
-        const update: Partial<ReturnType<typeof EformsignDocMapper.toPrismaUpdate>> & {
-            branchId: string;
-        } = {
-            ...EformsignDocMapper.toPrismaUpdate(doc),
-            branchId: branchid,
-        };
+        const update: Partial<ReturnType<typeof EformsignDocMapper.toPrismaUpdate>>
+            & { branchId: string } = options?.preserveExistingMirrorProjection
+                ? {
+                    branchId: branchid,
+                    clientId: doc.clientId,
+                    documentKind: doc.documentKind,
+                }
+                : {
+                    ...EformsignDocMapper.toPrismaUpdate(doc),
+                    branchId: branchid,
+                };
         delete update.documentId;
 
         return this.conditionalUpsertByDocumentId({
@@ -663,24 +674,41 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                 }]),
             ...(options?.markMirrorPending
                 ? [{
-                    // A completed projection owns a mirror attempt only if it advances
-                    // the vendor generation or changes an open row into a completion.
-                    // Equal-version completed retries must not downgrade a newer
-                    // syncing/ready attempt back to pending.
+                    // The detail attempt is the publication owner. A list status can
+                    // intentionally lag behind a completion webhook, so it must never
+                    // authorize a same-generation ready/syncing row to move back to
+                    // pending. Same-generation repair is limited to retryable attempts
+                    // or a detail that itself is still at the review stage.
                     OR: [
-                        { updatedDate: { lt: doc.updatedDate } },
+                        { detailSourceUpdatedDate: null },
+                        { detailSourceUpdatedDate: { lt: doc.updatedDate } },
                         {
-                            statusType: {
-                                notIn: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES],
-                            },
-                        },
-                        ...(UNASSIGNED_TERMINAL_STATUS_CODES.has(doc.statusType)
-                            ? [{
-                                statusType: {
-                                    in: [...UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES],
+                            AND: [
+                                { detailSourceUpdatedDate: doc.updatedDate },
+                                {
+                                    OR: [
+                                        {
+                                            syncStatus: {
+                                                in: [...RETRYABLE_MIRROR_SYNC_STATUSES],
+                                            },
+                                        },
+                                        ...(UNASSIGNED_FORWARD_STATUS_CODES_AFTER_REVIEW_STAGE
+                                            .has(doc.statusType)
+                                            ? UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES
+                                                .map((statusType) => ({
+                                                    detailPayload: {
+                                                        path: [
+                                                            "current_status",
+                                                            "status_type",
+                                                        ],
+                                                        equals: statusType,
+                                                    },
+                                                }))
+                                            : []),
+                                    ],
                                 },
-                            }]
-                            : []),
+                            ],
+                        },
                     ],
                 }]
                 : []),

--- a/backend/infrastructure/database/repositories/sb.eformsign-document-mirror.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-document-mirror.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
 
+import { EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES } from "domain/constants/eformsign-doc-status.constants";
 import {
     EformsignDocumentFileType,
     EformsignDocumentFileMetadata,
@@ -14,6 +15,7 @@ import {
     SaveEformsignDocumentFileParams,
 } from "domain/repositories/eformsign-document-mirror.repository.interface";
 import { EformsignApiDocumentResponse } from "domain/repositories/eformsign.client.interface";
+import { isPendingEformsignDocColumnError } from "infrastructure/database/eformsign-doc-compat";
 import { PrismaService } from "infrastructure/database/prisma.service";
 
 const MAX_SYNC_ERROR_LENGTH = 2_000;
@@ -132,6 +134,32 @@ implements IEformsignDocumentMirrorRepository {
             select: { documentId: true },
         });
         return rows.map((row) => row.documentId);
+    }
+
+    async findUnreadyCompletedDocumentIds(): Promise<string[]> {
+        try {
+            const rows = await this.prisma.eformsign_doc.findMany({
+                where: {
+                    statusType: { in: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES] },
+                    syncStatus: { not: "ready" },
+                },
+                select: { documentId: true },
+            });
+            return rows.map((row) => row.documentId);
+        } catch (error) {
+            if (!isPendingEformsignDocColumnError(error)) {
+                throw error;
+            }
+
+            // A database without sync_status cannot prove any completed row ready.
+            const rows = await this.prisma.eformsign_doc.findMany({
+                where: {
+                    statusType: { in: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES] },
+                },
+                select: { documentId: true },
+            });
+            return rows.map((row) => row.documentId);
+        }
     }
 
     async findPermanentPurgeRequestedDocumentIds(): Promise<string[]> {

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -86,6 +86,7 @@ describe("EformsignController (Integration)", () => {
     };
     const permanentPurgeLookup = {
         findListExcludedDocumentIds: jest.fn().mockResolvedValue([]),
+        findUnreadyCompletedDocumentIds: jest.fn().mockResolvedValue([]),
         findPermanentPurgeRequestedDocumentIds: jest.fn().mockResolvedValue([]),
     };
 
@@ -99,6 +100,8 @@ describe("EformsignController (Integration)", () => {
         documentMirrorService.clearPermanentPurgeRequest.mockReset();
         permanentPurgeLookup.findListExcludedDocumentIds.mockReset();
         permanentPurgeLookup.findListExcludedDocumentIds.mockResolvedValue([]);
+        permanentPurgeLookup.findUnreadyCompletedDocumentIds.mockReset();
+        permanentPurgeLookup.findUnreadyCompletedDocumentIds.mockResolvedValue([]);
         permanentPurgeLookup.findPermanentPurgeRequestedDocumentIds.mockReset();
         permanentPurgeLookup.findPermanentPurgeRequestedDocumentIds.mockResolvedValue([]);
         const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -701,8 +704,8 @@ describe("EformsignController (Integration)", () => {
     describe("local source-of-truth document reads", () => {
         let mirrorApp: INestApplication;
         const mirrorRepository = {
-            findAll: jest.fn().mockResolvedValue([]),
-            findAllForHeadquarters: jest.fn().mockResolvedValue([]),
+            findAllVisibleInMirror: jest.fn().mockResolvedValue([]),
+            findAllVisibleInMirrorForHeadquarters: jest.fn().mockResolvedValue([]),
         };
 
         const createMirrorRow = (overrides: {
@@ -744,8 +747,8 @@ describe("EformsignController (Integration)", () => {
         };
 
         beforeEach(async () => {
-            mirrorRepository.findAll.mockResolvedValue([]);
-            mirrorRepository.findAllForHeadquarters.mockResolvedValue([]);
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([]);
+            mirrorRepository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([]);
             const fixture = await Test.createTestingModule({
                 controllers: [EformsignController],
                 providers: [
@@ -792,7 +795,7 @@ describe("EformsignController (Integration)", () => {
         });
 
         it("paginates the mirror without calling eformsign", async () => {
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-old", createdDate: "2026-07-01T00:00:00.000Z" }),
                 createMirrorRow({ documentId: "doc-new", createdDate: "2026-07-02T00:00:00.000Z" }),
             ]);
@@ -816,7 +819,7 @@ describe("EformsignController (Integration)", () => {
         it("keeps paging over one generation when the list changes underneath", async () => {
             // 페이지 사이에 문서가 목록에서 빠지면, 매 요청 새로 만들던 시절에는 나머지가
             // 한 칸씩 당겨져 마지막 문서를 영영 못 보게 된다. 스냅샷 세대가 그걸 막는다.
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-1", createdDate: "2026-07-03T00:00:00.000Z" }),
                 createMirrorRow({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
             ]);
@@ -826,7 +829,7 @@ describe("EformsignController (Integration)", () => {
             expect(first.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-1"]);
 
             // 첫 페이지의 문서가 사라져도 두 번째 페이지는 같은 세대에서 잘린다.
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
             ]);
             const second = await request(mirrorApp.getHttpServer())
@@ -839,7 +842,7 @@ describe("EformsignController (Integration)", () => {
         it("reports the generation so the client can notice the list moved", async () => {
             // 클라이언트는 뒤 페이지의 snapshot_version이 다르면 페이지네이션을 리셋한다.
             // 이 값을 빼면 목록이 아래에서 밀려도 신호가 없어 문서를 조용히 건너뛴다.
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-1" }),
             ]);
 
@@ -850,7 +853,7 @@ describe("EformsignController (Integration)", () => {
         });
 
         it("answers each tab from status codes", async () => {
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-open", statusType: "060" }),
                 createMirrorRow({ documentId: "doc-done", statusType: "050" }),
                 createMirrorRow({ documentId: "doc-gone", statusType: "080" }),
@@ -872,7 +875,7 @@ describe("EformsignController (Integration)", () => {
         });
 
         it("keeps a stale tombstone in unfiltered all reads but fences it from deletion-aware filters", async () => {
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-tombstone", statusType: "060" }),
             ]);
 
@@ -890,7 +893,7 @@ describe("EformsignController (Integration)", () => {
 
             // Simulate a failed invalidation: the cached entry remains pre-delete, but
             // the durable local row is now a deletion tombstone.
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-tombstone", statusType: "049" }),
             ]);
             permanentPurgeLookup.findListExcludedDocumentIds.mockResolvedValue([
@@ -918,7 +921,7 @@ describe("EformsignController (Integration)", () => {
         });
 
         it("shows the customer name on the page it returns", async () => {
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-1", customerName: "최고객" }),
             ]);
 
@@ -932,7 +935,7 @@ describe("EformsignController (Integration)", () => {
 
         it("reads the headquarters scope, including unclaimed documents", async () => {
             branchFindUnique.mockResolvedValue({ slug: "incheon" });
-            mirrorRepository.findAllForHeadquarters.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-unclaimed" }),
             ]);
 
@@ -940,7 +943,8 @@ describe("EformsignController (Integration)", () => {
                 .get("/api/documents?accessToken=access-token");
 
             expect(response.status).toBe(200);
-            expect(mirrorRepository.findAllForHeadquarters).toHaveBeenCalledWith("branch-1");
+            expect(mirrorRepository.findAllVisibleInMirrorForHeadquarters)
+                .toHaveBeenCalledWith("branch-1");
             expect(response.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-unclaimed"]);
         });
 
@@ -950,10 +954,10 @@ describe("EformsignController (Integration)", () => {
             // 이 값을 쓰지 않는다(단건 조회로 넘어간다). 틀린 이름을 보여주는 것보다
             // 비워 두는 편이 낫고, 웹훅이 한 번이라도 닿으면 진짜 고객명이 채워진다.
             branchFindUnique.mockResolvedValue({ slug: "incheon" });
-            mirrorRepository.findAllForHeadquarters.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-unclaimed", customerName: null }),
             ]);
-            mirrorRepository.findAll.mockResolvedValue([]);
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([]);
 
             const response = await request(mirrorApp.getHttpServer())
                 .get("/api/documents?accessToken=access-token");
@@ -962,7 +966,7 @@ describe("EformsignController (Integration)", () => {
         });
 
         it("still names a branch-owned document from its recipient", async () => {
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-owned", customerName: null }),
             ]);
 
@@ -978,10 +982,10 @@ describe("EformsignController (Integration)", () => {
             // 표시용과 검색용은 분리돼 있다. 서빙 경로는 findAll(branchId)로 검색 코퍼스를
             // 만들어 미배정 문서의 수신자명을 찾지 못하므로, 여기서도 찾으면 안 된다.
             branchFindUnique.mockResolvedValue({ slug: "incheon" });
-            mirrorRepository.findAllForHeadquarters.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-unclaimed", customerName: null }),
             ]);
-            mirrorRepository.findAll.mockResolvedValue([]);
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([]);
 
             const response = await request(mirrorApp.getHttpServer())
                 .get("/api/documents?accessToken=access-token&search=%EC%86%A1%EC%A7%84%ED%98%B8");
@@ -990,7 +994,7 @@ describe("EformsignController (Integration)", () => {
         });
 
         it("counts statuses from the same generation the list pages over", async () => {
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-1", statusType: "060" }),
                 createMirrorRow({ documentId: "doc-2", statusType: "050" }),
             ]);

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -816,9 +816,9 @@ describe("EformsignController (Integration)", () => {
             expect(shadowCompareService.compareInBackground).not.toHaveBeenCalled();
         });
 
-        it("keeps paging over one generation when the list changes underneath", async () => {
-            // 페이지 사이에 문서가 목록에서 빠지면, 매 요청 새로 만들던 시절에는 나머지가
-            // 한 칸씩 당겨져 마지막 문서를 영영 못 보게 된다. 스냅샷 세대가 그걸 막는다.
+        it("changes the generation when the local mirror list moves between pages", async () => {
+            // 페이지 사이에 로컬 미러가 바뀌면 새 세대를 발행한다. 클라이언트는 이 신호를
+            // 보고 첫 페이지부터 다시 읽으므로 이동한 문서를 조용히 건너뛰지 않는다.
             mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-1", createdDate: "2026-07-03T00:00:00.000Z" }),
                 createMirrorRow({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
@@ -827,16 +827,19 @@ describe("EformsignController (Integration)", () => {
             const first = await request(mirrorApp.getHttpServer())
                 .get("/api/documents?accessToken=access-token&limit=1&skip=0");
             expect(first.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-1"]);
+            expect(typeof first.body.snapshot_version).toBe("string");
 
-            // 첫 페이지의 문서가 사라져도 두 번째 페이지는 같은 세대에서 잘린다.
+            // 첫 페이지의 문서가 사라지면 stale 세대를 재사용하지 않고 새 세대를 돌려준다.
             mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
             ]);
             const second = await request(mirrorApp.getHttpServer())
                 .get("/api/documents?accessToken=access-token&limit=1&skip=1");
 
-            expect(second.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-2"]);
+            expect(second.body.documents).toEqual([]);
             expect(second.body.has_more).toBe(false);
+            expect(typeof second.body.snapshot_version).toBe("string");
+            expect(second.body.snapshot_version).not.toBe(first.body.snapshot_version);
         });
 
         it("reports the generation so the client can notice the list moved", async () => {

--- a/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
@@ -1,6 +1,7 @@
 import { SbEformsignDocRepository } from "infrastructure/database/repositories/sb.eformsign-doc.repository";
 import { PrismaService } from "infrastructure/database/prisma.service";
 import {
+    EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES,
     UNASSIGNED_FORWARD_STATUS_CODES_AFTER_REVIEW_STAGE,
     UNASSIGNED_REVIEW_STAGE_STATUS_CODES,
     UNASSIGNED_TERMINAL_STATUS_CODES,
@@ -162,6 +163,118 @@ describe("SbEformsignDocRepository", () => {
                 ],
             },
         }));
+    });
+
+    it("shows completed branch documents only after the mirror is ready", async () => {
+        eformsignDocModel.findMany.mockResolvedValue([legacyRow]);
+
+        await expect(repository.findAllVisibleInMirror("branch-1")).resolves.toHaveLength(1);
+
+        const completedStatuses = [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES];
+        expect(eformsignDocModel.findMany).toHaveBeenCalledWith(expect.objectContaining({
+            where: {
+                permanentPurgeRequestedAt: null,
+                AND: [
+                    { branchId: "branch-1" },
+                    {
+                        OR: [
+                            { statusType: { notIn: completedStatuses } },
+                            {
+                                statusType: { in: completedStatuses },
+                                syncStatus: "ready",
+                            },
+                        ],
+                    },
+                ],
+            },
+        }));
+    });
+
+    it("applies the same completed-ready gate to headquarters and unclaimed rows", async () => {
+        eformsignDocModel.findMany.mockResolvedValue([legacyRow]);
+
+        await expect(repository.findAllVisibleInMirrorForHeadquarters("branch-1"))
+            .resolves.toHaveLength(1);
+
+        const completedStatuses = [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES];
+        expect(eformsignDocModel.findMany).toHaveBeenCalledWith(expect.objectContaining({
+            where: {
+                permanentPurgeRequestedAt: null,
+                AND: [
+                    {
+                        OR: [
+                            { branchId: "branch-1" },
+                            { branchId: null },
+                        ],
+                    },
+                    {
+                        OR: [
+                            { statusType: { notIn: completedStatuses } },
+                            {
+                                statusType: { in: completedStatuses },
+                                syncStatus: "ready",
+                            },
+                        ],
+                    },
+                ],
+            },
+        }));
+    });
+
+    it.each([
+        {
+            label: "branch",
+            read: (subject: SbEformsignDocRepository) =>
+                subject.findAllVisibleInMirror("branch-1"),
+            scope: { branchId: "branch-1" },
+        },
+        {
+            label: "headquarters",
+            read: (subject: SbEformsignDocRepository) =>
+                subject.findAllVisibleInMirrorForHeadquarters("branch-1"),
+            scope: {
+                OR: [
+                    { branchId: "branch-1" },
+                    { branchId: null },
+                ],
+            },
+        },
+    ])("fails closed for completed $label rows when sync_status is not deployed", async ({
+        read,
+        scope,
+    }) => {
+        const missingSyncStatus = Object.assign(
+            new Error("The column `eformsign_doc.sync_status` does not exist"),
+            {
+                code: "P2022",
+                meta: { column: "eformsign_doc.sync_status" },
+            },
+        );
+        eformsignDocModel.findMany.mockImplementation(async (query: {
+            where?: unknown;
+        }) => {
+            if (JSON.stringify(query.where).includes("syncStatus")) {
+                throw missingSyncStatus;
+            }
+            return [legacyRow];
+        });
+
+        await expect(read(repository)).resolves.toHaveLength(1);
+
+        expect(eformsignDocModel.findMany).toHaveBeenLastCalledWith({
+            where: {
+                permanentPurgeRequestedAt: null,
+                AND: [
+                    scope,
+                    {
+                        statusType: {
+                            notIn: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES],
+                        },
+                    },
+                ],
+            },
+            select: expect.any(Object),
+        });
     });
 
     it("retries document reads when Prisma reports P2022 without column metadata", async () => {
@@ -772,6 +885,22 @@ describe("SbEformsignDocRepository", () => {
         expect(args.data).not.toHaveProperty("serviceRecordCaseId");
         expect(args.data).not.toHaveProperty("snapshotVersion");
         expect(args.data).not.toHaveProperty("snapshotChunkIndex");
+    });
+
+    it("atomically withdraws a completed projection before mirror files are synchronized", async () => {
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 1 });
+        eformsignDocModel.findFirst.mockResolvedValue({
+            ...legacyRow,
+            branchId: "branch-1",
+        });
+
+        await repository.upsertUnassignedByDocumentId(createEntity(), {
+            allowAssignedUpdate: true,
+            markMirrorPending: true,
+        });
+
+        expect(eformsignDocModel.updateMany.mock.calls[0][0].data)
+            .toEqual(expect.objectContaining({ statusType: "050", syncStatus: "pending" }));
     });
 
     it("creates a newly discovered document with every local-only field unassigned", async () => {

--- a/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
@@ -4,6 +4,7 @@ import {
     EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES,
     UNASSIGNED_FORWARD_STATUS_CODES_AFTER_REVIEW_STAGE,
     UNASSIGNED_REVIEW_STAGE_STATUS_CODES,
+    UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES,
     UNASSIGNED_TERMINAL_STATUS_CODES,
 } from "domain/constants/eformsign-doc-status.constants";
 import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
@@ -899,8 +900,150 @@ describe("SbEformsignDocRepository", () => {
             markMirrorPending: true,
         });
 
-        expect(eformsignDocModel.updateMany.mock.calls[0][0].data)
+        const update = eformsignDocModel.updateMany.mock.calls[0][0];
+        expect(update.data)
             .toEqual(expect.objectContaining({ statusType: "050", syncStatus: "pending" }));
+        expect(update.where).toEqual({
+            AND: [
+                { documentId: "doc-1" },
+                {
+                    updatedDate: { lte: legacyRow.updatedDate },
+                    permanentPurgeRequestedAt: null,
+                    statusType: { notIn: ["047", "049", "099"] },
+                    OR: [
+                        { updatedDate: { lt: legacyRow.updatedDate } },
+                        {
+                            statusType: {
+                                notIn: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES],
+                            },
+                        },
+                        {
+                            statusType: {
+                                in: [...UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES],
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it.each(["072", "050"])(
+        "allows a same-generation review-stage row to advance to terminal status %s",
+        async (statusType) => {
+            eformsignDocModel.updateMany.mockResolvedValue({ count: 1 });
+            eformsignDocModel.findFirst.mockResolvedValue({
+                ...legacyRow,
+                statusType,
+                branchId: "branch-1",
+            });
+            const incoming = EformsignDocEntity.reconstitute({
+                ...legacyRow,
+                statusType,
+                documentKind: null,
+                employeeScheduleId: null,
+                templateId: null,
+            });
+
+            await repository.upsertUnassignedByDocumentId(incoming, {
+                allowAssignedUpdate: true,
+                markMirrorPending: true,
+            });
+
+            const staleGuard = eformsignDocModel.updateMany.mock.calls[0][0].where.AND[1];
+            expect(staleGuard.OR).toContainEqual({
+                statusType: {
+                    in: [...UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES],
+                },
+            });
+        },
+    );
+
+    it("refuses a same-generation retry of an already terminal status", async () => {
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 0 });
+        eformsignDocModel.create.mockRejectedValue(
+            Object.assign(new Error("Unique constraint failed"), { code: "P2002" }),
+        );
+        eformsignDocModel.count.mockResolvedValue(1);
+
+        await expect(repository.upsertUnassignedByDocumentId(createEntity(), {
+            allowAssignedUpdate: true,
+            markMirrorPending: true,
+        })).rejects.toBeInstanceOf(EformsignDocStaleUpdateError);
+
+        const staleGuard = eformsignDocModel.updateMany.mock.calls[0][0].where.AND[1];
+        expect(staleGuard.OR).toEqual([
+            { updatedDate: { lt: legacyRow.updatedDate } },
+            {
+                statusType: {
+                    notIn: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES],
+                },
+            },
+            {
+                statusType: {
+                    in: [...UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES],
+                },
+            },
+        ]);
+    });
+
+    it("refuses a same-generation terminal row moving back to review stage", async () => {
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 0 });
+        eformsignDocModel.create.mockRejectedValue(
+            Object.assign(new Error("Unique constraint failed"), { code: "P2002" }),
+        );
+        eformsignDocModel.count.mockResolvedValue(1);
+        const incoming = EformsignDocEntity.reconstitute({
+            ...legacyRow,
+            statusType: "062",
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: null,
+        });
+
+        await expect(repository.upsertUnassignedByDocumentId(incoming, {
+            allowAssignedUpdate: true,
+            markMirrorPending: true,
+        })).rejects.toBeInstanceOf(EformsignDocStaleUpdateError);
+
+        const staleGuard = eformsignDocModel.updateMany.mock.calls[0][0].where.AND[1];
+        expect(staleGuard.AND[1].OR).toEqual([
+            { updatedDate: { lt: legacyRow.updatedDate } },
+            {
+                statusType: {
+                    notIn: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES],
+                },
+            },
+        ]);
+    });
+
+    it("allows a newer terminal generation regardless of the stored completion status", async () => {
+        const newerUpdatedDate = new Date("2026-07-02T00:00:00.000Z");
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 1 });
+        eformsignDocModel.findFirst.mockResolvedValue({
+            ...legacyRow,
+            updatedDate: newerUpdatedDate,
+            statusType: "072",
+            branchId: "branch-1",
+        });
+        const incoming = EformsignDocEntity.reconstitute({
+            ...legacyRow,
+            updatedDate: newerUpdatedDate,
+            statusType: "072",
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: null,
+        });
+
+        await repository.upsertUnassignedByDocumentId(incoming, {
+            allowAssignedUpdate: true,
+            markMirrorPending: true,
+        });
+
+        const staleGuard = eformsignDocModel.updateMany.mock.calls[0][0].where.AND[1];
+        expect(staleGuard.OR).toContainEqual({
+            updatedDate: { lt: newerUpdatedDate },
+        });
     });
 
     it("creates a newly discovered document with every local-only field unassigned", async () => {
@@ -1015,6 +1158,10 @@ describe("SbEformsignDocRepository", () => {
         ["062", "063"],
         ["071", "060"],
         ["071", "063"],
+        ["62", "060"],
+        ["71", "060"],
+        ["doc_accept_participant", "060"],
+        ["doc_reject_reviewer", "060"],
     ])(
         "blocks review-stage status %s from transitioning backward to %s in the updateMany predicate",
         async (storedStatus, incomingStatus) => {
@@ -1045,7 +1192,7 @@ describe("SbEformsignDocRepository", () => {
                     OR: [
                         {
                             statusType: {
-                                notIn: [...UNASSIGNED_REVIEW_STAGE_STATUS_CODES],
+                                notIn: [...UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES],
                             },
                         },
                         { statusType: incomingStatus },

--- a/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
@@ -1575,6 +1575,34 @@ describe("SbEformsignDocRepository", () => {
         );
     });
 
+    it("removes mirror-only predicates when a pending-column retry uses the legacy schema", async () => {
+        eformsignDocModel.updateMany
+            .mockRejectedValueOnce(pendingColumnError)
+            .mockResolvedValueOnce({ count: 1 });
+        eformsignDocModel.findFirst
+            .mockRejectedValueOnce(pendingColumnError)
+            .mockResolvedValueOnce(legacyRow);
+
+        await repository.upsertUnassignedByDocumentId(createEntity(), {
+            markMirrorPending: true,
+        });
+
+        const retry = eformsignDocModel.updateMany.mock.calls[1][0];
+        expect(retry.where.AND[0]).toEqual({
+            documentId: "doc-1",
+            branchId: null,
+        });
+        expect(retry.where.AND[1]).toEqual(expect.objectContaining({
+            updatedDate: { lte: legacyRow.updatedDate },
+            permanentPurgeRequestedAt: null,
+            statusType: { notIn: ["047", "049", "099"] },
+        }));
+        expect(JSON.stringify(retry.where)).not.toMatch(
+            /detailSourceUpdatedDate|detailPayload|syncStatus/,
+        );
+        expect(retry.data).not.toHaveProperty("syncStatus");
+    });
+
     it("refuses a stale mirror update without reporting an ownership conflict", async () => {
         // Zero updated rows while a row still matches the ownership predicate means the
         // stored state is already at least as new. Reporting a conflict here would send the

--- a/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
@@ -687,6 +687,62 @@ describe("SbEformsignDocRepository", () => {
         expect(eformsignDocModel.create).not.toHaveBeenCalled();
     });
 
+    it("updates only ownership when adoption must preserve an existing ready projection", async () => {
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 1 });
+        eformsignDocModel.findFirst.mockResolvedValue({
+            ...legacyRow,
+            branchId: "branch-1",
+            documentKind: "contract",
+            employeeScheduleId: null,
+            templateId: "template-1",
+        });
+
+        await repository.upsertByDocumentId("branch-1", createEntity(), {
+            preserveExistingMirrorProjection: true,
+        });
+
+        expect(eformsignDocModel.updateMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: {
+                    branchId: "branch-1",
+                    clientId: 55,
+                    documentKind: null,
+                },
+            }),
+        );
+        const update = eformsignDocModel.updateMany.mock.calls[0][0].data;
+        expect(update).not.toHaveProperty("statusType");
+        expect(update).not.toHaveProperty("statusDetail");
+        expect(update).not.toHaveProperty("updatedDate");
+        expect(update).not.toHaveProperty("stepType");
+        expect(update).not.toHaveProperty("templateId");
+        expect(update).not.toHaveProperty("expired");
+        expect(update).not.toHaveProperty("syncStatus");
+    });
+
+    it("still creates a complete pending projection for a newly adopted document", async () => {
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 0 });
+        eformsignDocModel.create.mockResolvedValue({
+            ...legacyRow,
+            branchId: "branch-1",
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: null,
+        });
+
+        await repository.upsertByDocumentId("branch-1", createEntity(), {
+            preserveExistingMirrorProjection: true,
+        });
+
+        expect(eformsignDocModel.create).toHaveBeenCalledWith({
+            data: expect.objectContaining({
+                documentId: "doc-1",
+                branchId: "branch-1",
+                statusType: "050",
+            }),
+        });
+    });
+
     it("retries the conditional documentId update and read without pending columns", async () => {
         eformsignDocModel.updateMany
             .mockRejectedValueOnce(pendingColumnError)
@@ -903,29 +959,39 @@ describe("SbEformsignDocRepository", () => {
         const update = eformsignDocModel.updateMany.mock.calls[0][0];
         expect(update.data)
             .toEqual(expect.objectContaining({ statusType: "050", syncStatus: "pending" }));
-        expect(update.where).toEqual({
-            AND: [
-                { documentId: "doc-1" },
-                {
-                    updatedDate: { lte: legacyRow.updatedDate },
-                    permanentPurgeRequestedAt: null,
-                    statusType: { notIn: ["047", "049", "099"] },
-                    OR: [
-                        { updatedDate: { lt: legacyRow.updatedDate } },
-                        {
-                            statusType: {
-                                notIn: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES],
-                            },
-                        },
-                        {
-                            statusType: {
-                                in: [...UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES],
-                            },
-                        },
-                    ],
-                },
-            ],
+        const staleGuard = update.where.AND[1];
+        expect(staleGuard.OR).toContainEqual({
+            detailSourceUpdatedDate: { lt: legacyRow.updatedDate },
         });
+        expect(staleGuard.OR).toContainEqual({
+            AND: expect.arrayContaining([
+                { detailSourceUpdatedDate: legacyRow.updatedDate },
+                {
+                    OR: expect.arrayContaining([
+                        { syncStatus: { in: ["pending", "partial", "failed"] } },
+                        {
+                            detailPayload: {
+                                path: ["current_status", "status_type"],
+                                equals: "062",
+                            },
+                        },
+                        {
+                            detailPayload: {
+                                path: ["current_status", "status_type"],
+                                equals: "doc_reject_reviewer",
+                            },
+                        },
+                    ]),
+                },
+            ]),
+        });
+        expect(JSON.stringify(staleGuard)).not.toContain(
+            JSON.stringify({
+                statusType: {
+                    notIn: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES],
+                },
+            }),
+        );
     });
 
     it.each(["072", "050"])(
@@ -952,9 +1018,25 @@ describe("SbEformsignDocRepository", () => {
 
             const staleGuard = eformsignDocModel.updateMany.mock.calls[0][0].where.AND[1];
             expect(staleGuard.OR).toContainEqual({
-                statusType: {
-                    in: [...UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES],
-                },
+                AND: expect.arrayContaining([
+                    { detailSourceUpdatedDate: legacyRow.updatedDate },
+                    {
+                        OR: expect.arrayContaining([
+                            {
+                                detailPayload: {
+                                    path: ["current_status", "status_type"],
+                                    equals: "062",
+                                },
+                            },
+                            {
+                                detailPayload: {
+                                    path: ["current_status", "status_type"],
+                                    equals: "071",
+                                },
+                            },
+                        ]),
+                    },
+                ]),
             });
         },
     );
@@ -973,16 +1055,17 @@ describe("SbEformsignDocRepository", () => {
 
         const staleGuard = eformsignDocModel.updateMany.mock.calls[0][0].where.AND[1];
         expect(staleGuard.OR).toEqual([
-            { updatedDate: { lt: legacyRow.updatedDate } },
+            { detailSourceUpdatedDate: null },
+            { detailSourceUpdatedDate: { lt: legacyRow.updatedDate } },
             {
-                statusType: {
-                    notIn: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES],
-                },
-            },
-            {
-                statusType: {
-                    in: [...UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES],
-                },
+                AND: expect.arrayContaining([
+                    { detailSourceUpdatedDate: legacyRow.updatedDate },
+                    {
+                        OR: expect.arrayContaining([
+                            { syncStatus: { in: ["pending", "partial", "failed"] } },
+                        ]),
+                    },
+                ]),
             },
         ]);
     });
@@ -1007,14 +1090,20 @@ describe("SbEformsignDocRepository", () => {
         })).rejects.toBeInstanceOf(EformsignDocStaleUpdateError);
 
         const staleGuard = eformsignDocModel.updateMany.mock.calls[0][0].where.AND[1];
-        expect(staleGuard.AND[1].OR).toEqual([
-            { updatedDate: { lt: legacyRow.updatedDate } },
+        expect(staleGuard.AND[1].OR).toEqual(expect.arrayContaining([
+            { detailSourceUpdatedDate: null },
+            { detailSourceUpdatedDate: { lt: legacyRow.updatedDate } },
             {
-                statusType: {
-                    notIn: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES],
-                },
+                AND: expect.arrayContaining([
+                    { detailSourceUpdatedDate: legacyRow.updatedDate },
+                    {
+                        OR: expect.arrayContaining([
+                            { syncStatus: { in: ["pending", "partial", "failed"] } },
+                        ]),
+                    },
+                ]),
             },
-        ]);
+        ]));
     });
 
     it("allows a newer terminal generation regardless of the stored completion status", async () => {
@@ -1042,7 +1131,7 @@ describe("SbEformsignDocRepository", () => {
 
         const staleGuard = eformsignDocModel.updateMany.mock.calls[0][0].where.AND[1];
         expect(staleGuard.OR).toContainEqual({
-            updatedDate: { lt: newerUpdatedDate },
+            detailSourceUpdatedDate: { lt: newerUpdatedDate },
         });
     });
 

--- a/backend/test/repositories/sb.eformsign-document-mirror.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-document-mirror.repository.spec.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@prisma/client";
 
+import { EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES } from "domain/constants/eformsign-doc-status.constants";
 import { SbEformsignDocumentMirrorRepository } from "infrastructure/database/repositories/sb.eformsign-document-mirror.repository";
 
 describe("SbEformsignDocumentMirrorRepository", () => {
@@ -14,6 +15,43 @@ describe("SbEformsignDocumentMirrorRepository", () => {
             return Promise.all(operation as Promise<unknown>[]);
         });
     }
+
+    it("finds unready completed rows and hides every completed row before sync_status exists", async () => {
+        const missingSyncStatus = Object.assign(
+            new Error("The column `eformsign_doc.sync_status` does not exist"),
+            {
+                code: "P2022",
+                meta: { column: "eformsign_doc.sync_status" },
+            },
+        );
+        const findMany = jest.fn()
+            .mockResolvedValueOnce([{ documentId: "syncing-document" }])
+            .mockRejectedValueOnce(missingSyncStatus)
+            .mockResolvedValueOnce([{ documentId: "legacy-completed-document" }]);
+        const repository = new SbEformsignDocumentMirrorRepository({
+            eformsign_doc: { findMany },
+        } as never);
+
+        await expect(repository.findUnreadyCompletedDocumentIds())
+            .resolves.toEqual(["syncing-document"]);
+        await expect(repository.findUnreadyCompletedDocumentIds())
+            .resolves.toEqual(["legacy-completed-document"]);
+
+        const completedValues = [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES];
+        expect(findMany).toHaveBeenNthCalledWith(1, {
+            where: {
+                statusType: { in: completedValues },
+                syncStatus: { not: "ready" },
+            },
+            select: { documentId: true },
+        });
+        expect(findMany).toHaveBeenNthCalledWith(3, {
+            where: {
+                statusType: { in: completedValues },
+            },
+            select: { documentId: true },
+        });
+    });
 
     it("returns a file only when it belongs to the current non-purged detail", async () => {
         const file = {

--- a/backend/test/services/eformsign-document-mirror.service.spec.ts
+++ b/backend/test/services/eformsign-document-mirror.service.spec.ts
@@ -175,7 +175,9 @@ describe("EformsignDocumentMirrorService", () => {
     it("persists every non-secret detail value and both PDF files", async () => {
         const detail = richDetail();
         const repository = {
-            findState: jest.fn().mockResolvedValue(null),
+            findState: jest.fn()
+                .mockResolvedValueOnce(null)
+                .mockResolvedValue({ branchId: "branch-1" }),
             findFile: jest.fn(),
             saveDetail: jest.fn().mockResolvedValue(true),
             saveFile: jest.fn().mockResolvedValue(true),
@@ -199,12 +201,17 @@ describe("EformsignDocumentMirrorService", () => {
                 body: PDF,
             }),
         };
+        const snapshots = {
+            bumpVersion: jest.fn().mockResolvedValue(1),
+            bumpCompanyEpoch: jest.fn().mockResolvedValue(undefined),
+        };
         const service = new EformsignDocumentMirrorService(
             client as never,
             repository as never,
             mirrorUsecase as never,
             linkByPhoneUsecase as never,
             vendorService as never,
+            snapshots as never,
         );
 
         const result = await service.syncDocumentWithToken(
@@ -267,6 +274,7 @@ describe("EformsignDocumentMirrorService", () => {
             "ready",
             null,
         );
+        expect(snapshots.bumpVersion).toHaveBeenCalledTimes(2);
     });
 
     it("reports ownership changes when ready mirror reconciliation links a branchless document", async () => {
@@ -866,11 +874,17 @@ describe("EformsignDocumentMirrorService", () => {
     it("fails a completed mirror when its current-version audit trail is unavailable", async () => {
         const detail = richDetail();
         const repository = {
-            findState: jest.fn().mockResolvedValue(null),
+            findState: jest.fn()
+                .mockResolvedValueOnce(null)
+                .mockResolvedValue({ branchId: "branch-1" }),
             saveDetail: jest.fn().mockResolvedValue(true),
             saveFile: jest.fn().mockResolvedValue(true),
             markSyncFinished: jest.fn().mockResolvedValue(true),
             markSyncFailed: jest.fn().mockResolvedValue(undefined),
+        };
+        const snapshots = {
+            bumpVersion: jest.fn().mockResolvedValue(1),
+            bumpCompanyEpoch: jest.fn().mockResolvedValue(undefined),
         };
         const service = new EformsignDocumentMirrorService(
             { getDocument: jest.fn().mockResolvedValue(detail) } as never,
@@ -892,6 +906,7 @@ describe("EformsignDocumentMirrorService", () => {
                         body: Buffer.alloc(0),
                     }),
             } as never,
+            snapshots as never,
         );
 
         await expect(service.syncDocumentWithToken("token", "doc-1", { force: true }))
@@ -904,6 +919,7 @@ describe("EformsignDocumentMirrorService", () => {
             expect.any(Date),
             expect.stringContaining("audit_trail"),
         );
+        expect(snapshots.bumpVersion).toHaveBeenCalledTimes(1);
     });
 
     it("does not reconcile a completion after a newer same-version generation wins finish CAS", async () => {

--- a/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
+++ b/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
@@ -92,12 +92,15 @@ function createQuery(overrides: Partial<ListShadowCompareQuery> = {}): ListShado
 }
 
 describe("EformsignListShadowCompareService", () => {
-    let repository: { findAll: jest.Mock; findAllForHeadquarters: jest.Mock };
+    let repository: {
+        findAllVisibleInMirror: jest.Mock;
+        findAllVisibleInMirrorForHeadquarters: jest.Mock;
+    };
 
     beforeEach(() => {
         repository = {
-            findAll: jest.fn().mockResolvedValue([]),
-            findAllForHeadquarters: jest.fn().mockResolvedValue([]),
+            findAllVisibleInMirror: jest.fn().mockResolvedValue([]),
+            findAllVisibleInMirrorForHeadquarters: jest.fn().mockResolvedValue([]),
         };
     });
 
@@ -139,7 +142,7 @@ describe("EformsignListShadowCompareService", () => {
             service.compareInBackground(createQuery(), servedFrom([]));
             await settle();
 
-            expect(repository.findAll).not.toHaveBeenCalled();
+            expect(repository.findAllVisibleInMirror).not.toHaveBeenCalled();
         },
     );
 
@@ -148,7 +151,7 @@ describe("EformsignListShadowCompareService", () => {
             createMirrorDocument({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
             createMirrorDocument({ documentId: "doc-1", createdDate: "2026-07-01T00:00:00.000Z" }),
         ];
-        repository.findAll.mockResolvedValue(documents);
+        repository.findAllVisibleInMirror.mockResolvedValue(documents);
         const service = createService("true");
         const logger = spyOnLogger(service);
 
@@ -161,7 +164,7 @@ describe("EformsignListShadowCompareService", () => {
 
     it("names the documents each side is missing", async () => {
         const shared = createMirrorDocument({ documentId: "doc-1" });
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             shared,
             createMirrorDocument({ documentId: "doc-3" }),
         ]);
@@ -188,7 +191,7 @@ describe("EformsignListShadowCompareService", () => {
             documentId: "doc-b",
             createdDate: "2026-07-02T00:00:00.000Z",
         });
-        repository.findAll.mockResolvedValue([a, b]);
+        repository.findAllVisibleInMirror.mockResolvedValue([a, b]);
         const service = createService("true");
         const logger = spyOnLogger(service);
 
@@ -211,7 +214,7 @@ describe("EformsignListShadowCompareService", () => {
             documentId: "doc-b",
             createdDate: "2026-07-02T00:00:00.000Z",
         });
-        repository.findAll.mockResolvedValue([a, b]);
+        repository.findAllVisibleInMirror.mockResolvedValue([a, b]);
         const service = createService("true");
         const logger = spyOnLogger(service);
 
@@ -228,7 +231,7 @@ describe("EformsignListShadowCompareService", () => {
     it("reports documents whose values differ even when the list itself matches", async () => {
         // Membership and order can agree while the row serves a different status, and the
         // UI reads that directly — it drives the pill and which actions are offered.
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-1", statusType: "060" }),
         ]);
         const service = createService("true");
@@ -245,7 +248,7 @@ describe("EformsignListShadowCompareService", () => {
 
     it("applies the same template filter the served list did", async () => {
         const kept = createMirrorDocument({ documentId: "doc-keep", templateId: "template-1" });
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             kept,
             createMirrorDocument({ documentId: "doc-drop", templateId: "template-9" }),
         ]);
@@ -263,7 +266,7 @@ describe("EformsignListShadowCompareService", () => {
 
     it("matches 초성 against the recipient name, the way the served search does", async () => {
         const song = createMirrorDocument({ documentId: "doc-song", stepRecipientName: "송진호" });
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             song,
             createMirrorDocument({ documentId: "doc-park", stepRecipientName: "박수신" }),
         ]);
@@ -281,7 +284,7 @@ describe("EformsignListShadowCompareService", () => {
         // The vendor list is fetched without include_fields, so the served search never
         // sees a customer name on the document and matches the recipient name instead.
         // Searching the mirror's own column would find documents the served path cannot.
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({
                 documentId: "doc-hidden",
                 customerName: "최고객",
@@ -302,14 +305,14 @@ describe("EformsignListShadowCompareService", () => {
     it("searches headquarters recipient names from branch-owned rows only", async () => {
         // The served path builds its recipient-name corpus from findAll(branchId), so an
         // unassigned document's recipient name is not searchable there.
-        repository.findAllForHeadquarters.mockResolvedValue([
+        repository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([
             createMirrorDocument({
                 documentId: "doc-unassigned",
                 documentName: null,
                 stepRecipientName: "박수신",
             }),
         ]);
-        repository.findAll.mockResolvedValue([]);
+        repository.findAllVisibleInMirror.mockResolvedValue([]);
         const service = createService("true");
         const logger = spyOnLogger(service);
 
@@ -325,7 +328,7 @@ describe("EformsignListShadowCompareService", () => {
 
     it("reads the headquarters corpus from the method that includes unclaimed rows", async () => {
         const hqDocument = createMirrorDocument({ documentId: "doc-hq" });
-        repository.findAllForHeadquarters.mockResolvedValue([hqDocument]);
+        repository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([hqDocument]);
         const service = createService("true");
         spyOnLogger(service);
 
@@ -335,10 +338,10 @@ describe("EformsignListShadowCompareService", () => {
         );
         await settle();
 
-        expect(repository.findAllForHeadquarters).toHaveBeenCalledWith("branch-1");
+        expect(repository.findAllVisibleInMirrorForHeadquarters).toHaveBeenCalledWith("branch-1");
         // findAll is still consulted, but only for the recipient-name search corpus the
         // served path builds the same way — not for which documents the list contains.
-        expect(repository.findAll).toHaveBeenCalledWith("branch-1");
+        expect(repository.findAllVisibleInMirror).toHaveBeenCalledWith("branch-1");
     });
 
     it("stands in for the vendor inbox with local status categories on the tab endpoints", async () => {
@@ -346,7 +349,7 @@ describe("EformsignListShadowCompareService", () => {
         // document sat in — the switch has to answer them from status codes. Comparing
         // that substitution is the only way to learn whether it lands the same content.
         const drafting = createMirrorDocument({ documentId: "doc-open", statusType: "060" });
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             drafting,
             createMirrorDocument({ documentId: "doc-done", statusType: "050" }),
         ]);
@@ -367,7 +370,7 @@ describe("EformsignListShadowCompareService", () => {
         // The list renders updated_date as the signed date, so a mirror that is right
         // about membership and status can still show users the wrong day.
         const mirrored = createMirrorDocument({ documentId: "doc-1" });
-        repository.findAll.mockResolvedValue([mirrored]);
+        repository.findAllVisibleInMirror.mockResolvedValue([mirrored]);
         const service = createService("true");
         const logger = spyOnLogger(service);
 
@@ -393,7 +396,7 @@ describe("EformsignListShadowCompareService", () => {
             documentId: "doc-2026",
             createdDate: "2026-07-20T00:00:00.000Z",
         });
-        repository.findAll.mockResolvedValue([older, newer]);
+        repository.findAllVisibleInMirror.mockResolvedValue([older, newer]);
         const service = createService("true");
         const logger = spyOnLogger(service);
 
@@ -409,7 +412,7 @@ describe("EformsignListShadowCompareService", () => {
     it("keeps the search term itself out of the log", async () => {
         // Searches are customer names often enough that the term does not belong in a
         // centralised log, and a raw value could break the log line apart.
-        repository.findAll.mockResolvedValue([]);
+        repository.findAllVisibleInMirror.mockResolvedValue([]);
         const service = createService("true");
         const logger = spyOnLogger(service);
 
@@ -429,7 +432,7 @@ describe("EformsignListShadowCompareService", () => {
         // Every list request would otherwise load the whole branch mirror and sort it,
         // competing with the served requests for the same connection pool.
         let release: (() => void) | undefined;
-        repository.findAll.mockImplementation(() => new Promise((resolve) => {
+        repository.findAllVisibleInMirror.mockImplementation(() => new Promise((resolve) => {
             release = () => resolve([]);
         }));
         const service = createService("true");
@@ -439,7 +442,7 @@ describe("EformsignListShadowCompareService", () => {
         service.compareInBackground(createQuery(), served);
         service.compareInBackground(createQuery(), served);
         service.compareInBackground(createQuery(), served);
-        expect(repository.findAll).toHaveBeenCalledTimes(1);
+        expect(repository.findAllVisibleInMirror).toHaveBeenCalledTimes(1);
 
         release?.();
         await settle();
@@ -452,7 +455,7 @@ describe("EformsignListShadowCompareService", () => {
     it("never lets a comparison failure escape into the request", async () => {
         // The response has already been sent by the time this runs; throwing here would
         // become an unhandled rejection, not an error the caller could do anything with.
-        repository.findAll.mockRejectedValue(new Error("mirror unavailable"));
+        repository.findAllVisibleInMirror.mockRejectedValue(new Error("mirror unavailable"));
         const service = createService("true");
         const logger = spyOnLogger(service);
 

--- a/backend/test/services/eformsign-mirror-list.service.spec.ts
+++ b/backend/test/services/eformsign-mirror-list.service.spec.ts
@@ -58,19 +58,22 @@ function createQuery(overrides: Partial<MirrorListQuery> = {}): MirrorListQuery 
 }
 
 describe("EformsignMirrorListService", () => {
-    let repository: { findAll: jest.Mock; findAllForHeadquarters: jest.Mock };
+    let repository: {
+        findAllVisibleInMirror: jest.Mock;
+        findAllVisibleInMirrorForHeadquarters: jest.Mock;
+    };
     let service: EformsignMirrorListService;
 
     beforeEach(() => {
         repository = {
-            findAll: jest.fn().mockResolvedValue([]),
-            findAllForHeadquarters: jest.fn().mockResolvedValue([]),
+            findAllVisibleInMirror: jest.fn().mockResolvedValue([]),
+            findAllVisibleInMirrorForHeadquarters: jest.fn().mockResolvedValue([]),
         };
         service = new EformsignMirrorListService(repository as never);
     });
 
     it("returns documents newest first, tie-broken by id", async () => {
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-b", createdDate: "2026-07-01T00:00:00.000Z" }),
             createMirrorDocument({ documentId: "doc-c", createdDate: "2026-07-02T00:00:00.000Z" }),
             createMirrorDocument({ documentId: "doc-a", createdDate: "2026-07-01T00:00:00.000Z" }),
@@ -82,18 +85,19 @@ describe("EformsignMirrorListService", () => {
     });
 
     it("reads the headquarters scope from the method that includes unclaimed rows", async () => {
-        repository.findAllForHeadquarters.mockResolvedValue([
+        repository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-hq" }),
         ]);
 
         const { documents } = await service.buildList(createQuery({ isHeadquarters: true }));
 
-        expect(repository.findAllForHeadquarters).toHaveBeenCalledWith("branch-1");
+        expect(repository.findAllVisibleInMirrorForHeadquarters)
+            .toHaveBeenCalledWith("branch-1");
         expect(documents.map((document) => document.id)).toEqual(["doc-hq"]);
     });
 
     it("selects a tab by status rather than by vendor inbox", async () => {
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-open", statusType: "060" }),
             createMirrorDocument({ documentId: "doc-done", statusType: "050" }),
             createMirrorDocument({ documentId: "doc-gone", statusType: "080" }),
@@ -111,7 +115,7 @@ describe("EformsignMirrorListService", () => {
     it("puts a deleted document in the rejected tab, where the desktop shows it", async () => {
         // 047/049 land in the "unknown" category, which also holds every unrecognised
         // status — those belong in 진행 중, and only the deleted ones in 기간 만료.
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-deleted", statusType: "049" }),
             createMirrorDocument({ documentId: "doc-strange", statusType: "999" }),
         ]);
@@ -124,7 +128,7 @@ describe("EformsignMirrorListService", () => {
     });
 
     it("applies template include and exclude across a comma-separated list", async () => {
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-1", templateId: "t-1" }),
             createMirrorDocument({ documentId: "doc-2", templateId: "t-2" }),
             createMirrorDocument({ documentId: "doc-3", templateId: "t-9" }),
@@ -142,7 +146,7 @@ describe("EformsignMirrorListService", () => {
     });
 
     it("excludes deleted documents only when asked", async () => {
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-live", statusType: "060" }),
             createMirrorDocument({ documentId: "doc-deleted", statusType: "047" }),
             createMirrorDocument({ documentId: "doc-deleted-legacy", statusType: "099" }),
@@ -156,7 +160,7 @@ describe("EformsignMirrorListService", () => {
     });
 
     it("searches the recipient name, including by 초성", async () => {
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-song", stepRecipientName: "송진호" }),
             createMirrorDocument({ documentId: "doc-park", stepRecipientName: "박수신" }),
         ]);
@@ -172,7 +176,7 @@ describe("EformsignMirrorListService", () => {
         // The API path's search index is built before enrichment, so a customer name never
         // reaches it. Matching one here would change what the search finds the moment the
         // source switches — a feature change smuggled in as a migration.
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({
                 documentId: "doc-1",
                 customerName: "최고객",
@@ -189,14 +193,14 @@ describe("EformsignMirrorListService", () => {
     it("only searches recipient names the branch owns", async () => {
         // Headquarters sees unclaimed documents, but the API path builds its recipient-name
         // corpus from findAll(branchId), so their names are not searchable there.
-        repository.findAllForHeadquarters.mockResolvedValue([
+        repository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([
             createMirrorDocument({
                 documentId: "doc-unassigned",
                 documentName: "무관한 제목",
                 stepRecipientName: "박수신",
             }),
         ]);
-        repository.findAll.mockResolvedValue([]);
+        repository.findAllVisibleInMirror.mockResolvedValue([]);
 
         const { documents } = await service.buildList(
             createQuery({ isHeadquarters: true, search: "박수신" }),
@@ -211,8 +215,8 @@ describe("enrichMirrorPage", () => {
 
     it("fills in the customer name the list renders", async () => {
         const service = new EformsignMirrorListService({
-            findAll: jest.fn().mockResolvedValue([entity]),
-            findAllForHeadquarters: jest.fn(),
+            findAllVisibleInMirror: jest.fn().mockResolvedValue([entity]),
+            findAllVisibleInMirrorForHeadquarters: jest.fn(),
         } as never);
         const { documents } = await service.buildList(createQuery());
 
@@ -236,8 +240,8 @@ describe("enrichMirrorPage", () => {
             stepRecipientName: "송진호",
         });
         const service = new EformsignMirrorListService({
-            findAll: jest.fn().mockResolvedValue([titled, named]),
-            findAllForHeadquarters: jest.fn(),
+            findAllVisibleInMirror: jest.fn().mockResolvedValue([titled, named]),
+            findAllVisibleInMirrorForHeadquarters: jest.fn(),
         } as never);
         const { documents } = await service.buildList(createQuery());
 
@@ -259,8 +263,8 @@ describe("enrichMirrorPage", () => {
             stepRecipientName: "수신자",
         });
         const service = new EformsignMirrorListService({
-            findAll: jest.fn().mockResolvedValue([sentinel]),
-            findAllForHeadquarters: jest.fn(),
+            findAllVisibleInMirror: jest.fn().mockResolvedValue([sentinel]),
+            findAllVisibleInMirrorForHeadquarters: jest.fn(),
         } as never);
         const { documents } = await service.buildList(createQuery());
 

--- a/backend/test/usecases/eformsign-doc/adopt-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/adopt-eformsign-doc.usecase.spec.ts
@@ -45,6 +45,7 @@ describe("AdoptEformsignDocUsecase", () => {
         expect(create.execute).toHaveBeenNthCalledWith(2, "branch-1", expect.objectContaining({
             documentId: "doc-1",
             clientId: 7,
+            preserveExistingMirrorProjection: true,
             templateName: "표준 계약서",
             customerName: "김고객",
             creatorName: "생성자",

--- a/backend/test/usecases/eformsign-doc/adopt-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/adopt-eformsign-doc.usecase.spec.ts
@@ -9,10 +9,12 @@ describe("AdoptEformsignDocUsecase", () => {
         const now = Date.parse("2026-07-03T00:00:00.000Z");
         jest.spyOn(Date, "now").mockReturnValue(now);
         const create = { execute: jest.fn().mockResolvedValue({ documentId: "doc-1" }) };
+        const mirror = { syncDocumentWithToken: jest.fn().mockResolvedValue(undefined) };
         const usecase = new AdoptEformsignDocUsecase(
             { execute: jest.fn().mockResolvedValue({ oauth_token: { access_token: "token" } }) } as never,
             { execute: jest.fn().mockResolvedValue({
                 id: "doc-1",
+                updated_date: 1_751_500_800_000,
                 document_name: "계약서 - 고객",
                 template: { id: "template-1", name: "표준 계약서" },
                 creator: { name: "생성자" },
@@ -33,6 +35,7 @@ describe("AdoptEformsignDocUsecase", () => {
             }) } as never,
             create as never,
             { findByPhone: jest.fn() } as never,
+            mirror as never,
         );
 
         await usecase.execute("branch-1", { documentId: "doc-1", clientId: 7 });
@@ -49,6 +52,15 @@ describe("AdoptEformsignDocUsecase", () => {
             stepRecipientTypes: ["01", "06"],
             expiredDate: new Date(now + 3 * 24 * 60 * 60 * 1000),
         }));
+        expect(mirror.syncDocumentWithToken).toHaveBeenNthCalledWith(
+            2,
+            "token",
+            "doc-1",
+            { expectedUpdatedDate: 1_751_500_800_000 },
+        );
+        expect(create.execute.mock.invocationCallOrder[0]!).toBeLessThan(
+            mirror.syncDocumentWithToken.mock.invocationCallOrder[0]!,
+        );
     });
 
     it.each([
@@ -56,6 +68,7 @@ describe("AdoptEformsignDocUsecase", () => {
         ["50", "050"],
     ])("normalizes persisted vendor status %s to %s", async (rawStatus, expectedStatus) => {
         const create = { execute: jest.fn().mockResolvedValue({ documentId: "doc-status" }) };
+        const mirror = { syncDocumentWithToken: jest.fn().mockResolvedValue(undefined) };
         const usecase = new AdoptEformsignDocUsecase(
             { execute: jest.fn().mockResolvedValue({ oauth_token: { access_token: "token" } }) } as never,
             { execute: jest.fn().mockResolvedValue({
@@ -74,6 +87,7 @@ describe("AdoptEformsignDocUsecase", () => {
             }) } as never,
             create as never,
             { findByPhone: jest.fn() } as never,
+            mirror as never,
         );
 
         await usecase.execute("branch-1", { documentId: "doc-status", clientId: 7 });
@@ -86,6 +100,7 @@ describe("AdoptEformsignDocUsecase", () => {
 
     it("preserves no-expiry semantics when adopting a document with zero remaining days", async () => {
         const create = { execute: jest.fn().mockResolvedValue({ documentId: "doc-no-expiry" }) };
+        const mirror = { syncDocumentWithToken: jest.fn().mockResolvedValue(undefined) };
         const usecase = new AdoptEformsignDocUsecase(
             { execute: jest.fn().mockResolvedValue({ oauth_token: { access_token: "token" } }) } as never,
             { execute: jest.fn().mockResolvedValue({
@@ -105,6 +120,7 @@ describe("AdoptEformsignDocUsecase", () => {
             }) } as never,
             create as never,
             { findByPhone: jest.fn() } as never,
+            mirror as never,
         );
 
         await usecase.execute("branch-1", { documentId: "doc-no-expiry", clientId: 7 });
@@ -115,5 +131,35 @@ describe("AdoptEformsignDocUsecase", () => {
                 expiredDate: new Date("9999-12-31T23:59:59.999Z"),
             }),
         );
+    });
+
+    it("fails adoption when the adopted document cannot be mirrored", async () => {
+        const mirrorError = new Error("mirror failed");
+        const usecase = new AdoptEformsignDocUsecase(
+            { execute: jest.fn().mockResolvedValue({ oauth_token: { access_token: "token" } }) } as never,
+            { execute: jest.fn().mockResolvedValue({
+                id: "doc-complete",
+                updated_date: 1_751_500_800_000,
+                document_name: "완료 계약서",
+                template: { id: "template-1", name: "표준 계약서" },
+                current_status: {
+                    status_type: "003",
+                    status_doc_detail: "완료",
+                    step_type: "05",
+                    step_index: "1",
+                    step_name: "완료",
+                    step_recipients: [],
+                    expired_date: 0,
+                },
+            }) } as never,
+            { execute: jest.fn().mockResolvedValue({ documentId: "doc-complete" }) } as never,
+            { findByPhone: jest.fn() } as never,
+            { syncDocumentWithToken: jest.fn().mockRejectedValue(mirrorError) } as never,
+        );
+
+        await expect(usecase.execute("branch-1", {
+            documentId: "doc-complete",
+            clientId: 7,
+        })).rejects.toBe(mirrorError);
     });
 });

--- a/backend/test/usecases/eformsign-doc/adopt-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/adopt-eformsign-doc.usecase.spec.ts
@@ -51,6 +51,39 @@ describe("AdoptEformsignDocUsecase", () => {
         }));
     });
 
+    it.each([
+        ["doc_complete", "003"],
+        ["50", "050"],
+    ])("normalizes persisted vendor status %s to %s", async (rawStatus, expectedStatus) => {
+        const create = { execute: jest.fn().mockResolvedValue({ documentId: "doc-status" }) };
+        const usecase = new AdoptEformsignDocUsecase(
+            { execute: jest.fn().mockResolvedValue({ oauth_token: { access_token: "token" } }) } as never,
+            { execute: jest.fn().mockResolvedValue({
+                id: "doc-status",
+                document_name: "계약서",
+                template: { id: "template-1", name: "표준 계약서" },
+                current_status: {
+                    status_type: rawStatus,
+                    status_doc_detail: "완료",
+                    step_type: "05",
+                    step_index: "1",
+                    step_name: "완료",
+                    step_recipients: [],
+                    expired_date: 0,
+                },
+            }) } as never,
+            create as never,
+            { findByPhone: jest.fn() } as never,
+        );
+
+        await usecase.execute("branch-1", { documentId: "doc-status", clientId: 7 });
+
+        expect(create.execute).toHaveBeenCalledWith(
+            "branch-1",
+            expect.objectContaining({ statusType: expectedStatus }),
+        );
+    });
+
     it("preserves no-expiry semantics when adopting a document with zero remaining days", async () => {
         const create = { execute: jest.fn().mockResolvedValue({ documentId: "doc-no-expiry" }) };
         const usecase = new AdoptEformsignDocUsecase(

--- a/backend/test/usecases/eformsign-doc/create-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/create-eformsign-doc.usecase.spec.ts
@@ -127,6 +127,21 @@ describe("CreateEformsignDocUsecase", () => {
         expect(eformsignDocRepository.upsertByDocumentId).toHaveBeenCalledTimes(1);
     });
 
+    it("keeps an existing ready projection intact while adoption assigns ownership", async () => {
+        const client = createClient(7, "010-1234-5678");
+        clientRepository.findById.mockResolvedValue(client);
+
+        await usecase.execute(branchId, createParams({
+            preserveExistingMirrorProjection: true,
+        }));
+
+        expect(eformsignDocRepository.upsertByDocumentId).toHaveBeenCalledWith(
+            branchId,
+            expect.objectContaining({ clientId: 7, documentId }),
+            { preserveExistingMirrorProjection: true },
+        );
+    });
+
     it("falls back to the supplied client when recipient phone has no client match", async () => {
         const client = createClient(7, "010-0000-0000");
         clientRepository.findById.mockResolvedValue(client);

--- a/backend/test/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.spec.ts
@@ -402,7 +402,7 @@ describe("MirrorUnassignedEformsignDocUsecase", () => {
 
         expect(repository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
             expect.objectContaining({ statusType: "050", expired: false }),
-            expect.not.objectContaining({ updateExpired: false }),
+            expect.objectContaining({ markMirrorPending: true }),
         );
     });
 

--- a/backend/test/usecases/eformsign-doc/service-record-case-snapshot.spec.ts
+++ b/backend/test/usecases/eformsign-doc/service-record-case-snapshot.spec.ts
@@ -148,7 +148,7 @@ function setup() {
         created_date: Date.now(),
         updated_date: Date.now(),
         current_status: {
-            status_type: "070",
+            status_type: "doc_accept_reviewer",
             status_doc_type: "진행중",
             status_doc_detail: "검토 요청",
             step_type: "06",
@@ -375,6 +375,7 @@ describe("client-owned service record snapshot", () => {
                 creatorName: "검토자",
                 lastEditorName: "최종 편집자",
                 stepRecipientTypes: "01",
+                statusType: "072",
             }),
             update: expect.objectContaining({
                 documentName: chunk.documentName,
@@ -383,7 +384,7 @@ describe("client-owned service record snapshot", () => {
                 creatorName: "검토자",
                 lastEditorName: "최종 편집자",
                 stepRecipientTypes: "01",
-                statusType: "070",
+                statusType: "072",
                 statusDetail: "검토 요청",
                 stepType: "06",
                 stepIndex: "2",

--- a/frontend/src/hooks/__tests__/useInfiniteContracts.excludeDeleted.test.tsx
+++ b/frontend/src/hooks/__tests__/useInfiniteContracts.excludeDeleted.test.tsx
@@ -115,4 +115,61 @@ describe("useInfiniteContracts — the All tab and deletion tombstones", () => {
       exact: true,
     });
   });
+
+  it.each([
+    ["the later page omits it", "1:100", undefined],
+    ["the first page omits it", undefined, "1:100"],
+  ])(
+    "restarts desktop offset pagination when %s",
+    async (_description, firstSnapshotVersion, laterSnapshotVersion) => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0 } },
+      });
+      const documents = Array.from({ length: 20 }, (_, index) => ({
+        id: `document-${index + 1}`,
+        created_date: 100 - index,
+        current_status: { status_type: "060" },
+      }));
+      const firstPage = {
+        documents,
+        total_rows: 21,
+        limit: 20,
+        skip: 0,
+        has_more: true,
+        ...(firstSnapshotVersion === undefined
+          ? {}
+          : { snapshot_version: firstSnapshotVersion }),
+      };
+      const laterPage = {
+        documents: [{
+          id: "document-21",
+          created_date: 79,
+          current_status: { status_type: "060" },
+        }],
+        total_rows: 21,
+        limit: 20,
+        skip: 20,
+        has_more: false,
+        ...(laterSnapshotVersion === undefined
+          ? {}
+          : { snapshot_version: laterSnapshotVersion }),
+      };
+      mockedApi.getAllDocuments
+        .mockResolvedValueOnce(firstPage as never)
+        .mockResolvedValueOnce(laterPage as never)
+        .mockResolvedValue(firstPage as never);
+      const resetQueries = jest.spyOn(queryClient, "resetQueries");
+      const { result } = renderHook(
+        () => useInfiniteContracts({ filterType: null }),
+        { wrapper: wrapperFor(queryClient) },
+      );
+
+      await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+      await act(async () => {
+        await result.current.fetchNextPage();
+      });
+
+      await waitFor(() => expect(resetQueries).toHaveBeenCalledTimes(1));
+    },
+  );
 });

--- a/frontend/src/hooks/__tests__/useInfiniteContracts.excludeDeleted.test.tsx
+++ b/frontend/src/hooks/__tests__/useInfiniteContracts.excludeDeleted.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { eformsignApi } from "@/services/api";
@@ -20,6 +20,14 @@ function wrapper({ children }: { children: ReactNode }) {
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function wrapperFor(queryClient: QueryClient) {
+  return function QueryWrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
 }
 
 function emptyPage() {
@@ -55,5 +63,56 @@ describe("useInfiniteContracts — the All tab and deletion tombstones", () => {
     expect(mockedApi.getExpiredDocuments).not.toHaveBeenCalledWith(
       expect.objectContaining({ excludeDeleted: true }),
     );
+  });
+
+  it("restarts desktop offset pagination when the semantic snapshot changes", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const documents = Array.from({ length: 20 }, (_, index) => ({
+      id: `document-${index + 1}`,
+      created_date: 100 - index,
+      current_status: { status_type: "060" },
+    }));
+    const firstPage = {
+      documents,
+      total_rows: 21,
+      limit: 20,
+      skip: 0,
+      has_more: true,
+      snapshot_version: "1:100",
+    };
+    const conflictingPage = {
+      documents: [{
+        id: "document-21",
+        created_date: 79,
+        current_status: { status_type: "060" },
+      }],
+      total_rows: 20,
+      limit: 20,
+      skip: 20,
+      has_more: false,
+      snapshot_version: "1:100:fvisibility",
+    };
+    mockedApi.getAllDocuments
+      .mockResolvedValueOnce(firstPage as never)
+      .mockResolvedValueOnce(conflictingPage as never)
+      .mockResolvedValue(firstPage as never);
+    const resetQueries = jest.spyOn(queryClient, "resetQueries");
+    const { result } = renderHook(
+      () => useInfiniteContracts({ filterType: null }),
+      { wrapper: wrapperFor(queryClient) },
+    );
+
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(resetQueries).toHaveBeenCalledTimes(1));
+    expect(resetQueries).toHaveBeenCalledWith({
+      queryKey: expect.arrayContaining(["infinite", "all"]),
+      exact: true,
+    });
   });
 });

--- a/frontend/src/hooks/__tests__/useInfiniteContracts.excludeDeleted.test.tsx
+++ b/frontend/src/hooks/__tests__/useInfiniteContracts.excludeDeleted.test.tsx
@@ -116,6 +116,61 @@ describe("useInfiniteContracts — the All tab and deletion tombstones", () => {
     });
   });
 
+  it("re-arms the desktop drift guard after pagination becomes coherent", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const documents = Array.from({ length: 20 }, (_, index) => ({
+      id: `document-${index + 1}`,
+      created_date: 100 - index,
+      current_status: { status_type: "060" },
+    }));
+    const firstPage = {
+      documents,
+      total_rows: 21,
+      limit: 20,
+      skip: 0,
+      has_more: true,
+      snapshot_version: "1:100",
+    };
+    const conflictingPage = {
+      documents: [{
+        id: "document-21",
+        created_date: 79,
+        current_status: { status_type: "060" },
+      }],
+      total_rows: 21,
+      limit: 20,
+      skip: 20,
+      has_more: false,
+    };
+    mockedApi.getAllDocuments
+      .mockResolvedValueOnce(firstPage as never)
+      .mockResolvedValueOnce(conflictingPage as never)
+      .mockResolvedValueOnce(firstPage as never)
+      .mockResolvedValueOnce(conflictingPage as never)
+      .mockResolvedValue(firstPage as never);
+    const resetQueries = jest.spyOn(queryClient, "resetQueries");
+    const { result } = renderHook(
+      () => useInfiniteContracts({ filterType: null }),
+      { wrapper: wrapperFor(queryClient) },
+    );
+
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+    await waitFor(() => expect(resetQueries).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockedApi.getAllDocuments).toHaveBeenCalledTimes(3));
+
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(resetQueries).toHaveBeenCalledTimes(2));
+  });
+
   it.each([
     ["the later page omits it", "1:100", undefined],
     ["the first page omits it", undefined, "1:100"],

--- a/frontend/src/hooks/useInfiniteContracts.ts
+++ b/frontend/src/hooks/useInfiniteContracts.ts
@@ -161,10 +161,11 @@ export function useInfiniteContracts({
   const lastSnapshotResetRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (
-      baseSnapshotGeneration === undefined
-      || conflictingSnapshotGeneration === undefined
-    ) return;
+    if (baseSnapshotGeneration === undefined) return;
+    if (conflictingSnapshotGeneration === undefined) {
+      lastSnapshotResetRef.current = null;
+      return;
+    }
     const signature =
       `${queryKey.join("|")}::${baseSnapshotGeneration}->${conflictingSnapshotGeneration}`;
     if (lastSnapshotResetRef.current === signature) return;

--- a/frontend/src/hooks/useInfiniteContracts.ts
+++ b/frontend/src/hooks/useInfiniteContracts.ts
@@ -11,6 +11,7 @@ import { UNKNOWN_CUSTOMER_NAME, customerName } from "@/lib/eformsign/display-nam
 const PAGE_SIZE = 20;
 const EMPTY_DOCUMENTS: EformsignDocument[] = [];
 const EMPTY_EXCLUDED_NAMES: readonly string[] = [];
+const UNVERSIONED_SNAPSHOT_GENERATION = "<unversioned>";
 
 // Filter documents by actual status code. Used as a safety net for the merged
 // "전체" endpoint; per-status endpoints are already filtered server-side.
@@ -141,29 +142,37 @@ export function useInfiniteContracts({
   // Offset pagination is valid only while every page belongs to the same effective
   // mirror generation. A live readiness/tombstone fence can change membership even
   // when Valkey invalidation fails, so restart from page 1 when a later page reports
-  // a different semantic snapshot version.
+  // a different semantic snapshot generation. Presence is part of that
+  // generation: mixing a cache-backed versioned page with an unversioned
+  // cache-bypass page is no safer than mixing two different versions.
   const pages = query.data?.pages;
   const baseSnapshotVersion = pages?.[0]?.snapshot_version;
-  const conflictingSnapshotVersion = useMemo(() => {
-    if (!pages || !baseSnapshotVersion) return undefined;
+  const baseSnapshotGeneration = pages?.length
+    ? (baseSnapshotVersion ?? UNVERSIONED_SNAPSHOT_GENERATION)
+    : undefined;
+  const conflictingSnapshotGeneration = useMemo(() => {
+    if (!pages || baseSnapshotGeneration === undefined) return undefined;
     return pages
       .slice(1)
-      .find((page) =>
-        page.snapshot_version && page.snapshot_version !== baseSnapshotVersion)
-      ?.snapshot_version;
-  }, [pages, baseSnapshotVersion]);
+      .map((page) =>
+        page.snapshot_version ?? UNVERSIONED_SNAPSHOT_GENERATION)
+      .find((generation) => generation !== baseSnapshotGeneration);
+  }, [pages, baseSnapshotGeneration]);
   const lastSnapshotResetRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!baseSnapshotVersion || !conflictingSnapshotVersion) return;
+    if (
+      baseSnapshotGeneration === undefined
+      || conflictingSnapshotGeneration === undefined
+    ) return;
     const signature =
-      `${queryKey.join("|")}::${baseSnapshotVersion}->${conflictingSnapshotVersion}`;
+      `${queryKey.join("|")}::${baseSnapshotGeneration}->${conflictingSnapshotGeneration}`;
     if (lastSnapshotResetRef.current === signature) return;
     lastSnapshotResetRef.current = signature;
     void queryClient.resetQueries({ queryKey, exact: true });
   }, [
-    baseSnapshotVersion,
-    conflictingSnapshotVersion,
+    baseSnapshotGeneration,
+    conflictingSnapshotGeneration,
     queryClient,
     queryKey,
   ]);

--- a/frontend/src/hooks/useInfiniteContracts.ts
+++ b/frontend/src/hooks/useInfiniteContracts.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { useMemo } from "react";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef } from "react";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { eformsignApi } from "@/services/api";
 import { EformsignDocument, EformsignDocumentsResponse } from "@/lib/eformsign/types";
 import { eformsignQueryKeys } from "@/hooks/useEformsignDocuments";
@@ -91,8 +91,18 @@ export function useInfiniteContracts({
   excludedNames = EMPTY_EXCLUDED_NAMES,
   templateFilter,
 }: UseInfiniteContractsOptions = {}) {
+  const queryClient = useQueryClient();
+  const templateId = templateFilter?.templateId;
+  const templateMatch = templateFilter?.templateMatch;
+  const queryKey = useMemo(
+    () => infiniteContractsQueryKeys.documents(
+      filterType,
+      templateId && templateMatch ? { templateId, templateMatch } : undefined,
+    ),
+    [filterType, templateId, templateMatch],
+  );
   const query = useInfiniteQuery<EformsignDocumentsResponse>({
-    queryKey: infiniteContractsQueryKeys.documents(filterType, templateFilter),
+    queryKey,
     initialPageParam: 0,
     queryFn: async ({ pageParam }) => {
       const skip = typeof pageParam === "number" ? pageParam : 0;
@@ -127,6 +137,36 @@ export function useInfiniteContracts({
     gcTime: 1000 * 60 * 60, // 1 hour
     refetchOnWindowFocus: false,
   });
+
+  // Offset pagination is valid only while every page belongs to the same effective
+  // mirror generation. A live readiness/tombstone fence can change membership even
+  // when Valkey invalidation fails, so restart from page 1 when a later page reports
+  // a different semantic snapshot version.
+  const pages = query.data?.pages;
+  const baseSnapshotVersion = pages?.[0]?.snapshot_version;
+  const conflictingSnapshotVersion = useMemo(() => {
+    if (!pages || !baseSnapshotVersion) return undefined;
+    return pages
+      .slice(1)
+      .find((page) =>
+        page.snapshot_version && page.snapshot_version !== baseSnapshotVersion)
+      ?.snapshot_version;
+  }, [pages, baseSnapshotVersion]);
+  const lastSnapshotResetRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!baseSnapshotVersion || !conflictingSnapshotVersion) return;
+    const signature =
+      `${queryKey.join("|")}::${baseSnapshotVersion}->${conflictingSnapshotVersion}`;
+    if (lastSnapshotResetRef.current === signature) return;
+    lastSnapshotResetRef.current = signature;
+    void queryClient.resetQueries({ queryKey, exact: true });
+  }, [
+    baseSnapshotVersion,
+    conflictingSnapshotVersion,
+    queryClient,
+    queryKey,
+  ]);
 
   // Flatten loaded pages into a single document list, deduping by id.
   // The backend's getAllDocuments only dedupes within a single response, so a

--- a/mobile/src/hooks/__tests__/useInfiniteContracts.test.tsx
+++ b/mobile/src/hooks/__tests__/useInfiniteContracts.test.tsx
@@ -348,7 +348,7 @@ describe("useInfiniteContracts", () => {
     expect(result.current.loadedCount).toBe(9);
   });
 
-  it("resets once on snapshot drift and suppresses the same mismatch after refetch", async () => {
+  it("re-arms the snapshot drift guard after a coherent refetch", async () => {
     const firstPage = createPage({
       ids: documentIds(1, 9),
       totalRows: 15,
@@ -369,7 +369,8 @@ describe("useInfiniteContracts", () => {
       .mockResolvedValueOnce(firstPage)
       .mockResolvedValueOnce(conflictingPage)
       .mockResolvedValueOnce(firstPage)
-      .mockResolvedValueOnce(conflictingPage);
+      .mockResolvedValueOnce(conflictingPage)
+      .mockResolvedValue(firstPage);
     const resetQueriesSpy = jest.spyOn(queryClient, "resetQueries");
 
     const { result } = renderHook(() => useInfiniteContracts(), {
@@ -396,7 +397,7 @@ describe("useInfiniteContracts", () => {
     });
     await waitFor(() => expect(mockedGetAllDocuments).toHaveBeenCalledTimes(4));
 
-    expect(resetQueriesSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(resetQueriesSpy).toHaveBeenCalledTimes(2));
     resetQueriesSpy.mockRestore();
   });
 

--- a/mobile/src/hooks/__tests__/useInfiniteContracts.test.tsx
+++ b/mobile/src/hooks/__tests__/useInfiniteContracts.test.tsx
@@ -395,9 +395,8 @@ describe("useInfiniteContracts", () => {
     await act(async () => {
       await result.current.fetchNextPage();
     });
-    await waitFor(() => expect(mockedGetAllDocuments).toHaveBeenCalledTimes(4));
-
     await waitFor(() => expect(resetQueriesSpy).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockedGetAllDocuments).toHaveBeenCalledTimes(5));
     resetQueriesSpy.mockRestore();
   });
 

--- a/mobile/src/hooks/__tests__/useInfiniteContracts.test.tsx
+++ b/mobile/src/hooks/__tests__/useInfiniteContracts.test.tsx
@@ -400,6 +400,48 @@ describe("useInfiniteContracts", () => {
     resetQueriesSpy.mockRestore();
   });
 
+  it.each([
+    ["the later page omits it", "1:100", undefined],
+    ["the first page omits it", undefined, "1:100"],
+  ])(
+    "resets mobile offset pagination when %s",
+    async (_description, firstSnapshotVersion, laterSnapshotVersion) => {
+      const firstPage = createPage({
+        ids: documentIds(1, 9),
+        totalRows: 15,
+        limit: 9,
+        skip: 0,
+        hasMore: true,
+        snapshotVersion: firstSnapshotVersion,
+      });
+      const laterPage = createPage({
+        ids: documentIds(10, 6),
+        totalRows: 15,
+        limit: 6,
+        skip: 9,
+        hasMore: false,
+        snapshotVersion: laterSnapshotVersion,
+      });
+      mockedGetAllDocuments
+        .mockResolvedValueOnce(firstPage)
+        .mockResolvedValueOnce(laterPage)
+        .mockResolvedValue(firstPage);
+      const resetQueriesSpy = jest.spyOn(queryClient, "resetQueries");
+
+      const { result } = renderHook(() => useInfiniteContracts(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+      await act(async () => {
+        await result.current.fetchNextPage();
+      });
+
+      await waitFor(() => expect(resetQueriesSpy).toHaveBeenCalledTimes(1));
+      resetQueriesSpy.mockRestore();
+    },
+  );
+
   it("keeps loaded documents and exposes a load-more error when the next page fails", async () => {
     mockedGetAllDocuments
       .mockResolvedValueOnce(

--- a/mobile/src/hooks/useInfiniteContracts.ts
+++ b/mobile/src/hooks/useInfiniteContracts.ts
@@ -212,17 +212,17 @@ export function useInfiniteContracts({
       .find((generation) => generation !== baseSnapshotGeneration);
   }, [pages, baseSnapshotGeneration]);
 
-  // Loop guard: at most one reset per (query key, base -> conflicting) pair. A
-  // repeat of the exact same mismatch after a reset is swallowed rather than
-  // resetting forever.
+  // Loop guard: reset a given mismatch once while it remains present. Re-arm
+  // after the pages become coherent so a later recurrence is handled too.
   const lastSnapshotResetRef = useRef<string | null>(null);
   const queryKey = options.queryKey;
 
   useEffect(() => {
-    if (
-      baseSnapshotGeneration === undefined
-      || conflictingSnapshotGeneration === undefined
-    ) return;
+    if (baseSnapshotGeneration === undefined) return;
+    if (conflictingSnapshotGeneration === undefined) {
+      lastSnapshotResetRef.current = null;
+      return;
+    }
 
     const signature =
       `${queryKey.join("|")}::${baseSnapshotGeneration}->${conflictingSnapshotGeneration}`;

--- a/mobile/src/hooks/useInfiniteContracts.ts
+++ b/mobile/src/hooks/useInfiniteContracts.ts
@@ -16,6 +16,7 @@ export const CONTRACTS_NEXT_PAGE_SIZE = 6;
 
 export const CONTRACTS_PAGE_STALE_TIME = 1000 * 60 * 5; // 5 minutes
 export const CONTRACTS_PAGE_GC_TIME = 1000 * 60 * 60; // 1 hour
+const UNVERSIONED_SNAPSHOT_GENERATION = "<unversioned>";
 
 /** Offset page cursor sent to `GET /eformsign/documents`. */
 export interface ContractsPageParam {
@@ -195,18 +196,21 @@ export function useInfiniteContracts({
 
   // --- snapshot_version drift guard -----------------------------------------
   // Offset pagination is only coherent against a stable snapshot. If the backend
-  // reports a different snapshot for a later page, the underlying list changed
-  // mid-pagination and the loaded pages may hold duplicates or gaps — restart
-  // from page 1. The field is optional (absent when the cache is bypassed), which
-  // simply means "no signal".
+  // reports a different snapshot generation for a later page, the underlying
+  // list changed mid-pagination and the loaded pages may hold duplicates or gaps
+  // — restart from page 1. Versioned and unversioned pages are distinct
+  // generations because omission means the backend bypassed the snapshot cache.
   const baseSnapshotVersion = pages?.[0]?.snapshot_version;
-  const conflictingSnapshotVersion = useMemo(() => {
-    if (!pages || !baseSnapshotVersion) return undefined;
+  const baseSnapshotGeneration = pages?.length
+    ? (baseSnapshotVersion ?? UNVERSIONED_SNAPSHOT_GENERATION)
+    : undefined;
+  const conflictingSnapshotGeneration = useMemo(() => {
+    if (!pages || baseSnapshotGeneration === undefined) return undefined;
     return pages
       .slice(1)
-      .find((page) => page.snapshot_version && page.snapshot_version !== baseSnapshotVersion)
-      ?.snapshot_version;
-  }, [pages, baseSnapshotVersion]);
+      .map((page) => page.snapshot_version ?? UNVERSIONED_SNAPSHOT_GENERATION)
+      .find((generation) => generation !== baseSnapshotGeneration);
+  }, [pages, baseSnapshotGeneration]);
 
   // Loop guard: at most one reset per (query key, base -> conflicting) pair. A
   // repeat of the exact same mismatch after a reset is swallowed rather than
@@ -215,14 +219,23 @@ export function useInfiniteContracts({
   const queryKey = options.queryKey;
 
   useEffect(() => {
-    if (!baseSnapshotVersion || !conflictingSnapshotVersion) return;
+    if (
+      baseSnapshotGeneration === undefined
+      || conflictingSnapshotGeneration === undefined
+    ) return;
 
-    const signature = `${queryKey.join("|")}::${baseSnapshotVersion}->${conflictingSnapshotVersion}`;
+    const signature =
+      `${queryKey.join("|")}::${baseSnapshotGeneration}->${conflictingSnapshotGeneration}`;
     if (lastSnapshotResetRef.current === signature) return;
     lastSnapshotResetRef.current = signature;
 
     void queryClient.resetQueries({ queryKey, exact: true });
-  }, [baseSnapshotVersion, conflictingSnapshotVersion, queryClient, queryKey]);
+  }, [
+    baseSnapshotGeneration,
+    conflictingSnapshotGeneration,
+    queryClient,
+    queryKey,
+  ]);
 
   return {
     // Spreading opts out of react-query's tracked-props optimization (every


### PR DESCRIPTION
## Summary
- gate local mirror list publication so completed documents appear only after detail and both required PDFs reach ready
- atomically withdraw a completed projection before file mirroring and re-publish only after the ready CAS succeeds
- fence stale cached snapshots against current DB readiness, including Valkey invalidation failure
- fail closed while sync_status is not yet deployed and normalize legacy/raw completed status forms

## Review context
This addresses the P1 review finding on preview PR #427 that a completed list projection could be visible before PDF mirroring succeeded.

## Validation
- independent P0-P2 review: APPROVE
- backend focused: 10 suites passed, 226 tests passed, 29 skipped
- backend full: 187 suites passed; 2,143 passed, 37 skipped
- backend type-check: passed
- backend lint: passed with 76 pre-existing warnings and no errors
- backend build: passed
- Prisma validate: passed
- git diff --check: passed
- security diff scan: no schema, dependency, environment, auth, secret-log, or dangerous API changes

## Database and rollout
- no schema or database patch changes
- no backfill is required for this fix
- pre-migration compatibility hides all completed rows until sync_status is available, rather than publishing unverifiable rows

## Security impact
- no credential, authorization, or tenant-boundary changes
- branch and headquarters scopes retain their existing ownership predicates

## Rollback
Revert this single commit. The previous behavior will be restored; no database rollback or data deletion is needed.