### PR TITLE
[fix] 모바일 회원가입 1단계 전환 복구

### DIFF
--- a/mobile/src/app/(shell)/(auth)/register/page.test.tsx
+++ b/mobile/src/app/(shell)/(auth)/register/page.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { authApi } from "@/services/api";
+
+import RegisterPage from "./page";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/services/api", () => ({
+  authApi: {
+    checkEmailExists: jest.fn(),
+    register: jest.fn(),
+  },
+}));
+
+const mockCheckEmailExists = jest.mocked(authApi.checkEmailExists);
+
+describe("RegisterPage", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockCheckEmailExists.mockReset();
+    mockCheckEmailExists.mockResolvedValue({ exists: false, linkable: false });
+  });
+
+  it("advances to the profile step when the account fields are valid", async () => {
+    const user = userEvent.setup();
+
+    render(<RegisterPage />);
+
+    await user.type(screen.getByLabelText("이메일"), "new.user@example.com");
+    await user.type(screen.getByLabelText("이름"), "테스트");
+    await user.type(screen.getByLabelText("비밀번호"), "Password1!");
+    await user.type(screen.getByLabelText("비밀번호 확인"), "Password1!");
+
+    await waitFor(() => {
+      expect(mockCheckEmailExists).toHaveBeenCalledWith("new.user@example.com");
+    });
+
+    await user.click(screen.getByRole("button", { name: "다음" }));
+
+    expect(await screen.findByLabelText("전화번호")).toBeInTheDocument();
+  });
+});

--- a/mobile/src/app/(shell)/(auth)/register/page.tsx
+++ b/mobile/src/app/(shell)/(auth)/register/page.tsx
@@ -215,8 +215,10 @@ export default function RegisterPage() {
     const result = registerSchema.safeParse(getCombinedFormData());
     if (!result.success) {
       const fieldErrors = collectFieldErrors(result.error.issues, ACCOUNT_FIELDS);
-      setErrors(fieldErrors);
-      return;
+      if (Object.keys(fieldErrors).length > 0) {
+        setErrors(fieldErrors);
+        return;
+      }
     }
 
     setErrors({});


### PR DESCRIPTION
## 1. 변경 요약

1. 모바일 회원가입 1단계에서 계정 필드 오류가 실제로 존재할 때만 단계 전환을 중단하도록 수정했습니다.
2. 전체 등록 스키마가 아직 입력할 수 없는 전화번호·생년월일을 필수로 검사한 뒤, 표시할 계정 오류가 없어도 조기 반환하던 것이 원인이었습니다.
3. 유효한 계정 정보를 입력하면 프로필 단계로 이동하는 회귀 테스트를 추가했습니다.

## 2. 테스트

- `pnpm --filter ./mobile exec jest --runInBand --runTestsByPath 'src/app/(shell)/(auth)/register/page.test.tsx'` — 통과
- `pnpm --filter ./mobile exec jest --runInBand` — 148 suites, 837 tests 통과
- 변경 파일 ESLint — 오류 0, 기존 baseline 경고 13개
- `pnpm lint:ui-architecture` — 통과
- `pnpm --filter ./mobile type-check` — 통과
- 임시 `NEXT_PUBLIC_API_BASE_URL`을 사용한 `pnpm --filter ./mobile build` — 통과
- 로컬 production build 브라우저 검증 — 회원가입 `1 / 3`에서 `2 / 3` 전환 확인, 브라우저 오류 없음

## 3. 영향 범위

1. 사용자 영향: 모바일 회원가입에서 유효한 계정 정보를 입력한 사용자가 프로필 단계로 정상 이동합니다.
2. 운영 영향: 최종 제출 시 전체 스키마 검증과 이메일 중복 검사는 그대로 유지됩니다.
3. 롤백 계획: 이 PR의 단일 커밋을 revert하면 이전 단계 전환 동작으로 복원됩니다.

## 4. 체크리스트

- [x] 테스트, lint, typecheck, build를 확인했습니다.
- [x] 새 의존성, 환경변수, 스키마 변경이 없습니다.
- [x] 보안 검토에서 최종 제출 검증 우회가 없음을 확인했습니다.

### 참고

`pnpm audit --prod --audit-level high`는 이 변경과 무관한 기존 backend CLI 의존성 경로에서 취약점 2개(중간 1, 높음 1)를 보고합니다.