### PR TITLE
fix(eformsign): avoid PDF blob reads for HEAD

### DIFF
--- a/backend/application/services/eformsign-document-mirror.service.ts
+++ b/backend/application/services/eformsign-document-mirror.service.ts
@@ -91,6 +91,13 @@ export interface StoredEformsignDocumentFileResponse {
     body: Buffer;
 }
 
+export interface StoredEformsignDocumentFileMetadataResponse {
+    status: 200;
+    contentType: string;
+    contentDisposition: string | null;
+    byteSize: number;
+}
+
 export class EformsignStoredFileIntegrityError extends Error {
     constructor(documentId: string, fileType: EformsignDocumentFileType) {
         super(`Stored eformsign ${fileType} failed integrity validation for ${documentId}`);
@@ -189,6 +196,35 @@ export class EformsignDocumentMirrorService {
             contentType: metadata.contentType,
             contentDisposition: safeContentDisposition(metadata.contentDisposition),
             body,
+        };
+    }
+
+    async getStoredFileMetadata(
+        documentId: string,
+        fileType: EformsignDocumentFileType,
+    ): Promise<StoredEformsignDocumentFileMetadataResponse | null> {
+        const state = await this.mirrorRepository.findState(documentId);
+        const file = state?.files.find((candidate) =>
+            candidate.fileType === fileType
+            && state.detailSourceUpdatedDate
+            && candidate.sourceUpdatedDate.getTime()
+                === state.detailSourceUpdatedDate.getTime(),
+        );
+        if (
+            !state?.detailPayload
+            || !state.detailSourceUpdatedDate
+            || state.syncStatus !== "ready"
+            || Boolean(state.permanentPurgeRequestedAt)
+            || !file
+        ) {
+            return null;
+        }
+
+        return {
+            status: 200,
+            contentType: file.contentType,
+            contentDisposition: safeContentDisposition(file.contentDisposition),
+            byteSize: file.byteSize,
         };
     }
 

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Controller, Post, Get, Delete, Body, Query, Param, HttpException, HttpStatus, UseGuards, Res, ServiceUnavailableException } from "@nestjs/common";
+import { BadRequestException, Controller, Post, Get, Head, Delete, Body, Query, Param, HttpException, HttpStatus, UseGuards, Res, ServiceUnavailableException } from "@nestjs/common";
 import { EformsignService } from "../../application/services/eformsign.service";
 import { EformsignDocService } from "../../application/services/eformsign-doc.service";
 import { AreaTemplateService } from "../../application/services/area-template.service";
@@ -791,6 +791,52 @@ export class EformsignController {
                 });
             }
             return document;
+        } catch (error) {
+            throwHttpOrInternalError(error);
+        }
+    }
+
+    /**
+     * Read document PDF metadata without loading the stored bytes.
+     */
+    @Head("documents/:documentId/download_files")
+    async headDocumentFile(
+        @CurrentTenant() tenant: { branchId?: string },
+        @Param("documentId") documentId: string,
+        @Query("fileType") fileType: string | undefined,
+        @Res() res: Response,
+    ) {
+        try {
+            const parsedFileType = parseDownloadFileType(fileType);
+            const allowedDocuments = await this.filterDocumentsByBranch(
+                tenant.branchId ?? "",
+                [{ id: documentId }],
+            );
+            if (allowedDocuments.length === 0) {
+                throw new HttpException(
+                    { error: "Document access forbidden" },
+                    HttpStatus.FORBIDDEN,
+                );
+            }
+            const file = await this.documentMirrorService.getStoredFileMetadata(
+                documentId,
+                parsedFileType,
+            );
+            if (!file) {
+                throw new ServiceUnavailableException({
+                    error: "Document file is waiting for local synchronization",
+                    documentId,
+                    fileType: parsedFileType,
+                });
+            }
+
+            res.status(file.status);
+            res.set({
+                "Content-Type": file.contentType,
+                ...(file.contentDisposition ? { "Content-Disposition": file.contentDisposition } : {}),
+                "Content-Length": String(file.byteSize),
+            });
+            res.end();
         } catch (error) {
             throwHttpOrInternalError(error);
         }

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -79,6 +79,7 @@ describe("EformsignController (Integration)", () => {
     const documentMirrorService = {
         getStoredDetail: jest.fn(),
         getStoredFile: jest.fn(),
+        getStoredFileMetadata: jest.fn(),
         markDocumentsDeleted: jest.fn(),
         purgeDocuments: jest.fn(),
         requestPermanentPurge: jest.fn(),
@@ -94,6 +95,7 @@ describe("EformsignController (Integration)", () => {
         shadowCompareService.compareInBackground.mockClear();
         documentMirrorService.getStoredDetail.mockReset();
         documentMirrorService.getStoredFile.mockReset();
+        documentMirrorService.getStoredFileMetadata.mockReset();
         documentMirrorService.markDocumentsDeleted.mockReset();
         documentMirrorService.purgeDocuments.mockReset();
         documentMirrorService.requestPermanentPurge.mockReset();
@@ -215,6 +217,7 @@ describe("EformsignController (Integration)", () => {
             async (documentId: string) => ({ id: documentId }),
         );
         documentMirrorService.getStoredFile.mockResolvedValue(null);
+        documentMirrorService.getStoredFileMetadata.mockResolvedValue(null);
         documentMirrorService.markDocumentsDeleted.mockResolvedValue(undefined);
         documentMirrorService.purgeDocuments.mockResolvedValue(undefined);
         documentMirrorService.requestPermanentPurge.mockImplementation(
@@ -620,6 +623,31 @@ describe("EformsignController (Integration)", () => {
             .get("/api/documents/doc-1/download_files?accessToken=access-token&fileType=zip");
 
         expect(response.status).toBe(400);
+        expect(documentMirrorService.getStoredFile).not.toHaveBeenCalled();
+    });
+
+    it("serves document PDF metadata for HEAD without loading stored bytes", async () => {
+        eformsignDocService.findAll.mockResolvedValue([
+            { documentId: "branch-1-doc" },
+        ] as any);
+        documentMirrorService.getStoredFileMetadata.mockResolvedValue({
+            status: 200,
+            contentType: "application/pdf",
+            contentDisposition: "inline",
+            byteSize: 321,
+        });
+
+        const response = await request(app.getHttpServer())
+            .head("/api/documents/branch-1-doc/download_files?fileType=document");
+
+        expect(response.status).toBe(200);
+        expect(response.headers["content-type"]).toContain("application/pdf");
+        expect(response.headers["content-length"]).toBe("321");
+        expect(response.text).toBeUndefined();
+        expect(documentMirrorService.getStoredFileMetadata).toHaveBeenCalledWith(
+            "branch-1-doc",
+            "document",
+        );
         expect(documentMirrorService.getStoredFile).not.toHaveBeenCalled();
     });
 

--- a/backend/test/services/eformsign-document-mirror.service.spec.ts
+++ b/backend/test/services/eformsign-document-mirror.service.spec.ts
@@ -1502,6 +1502,49 @@ describe("EformsignDocumentMirrorService", () => {
         }));
     });
 
+    it("returns current stored PDF metadata without reading the PDF bytes", async () => {
+        const sourceUpdatedDate = new Date(UPDATED_AT);
+        const repository = {
+            findState: jest.fn().mockResolvedValue({
+                documentId: "doc-1",
+                branchId: "branch-1",
+                detailPayload: richDetail(),
+                detailSourceUpdatedDate: sourceUpdatedDate,
+                detailSyncedAt: sourceUpdatedDate,
+                syncStatus: "ready",
+                syncError: null,
+                permanentPurgeRequestedAt: null,
+                files: [{
+                    fileType: "document",
+                    contentType: "application/pdf",
+                    contentDisposition: "inline",
+                    byteSize: PDF.length,
+                    sha256: "hash",
+                    sourceUpdatedDate,
+                    syncedAt: sourceUpdatedDate,
+                }],
+            }),
+            findFile: jest.fn(),
+        };
+        const service = new EformsignDocumentMirrorService(
+            {} as never,
+            repository as never,
+            {} as never,
+            {} as never,
+            {} as never,
+        );
+
+        await expect(service.getStoredFileMetadata("doc-1", "document"))
+            .resolves.toEqual({
+                status: 200,
+                contentType: "application/pdf",
+                contentDisposition: "inline",
+                byteSize: PDF.length,
+            });
+        expect(repository.findState).toHaveBeenCalledWith("doc-1");
+        expect(repository.findFile).not.toHaveBeenCalled();
+    });
+
     it("repairs an integrity-failed current version with both PDFs", async () => {
         const detail = richDetail();
         const previousAttempt = new Date(UPDATED_AT);

--- a/frontend/src/app/api/eformsign/documents/[documentId]/preview/__tests__/route.test.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/preview/__tests__/route.test.ts
@@ -9,10 +9,12 @@ import { GET, HEAD } from "../route";
 jest.mock("@/lib/api/server", () => ({
   serverAPIClient: {
     get: jest.fn(),
+    head: jest.fn(),
   },
 }));
 
 const mockServerGet = serverAPIClient.get as jest.Mock;
+const mockServerHead = serverAPIClient.head as jest.Mock;
 const context = { params: Promise.resolve({ documentId: "doc-1" }) };
 
 function createRequest(method: "GET" | "HEAD"): NextRequest {
@@ -30,6 +32,7 @@ function createRequest(method: "GET" | "HEAD"): NextRequest {
 describe("eformsign document preview route", () => {
   beforeEach(() => {
     mockServerGet.mockReset();
+    mockServerHead.mockReset();
   });
 
   it("returns PDF bytes for GET", async () => {
@@ -48,10 +51,12 @@ describe("eformsign document preview route", () => {
   });
 
   it("returns only PDF metadata for HEAD", async () => {
-    mockServerGet.mockResolvedValue({
+    mockServerHead.mockResolvedValue({
       status: 200,
-      headers: { "content-type": "application/pdf" },
-      data: new Uint8Array([1, 2, 3]),
+      headers: {
+        "content-type": "application/pdf",
+        "content-length": "3",
+      },
     });
 
     const response = await HEAD(createRequest("HEAD"), context);
@@ -60,13 +65,13 @@ describe("eformsign document preview route", () => {
     expect(response.headers.get("Content-Type")).toBe("application/pdf");
     expect(response.headers.get("Content-Length")).toBe("3");
     expect((await response.arrayBuffer()).byteLength).toBe(0);
-    expect(mockServerGet).toHaveBeenCalledWith(
+    expect(mockServerHead).toHaveBeenCalledWith(
       "/api/documents/doc-1/download_files",
       expect.objectContaining({
         params: { fileType: "document" },
-        responseType: "arraybuffer",
       }),
     );
+    expect(mockServerGet).not.toHaveBeenCalled();
   });
 
   it("does not contact the backend for an unauthenticated HEAD request", async () => {
@@ -80,10 +85,11 @@ describe("eformsign document preview route", () => {
     expect(response.status).toBe(401);
     expect((await response.arrayBuffer()).byteLength).toBe(0);
     expect(mockServerGet).not.toHaveBeenCalled();
+    expect(mockServerHead).not.toHaveBeenCalled();
   });
 
   it("preserves a backend access denial for HEAD without returning its body", async () => {
-    mockServerGet.mockRejectedValue(
+    mockServerHead.mockRejectedValue(
       Object.assign(new Error("forbidden"), {
         response: {
           status: 403,
@@ -102,7 +108,7 @@ describe("eformsign document preview route", () => {
   });
 
   it("preserves retry metadata for a pending local PDF without forwarding cookies", async () => {
-    mockServerGet.mockRejectedValue(
+    mockServerHead.mockRejectedValue(
       Object.assign(new Error("not ready"), {
         response: {
           status: 503,
@@ -125,7 +131,7 @@ describe("eformsign document preview route", () => {
   });
 
   it("returns a bodyless bad-gateway response for a HEAD transport failure", async () => {
-    mockServerGet.mockRejectedValue(new Error("connection refused"));
+    mockServerHead.mockRejectedValue(new Error("connection refused"));
 
     const response = await HEAD(createRequest("HEAD"), context);
 

--- a/frontend/src/app/api/eformsign/documents/[documentId]/preview/route.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/preview/route.ts
@@ -60,29 +60,45 @@ async function proxyPreview(
     const { documentId } = await params;
     const attachment = request.nextUrl.searchParams.get("attachment") === "true";
 
-    const response = await serverAPIClient.get(`/api/documents/${documentId}/download_files`, {
+    const upstreamPath = `/api/documents/${documentId}/download_files`;
+    const upstreamConfig = {
       params: {
         fileType: "document",
       },
       headers: getAuthHeaders(authToken),
-      responseType: "arraybuffer",
-    });
+    };
+    const response = includeBody
+      ? await serverAPIClient.get(upstreamPath, {
+          ...upstreamConfig,
+          responseType: "arraybuffer",
+        })
+      : await serverAPIClient.head(upstreamPath, upstreamConfig);
 
     const contentType = String(response.headers["content-type"] ?? "application/octet-stream");
 
-    if (contentType.includes("application/json")) {
-      if (!includeBody) {
-        return new NextResponse(null, {
-          status: response.status,
-          headers: { "Content-Type": contentType },
-        });
-      }
+    if (!includeBody) {
+      const contentLength = response.headers["content-length"];
+      return new NextResponse(null, {
+        status: response.status,
+        headers: {
+          "Content-Type": contentType,
+          "Content-Disposition": attachment
+            ? `attachment; filename="${documentId}.pdf"`
+            : "inline",
+          ...(contentLength !== undefined
+            ? { "Content-Length": String(contentLength) }
+            : {}),
+          "Cache-Control": "no-store",
+        },
+      });
+    }
 
+    if (contentType.includes("application/json")) {
       const payload = JSON.parse(Buffer.from(response.data).toString("utf-8"));
       return NextResponse.json(payload, { status: response.status });
     }
 
-    return new NextResponse(includeBody ? response.data : null, {
+    return new NextResponse(response.data, {
       status: response.status,
       headers: {
         "Content-Type": contentType,


### PR DESCRIPTION
## Context

Codex current-HEAD review on preview PR #440 found that the frontend HEAD probe still proxied an upstream GET, causing the local DB PDF blob to be loaded and buffered before the body was discarded.

## Changes

- add a dedicated backend HEAD controller path that returns stored PDF metadata only
- source metadata through mirror `findState`, which excludes the PDF `content` column
- proxy frontend HEAD with Axios `.head()` while preserving 403/503 and safe headers
- keep GET as the only path that loads, hashes, and transfers PDF bytes
- add service, controller integration, and frontend route regressions proving blob GET is not called

## Validation

- backend: 187 suites, 2,171 passed / 37 skipped
- frontend: 142 suites, 650 passed
- mobile: 148 suites, 837 passed
- shared: Jest 61 + Node 59 passed
- all workspace type-checks passed
- lint: 0 errors; existing warnings only
- UI architecture baseline gate passed
- backend, frontend, and mobile production builds passed; mobile used `NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:3001`
- `git diff --check` passed

## Security and data impact

No schema, migration, dependency, environment, or workflow changes. Tenant authorization and mirror readiness checks are identical to the existing GET path. Content-Disposition is sanitized in the mirror service, HEAD responses remain bodyless, and error header forwarding remains allowlisted with no cookies.

## Rollback

Revert this PR to restore the prior HEAD proxy behavior. No DB rollback or data deletion is required.