### PR TITLE
fix(eformsign): address preview review findings

### DIFF
--- a/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
+++ b/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
@@ -220,7 +220,7 @@ describe("EformsignDocumentSnapshotService", () => {
             { excludeTombstones: true },
         );
 
-        expect(build).toHaveBeenCalledTimes(3);
+        expect(build).toHaveBeenCalledTimes(1);
         expect(defaultResult).toEqual({
             entries: [
                 createEntry("safe-document"),
@@ -272,7 +272,7 @@ describe("EformsignDocumentSnapshotService", () => {
 
         const result = await service.getOrBuild(createMirrorParams(), build);
 
-        expect(build).toHaveBeenCalledTimes(2);
+        expect(build).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
             entries: [createEntry("safe-document")],
             snapshotVersion: expect.stringMatching(/^0:\d+:f[0-9a-f]{12}$/),
@@ -292,7 +292,7 @@ describe("EformsignDocumentSnapshotService", () => {
         expect(restored.snapshotVersion).toBe(initialResult.snapshotVersion);
     });
 
-    it("should add a newly ready row even when its version bump failed", async () => {
+    it("should preserve a cached pagination generation when a ready-row bump fails", async () => {
         const exclusionLookup = createSnapshotExclusionLookup();
         const redis = createRedisStub();
         let snapshotPayload: string | null = null;
@@ -323,17 +323,17 @@ describe("EformsignDocumentSnapshotService", () => {
             createEntry("newly-ready-document"),
         ];
 
-        const recovered = await service.getOrBuild(createMirrorParams(), build);
+        const cached = await service.getOrBuild(createMirrorParams(), build);
 
+        expect(build).toHaveBeenCalledTimes(1);
+        expect(cached.entries).toEqual([createEntry("safe-document")]);
+        expect(cached.snapshotVersion).toBe(initial.snapshotVersion);
+
+        snapshotPayload = null;
+        const rebuilt = await service.getOrBuild(createMirrorParams(), build);
         expect(build).toHaveBeenCalledTimes(2);
-        expect(recovered.entries).toEqual(liveEntries);
-        expect(recovered.snapshotVersion).toMatch(/^0:\d+:f[0-9a-f]{12}$/);
-        expect(recovered.snapshotVersion).not.toBe(initial.snapshotVersion);
-
-        const stable = await service.getOrBuild(createMirrorParams(), build);
-        expect(build).toHaveBeenCalledTimes(3);
-        expect(stable.entries).toEqual(liveEntries);
-        expect(stable.snapshotVersion).toBe(recovered.snapshotVersion);
+        expect(rebuilt.entries).toEqual(liveEntries);
+        expect(rebuilt.cached).toBe(false);
     });
 
     it("should apply the readiness fence only to mirror snapshots", async () => {
@@ -420,7 +420,7 @@ describe("EformsignDocumentSnapshotService", () => {
             { excludeTombstones: true },
         );
 
-        expect(build).toHaveBeenCalledTimes(2);
+        expect(build).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
             entries: [createEntry("hq-safe-document")],
             snapshotVersion: expect.stringMatching(/^0:\d+:f[0-9a-f]{12}$/),
@@ -714,7 +714,7 @@ describe("EformsignDocumentSnapshotService", () => {
         const storedKeys = Array.from(internals.memoryStore.keys());
 
         expect(storedKeys).toEqual(["eformsign:doclist:v1:mirror:branch-a:all:0"]);
-        expect(build).toHaveBeenCalledTimes(2);
+        expect(build).toHaveBeenCalledTimes(1);
         // And still distinct from the vendor snapshot of the same scope, so flipping the
         // switch back does not keep serving the source it was flipped away from.
         expect(internals.snapshotKey(createParams(), 0)).not.toBe(storedKeys[0]);

--- a/backend/application/services/eformsign-document-snapshot.service.ts
+++ b/backend/application/services/eformsign-document-snapshot.service.ts
@@ -423,40 +423,6 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
                 returnOptions,
                 params.source,
             );
-            if (params.source === "mirror") {
-                // Mirror snapshots are an optimization over local DB reads, not an
-                // authority boundary. A failed Valkey generation bump can leave an
-                // old snapshot that a subtractive readiness fence cannot repair when
-                // a newly-ready row was absent. Rebuild the exact local scope and use
-                // a stable content fence whenever it diverges. This keeps reads
-                // vendor-free while making cache invalidation failure fail closed.
-                const liveVisible = await this.excludeSnapshotEntries(
-                    await this.buildSafeEntries(build),
-                    returnOptions,
-                    params.source,
-                );
-                const contentFence = snapshotEntriesEqual(
-                    cachedVisible.entries,
-                    liveVisible.entries,
-                )
-                    ? (
-                        cachedVisible.visibilityFence
-                        ?? liveVisible.visibilityFence
-                    )
-                    : snapshotEntriesFence(liveVisible.entries);
-                this.logger.log(
-                    `documentSnapshot hit branch=${params.branchId} scope=${params.scope}`
-                    + ` docs=${liveVisible.entries.length}`,
-                );
-                return {
-                    entries: liveVisible.entries,
-                    snapshotVersion: formatSnapshotVersion(
-                        read.snapshot,
-                        contentFence,
-                    ),
-                    cached: true,
-                };
-            }
             this.logger.log(
                 `documentSnapshot hit branch=${params.branchId} scope=${params.scope} docs=${cachedVisible.entries.length}`,
             );
@@ -748,22 +714,6 @@ function formatSnapshotVersion(
 ): string {
     const baseVersion = `${snapshot.version}:${snapshot.builtAt}`;
     return visibilityFence ? `${baseVersion}:f${visibilityFence}` : baseVersion;
-}
-
-function snapshotEntriesEqual<TDoc>(
-    left: DocumentSnapshotEntry<TDoc>[],
-    right: DocumentSnapshotEntry<TDoc>[],
-): boolean {
-    return JSON.stringify(left) === JSON.stringify(right);
-}
-
-function snapshotEntriesFence<TDoc>(
-    entries: DocumentSnapshotEntry<TDoc>[],
-): string {
-    return createHash("sha256")
-        .update(JSON.stringify(entries))
-        .digest("hex")
-        .slice(0, 12);
 }
 
 function describeError(error: unknown): string {

--- a/backend/application/usecases/eformsign-doc/adopt-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/adopt-eformsign-doc.usecase.ts
@@ -84,11 +84,12 @@ export class AdoptEformsignDocUsecase {
         } catch {
             // Ownership and client linkage were committed above. Returning a failure
             // here would tell the caller to retry an adoption that already succeeded.
-            // Keep the row non-ready and let the six-hour reconciliation sweep retry
-            // the local detail/PDF mirror without exposing identifiers in logs.
+            // Keep the row non-ready and expose a machine-readable warning so callers
+            // cannot report the local detail/PDF mirror as complete. The durable failed
+            // state remains eligible for an operational reconciliation without claiming
+            // that a scheduler or distributed lock is currently available.
             this.logger.warn(
-                "Eformsign adoption committed, but immediate mirror synchronization failed;"
-                + " scheduled reconciliation will retry",
+                "Eformsign adoption committed, but the local mirror remains incomplete",
             );
             return Object.assign(result, {
                 warnings: [

--- a/backend/application/usecases/eformsign-doc/adopt-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/adopt-eformsign-doc.usecase.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 
 import { EformsignDocumentMirrorService } from "application/services/eformsign-document-mirror.service";
 import { documentCustomerNameValue } from "application/utils/eformsign-document-customer-name";
@@ -18,6 +18,8 @@ export interface AdoptEformsignDocParams {
 
 @Injectable()
 export class AdoptEformsignDocUsecase {
+    private readonly logger = new Logger(AdoptEformsignDocUsecase.name);
+
     constructor(
         private readonly getAccessTokenUsecase: GetEformsignAccessTokenUsecase,
         private readonly fetchEformsignDocFromApiUsecase: FetchEformsignDocFromApiUsecase,
@@ -73,11 +75,28 @@ export class AdoptEformsignDocUsecase {
                 ?? null,
         });
 
-        await this.documentMirrorService.syncDocumentWithToken(
-            token.oauth_token.access_token,
-            remote.id || params.documentId,
-            { expectedUpdatedDate: remote.updated_date },
-        );
+        try {
+            await this.documentMirrorService.syncDocumentWithToken(
+                token.oauth_token.access_token,
+                remote.id || params.documentId,
+                { expectedUpdatedDate: remote.updated_date },
+            );
+        } catch {
+            // Ownership and client linkage were committed above. Returning a failure
+            // here would tell the caller to retry an adoption that already succeeded.
+            // Keep the row non-ready and let the six-hour reconciliation sweep retry
+            // the local detail/PDF mirror without exposing identifiers in logs.
+            this.logger.warn(
+                "Eformsign adoption committed, but immediate mirror synchronization failed;"
+                + " scheduled reconciliation will retry",
+            );
+            return Object.assign(result, {
+                warnings: [
+                    ...(result.warnings ?? []),
+                    "mirror_sync_failed" as const,
+                ],
+            });
+        }
 
         return result;
     }

--- a/backend/application/usecases/eformsign-doc/create-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/create-eformsign-doc.usecase.ts
@@ -35,8 +35,10 @@ export interface CreateEformsignDocParams {
     preserveExistingMirrorProjection?: boolean;
 }
 
+export type CreateEformsignDocWarning = "client_link_failed" | "mirror_sync_failed";
+
 export type CreateEformsignDocResult = EformsignDocEntity & {
-    warnings?: Array<"client_link_failed">;
+    warnings?: CreateEformsignDocWarning[];
 };
 
 @Injectable()
@@ -97,7 +99,7 @@ export class CreateEformsignDocUsecase {
                 { preserveExistingMirrorProjection: true },
             )
             : await this.eformsignDocRepository.upsertByDocumentId(branchid, entity);
-        const warnings: Array<"client_link_failed"> = [];
+        const warnings: CreateEformsignDocWarning[] = [];
 
         // If linkToClient is true, also update client.e_doc_id to track this document
         if (params.linkToClient) {

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -816,9 +816,9 @@ describe("EformsignController (Integration)", () => {
             expect(shadowCompareService.compareInBackground).not.toHaveBeenCalled();
         });
 
-        it("changes the generation when the local mirror list moves between pages", async () => {
-            // 페이지 사이에 로컬 미러가 바뀌면 새 세대를 발행한다. 클라이언트는 이 신호를
-            // 보고 첫 페이지부터 다시 읽으므로 이동한 문서를 조용히 건너뛰지 않는다.
+        it("keeps the cached generation stable when the local mirror moves between pages", async () => {
+            // 이미 배포된 클라이언트는 snapshot_version을 해석하지 않을 수 있다.
+            // 캐시 hit에서 live 목록으로 바꾸지 않아 offset이 같은 세대를 계속 걷게 한다.
             mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-1", createdDate: "2026-07-03T00:00:00.000Z" }),
                 createMirrorRow({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
@@ -828,18 +828,21 @@ describe("EformsignController (Integration)", () => {
                 .get("/api/documents?accessToken=access-token&limit=1&skip=0");
             expect(first.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-1"]);
             expect(typeof first.body.snapshot_version).toBe("string");
+            const callsAfterFirstPage = mirrorRepository.findAllVisibleInMirror.mock.calls.length;
 
-            // 첫 페이지의 문서가 사라지면 stale 세대를 재사용하지 않고 새 세대를 돌려준다.
+            // 첫 페이지 뒤에 live 목록이 바뀌어도 두 번째 페이지는 저장된 세대의 doc-2다.
             mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
             ]);
             const second = await request(mirrorApp.getHttpServer())
                 .get("/api/documents?accessToken=access-token&limit=1&skip=1");
 
-            expect(second.body.documents).toEqual([]);
+            expect(second.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-2"]);
             expect(second.body.has_more).toBe(false);
-            expect(typeof second.body.snapshot_version).toBe("string");
-            expect(second.body.snapshot_version).not.toBe(first.body.snapshot_version);
+            expect(second.body.snapshot_version).toBe(first.body.snapshot_version);
+            expect(mirrorRepository.findAllVisibleInMirror).toHaveBeenCalledTimes(
+                callsAfterFirstPage,
+            );
         });
 
         it("reports the generation so the client can notice the list moved", async () => {

--- a/backend/test/usecases/eformsign-doc/adopt-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/adopt-eformsign-doc.usecase.spec.ts
@@ -1,3 +1,5 @@
+import { Logger } from "@nestjs/common";
+
 import { AdoptEformsignDocUsecase } from "application/usecases/eformsign-doc/adopt-eformsign-doc.usecase";
 
 describe("AdoptEformsignDocUsecase", () => {
@@ -134,8 +136,13 @@ describe("AdoptEformsignDocUsecase", () => {
         );
     });
 
-    it("fails adoption when the adopted document cannot be mirrored", async () => {
+    it("keeps adoption successful when post-commit mirroring must be retried", async () => {
         const mirrorError = new Error("mirror failed");
+        const createResult = {
+            documentId: "doc-complete",
+            warnings: ["client_link_failed" as const],
+        };
+        const warn = jest.spyOn(Logger.prototype, "warn").mockImplementation();
         const usecase = new AdoptEformsignDocUsecase(
             { execute: jest.fn().mockResolvedValue({ oauth_token: { access_token: "token" } }) } as never,
             { execute: jest.fn().mockResolvedValue({
@@ -153,7 +160,7 @@ describe("AdoptEformsignDocUsecase", () => {
                     expired_date: 0,
                 },
             }) } as never,
-            { execute: jest.fn().mockResolvedValue({ documentId: "doc-complete" }) } as never,
+            { execute: jest.fn().mockResolvedValue(createResult) } as never,
             { findByPhone: jest.fn() } as never,
             { syncDocumentWithToken: jest.fn().mockRejectedValue(mirrorError) } as never,
         );
@@ -161,6 +168,12 @@ describe("AdoptEformsignDocUsecase", () => {
         await expect(usecase.execute("branch-1", {
             documentId: "doc-complete",
             clientId: 7,
-        })).rejects.toBe(mirrorError);
+        })).resolves.toMatchObject({
+            documentId: "doc-complete",
+            warnings: ["client_link_failed", "mirror_sync_failed"],
+        });
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("scheduled reconciliation"));
+        expect(warn.mock.calls.flat().join(" ")).not.toContain("doc-complete");
+        expect(warn.mock.calls.flat().join(" ")).not.toContain(mirrorError.message);
     });
 });

--- a/backend/test/usecases/eformsign-doc/adopt-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/adopt-eformsign-doc.usecase.spec.ts
@@ -172,7 +172,8 @@ describe("AdoptEformsignDocUsecase", () => {
             documentId: "doc-complete",
             warnings: ["client_link_failed", "mirror_sync_failed"],
         });
-        expect(warn).toHaveBeenCalledWith(expect.stringContaining("scheduled reconciliation"));
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("local mirror remains incomplete"));
+        expect(warn.mock.calls.flat().join(" ")).not.toContain("will retry");
         expect(warn.mock.calls.flat().join(" ")).not.toContain("doc-complete");
         expect(warn.mock.calls.flat().join(" ")).not.toContain(mirrorError.message);
     });

--- a/frontend/src/app/api/eformsign/documents/[documentId]/preview/__tests__/route.test.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/preview/__tests__/route.test.ts
@@ -81,4 +81,56 @@ describe("eformsign document preview route", () => {
     expect((await response.arrayBuffer()).byteLength).toBe(0);
     expect(mockServerGet).not.toHaveBeenCalled();
   });
+
+  it("preserves a backend access denial for HEAD without returning its body", async () => {
+    mockServerGet.mockRejectedValue(
+      Object.assign(new Error("forbidden"), {
+        response: {
+          status: 403,
+          headers: { "content-type": "application/json" },
+          data: { error: "sensitive backend detail" },
+        },
+      }),
+    );
+
+    const response = await HEAD(createRequest("HEAD"), context);
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect((await response.arrayBuffer()).byteLength).toBe(0);
+  });
+
+  it("preserves retry metadata for a pending local PDF without forwarding cookies", async () => {
+    mockServerGet.mockRejectedValue(
+      Object.assign(new Error("not ready"), {
+        response: {
+          status: 503,
+          headers: {
+            "content-type": "application/json",
+            "retry-after": "30",
+            "set-cookie": "backend-session=secret",
+          },
+          data: { error: "waiting for local synchronization" },
+        },
+      }),
+    );
+
+    const response = await HEAD(createRequest("HEAD"), context);
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("30");
+    expect(response.headers.get("Set-Cookie")).toBeNull();
+    expect((await response.arrayBuffer()).byteLength).toBe(0);
+  });
+
+  it("returns a bodyless bad-gateway response for a HEAD transport failure", async () => {
+    mockServerGet.mockRejectedValue(new Error("connection refused"));
+
+    const response = await HEAD(createRequest("HEAD"), context);
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect((await response.arrayBuffer()).byteLength).toBe(0);
+  });
 });

--- a/frontend/src/app/api/eformsign/documents/[documentId]/preview/route.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/preview/route.ts
@@ -3,10 +3,45 @@ import { serverAPIClient } from "@/lib/api/server";
 import {
   getAuthHeaders,
   getAuthToken,
+  getUpstreamErrorStatus,
   unauthorizedResponse,
 } from "@/lib/api/route-utils";
 
 type RouteParams = { params: Promise<{ documentId: string }> };
+type UpstreamErrorWithHeaders = {
+  response?: {
+    headers?: Record<string, unknown>;
+  };
+};
+
+const HEAD_ERROR_HEADER_ALLOWLIST = [
+  "content-type",
+  "retry-after",
+  "www-authenticate",
+] as const;
+
+function headErrorResponse(error: unknown): NextResponse {
+  const upstreamHeaders = (
+    error && typeof error === "object"
+      ? (error as UpstreamErrorWithHeaders).response?.headers
+      : undefined
+  );
+  const headers = new Headers();
+
+  for (const name of HEAD_ERROR_HEADER_ALLOWLIST) {
+    const value = upstreamHeaders?.[name];
+    if (typeof value === "string" || typeof value === "number") {
+      headers.set(name, String(value));
+    }
+  }
+
+  headers.set("Cache-Control", "no-store");
+
+  return new NextResponse(null, {
+    status: getUpstreamErrorStatus(error, 502),
+    headers,
+  });
+}
 
 async function proxyPreview(
   request: NextRequest,
@@ -59,7 +94,7 @@ async function proxyPreview(
     });
   } catch (error) {
     if (!includeBody) {
-      return new NextResponse(null, { status: 500 });
+      return headErrorResponse(error);
     }
 
     return NextResponse.json(

--- a/frontend/src/components/app/contracts/ContractCreationForm.test.tsx
+++ b/frontend/src/components/app/contracts/ContractCreationForm.test.tsx
@@ -25,6 +25,18 @@ describe("ContractCreationForm compensation flows", () => {
     expect(branch).not.toContain("openDocument(");
   });
 
+  it("should not report adoption success while the local mirror is incomplete", () => {
+    const branch = source.slice(
+      source.indexOf('headless.reason === "local_persist_failed"'),
+      source.indexOf('headless.reason === "remote_unconfirmed"'),
+    );
+    expect(branch).toContain('adopted.warnings?.includes("mirror_sync_failed")');
+    expect(branch).toContain("전자문서와 PDF 동기화가 완료되지 않았습니다.");
+    expect(branch).toContain("markCreationProgressFailed()");
+    expect(branch.indexOf('adopted.warnings?.includes("mirror_sync_failed")'))
+      .toBeLessThan(branch.indexOf("setIsCreationSuccessOpen(true)"));
+  });
+
   it("should request approval and retry duplicate pending documents with force true", () => {
     const branch = source.slice(
       source.indexOf('headless.reason === "duplicate_pending_document"'),

--- a/frontend/src/components/app/contracts/ContractCreationForm.tsx
+++ b/frontend/src/components/app/contracts/ContractCreationForm.tsx
@@ -854,7 +854,18 @@ export const ContractCreationForm = ({
 
           if (headless.reason === "local_persist_failed" && headless.remoteDocumentId) {
             try {
-              await eformsignApi.adoptDocument(headless.remoteDocumentId, finalClientId);
+              const adopted = await eformsignApi.adoptDocument(
+                headless.remoteDocumentId,
+                finalClientId,
+              );
+              if (adopted.warnings?.includes("mirror_sync_failed")) {
+                setSubmitError(
+                  "문서는 생성·전송되었지만 전자문서와 PDF 동기화가 완료되지 않았습니다. "
+                  + "새 계약서를 다시 만들지 말고 잠시 후 전자문서 목록에서 확인해 주세요.",
+                );
+                markCreationProgressFailed();
+                return;
+              }
               setCreationProgress({ step: "sent", completed: true, failed: false });
               queryClient.invalidateQueries({ queryKey: eformsignQueryKeys.documents() });
               setIsCreationSuccessOpen(true);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -260,7 +260,14 @@ export const eformsignApi = {
         });
         return data;
     },
-    adoptDocument: async (documentId: string, clientId?: number): Promise<{ id?: number; documentId: string }> => {
+    adoptDocument: async (
+        documentId: string,
+        clientId?: number,
+    ): Promise<{
+        id?: number;
+        documentId: string;
+        warnings?: Array<"client_link_failed" | "mirror_sync_failed">;
+    }> => {
         const { data } = await api.post('/eformsign-docs/adopt', { documentId, clientId });
         return data;
     },

--- a/mobile/src/app/(shell)/contracts/new/page.test.ts
+++ b/mobile/src/app/(shell)/contracts/new/page.test.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs";
+
+const source = fs.readFileSync(require.resolve("./page"), "utf8");
+
+describe("mobile contract creation compensation flow", () => {
+  it("does not navigate after adoption leaves the local mirror incomplete", () => {
+    const branch = source.slice(
+      source.indexOf('headless.reason === "local_persist_failed"'),
+      source.indexOf('headless.reason === "remote_unconfirmed"'),
+    );
+
+    expect(branch).toContain('adopted.warnings?.includes("mirror_sync_failed")');
+    expect(branch).toContain("전자문서와 PDF 동기화가 완료되지 않았습니다.");
+    expect(branch).toContain("completed: false");
+    expect(branch).toContain("failed: true");
+    expect(branch.indexOf('adopted.warnings?.includes("mirror_sync_failed")'))
+      .toBeLessThan(branch.indexOf('router.push("/contracts")'));
+  });
+});

--- a/mobile/src/app/(shell)/contracts/new/page.tsx
+++ b/mobile/src/app/(shell)/contracts/new/page.tsx
@@ -841,7 +841,22 @@ export default function ContractCreationPage() {
 
         if (headless.reason === "local_persist_failed" && headless.remoteDocumentId) {
           try {
-            await eformsignApi.adoptDocument(headless.remoteDocumentId, finalClientId);
+            const adopted = await eformsignApi.adoptDocument(
+              headless.remoteDocumentId,
+              finalClientId,
+            );
+            if (adopted.warnings?.includes("mirror_sync_failed")) {
+              setProgressErrorHint(
+                "문서는 생성·전송되었지만 전자문서와 PDF 동기화가 완료되지 않았습니다. "
+                + "새 계약서를 다시 만들지 말고 잠시 후 전자문서 목록에서 확인해 주세요.",
+              );
+              setCreationProgress((current) => ({
+                step: current.step ?? "client-started",
+                completed: false,
+                failed: true,
+              }));
+              return;
+            }
             startNavigation();
             setCreationProgress({ step: "sent", completed: true, failed: false });
             queryClient.invalidateQueries({ queryKey: eformsignQueryKeys.documents() });

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -335,7 +335,14 @@ export const eformsignApi = {
         });
         return data;
     },
-    adoptDocument: async (documentId: string, clientId?: number): Promise<{ id?: number; documentId: string }> => {
+    adoptDocument: async (
+        documentId: string,
+        clientId?: number,
+    ): Promise<{
+        id?: number;
+        documentId: string;
+        warnings?: Array<"client_link_failed" | "mirror_sync_failed">;
+    }> => {
         const { data } = await api.post('/eformsign-docs/adopt', { documentId, clientId });
         return data;
     },


### PR DESCRIPTION
## Summary
- keep cached document-list generations stable across offset pagination
- keep adoption successful after the ownership commit while returning an explicit `mirror_sync_failed` warning for deferred mirror reconciliation
- preserve safe upstream HEAD error statuses and retry/auth metadata without forwarding bodies or cookies

## Context
These changes address the three actionable current-head Codex review threads on preview PR #440. Functional corrections land in `dev` first and will then be promoted back through `preview` and `main`.

## Verification
- backend: 187 suites, 2,169 passed, 37 skipped
- frontend: 142 suites, 649 passed
- mobile: 147 suites, 836 passed
- shared: Jest 61 passed; ESLint plugin Node tests 59 passed
- backend/frontend/mobile/shared type checks passed
- backend/frontend/mobile lint passed with 0 errors (existing warnings only)
- backend/frontend/mobile production builds passed; mobile used an explicit validation API base URL
- UI architecture gate and `git diff --check` passed
- added-change secret pattern review passed

## Data and rollout
- no schema, migration, or environment-variable changes
- no backfill is required before merge
- after merge, verify the exact dev deployment, run the supplemental idempotent eformsign backfill/readiness check, and then update #440 from the new `dev` head

## Security
- adoption failure logs contain neither document identifiers nor vendor error messages
- HEAD failures return no response body and forward only allowlisted headers
- transport failures are reported as 502 with `Cache-Control: no-store`

## Rollback
Revert this PR. No database rollback is necessary.