### PR TITLE
fix(frontend): eformsign PDF 미리보기 HEAD 500 복구

### DIFF
--- a/frontend/src/app/api/eformsign/documents/[documentId]/preview/__tests__/route.test.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/preview/__tests__/route.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+import { GET, HEAD } from "../route";
+
+jest.mock("@/lib/api/server", () => ({
+  serverAPIClient: {
+    get: jest.fn(),
+  },
+}));
+
+const mockServerGet = serverAPIClient.get as jest.Mock;
+const context = { params: Promise.resolve({ documentId: "doc-1" }) };
+
+function createRequest(method: "GET" | "HEAD"): NextRequest {
+  return new NextRequest(
+    "http://localhost/api/eformsign/documents/doc-1/preview",
+    {
+      method,
+      headers: {
+        cookie: "auth_token=auth-token",
+      },
+    },
+  );
+}
+
+describe("eformsign document preview route", () => {
+  beforeEach(() => {
+    mockServerGet.mockReset();
+  });
+
+  it("returns PDF bytes for GET", async () => {
+    const pdf = new Uint8Array([1, 2, 3]);
+    mockServerGet.mockResolvedValue({
+      status: 200,
+      headers: { "content-type": "application/pdf" },
+      data: pdf,
+    });
+
+    const response = await GET(createRequest("GET"), context);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Length")).toBe("3");
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(pdf);
+  });
+
+  it("returns only PDF metadata for HEAD", async () => {
+    mockServerGet.mockResolvedValue({
+      status: 200,
+      headers: { "content-type": "application/pdf" },
+      data: new Uint8Array([1, 2, 3]),
+    });
+
+    const response = await HEAD(createRequest("HEAD"), context);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/pdf");
+    expect(response.headers.get("Content-Length")).toBe("3");
+    expect((await response.arrayBuffer()).byteLength).toBe(0);
+    expect(mockServerGet).toHaveBeenCalledWith(
+      "/api/documents/doc-1/download_files",
+      expect.objectContaining({
+        params: { fileType: "document" },
+        responseType: "arraybuffer",
+      }),
+    );
+  });
+
+  it("does not contact the backend for an unauthenticated HEAD request", async () => {
+    const request = new NextRequest(
+      "http://localhost/api/eformsign/documents/doc-1/preview",
+      { method: "HEAD" },
+    );
+
+    const response = await HEAD(request, context);
+
+    expect(response.status).toBe(401);
+    expect((await response.arrayBuffer()).byteLength).toBe(0);
+    expect(mockServerGet).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/api/eformsign/documents/[documentId]/preview/route.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/preview/route.ts
@@ -8,12 +8,18 @@ import {
 
 type RouteParams = { params: Promise<{ documentId: string }> };
 
-export async function GET(request: NextRequest, { params }: RouteParams) {
+async function proxyPreview(
+  request: NextRequest,
+  { params }: RouteParams,
+  includeBody: boolean,
+) {
   try {
     const authToken = getAuthToken(request);
 
     if (!authToken) {
-      return unauthorizedResponse("Authentication required. Please log in.");
+      return includeBody
+        ? unauthorizedResponse("Authentication required. Please log in.")
+        : new NextResponse(null, { status: 401 });
     }
 
     const { documentId } = await params;
@@ -30,11 +36,18 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const contentType = String(response.headers["content-type"] ?? "application/octet-stream");
 
     if (contentType.includes("application/json")) {
+      if (!includeBody) {
+        return new NextResponse(null, {
+          status: response.status,
+          headers: { "Content-Type": contentType },
+        });
+      }
+
       const payload = JSON.parse(Buffer.from(response.data).toString("utf-8"));
       return NextResponse.json(payload, { status: response.status });
     }
 
-    return new NextResponse(response.data, {
+    return new NextResponse(includeBody ? response.data : null, {
       status: response.status,
       headers: {
         "Content-Type": contentType,
@@ -45,9 +58,21 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       },
     });
   } catch (error) {
+    if (!includeBody) {
+      return new NextResponse(null, { status: 500 });
+    }
+
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Failed to preview eformsign document" },
       { status: 500 }
     );
   }
+}
+
+export async function GET(request: NextRequest, context: RouteParams) {
+  return proxyPreview(request, context, true);
+}
+
+export async function HEAD(request: NextRequest, context: RouteParams) {
+  return proxyPreview(request, context, false);
 }


### PR DESCRIPTION
## 문제

최신 dev 배포에서 완료 전자문서의 상세·로컬 PDF 데이터는 정상이고 readiness 누락도 0이지만, `/api/eformsign/documents/:id/preview`의 브라우저 사전 HEAD 요청이 Vercel에서 500을 반환해 PDF 대화상자가 오류 상태로 멈췄습니다.

## 변경

- Next.js 자동 HEAD 생성에 의존하지 않고 명시적 HEAD 핸들러를 추가했습니다.
- GET과 HEAD가 동일한 인증 및 로컬 DB PDF 조회 경로를 사용합니다.
- HEAD는 PDF 본문을 응답에 싣지 않고 `Content-Type`, `Content-Disposition`, `Content-Length`만 반환합니다.
- GET, HEAD, 비인증 HEAD 회귀 테스트를 추가했습니다.

## 검증

- focused route test: 3 passed
- frontend full Jest: 142 suites / 646 tests passed
- frontend typecheck: passed
- frontend lint: 0 errors (existing warnings only)
- frontend build: passed
- UI architecture baseline gate: passed
- `git diff --check`: passed
- added-secret pattern scan: 0

## 영향 및 롤백

- DB/schema/API 응답 본문 계약 변경 없음
- vendor API 읽기 경로 추가 없음; 기존 로컬 DB PDF backend endpoint만 사용
- 문제 발생 시 이 단일 커밋을 revert하면 이전 자동 HEAD 동작으로 복원됩니다.
