### PR TITLE
fix: refresh contract lists after mirror sync warnings

### DIFF
--- a/frontend/src/components/app/contracts/ContractCreationForm.test.tsx
+++ b/frontend/src/components/app/contracts/ContractCreationForm.test.tsx
@@ -33,6 +33,13 @@ describe("ContractCreationForm compensation flows", () => {
     expect(branch).toContain('adopted.warnings?.includes("mirror_sync_failed")');
     expect(branch).toContain("전자문서와 PDF 동기화가 완료되지 않았습니다.");
     expect(branch).toContain("markCreationProgressFailed()");
+    const warningBranch = branch.slice(
+      branch.indexOf('adopted.warnings?.includes("mirror_sync_failed")'),
+      branch.indexOf("markCreationProgressFailed()"),
+    );
+    expect(warningBranch).toContain(
+      "queryClient.invalidateQueries({ queryKey: eformsignQueryKeys.documents() })",
+    );
     expect(branch.indexOf('adopted.warnings?.includes("mirror_sync_failed")'))
       .toBeLessThan(branch.indexOf("setIsCreationSuccessOpen(true)"));
   });

--- a/frontend/src/components/app/contracts/ContractCreationForm.tsx
+++ b/frontend/src/components/app/contracts/ContractCreationForm.tsx
@@ -859,6 +859,7 @@ export const ContractCreationForm = ({
                 finalClientId,
               );
               if (adopted.warnings?.includes("mirror_sync_failed")) {
+                queryClient.invalidateQueries({ queryKey: eformsignQueryKeys.documents() });
                 setSubmitError(
                   "문서는 생성·전송되었지만 전자문서와 PDF 동기화가 완료되지 않았습니다. "
                   + "새 계약서를 다시 만들지 말고 잠시 후 전자문서 목록에서 확인해 주세요.",

--- a/mobile/src/app/(shell)/contracts/new/page.test.ts
+++ b/mobile/src/app/(shell)/contracts/new/page.test.ts
@@ -13,6 +13,13 @@ describe("mobile contract creation compensation flow", () => {
     expect(branch).toContain("전자문서와 PDF 동기화가 완료되지 않았습니다.");
     expect(branch).toContain("completed: false");
     expect(branch).toContain("failed: true");
+    const warningBranch = branch.slice(
+      branch.indexOf('adopted.warnings?.includes("mirror_sync_failed")'),
+      branch.indexOf("return;", branch.indexOf('adopted.warnings?.includes("mirror_sync_failed")')),
+    );
+    expect(warningBranch).toContain(
+      "queryClient.invalidateQueries({ queryKey: eformsignQueryKeys.documents() })",
+    );
     expect(branch.indexOf('adopted.warnings?.includes("mirror_sync_failed")'))
       .toBeLessThan(branch.indexOf('router.push("/contracts")'));
   });

--- a/mobile/src/app/(shell)/contracts/new/page.tsx
+++ b/mobile/src/app/(shell)/contracts/new/page.tsx
@@ -846,6 +846,7 @@ export default function ContractCreationPage() {
               finalClientId,
             );
             if (adopted.warnings?.includes("mirror_sync_failed")) {
+              queryClient.invalidateQueries({ queryKey: eformsignQueryKeys.documents() });
               setProgressErrorHint(
                 "문서는 생성·전송되었지만 전자문서와 PDF 동기화가 완료되지 않았습니다. "
                 + "새 계약서를 다시 만들지 말고 잠시 후 전자문서 목록에서 확인해 주세요.",


### PR DESCRIPTION
## Summary
- invalidate the desktop eformsign document query after adoption commits with `mirror_sync_failed`
- apply the same cache refresh before the mobile warning state returns
- add regression assertions that the invalidation occurs inside the warning branch before it exits

## Why
PR #440 current-HEAD review found that adoption ownership and client linkage can be committed while the warning branch leaves a previously loaded contracts cache stale for up to its normal stale window.

## Validation
- focused desktop compensation tests: 5 passed
- focused mobile compensation test: 1 passed
- full workspace tests: backend 187 suites / 2,171 passed; shared 61 Jest + 59 Node; frontend 142 suites / 650 passed; mobile 148 suites / 837 passed
- backend/shared/frontend/mobile type-check passed
- lint passed with existing warnings only; UI architecture gate passed
- backend, frontend, and mobile production builds passed; mobile used an explicit validation API base URL
- `git diff --check` and secret-pattern diff scan passed

## Data / security / rollback
- no schema, migration, API response, auth, or dependency changes
- no new logging or personal data exposure
- rollback is a normal revert of this single commit; it only restores the previous cache behavior