### PR TITLE
fix(backend): compat read가 자기 필터 때문에 실패하지 않도록 (PR #431 리뷰 4건 중 1건)

### DIFF
--- a/backend/infrastructure/database/eformsign-doc-compat.ts
+++ b/backend/infrastructure/database/eformsign-doc-compat.ts
@@ -49,6 +49,7 @@ type PendingEformsignDocData = {
     documentKind?: unknown;
     employeeScheduleId?: unknown;
     templateId?: unknown;
+    permanentPurgeRequestedAt?: unknown;
     documentName?: unknown;
     documentNumber?: unknown;
     templateName?: unknown;
@@ -114,6 +115,15 @@ const PENDING_EFORMSIGN_DOC_COLUMN_GROUPS = [
             { databaseName: "sync_error_at", prismaName: "syncErrorAt" },
         ],
     },
+    {
+        // Migration: 20260730040000_add_eformsign_doc_permanent_purge_intent
+        columns: [
+            {
+                databaseName: "permanent_purge_requested_at",
+                prismaName: "permanentPurgeRequestedAt",
+            },
+        ],
+    },
 ] as const satisfies readonly { columns: readonly PendingEformsignDocColumn[] }[];
 
 export const PENDING_EFORMSIGN_DOC_COLUMN_NAMES = PENDING_EFORMSIGN_DOC_COLUMN_GROUPS.flatMap(
@@ -150,6 +160,7 @@ const PENDING_EFORMSIGN_DOC_NULLS = {
     documentKind: null,
     employeeScheduleId: null,
     templateId: null,
+    permanentPurgeRequestedAt: null,
     documentName: null,
     documentNumber: null,
     templateName: null,
@@ -200,6 +211,49 @@ export const readWithEformsignDocCompat = async <TRow>(
         }
         return read({ ...EFORMSIGN_DOC_COMPAT_READ_SELECT });
     }
+};
+
+/**
+ * Drops `pendingColumn: null` predicates from a filter so it can run against a database
+ * that does not have the column yet.
+ *
+ * Narrowing the select is only half of a compatibility read. Callers also filter on these
+ * columns — `permanentPurgeRequestedAt: null` appears in nearly every document read — and
+ * a predicate naming a missing column fails no matter what is selected, so the retry used
+ * to fail exactly like the first attempt.
+ *
+ * Only the `: null` form is dropped, and that is a semantic identity: if the column does
+ * not exist, no row can carry a value, so "is null" is true of every row. Any other
+ * comparison is left in place to fail loudly rather than be silently reinterpreted —
+ * `{ not: null }` would flip from matching nothing to matching everything.
+ */
+export const stripPendingEformsignDocPredicates = (
+    where: Prisma.eformsign_docWhereInput,
+): Prisma.eformsign_docWhereInput => {
+    const pendingNames = new Set<string>(
+        PENDING_EFORMSIGN_DOC_COLUMN_GROUPS.flatMap((group) =>
+            group.columns.map((column) => column.prismaName as string),
+        ),
+    );
+
+    const strip = (node: Prisma.eformsign_docWhereInput): Prisma.eformsign_docWhereInput => {
+        const stripped: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(node)) {
+            if (pendingNames.has(key) && value === null) {
+                continue;
+            }
+            if ((key === "AND" || key === "OR" || key === "NOT") && value !== undefined) {
+                stripped[key] = Array.isArray(value)
+                    ? value.map((entry) => strip(entry as Prisma.eformsign_docWhereInput))
+                    : strip(value as Prisma.eformsign_docWhereInput);
+                continue;
+            }
+            stripped[key] = value;
+        }
+        return stripped as Prisma.eformsign_docWhereInput;
+    };
+
+    return strip(where);
 };
 
 export const eformsignDocCompatReadSelect = (

--- a/backend/infrastructure/database/eformsign-doc-compat.ts
+++ b/backend/infrastructure/database/eformsign-doc-compat.ts
@@ -228,21 +228,34 @@ export const readWithEformsignDocCompat = async <TRow>(
  * `{ not: null }` would flip from matching nothing to matching everything.
  */
 export const stripPendingEformsignDocPredicates = (
+    error: unknown,
     where: Prisma.eformsign_docWhereInput,
 ): Prisma.eformsign_docWhereInput => {
-    const pendingNames = new Set<string>(
-        PENDING_EFORMSIGN_DOC_COLUMN_GROUPS.flatMap((group) =>
-            group.columns.map((column) => column.prismaName as string),
-        ),
-    );
+    // Only the columns the database is actually missing. A predicate on a column an
+    // earlier migration already added still means what it says, and dropping it would
+    // widen the retry — a filter excluding purge-pending rows would start including them.
+    const kept = keptPendingEformsignDocColumns(error);
+    const missingNames = PENDING_EFORMSIGN_DOC_COLUMN_GROUPS
+        .flatMap((group) => group.columns.map((column) => column.prismaName as string))
+        .filter((name) => !kept.has(name));
+    if (missingNames.length === 0) {
+        return where;
+    }
+    const missing = new Set(missingNames);
 
+    // AND is the only operator this descends into, because it is the only one where
+    // deleting a vacuously-true leaf preserves the meaning of the whole. Under OR a true
+    // leaf makes the branch true, and under NOT it makes it false; an empty object says
+    // neither, so both are left exactly as they are and fail loudly instead of quietly
+    // answering a different question. Every filter that actually needs this puts its
+    // pending predicates at the top level or in an AND chain.
     const strip = (node: Prisma.eformsign_docWhereInput): Prisma.eformsign_docWhereInput => {
         const stripped: Record<string, unknown> = {};
         for (const [key, value] of Object.entries(node)) {
-            if (pendingNames.has(key) && value === null) {
+            if (missing.has(key) && value === null) {
                 continue;
             }
-            if ((key === "AND" || key === "OR" || key === "NOT") && value !== undefined) {
+            if (key === "AND" && value !== undefined && value !== null) {
                 stripped[key] = Array.isArray(value)
                     ? value.map((entry) => strip(entry as Prisma.eformsign_docWhereInput))
                     : strip(value as Prisma.eformsign_docWhereInput);
@@ -258,20 +271,35 @@ export const stripPendingEformsignDocPredicates = (
 
 export const eformsignDocCompatReadSelect = (
     error: unknown,
+    // The caller's own projection, so a compatibility retry reads no more than the query
+    // it is standing in for. Widening to every surviving pending column would have pulled
+    // detailPayload into list reads — the one column EFORMSIGN_DOC_DOMAIN_READ_SELECT
+    // exists to keep out of them.
+    desiredSelect: Prisma.eformsign_docSelect = EFORMSIGN_DOC_DOMAIN_READ_SELECT,
 ): Prisma.eformsign_docSelect => {
     // Prisma sometimes raises P2022 with no column metadata and nothing nameable in the
     // message. That says a pending column is missing without saying which, so a read drops
     // to the floor — the assumption that cannot be wrong. Writes throw in the same
     // situation instead, because silently dropping data a caller asked to store is worse
     // than failing; a read losing columns it could have kept is recoverable.
-    const keptGroupCount = Math.max(findEformsignDocGroupIndex(error), 0);
+    const kept = keptPendingEformsignDocColumns(error);
     const select: Prisma.eformsign_docSelect = { ...EFORMSIGN_DOC_COMPAT_READ_SELECT };
-    for (const group of PENDING_EFORMSIGN_DOC_COLUMN_GROUPS.slice(0, keptGroupCount)) {
-        for (const column of group.columns) {
-            select[column.prismaName] = true;
+    for (const [column, wanted] of Object.entries(desiredSelect)) {
+        if (wanted && kept.has(column)) {
+            select[column as keyof Prisma.eformsign_docSelect] = true;
         }
     }
     return select;
+};
+
+/** Pending columns from migrations that ran before the one the error names. */
+const keptPendingEformsignDocColumns = (error: unknown): Set<string> => {
+    const keptGroupCount = Math.max(findEformsignDocGroupIndex(error), 0);
+    return new Set(
+        PENDING_EFORMSIGN_DOC_COLUMN_GROUPS
+            .slice(0, keptGroupCount)
+            .flatMap((group) => group.columns.map((column) => column.prismaName as string)),
+    );
 };
 
 /**

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -811,7 +811,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
 
             const doc = await readWithEformsignDocCompat(error, (select) =>
                 this.prismaService.eformsign_doc.findFirst({
-                    where: stripPendingEformsignDocPredicates(where),
+                    where: stripPendingEformsignDocPredicates(error, where),
                     select,
                 }));
             return doc ? EformsignDocMapper.toDomain(toCompatDomainRow(doc)) : null;
@@ -832,7 +832,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
 
             const docs = await readWithEformsignDocCompat(error, (select) =>
                 this.prismaService.eformsign_doc.findMany({
-                    where: stripPendingEformsignDocPredicates(where),
+                    where: stripPendingEformsignDocPredicates(error, where),
                     select,
                 }));
             return docs.map((doc) => EformsignDocMapper.toDomain(toCompatDomainRow(doc)));

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -21,6 +21,7 @@ import {
 import {
     EFORMSIGN_DOC_DOMAIN_READ_SELECT,
     readWithEformsignDocCompat,
+    stripPendingEformsignDocPredicates,
     isPendingEformsignDocColumnError,
     omitPendingEformsignDocColumns,
     toCompatDomainRow,
@@ -809,7 +810,10 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
             }
 
             const doc = await readWithEformsignDocCompat(error, (select) =>
-                this.prismaService.eformsign_doc.findFirst({ where, select }));
+                this.prismaService.eformsign_doc.findFirst({
+                    where: stripPendingEformsignDocPredicates(where),
+                    select,
+                }));
             return doc ? EformsignDocMapper.toDomain(toCompatDomainRow(doc)) : null;
         }
     }
@@ -827,7 +831,10 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
             }
 
             const docs = await readWithEformsignDocCompat(error, (select) =>
-                this.prismaService.eformsign_doc.findMany({ where, select }));
+                this.prismaService.eformsign_doc.findMany({
+                    where: stripPendingEformsignDocPredicates(where),
+                    select,
+                }));
             return docs.map((doc) => EformsignDocMapper.toDomain(toCompatDomainRow(doc)));
         }
     }

--- a/backend/test/infrastructure/eformsign-doc-compat.spec.ts
+++ b/backend/test/infrastructure/eformsign-doc-compat.spec.ts
@@ -3,6 +3,7 @@ import {
     eformsignDocCompatReadSelect,
     omitPendingEformsignDocColumns,
     readWithEformsignDocCompat,
+    stripPendingEformsignDocPredicates,
     toCompatDomainRow,
 } from "infrastructure/database/eformsign-doc-compat";
 
@@ -47,6 +48,23 @@ describe("eformsignDocCompatReadSelect", () => {
         ]) {
             expect(select[column as keyof typeof select]).toBeUndefined();
         }
+    });
+
+    it("keeps everything up to the newest migration when only it is missing", () => {
+        // The purge-intent migration is the newest group; a database missing only it must
+        // still return every column the four earlier migrations added.
+        const select = eformsignDocCompatReadSelect(
+            missingColumnError("permanent_purge_requested_at"),
+        );
+
+        expect(select).toMatchObject({
+            templateId: true,
+            documentName: true,
+            customerName: true,
+            detailPayload: true,
+            syncStatus: true,
+        });
+        expect(select["permanentPurgeRequestedAt" as keyof typeof select]).toBeUndefined();
     });
 
     it("falls back to the floor when the oldest migration is the missing one", () => {
@@ -107,6 +125,50 @@ describe("readWithEformsignDocCompat", () => {
         await readWithEformsignDocCompat(missingColumnError("customer_name"), read);
 
         expect(read).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("stripPendingEformsignDocPredicates", () => {
+    it("drops an is-null test for a column the database may not have", () => {
+        // Narrowing the select is only half a compatibility read: nearly every document
+        // filter carries `permanentPurgeRequestedAt: null`, and a predicate naming a
+        // missing column fails whatever is selected. Dropping it is a semantic identity —
+        // with no column, no row can carry a value, so "is null" is true of every row.
+        expect(stripPendingEformsignDocPredicates({
+            branchId: "branch-1",
+            permanentPurgeRequestedAt: null,
+        })).toEqual({ branchId: "branch-1" });
+    });
+
+    it("reaches into AND, OR and NOT", () => {
+        expect(stripPendingEformsignDocPredicates({
+            AND: [
+                { branchId: "branch-1" },
+                { permanentPurgeRequestedAt: null },
+                { OR: [{ templateId: null }, { documentId: "doc-1" }] },
+            ],
+        })).toEqual({
+            AND: [
+                { branchId: "branch-1" },
+                {},
+                { OR: [{}, { documentId: "doc-1" }] },
+            ],
+        });
+    });
+
+    it("leaves any comparison other than is-null alone", () => {
+        // `{ not: null }` means the opposite, and without the column it would flip from
+        // matching nothing to matching everything. Better to fail loudly than to answer
+        // a different question than the caller asked.
+        const where = { permanentPurgeRequestedAt: { not: null } };
+
+        expect(stripPendingEformsignDocPredicates(where)).toEqual(where);
+    });
+
+    it("leaves a filter with no pending columns untouched", () => {
+        const where = { branchId: "branch-1", documentId: "doc-1" };
+
+        expect(stripPendingEformsignDocPredicates(where)).toEqual(where);
     });
 });
 

--- a/backend/test/infrastructure/eformsign-doc-compat.spec.ts
+++ b/backend/test/infrastructure/eformsign-doc-compat.spec.ts
@@ -61,10 +61,29 @@ describe("eformsignDocCompatReadSelect", () => {
             templateId: true,
             documentName: true,
             customerName: true,
-            detailPayload: true,
-            syncStatus: true,
         });
         expect(select["permanentPurgeRequestedAt" as keyof typeof select]).toBeUndefined();
+    });
+
+    it("never widens past the projection the caller asked for", () => {
+        // The list select deliberately leaves detailPayload out — it is unbounded JSON and
+        // a page view would read one per row. A retry that selected every surviving pending
+        // column would have quietly reintroduced it for the whole deployment window.
+        const select = eformsignDocCompatReadSelect(
+            missingColumnError("permanent_purge_requested_at"),
+        );
+
+        expect(select["detailPayload" as keyof typeof select]).toBeUndefined();
+        expect(select["syncStatus" as keyof typeof select]).toBeUndefined();
+    });
+
+    it("still returns a pending column when the caller does want it", () => {
+        const select = eformsignDocCompatReadSelect(
+            missingColumnError("permanent_purge_requested_at"),
+            { documentId: true, detailPayload: true },
+        );
+
+        expect(select).toMatchObject({ detailPayload: true });
     });
 
     it("falls back to the floor when the oldest migration is the missing one", () => {
@@ -134,26 +153,46 @@ describe("stripPendingEformsignDocPredicates", () => {
         // filter carries `permanentPurgeRequestedAt: null`, and a predicate naming a
         // missing column fails whatever is selected. Dropping it is a semantic identity —
         // with no column, no row can carry a value, so "is null" is true of every row.
-        expect(stripPendingEformsignDocPredicates({
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
             branchId: "branch-1",
             permanentPurgeRequestedAt: null,
         })).toEqual({ branchId: "branch-1" });
     });
 
-    it("reaches into AND, OR and NOT", () => {
-        expect(stripPendingEformsignDocPredicates({
+    it("reaches into AND, where deleting a true leaf changes nothing", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
             AND: [
                 { branchId: "branch-1" },
                 { permanentPurgeRequestedAt: null },
-                { OR: [{ templateId: null }, { documentId: "doc-1" }] },
             ],
         })).toEqual({
             AND: [
                 { branchId: "branch-1" },
                 {},
-                { OR: [{}, { documentId: "doc-1" }] },
             ],
         });
+    });
+
+    it.each([
+        ["OR", { OR: [{ templateId: null }, { documentId: "doc-1" }] }],
+        ["NOT", { NOT: { templateId: null } }],
+    ])("leaves %s alone rather than changing what it means", (_operator, where) => {
+        // An empty object is not the true this leaf stood for. Under OR a true leaf makes
+        // the whole branch true, so dropping it would narrow the query to the other terms;
+        // under NOT it makes the branch false, so dropping it would widen to everything.
+        // Both are silently wrong answers, and a loud failure is the better one.
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), where))
+            .toEqual(where);
+    });
+
+    it("keeps a predicate whose column an earlier migration already added", () => {
+        // Only the missing group and later ones are vacuous. `templateId` shipped with the
+        // first group, so when a later migration is the missing one it is still there —
+        // dropping its predicate would widen the retry past what the caller asked for.
+        expect(stripPendingEformsignDocPredicates(
+            missingColumnError("permanent_purge_requested_at"),
+            { templateId: null, permanentPurgeRequestedAt: null },
+        )).toEqual({ templateId: null });
     });
 
     it("leaves any comparison other than is-null alone", () => {
@@ -162,13 +201,13 @@ describe("stripPendingEformsignDocPredicates", () => {
         // a different question than the caller asked.
         const where = { permanentPurgeRequestedAt: { not: null } };
 
-        expect(stripPendingEformsignDocPredicates(where)).toEqual(where);
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), where)).toEqual(where);
     });
 
     it("leaves a filter with no pending columns untouched", () => {
         const where = { branchId: "branch-1", documentId: "doc-1" };
 
-        expect(stripPendingEformsignDocPredicates(where)).toEqual(where);
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), where)).toEqual(where);
     });
 });
 

--- a/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
@@ -99,11 +99,15 @@ describe("SbEformsignDocRepository", () => {
         });
         expect(eformsignDocModel.findMany.mock.calls[0][0].select)
             .not.toHaveProperty("detailPayload");
+        // The retry drops `permanentPurgeRequestedAt: null` from the filter. A predicate
+        // naming a column the database does not have fails whatever is selected, so
+        // narrowing the select alone left the retry failing exactly like the first
+        // attempt. Dropping an "is null" test for a non-existent column changes nothing:
+        // with no column, no row can carry a value.
         expect(eformsignDocModel.findMany).toHaveBeenNthCalledWith(2, {
             where: {
                 clientId: 55,
                 branchId: "branch-1",
-                permanentPurgeRequestedAt: null,
             },
             select: expect.objectContaining({
                 documentId: true,
@@ -182,7 +186,6 @@ describe("SbEformsignDocRepository", () => {
             where: {
                 documentId: "doc-1",
                 branchId: "branch-1",
-                permanentPurgeRequestedAt: null,
             },
             select: expect.objectContaining({
                 documentId: true,


### PR DESCRIPTION
PR #431 리뷰 4건을 전부 구현해 본 결과입니다. **1건만 남기고 3건은 되돌렸습니다** — 이유가 본론입니다.

## 담긴 것 — P2: purge 컬럼 compat 미등록

`permanent_purge_requested_at`을 `PENDING_EFORMSIGN_DOC_COLUMN_GROUPS`에 등록했습니다. 그런데 등록만으로는 지적이 해결되지 않는다는 걸 구현하며 확인했습니다.

**select를 좁히는 것만으로는 처음부터 부족했습니다.** 거의 모든 문서 읽기가 `permanentPurgeRequestedAt: null`로 필터링하는데, 없는 컬럼을 참조하는 술어는 무엇을 select하든 실패합니다. 즉 재시도가 첫 시도와 똑같이 실패하고 있었습니다 — 폴백이 있으되 동작하지 않는 상태였습니다.

이제 재시도 전에 `pendingColumn: null` 술어를 필터에서 제거합니다. 이건 완화가 아니라 **의미상 항등**입니다: 컬럼이 없으면 어떤 행도 값을 가질 수 없으므로 "is null"은 모든 행에 참입니다.

`{ not: null }` 같은 다른 비교는 **그대로 두어 크게 실패하게** 합니다 — 컬럼이 없으면 "아무것도 매칭 안 함"에서 "전부 매칭"으로 뒤집혀 호출자가 묻지 않은 질문에 답하게 되기 때문입니다.

기존 스펙 2건이 "재시도가 술어를 유지한다"를 단언하고 있었는데, 그게 바로 결함이라 기대값을 함께 옮겼습니다.

## 되돌린 것 — 나머지 3건은 **의도된 설계**를 뒤집습니다

세 건 다 구현했다가, 작성자가 테스트로 명시적으로 고정해 둔 동작을 제 수정이 정반대로 바꾼다는 것을 발견하고 되돌렸습니다.

**P1 — 영구 삭제 후 durable fence 유지**
`purgeContent`에서 `permanentPurgeRequestedAt: null`을 지우지 않도록 바꿨더니, `sb.eformsign-document-mirror.repository.spec.ts`가 그 값이 `null`이어야 한다고 명시적으로 단언합니다. 코드 주석도 "even after the purge intent is cleared below"로 의도를 밝히고 있습니다.

**P1 — 소유권 무효화 실패 시 fail-closed**
bump 실패를 기억해 다음 읽기에서 재빌드하도록 만들었더니 4개 테스트가 깨졌습니다. 그중 하나는 이름부터 `should exclude a tombstoned unassigned document from a stale headquarters snapshot after its epoch bump fails` 이고, **stale 세대를 그대로 서빙하면서 반환 시점에 DB로 거르는 것**이 정답이라고 단언합니다. 코드 주석도 "Both are durable before cache invalidation, so lookup failure deliberately propagates"라고 설계를 밝힙니다.

**P2 — 일시적 purge 제외를 캐시에 굽지 않기**
저장 시점 제외(`buildSafeEntries`)를 제거했더니 3개 테스트가 깨졌습니다. mock 호출 횟수(`toHaveBeenCalledTimes(3)` = 저장 1 + 반환 2)에 저장 시점 호출이 명시적으로 박혀 있습니다.

### 판단

리뷰어가 틀린 게 아닙니다 — 세 지적 모두 실재하는 실패 모드입니다. 다만 **고치려면 ADR 004 작성자의 설계 결정이 필요**하고, 릴리스 후속 정리에서 제가 작성자의 테스트를 반대로 고쳐 쓰며 밀어붙일 일이 아닙니다.

도달 가능성도 참고가 됩니다: P1 2건은 `bumpVersion`이 null을 반환해야 하는데 Valkey가 없으면 메모리 경로로 항상 숫자를 반환하고, `VALKEY_URL`은 세 환경 모두 없습니다. P2 1건(clear-intent DB 실패)만 지금도 도달 가능합니다.

## 검증

`tsc` 통과, eslint 0 errors / 76 warnings(기준선 유지), jest **187 suites / 2137 passed / 37 skipped**. `eformsign-doc-compat.spec.ts`가 16건으로 늘어 그룹 경계·술어 제거·AND/OR/NOT 재귀·비-null 비교 보존을 고정합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwFGoYVNLBEkAfxbtLgrbG