### PR TITLE
release: preview → main — eformsign fixes and mobile registration

### DIFF
--- a/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
+++ b/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
@@ -12,6 +12,7 @@ import {
 
 interface SnapshotExclusionLookup {
     findListExcludedDocumentIds: jest.Mock<Promise<string[]>, []>;
+    findUnreadyCompletedDocumentIds: jest.Mock<Promise<string[]>, []>;
     findPermanentPurgeRequestedDocumentIds: jest.Mock<Promise<string[]>, []>;
 }
 
@@ -128,6 +129,7 @@ function createSnapshotExclusionLookup(
         findListExcludedDocumentIds: jest.fn().mockResolvedValue(
             excludedDocumentIds,
         ),
+        findUnreadyCompletedDocumentIds: jest.fn().mockResolvedValue([]),
         findPermanentPurgeRequestedDocumentIds: jest.fn().mockResolvedValue([]),
     };
 }
@@ -200,7 +202,7 @@ describe("EformsignDocumentSnapshotService", () => {
         ];
         const build = jest.fn().mockResolvedValue(staleEntries);
 
-        await service.getOrBuild(createMirrorParams(), build);
+        const initialResult = await service.getOrBuild(createMirrorParams(), build);
         redis.incr.mockRejectedValueOnce(new Error("Valkey unavailable during purge invalidation"));
         await expect(service.bumpVersion("branch-a")).resolves.toBeNull();
         exclusionLookup.findPermanentPurgeRequestedDocumentIds.mockResolvedValue([
@@ -218,20 +220,162 @@ describe("EformsignDocumentSnapshotService", () => {
             { excludeTombstones: true },
         );
 
-        expect(build).toHaveBeenCalledTimes(1);
+        expect(build).toHaveBeenCalledTimes(3);
         expect(defaultResult).toEqual({
             entries: [
                 createEntry("safe-document"),
                 createEntry("tombstoned-document"),
             ],
-            snapshotVersion: expect.stringMatching(/^0:\d+$/),
+            snapshotVersion: expect.stringMatching(/^0:\d+:f[0-9a-f]{12}$/),
             cached: true,
         });
         expect(deletionFilteredResult).toEqual({
             entries: [createEntry("safe-document")],
-            snapshotVersion: expect.stringMatching(/^0:\d+$/),
+            snapshotVersion: expect.stringMatching(/^0:\d+:f[0-9a-f]{12}$/),
             cached: true,
         });
+        expect(defaultResult.snapshotVersion).not.toBe(initialResult.snapshotVersion);
+        expect(deletionFilteredResult.snapshotVersion).not.toBe(defaultResult.snapshotVersion);
+    });
+
+    it("should fence an unready completed row from a stale mirror snapshot after a version bump fails", async () => {
+        const exclusionLookup = createSnapshotExclusionLookup();
+        const redis = createRedisStub();
+        let snapshotPayload: string | null = null;
+        redis.get.mockImplementation(async (key) => {
+            if (key === "eformsign:doclist-version:branch-a") {
+                return "0";
+            }
+            return snapshotPayload;
+        });
+        redis.set.mockImplementation(async (key, value) => {
+            if (key.startsWith("eformsign:doclist:")) {
+                snapshotPayload = value;
+            }
+            return "OK";
+        });
+        useRedisStub(redis);
+        const service = new EformsignDocumentSnapshotService(exclusionLookup);
+        const build = jest.fn().mockResolvedValue([
+            createEntry("safe-document"),
+            createEntry("completed-syncing-document"),
+        ]);
+
+        const initialResult = await service.getOrBuild(createMirrorParams(), build);
+        redis.incr.mockRejectedValueOnce(
+            new Error("Valkey unavailable during completed mirror invalidation"),
+        );
+        await expect(service.bumpVersion("branch-a")).resolves.toBeNull();
+        exclusionLookup.findUnreadyCompletedDocumentIds.mockResolvedValue([
+            "completed-syncing-document",
+        ]);
+
+        const result = await service.getOrBuild(createMirrorParams(), build);
+
+        expect(build).toHaveBeenCalledTimes(2);
+        expect(result).toEqual({
+            entries: [createEntry("safe-document")],
+            snapshotVersion: expect.stringMatching(/^0:\d+:f[0-9a-f]{12}$/),
+            cached: true,
+        });
+        expect(result.snapshotVersion).not.toBe(initialResult.snapshotVersion);
+
+        const sameFence = await service.getOrBuild(createMirrorParams(), build);
+        expect(sameFence.snapshotVersion).toBe(result.snapshotVersion);
+
+        exclusionLookup.findUnreadyCompletedDocumentIds.mockResolvedValue([]);
+        const restored = await service.getOrBuild(createMirrorParams(), build);
+        expect(restored.entries).toEqual([
+            createEntry("safe-document"),
+            createEntry("completed-syncing-document"),
+        ]);
+        expect(restored.snapshotVersion).toBe(initialResult.snapshotVersion);
+    });
+
+    it("should add a newly ready row even when its version bump failed", async () => {
+        const exclusionLookup = createSnapshotExclusionLookup();
+        const redis = createRedisStub();
+        let snapshotPayload: string | null = null;
+        redis.get.mockImplementation(async (key) => {
+            if (key === "eformsign:doclist-version:branch-a") {
+                return "0";
+            }
+            return snapshotPayload;
+        });
+        redis.set.mockImplementation(async (key, value) => {
+            if (key.startsWith("eformsign:doclist:")) {
+                snapshotPayload = value;
+            }
+            return "OK";
+        });
+        useRedisStub(redis);
+        const service = new EformsignDocumentSnapshotService(exclusionLookup);
+        let liveEntries = [createEntry("safe-document")];
+        const build = jest.fn(async () => liveEntries);
+
+        const initial = await service.getOrBuild(createMirrorParams(), build);
+        redis.incr.mockRejectedValueOnce(
+            new Error("Valkey unavailable during ready publication"),
+        );
+        await expect(service.bumpVersion("branch-a")).resolves.toBeNull();
+        liveEntries = [
+            createEntry("safe-document"),
+            createEntry("newly-ready-document"),
+        ];
+
+        const recovered = await service.getOrBuild(createMirrorParams(), build);
+
+        expect(build).toHaveBeenCalledTimes(2);
+        expect(recovered.entries).toEqual(liveEntries);
+        expect(recovered.snapshotVersion).toMatch(/^0:\d+:f[0-9a-f]{12}$/);
+        expect(recovered.snapshotVersion).not.toBe(initial.snapshotVersion);
+
+        const stable = await service.getOrBuild(createMirrorParams(), build);
+        expect(build).toHaveBeenCalledTimes(3);
+        expect(stable.entries).toEqual(liveEntries);
+        expect(stable.snapshotVersion).toBe(recovered.snapshotVersion);
+    });
+
+    it("should apply the readiness fence only to mirror snapshots", async () => {
+        const exclusionLookup = createSnapshotExclusionLookup();
+        exclusionLookup.findUnreadyCompletedDocumentIds.mockResolvedValue(["document-1"]);
+        const service = new EformsignDocumentSnapshotService(exclusionLookup);
+        const entry = createEntry("document-1");
+
+        const result = await service.getOrBuild(
+            createParams(),
+            jest.fn().mockResolvedValue([entry]),
+        );
+
+        expect(result.entries).toEqual([entry]);
+        expect(exclusionLookup.findUnreadyCompletedDocumentIds).not.toHaveBeenCalled();
+    });
+
+    it("should keep the base generation when live exclusions do not affect membership", async () => {
+        const exclusionLookup = createSnapshotExclusionLookup();
+        const service = new EformsignDocumentSnapshotService(exclusionLookup);
+        const build = jest.fn().mockResolvedValue([createEntry("document-1")]);
+
+        const initial = await service.getOrBuild(createMirrorParams(), build);
+        exclusionLookup.findUnreadyCompletedDocumentIds.mockResolvedValue([
+            "not-in-this-snapshot",
+        ]);
+        const cached = await service.getOrBuild(createMirrorParams(), build);
+
+        expect(cached.entries).toEqual(initial.entries);
+        expect(cached.snapshotVersion).toBe(initial.snapshotVersion);
+    });
+
+    it("should fail closed when the mirror readiness fence is unavailable", async () => {
+        const exclusionLookup = createSnapshotExclusionLookup();
+        const service = new EformsignDocumentSnapshotService(exclusionLookup);
+        const fenceError = new Error("mirror readiness lookup unavailable");
+        exclusionLookup.findUnreadyCompletedDocumentIds.mockRejectedValue(fenceError);
+
+        await expect(service.getOrBuild(
+            createMirrorParams(),
+            jest.fn().mockResolvedValue([createEntry("document-1")]),
+        )).rejects.toBe(fenceError);
     });
 
     it("should exclude a tombstoned unassigned document from a stale headquarters snapshot after its epoch bump fails", async () => {
@@ -276,10 +420,10 @@ describe("EformsignDocumentSnapshotService", () => {
             { excludeTombstones: true },
         );
 
-        expect(build).toHaveBeenCalledTimes(1);
+        expect(build).toHaveBeenCalledTimes(2);
         expect(result).toEqual({
             entries: [createEntry("hq-safe-document")],
-            snapshotVersion: expect.stringMatching(/^0:\d+$/),
+            snapshotVersion: expect.stringMatching(/^0:\d+:f[0-9a-f]{12}$/),
             cached: true,
         });
     });
@@ -570,7 +714,7 @@ describe("EformsignDocumentSnapshotService", () => {
         const storedKeys = Array.from(internals.memoryStore.keys());
 
         expect(storedKeys).toEqual(["eformsign:doclist:v1:mirror:branch-a:all:0"]);
-        expect(build).toHaveBeenCalledTimes(1);
+        expect(build).toHaveBeenCalledTimes(2);
         // And still distinct from the vendor snapshot of the same scope, so flipping the
         // switch back does not keep serving the source it was flipped away from.
         expect(internals.snapshotKey(createParams(), 0)).not.toBe(storedKeys[0]);

--- a/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
+++ b/backend/application/services/__tests__/eformsign-document-snapshot.service.spec.ts
@@ -220,7 +220,7 @@ describe("EformsignDocumentSnapshotService", () => {
             { excludeTombstones: true },
         );
 
-        expect(build).toHaveBeenCalledTimes(3);
+        expect(build).toHaveBeenCalledTimes(1);
         expect(defaultResult).toEqual({
             entries: [
                 createEntry("safe-document"),
@@ -272,7 +272,7 @@ describe("EformsignDocumentSnapshotService", () => {
 
         const result = await service.getOrBuild(createMirrorParams(), build);
 
-        expect(build).toHaveBeenCalledTimes(2);
+        expect(build).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
             entries: [createEntry("safe-document")],
             snapshotVersion: expect.stringMatching(/^0:\d+:f[0-9a-f]{12}$/),
@@ -292,7 +292,7 @@ describe("EformsignDocumentSnapshotService", () => {
         expect(restored.snapshotVersion).toBe(initialResult.snapshotVersion);
     });
 
-    it("should add a newly ready row even when its version bump failed", async () => {
+    it("should preserve a cached pagination generation when a ready-row bump fails", async () => {
         const exclusionLookup = createSnapshotExclusionLookup();
         const redis = createRedisStub();
         let snapshotPayload: string | null = null;
@@ -323,17 +323,17 @@ describe("EformsignDocumentSnapshotService", () => {
             createEntry("newly-ready-document"),
         ];
 
-        const recovered = await service.getOrBuild(createMirrorParams(), build);
+        const cached = await service.getOrBuild(createMirrorParams(), build);
 
+        expect(build).toHaveBeenCalledTimes(1);
+        expect(cached.entries).toEqual([createEntry("safe-document")]);
+        expect(cached.snapshotVersion).toBe(initial.snapshotVersion);
+
+        snapshotPayload = null;
+        const rebuilt = await service.getOrBuild(createMirrorParams(), build);
         expect(build).toHaveBeenCalledTimes(2);
-        expect(recovered.entries).toEqual(liveEntries);
-        expect(recovered.snapshotVersion).toMatch(/^0:\d+:f[0-9a-f]{12}$/);
-        expect(recovered.snapshotVersion).not.toBe(initial.snapshotVersion);
-
-        const stable = await service.getOrBuild(createMirrorParams(), build);
-        expect(build).toHaveBeenCalledTimes(3);
-        expect(stable.entries).toEqual(liveEntries);
-        expect(stable.snapshotVersion).toBe(recovered.snapshotVersion);
+        expect(rebuilt.entries).toEqual(liveEntries);
+        expect(rebuilt.cached).toBe(false);
     });
 
     it("should apply the readiness fence only to mirror snapshots", async () => {
@@ -420,7 +420,7 @@ describe("EformsignDocumentSnapshotService", () => {
             { excludeTombstones: true },
         );
 
-        expect(build).toHaveBeenCalledTimes(2);
+        expect(build).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
             entries: [createEntry("hq-safe-document")],
             snapshotVersion: expect.stringMatching(/^0:\d+:f[0-9a-f]{12}$/),
@@ -714,7 +714,7 @@ describe("EformsignDocumentSnapshotService", () => {
         const storedKeys = Array.from(internals.memoryStore.keys());
 
         expect(storedKeys).toEqual(["eformsign:doclist:v1:mirror:branch-a:all:0"]);
-        expect(build).toHaveBeenCalledTimes(2);
+        expect(build).toHaveBeenCalledTimes(1);
         // And still distinct from the vendor snapshot of the same scope, so flipping the
         // switch back does not keep serving the source it was flipped away from.
         expect(internals.snapshotKey(createParams(), 0)).not.toBe(storedKeys[0]);

--- a/backend/application/services/eformsign-document-mirror.service.ts
+++ b/backend/application/services/eformsign-document-mirror.service.ts
@@ -269,6 +269,10 @@ export class EformsignDocumentMirrorService {
         try {
             const remote = await this.eformsignClient.getDocument(accessToken, documentId);
             const sourceUpdatedDate = validSourceDate(remote.updated_date);
+            const statusType = normalizeEformsignStatusCode(
+                remote.current_status.status_type,
+            );
+            const isCompletedDocument = EFORMSIGN_COMPLETED_STATUS_CODES.has(statusType);
             attemptedSourceUpdatedDate = sourceUpdatedDate;
             try {
                 await this.mirrorDocumentUsecase.mirrorRemoteDocument(
@@ -331,6 +335,13 @@ export class EformsignDocumentMirrorService {
                 };
             }
 
+            if (isCompletedDocument) {
+                // saveDetail moves this generation to syncing. Invalidate the prior
+                // snapshot now so a completed row cannot stay published while either
+                // required PDF is missing or being replaced.
+                await this.invalidateDocumentSnapshots([documentId]);
+            }
+
             const storedFileTypes: EformsignDocumentFileType[] = [];
             const missingFileTypes: EformsignDocumentFileType[] = [];
             const shouldRepairFiles = !options.skipHealthySameVersionFileRepair
@@ -353,11 +364,8 @@ export class EformsignDocumentMirrorService {
                 storedFileTypes.push(...FILE_TYPES);
             }
 
-            const statusType = normalizeEformsignStatusCode(
-                remote.current_status.status_type,
-            );
             if (
-                EFORMSIGN_COMPLETED_STATUS_CODES.has(statusType)
+                isCompletedDocument
                 && missingFileTypes.length > 0
             ) {
                 throw new Error(
@@ -375,6 +383,11 @@ export class EformsignDocumentMirrorService {
                 partialMessage ? "partial" : "ready",
                 partialMessage,
             );
+            if (finishApplied && isCompletedDocument) {
+                // The list repository admits completed rows only at ready. Publish the
+                // successfully stored detail/PDF generation immediately.
+                await this.invalidateDocumentSnapshots([documentId]);
+            }
             let ownershipChanged = false;
             if (!finishApplied) {
                 // A newer attempt owns the terminal state. Reconcile only if that

--- a/backend/application/services/eformsign-document-mirror.service.ts
+++ b/backend/application/services/eformsign-document-mirror.service.ts
@@ -91,6 +91,13 @@ export interface StoredEformsignDocumentFileResponse {
     body: Buffer;
 }
 
+export interface StoredEformsignDocumentFileMetadataResponse {
+    status: 200;
+    contentType: string;
+    contentDisposition: string | null;
+    byteSize: number;
+}
+
 export class EformsignStoredFileIntegrityError extends Error {
     constructor(documentId: string, fileType: EformsignDocumentFileType) {
         super(`Stored eformsign ${fileType} failed integrity validation for ${documentId}`);
@@ -189,6 +196,35 @@ export class EformsignDocumentMirrorService {
             contentType: metadata.contentType,
             contentDisposition: safeContentDisposition(metadata.contentDisposition),
             body,
+        };
+    }
+
+    async getStoredFileMetadata(
+        documentId: string,
+        fileType: EformsignDocumentFileType,
+    ): Promise<StoredEformsignDocumentFileMetadataResponse | null> {
+        const state = await this.mirrorRepository.findState(documentId);
+        const file = state?.files.find((candidate) =>
+            candidate.fileType === fileType
+            && state.detailSourceUpdatedDate
+            && candidate.sourceUpdatedDate.getTime()
+                === state.detailSourceUpdatedDate.getTime(),
+        );
+        if (
+            !state?.detailPayload
+            || !state.detailSourceUpdatedDate
+            || state.syncStatus !== "ready"
+            || Boolean(state.permanentPurgeRequestedAt)
+            || !file
+        ) {
+            return null;
+        }
+
+        return {
+            status: 200,
+            contentType: file.contentType,
+            contentDisposition: safeContentDisposition(file.contentDisposition),
+            byteSize: file.byteSize,
         };
     }
 

--- a/backend/application/services/eformsign-document-snapshot.service.ts
+++ b/backend/application/services/eformsign-document-snapshot.service.ts
@@ -82,6 +82,15 @@ interface BuildOutcome<TDoc> {
     stored: boolean;
 }
 
+interface SnapshotExclusionResult<TDoc> {
+    entries: DocumentSnapshotEntry<TDoc>[];
+    /**
+     * Stable hash of live exclusions that actually changed this stored snapshot's
+     * membership. It becomes part of snapshotVersion so offset clients reset.
+     */
+    visibilityFence?: string;
+}
+
 interface MemoryEntry {
     expiresAt: number;
     payload: string;
@@ -110,12 +119,14 @@ const DISPLAY_FIELD_MEMORY_STORE_MAX_ENTRIES = 512;
 type SnapshotExclusionLookup = Pick<
     IEformsignDocumentMirrorRepository,
     | "findListExcludedDocumentIds"
+    | "findUnreadyCompletedDocumentIds"
     | "findPermanentPurgeRequestedDocumentIds"
 >;
 
 /** Direct unit construction has no Nest container; production DI must provide the repository token. */
 const NO_SNAPSHOT_EXCLUSIONS: SnapshotExclusionLookup = {
     findListExcludedDocumentIds: async () => [],
+    findUnreadyCompletedDocumentIds: async () => [],
     findPermanentPurgeRequestedDocumentIds: async () => [],
 };
 
@@ -370,10 +381,11 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
         const version = await this.getVersion(params.branchId);
         if (version === null) {
             return {
-                entries: await this.excludeSnapshotEntries(
+                entries: (await this.excludeSnapshotEntries(
                     await this.buildSafeEntries(build),
                     returnOptions,
-                ),
+                    params.source,
+                )).entries,
                 cached: false,
             };
         }
@@ -382,10 +394,11 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
             const epoch = await this.getCompanyEpoch();
             if (epoch === null) {
                 return {
-                    entries: await this.excludeSnapshotEntries(
+                    entries: (await this.excludeSnapshotEntries(
                         await this.buildSafeEntries(build),
                         returnOptions,
-                    ),
+                        params.source,
+                    )).entries,
                     cached: false,
                 };
             }
@@ -396,24 +409,63 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
         const read = await this.readSnapshot<TDoc>(key);
         if (read.status === "error") {
             return {
-                entries: await this.excludeSnapshotEntries(
+                entries: (await this.excludeSnapshotEntries(
                     await this.buildSafeEntries(build),
                     returnOptions,
-                ),
+                    params.source,
+                )).entries,
                 cached: false,
             };
         }
         if (read.status === "hit") {
-            const entries = await this.excludeSnapshotEntries(
+            const cachedVisible = await this.excludeSnapshotEntries(
                 read.snapshot.entries,
                 returnOptions,
+                params.source,
             );
+            if (params.source === "mirror") {
+                // Mirror snapshots are an optimization over local DB reads, not an
+                // authority boundary. A failed Valkey generation bump can leave an
+                // old snapshot that a subtractive readiness fence cannot repair when
+                // a newly-ready row was absent. Rebuild the exact local scope and use
+                // a stable content fence whenever it diverges. This keeps reads
+                // vendor-free while making cache invalidation failure fail closed.
+                const liveVisible = await this.excludeSnapshotEntries(
+                    await this.buildSafeEntries(build),
+                    returnOptions,
+                    params.source,
+                );
+                const contentFence = snapshotEntriesEqual(
+                    cachedVisible.entries,
+                    liveVisible.entries,
+                )
+                    ? (
+                        cachedVisible.visibilityFence
+                        ?? liveVisible.visibilityFence
+                    )
+                    : snapshotEntriesFence(liveVisible.entries);
+                this.logger.log(
+                    `documentSnapshot hit branch=${params.branchId} scope=${params.scope}`
+                    + ` docs=${liveVisible.entries.length}`,
+                );
+                return {
+                    entries: liveVisible.entries,
+                    snapshotVersion: formatSnapshotVersion(
+                        read.snapshot,
+                        contentFence,
+                    ),
+                    cached: true,
+                };
+            }
             this.logger.log(
-                `documentSnapshot hit branch=${params.branchId} scope=${params.scope} docs=${entries.length}`,
+                `documentSnapshot hit branch=${params.branchId} scope=${params.scope} docs=${cachedVisible.entries.length}`,
             );
             return {
-                entries,
-                snapshotVersion: formatSnapshotVersion(read.snapshot),
+                entries: cachedVisible.entries,
+                snapshotVersion: formatSnapshotVersion(
+                    read.snapshot,
+                    cachedVisible.visibilityFence,
+                ),
                 cached: true,
             };
         }
@@ -421,12 +473,21 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
         const inFlight = this.inFlight.get(key);
         if (inFlight) {
             const shared = (await inFlight) as BuildOutcome<TDoc>;
+            const visible = await this.excludeSnapshotEntries(
+                shared.snapshot.entries,
+                returnOptions,
+                params.source,
+            );
             return {
-                entries: await this.excludeSnapshotEntries(
-                    shared.snapshot.entries,
-                    returnOptions,
-                ),
-                ...(shared.stored ? { snapshotVersion: formatSnapshotVersion(shared.snapshot) } : {}),
+                entries: visible.entries,
+                ...(shared.stored
+                    ? {
+                        snapshotVersion: formatSnapshotVersion(
+                            shared.snapshot,
+                            visible.visibilityFence,
+                        ),
+                    }
+                    : {}),
                 cached: true,
             };
         }
@@ -437,12 +498,21 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
         void pending.catch(() => undefined).finally(() => this.inFlight.delete(key));
 
         const outcome = await pending;
+        const visible = await this.excludeSnapshotEntries(
+            outcome.snapshot.entries,
+            returnOptions,
+            params.source,
+        );
         return {
-            entries: await this.excludeSnapshotEntries(
-                outcome.snapshot.entries,
-                returnOptions,
-            ),
-            ...(outcome.stored ? { snapshotVersion: formatSnapshotVersion(outcome.snapshot) } : {}),
+            entries: visible.entries,
+            ...(outcome.stored
+                ? {
+                    snapshotVersion: formatSnapshotVersion(
+                        outcome.snapshot,
+                        visible.visibilityFence,
+                    ),
+                }
+                : {}),
             cached: false,
         };
     }
@@ -462,7 +532,10 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
     private async buildSafeEntries<TDoc>(
         build: () => Promise<DocumentSnapshotEntry<TDoc>[]>,
     ): Promise<DocumentSnapshotEntry<TDoc>[]> {
-        return this.excludePermanentPurgeEntries(await build());
+        const excludedIds = new Set(
+            await this.snapshotExclusionLookup.findPermanentPurgeRequestedDocumentIds(),
+        );
+        return this.filterExcludedSnapshotEntries(await build(), excludedIds);
     }
 
     /**
@@ -474,22 +547,44 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
     private async excludeSnapshotEntries<TDoc>(
         entries: DocumentSnapshotEntry<TDoc>[],
         options: DocumentSnapshotReturnOptions,
-    ): Promise<DocumentSnapshotEntry<TDoc>[]> {
-        const excludedIds = new Set(
-            options.excludeTombstones
-                ? await this.snapshotExclusionLookup.findListExcludedDocumentIds()
-                : await this.snapshotExclusionLookup.findPermanentPurgeRequestedDocumentIds(),
-        );
-        return this.filterExcludedSnapshotEntries(entries, excludedIds);
+        source: DocumentSnapshotKeyParams["source"],
+    ): Promise<SnapshotExclusionResult<TDoc>> {
+        const excludedIds = new Set(options.excludeTombstones
+            ? await this.snapshotExclusionLookup.findListExcludedDocumentIds()
+            : await this.snapshotExclusionLookup.findPermanentPurgeRequestedDocumentIds());
+        if (source === "mirror") {
+            for (const documentId of await this.snapshotExclusionLookup
+                .findUnreadyCompletedDocumentIds()) {
+                excludedIds.add(documentId);
+            }
+        }
+        const effectiveExcludedIds = entries
+            .map((entry) => this.snapshotEntryDocumentId(entry))
+            .filter((documentId): documentId is string =>
+                documentId !== null && excludedIds.has(documentId))
+            .sort();
+        const filteredEntries = this.filterExcludedSnapshotEntries(entries, excludedIds);
+        if (effectiveExcludedIds.length === 0) {
+            return { entries: filteredEntries };
+        }
+        return {
+            entries: filteredEntries,
+            visibilityFence: createHash("sha256")
+                .update(effectiveExcludedIds.join("\0"))
+                .digest("hex")
+                .slice(0, 12),
+        };
     }
 
-    private async excludePermanentPurgeEntries<TDoc>(
-        entries: DocumentSnapshotEntry<TDoc>[],
-    ): Promise<DocumentSnapshotEntry<TDoc>[]> {
-        const excludedIds = new Set(
-            await this.snapshotExclusionLookup.findPermanentPurgeRequestedDocumentIds(),
-        );
-        return this.filterExcludedSnapshotEntries(entries, excludedIds);
+    private snapshotEntryDocumentId<TDoc>(
+        entry: DocumentSnapshotEntry<TDoc>,
+    ): string | null {
+        const document = entry.document;
+        if (typeof document !== "object" || document === null || !("id" in document)) {
+            return null;
+        }
+        const documentId = (document as { id?: unknown }).id;
+        return typeof documentId === "string" ? documentId : null;
     }
 
     private filterExcludedSnapshotEntries<TDoc>(
@@ -501,12 +596,8 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
         }
 
         return entries.filter((entry) => {
-            const document = entry.document;
-            if (typeof document !== "object" || document === null || !("id" in document)) {
-                return true;
-            }
-            const documentId = (document as { id?: unknown }).id;
-            return typeof documentId !== "string" || !excludedIds.has(documentId);
+            const documentId = this.snapshotEntryDocumentId(entry);
+            return documentId === null || !excludedIds.has(documentId);
         });
     }
 
@@ -651,8 +742,28 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
     }
 }
 
-function formatSnapshotVersion(snapshot: { version: number; builtAt: number }): string {
-    return `${snapshot.version}:${snapshot.builtAt}`;
+function formatSnapshotVersion(
+    snapshot: { version: number; builtAt: number },
+    visibilityFence?: string,
+): string {
+    const baseVersion = `${snapshot.version}:${snapshot.builtAt}`;
+    return visibilityFence ? `${baseVersion}:f${visibilityFence}` : baseVersion;
+}
+
+function snapshotEntriesEqual<TDoc>(
+    left: DocumentSnapshotEntry<TDoc>[],
+    right: DocumentSnapshotEntry<TDoc>[],
+): boolean {
+    return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function snapshotEntriesFence<TDoc>(
+    entries: DocumentSnapshotEntry<TDoc>[],
+): string {
+    return createHash("sha256")
+        .update(JSON.stringify(entries))
+        .digest("hex")
+        .slice(0, 12);
 }
 
 function describeError(error: unknown): string {

--- a/backend/application/services/eformsign-document-snapshot.service.ts
+++ b/backend/application/services/eformsign-document-snapshot.service.ts
@@ -423,40 +423,6 @@ export class EformsignDocumentSnapshotService implements OnModuleDestroy {
                 returnOptions,
                 params.source,
             );
-            if (params.source === "mirror") {
-                // Mirror snapshots are an optimization over local DB reads, not an
-                // authority boundary. A failed Valkey generation bump can leave an
-                // old snapshot that a subtractive readiness fence cannot repair when
-                // a newly-ready row was absent. Rebuild the exact local scope and use
-                // a stable content fence whenever it diverges. This keeps reads
-                // vendor-free while making cache invalidation failure fail closed.
-                const liveVisible = await this.excludeSnapshotEntries(
-                    await this.buildSafeEntries(build),
-                    returnOptions,
-                    params.source,
-                );
-                const contentFence = snapshotEntriesEqual(
-                    cachedVisible.entries,
-                    liveVisible.entries,
-                )
-                    ? (
-                        cachedVisible.visibilityFence
-                        ?? liveVisible.visibilityFence
-                    )
-                    : snapshotEntriesFence(liveVisible.entries);
-                this.logger.log(
-                    `documentSnapshot hit branch=${params.branchId} scope=${params.scope}`
-                    + ` docs=${liveVisible.entries.length}`,
-                );
-                return {
-                    entries: liveVisible.entries,
-                    snapshotVersion: formatSnapshotVersion(
-                        read.snapshot,
-                        contentFence,
-                    ),
-                    cached: true,
-                };
-            }
             this.logger.log(
                 `documentSnapshot hit branch=${params.branchId} scope=${params.scope} docs=${cachedVisible.entries.length}`,
             );
@@ -748,22 +714,6 @@ function formatSnapshotVersion(
 ): string {
     const baseVersion = `${snapshot.version}:${snapshot.builtAt}`;
     return visibilityFence ? `${baseVersion}:f${visibilityFence}` : baseVersion;
-}
-
-function snapshotEntriesEqual<TDoc>(
-    left: DocumentSnapshotEntry<TDoc>[],
-    right: DocumentSnapshotEntry<TDoc>[],
-): boolean {
-    return JSON.stringify(left) === JSON.stringify(right);
-}
-
-function snapshotEntriesFence<TDoc>(
-    entries: DocumentSnapshotEntry<TDoc>[],
-): string {
-    return createHash("sha256")
-        .update(JSON.stringify(entries))
-        .digest("hex")
-        .slice(0, 12);
 }
 
 function describeError(error: unknown): string {

--- a/backend/application/services/eformsign-mirror-list.service.ts
+++ b/backend/application/services/eformsign-mirror-list.service.ts
@@ -72,15 +72,19 @@ export class EformsignMirrorListService {
     }): Promise<EformsignListDoc[]> {
         // For a regular branch the list rows and the search rows are the same query, so it
         // is read once; only headquarters needs the wider set as well.
-        const branchOwned = await this.eformsignDocRepository.findAll(query.branchId);
+        const branchOwned = await this.eformsignDocRepository.findAllVisibleInMirror(
+            query.branchId,
+        );
         const mirrored = query.isHeadquarters
-            ? await this.eformsignDocRepository.findAllForHeadquarters(query.branchId)
+            ? await this.eformsignDocRepository.findAllVisibleInMirrorForHeadquarters(
+                query.branchId,
+            )
             : branchOwned;
 
         // Branch-owned rows only, even for headquarters: the API path builds its
-        // recipient-name search corpus from findAll(branchId), so an unassigned document's
-        // recipient name is not searchable there either. Carried on the document so a
-        // cached generation keeps it without a second read.
+        // recipient-name search corpus from the branch-visible query, so an unassigned
+        // document's recipient name is not searchable there either. Carried on the
+        // document so a cached generation keeps it without a second read.
         const recipientNameById = new Map(
             branchOwned.map((document) => [
                 document.documentId,

--- a/backend/application/usecases/eformsign-doc/adopt-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/adopt-eformsign-doc.usecase.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 
 import { EformsignDocumentMirrorService } from "application/services/eformsign-document-mirror.service";
 import { documentCustomerNameValue } from "application/utils/eformsign-document-customer-name";
@@ -18,6 +18,8 @@ export interface AdoptEformsignDocParams {
 
 @Injectable()
 export class AdoptEformsignDocUsecase {
+    private readonly logger = new Logger(AdoptEformsignDocUsecase.name);
+
     constructor(
         private readonly getAccessTokenUsecase: GetEformsignAccessTokenUsecase,
         private readonly fetchEformsignDocFromApiUsecase: FetchEformsignDocFromApiUsecase,
@@ -73,11 +75,29 @@ export class AdoptEformsignDocUsecase {
                 ?? null,
         });
 
-        await this.documentMirrorService.syncDocumentWithToken(
-            token.oauth_token.access_token,
-            remote.id || params.documentId,
-            { expectedUpdatedDate: remote.updated_date },
-        );
+        try {
+            await this.documentMirrorService.syncDocumentWithToken(
+                token.oauth_token.access_token,
+                remote.id || params.documentId,
+                { expectedUpdatedDate: remote.updated_date },
+            );
+        } catch {
+            // Ownership and client linkage were committed above. Returning a failure
+            // here would tell the caller to retry an adoption that already succeeded.
+            // Keep the row non-ready and expose a machine-readable warning so callers
+            // cannot report the local detail/PDF mirror as complete. The durable failed
+            // state remains eligible for an operational reconciliation without claiming
+            // that a scheduler or distributed lock is currently available.
+            this.logger.warn(
+                "Eformsign adoption committed, but the local mirror remains incomplete",
+            );
+            return Object.assign(result, {
+                warnings: [
+                    ...(result.warnings ?? []),
+                    "mirror_sync_failed" as const,
+                ],
+            });
+        }
 
         return result;
     }

--- a/backend/application/usecases/eformsign-doc/adopt-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/adopt-eformsign-doc.usecase.ts
@@ -1,9 +1,11 @@
 import { Inject, Injectable } from "@nestjs/common";
 
+import { EformsignDocumentMirrorService } from "application/services/eformsign-document-mirror.service";
 import { documentCustomerNameValue } from "application/utils/eformsign-document-customer-name";
 import { EFORMSIGN_DOCUMENT_KIND } from "domain/entities/eformsign-doc.entity";
 import { CLIENT_REPOSITORY, IClientRepository } from "domain/repositories/client.repository.interface";
 import { eformsignExpiryDateFromRemainingDays } from "domain/utils/eformsign-expiry-date";
+import { normalizeEformsignStatusCode } from "domain/utils/eformsign-status-code";
 
 import { CreateEformsignDocResult, CreateEformsignDocUsecase } from "./create-eformsign-doc.usecase";
 import { FetchEformsignDocFromApiUsecase } from "./fetch-eformsign-doc-from-api.usecase";
@@ -21,6 +23,7 @@ export class AdoptEformsignDocUsecase {
         private readonly fetchEformsignDocFromApiUsecase: FetchEformsignDocFromApiUsecase,
         private readonly createEformsignDocUsecase: CreateEformsignDocUsecase,
         @Inject(CLIENT_REPOSITORY) private readonly clientRepository: IClientRepository,
+        private readonly documentMirrorService: EformsignDocumentMirrorService,
     ) {}
 
     async execute(branchId: string, params: AdoptEformsignDocParams): Promise<CreateEformsignDocResult> {
@@ -38,10 +41,10 @@ export class AdoptEformsignDocUsecase {
             throw new Error("clientId가 필요합니다.");
         }
 
-        return this.createEformsignDocUsecase.execute(branchId, {
+        const result = await this.createEformsignDocUsecase.execute(branchId, {
             documentId: remote.id || params.documentId,
             clientId,
-            statusType: remote.current_status.status_type || "000",
+            statusType: normalizeEformsignStatusCode(remote.current_status.status_type),
             statusDetail: remote.current_status.status_doc_detail || remote.current_status.step_name || "진행중",
             stepType: remote.current_status.step_type || "01",
             stepIndex: remote.current_status.step_index || "1",
@@ -54,6 +57,10 @@ export class AdoptEformsignDocUsecase {
                 Date.now(),
             ),
             linkToClient: true,
+            // Existing ready detail/PDFs describe the stored projection. Assign
+            // ownership first, but let the fenced mirror sync below publish the
+            // newly fetched vendor projection only after its artifacts are ready.
+            preserveExistingMirrorProjection: true,
             documentKind: EFORMSIGN_DOCUMENT_KIND.CONTRACT,
             templateId: remote.template?.id ?? null,
             documentName: remote.document_name,
@@ -65,5 +72,13 @@ export class AdoptEformsignDocUsecase {
                 ?.map((item) => item.recipient_type)
                 ?? null,
         });
+
+        await this.documentMirrorService.syncDocumentWithToken(
+            token.oauth_token.access_token,
+            remote.id || params.documentId,
+            { expectedUpdatedDate: remote.updated_date },
+        );
+
+        return result;
     }
 }

--- a/backend/application/usecases/eformsign-doc/create-and-send-service-record-snapshot.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/create-and-send-service-record-snapshot.usecase.ts
@@ -18,6 +18,7 @@ import {
 } from "infrastructure/database/eformsign-doc-compat";
 import { PrismaService } from "infrastructure/database/prisma.service";
 import { eformsignExpiryDateFromRemainingDays } from "domain/utils/eformsign-expiry-date";
+import { normalizeEformsignStatusCode } from "domain/utils/eformsign-status-code";
 import { captureServiceRecordError } from "infrastructure/observability/service-record-sentry";
 import { GetEformsignAccessTokenUsecase } from "./get-eformsign-access-token.usecase";
 import {
@@ -786,7 +787,7 @@ export class CreateAndSendServiceRecordSnapshotUsecase {
             stepRecipientTypes,
             createdDate,
             updatedDate,
-            statusType: remoteStatus?.status_type ?? "070",
+            statusType: normalizeEformsignStatusCode(remoteStatus?.status_type ?? "070"),
             statusDetail: remoteStatus?.status_doc_detail ?? "검토 요청",
             stepType: remoteStatus?.step_type ?? "06",
             stepIndex: remoteStatus?.step_index ?? "2",
@@ -814,7 +815,7 @@ export class CreateAndSendServiceRecordSnapshotUsecase {
             ...(stepRecipientTypes ? { stepRecipientTypes } : {}),
             ...(remoteStatus ? {
                 updatedDate,
-                statusType: remoteStatus.status_type,
+                statusType: normalizeEformsignStatusCode(remoteStatus.status_type),
                 // Only detail responses carry this. Omit rather than pass undefined so
                 // the intent is the code's, not Prisma's coincidental skip semantics.
                 ...(remoteStatus.status_doc_detail === undefined

--- a/backend/application/usecases/eformsign-doc/create-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/create-eformsign-doc.usecase.ts
@@ -31,6 +31,8 @@ export interface CreateEformsignDocParams {
     documentKind?: EformsignDocumentKind | null;
     employeeScheduleId?: number | null;
     templateId?: string | null;
+    /** Internal adopt-path fence; ordinary document creation must leave this unset. */
+    preserveExistingMirrorProjection?: boolean;
 }
 
 export type CreateEformsignDocResult = EformsignDocEntity & {
@@ -88,7 +90,13 @@ export class CreateEformsignDocUsecase {
             employeeScheduleId: params.employeeScheduleId ?? null,
             templateId: params.templateId ?? null,
         });
-        const createdDoc = await this.eformsignDocRepository.upsertByDocumentId(branchid, entity);
+        const createdDoc = params.preserveExistingMirrorProjection
+            ? await this.eformsignDocRepository.upsertByDocumentId(
+                branchid,
+                entity,
+                { preserveExistingMirrorProjection: true },
+            )
+            : await this.eformsignDocRepository.upsertByDocumentId(branchid, entity);
         const warnings: Array<"client_link_failed"> = [];
 
         // If linkToClient is true, also update client.e_doc_id to track this document

--- a/backend/application/usecases/eformsign-doc/create-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/create-eformsign-doc.usecase.ts
@@ -35,8 +35,10 @@ export interface CreateEformsignDocParams {
     preserveExistingMirrorProjection?: boolean;
 }
 
+export type CreateEformsignDocWarning = "client_link_failed" | "mirror_sync_failed";
+
 export type CreateEformsignDocResult = EformsignDocEntity & {
-    warnings?: Array<"client_link_failed">;
+    warnings?: CreateEformsignDocWarning[];
 };
 
 @Injectable()
@@ -97,7 +99,7 @@ export class CreateEformsignDocUsecase {
                 { preserveExistingMirrorProjection: true },
             )
             : await this.eformsignDocRepository.upsertByDocumentId(branchid, entity);
-        const warnings: Array<"client_link_failed"> = [];
+        const warnings: CreateEformsignDocWarning[] = [];
 
         // If linkToClient is true, also update client.e_doc_id to track this document
         if (params.linkToClient) {

--- a/backend/application/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.ts
@@ -4,6 +4,7 @@ import { EformsignDocumentSnapshotService } from "application/services/eformsign
 import { documentCustomerNameValue } from "application/utils/eformsign-document-customer-name";
 import { eformsignDocumentTemplateId } from "application/utils/eformsign-document-template-id";
 import {
+    EFORMSIGN_COMPLETED_STATUS_CODES,
     EFORMSIGN_EXPIRED_STATUS_CODE,
     EFORMSIGN_TERMINAL_STATUS_DETAILS,
     TERMINAL_STATUS_CODES,
@@ -150,6 +151,9 @@ export class MirrorUnassignedEformsignDocUsecase {
         const mirrored = await this.eformsignDocRepository.upsertUnassignedByDocumentId(doc, {
             ...(options.allowAssignedUpdate ? { allowAssignedUpdate: true } : {}),
             updateListDisplayFields: true,
+            ...(EFORMSIGN_COMPLETED_STATUS_CODES.has(statusType)
+                ? { markMirrorPending: true }
+                : {}),
             ...(knowsExpiredState ? {} : { updateExpired: false }),
             // A detail derived from the step name must not replace one a webhook wrote —
             // but one derived from a terminal status code must, because the stored detail

--- a/backend/domain/constants/eformsign-doc-status.constants.ts
+++ b/backend/domain/constants/eformsign-doc-status.constants.ts
@@ -9,6 +9,31 @@ export const EFORMSIGN_COMPLETED_STATUS_CODES: ReadonlySet<string> = new Set([
     "092",
 ]);
 
+/**
+ * Completed values that may already exist in storage from legacy/raw vendor writes.
+ * New writes are normalized, but publication queries must also fence old aliases and
+ * unpadded numeric forms until a normal sync rewrites them canonically.
+ */
+export const EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES: readonly string[] = [
+    ...EFORMSIGN_COMPLETED_STATUS_CODES,
+    "3",
+    "03",
+    "12",
+    "22",
+    "32",
+    "50",
+    "62",
+    "72",
+    "92",
+    "doc_complete",
+    "doc_accept_approval",
+    "doc_accept_reception",
+    "doc_accept_outsider",
+    "doc_accept_participant",
+    "doc_accept_reviewer",
+    "face_signature_complete",
+];
+
 const REJECTED_STATUS_CODES = [
     "011",
     "021",
@@ -39,6 +64,21 @@ export const TERMINAL_STATUS_CODES = new Set<string>([
  * re-mirrors a document that already has a local row.
  */
 export const UNASSIGNED_REVIEW_STAGE_STATUS_CODES = new Set<string>(["062", "071"]);
+
+/**
+ * Canonical review-stage codes plus raw values written by older vendor-ingestion paths.
+ * The repository normally receives normalized codes now, but an equal-generation forward
+ * transition must also be able to replace a legacy row without broadly reopening every
+ * completed status.
+ */
+export const UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES = [
+    "062",
+    "071",
+    "62",
+    "71",
+    "doc_accept_participant",
+    "doc_reject_reviewer",
+] as const;
 
 export const UNASSIGNED_TERMINAL_STATUS_CODES = new Set<string>(
     [...TERMINAL_STATUS_CODES].filter(

--- a/backend/domain/repositories/eformsign-doc.repository.interface.ts
+++ b/backend/domain/repositories/eformsign-doc.repository.interface.ts
@@ -70,6 +70,11 @@ export interface EformsignDocConditionalUpdateResult {
 export interface UpsertUnassignedEformsignDocOptions {
     allowAssignedUpdate?: boolean;
     updateListDisplayFields?: boolean;
+    /**
+     * Atomically withdraw a completed list projection before detail/PDF mirroring starts.
+     * The mirror service republishes it only after both required PDFs reach ready.
+     */
+    markMirrorPending?: boolean;
     updateExpired?: boolean;
     /**
      * The list endpoint carries no status detail, so a caller working from it only has a
@@ -93,6 +98,16 @@ export interface UpsertUnassignedEformsignDocOptions {
     updateCreatedDate?: boolean;
 }
 
+export interface UpsertEformsignDocByDocumentIdOptions {
+    /**
+     * Adoption may assign branch/client ownership to a row whose detail/PDF
+     * generation is already ready. Keep that existing vendor projection intact
+     * until the mirror service has fetched and fenced the replacement generation.
+     * A newly inserted row still receives the complete projection and starts pending.
+     */
+    preserveExistingMirrorProjection?: boolean;
+}
+
 export interface IEformsignDocRepository {
     findById(branchid: string, id: number): Promise<EformsignDocEntity | null>;
     findByDocumentId(branchid: string, documentId: string): Promise<EformsignDocEntity | null>;
@@ -110,11 +125,21 @@ export interface IEformsignDocRepository {
     findByClientId(branchid: string, clientId: number): Promise<EformsignDocEntity[]>;
     findAll(branchid: string): Promise<EformsignDocEntity[]>;
     /**
+     * Rows safe to expose through the local-only mirror list. Completed documents stay
+     * hidden until their detail and required PDFs reach the ready generation.
+     */
+    findAllVisibleInMirror(branchid: string): Promise<EformsignDocEntity[]>;
+    /**
      * Every document the headquarters list may show: ours plus the ones no branch has
      * claimed. Deliberately not "all rows minus other branches" done in memory — that is
      * the same rule, but expressed where the database can apply it.
      */
     findAllForHeadquarters(branchid: string): Promise<EformsignDocEntity[]>;
+    /**
+     * Headquarters equivalent of `findAllVisibleInMirror`, including unclaimed rows but
+     * applying the same completed-ready publication gate.
+     */
+    findAllVisibleInMirrorForHeadquarters(branchid: string): Promise<EformsignDocEntity[]>;
     findDocumentIdsForOtherBranches(branchid: string): Promise<string[]>;
     findDisplayFieldsByDocumentIds(
         branchid: string,
@@ -141,7 +166,11 @@ export interface IEformsignDocRepository {
         documentId: string,
         clientId: number,
     ): Promise<boolean>;
-    upsertByDocumentId(branchid: string, doc: EformsignDocEntity): Promise<EformsignDocEntity>;
+    upsertByDocumentId(
+        branchid: string,
+        doc: EformsignDocEntity,
+        options?: UpsertEformsignDocByDocumentIdOptions,
+    ): Promise<EformsignDocEntity>;
     upsertUnassignedByDocumentId(
         doc: EformsignDocEntity,
         options?: UpsertUnassignedEformsignDocOptions,

--- a/backend/domain/repositories/eformsign-document-mirror.repository.interface.ts
+++ b/backend/domain/repositories/eformsign-document-mirror.repository.interface.ts
@@ -113,6 +113,11 @@ export interface IEformsignDocumentMirrorRepository {
      * cached HQ snapshots can contain both branch-owned and unassigned rows.
      */
     findListExcludedDocumentIds(): Promise<string[]>;
+    /**
+     * Completed rows that are not safe to publish from a cached mirror generation.
+     * Global by document id so the same fence protects branch and headquarters caches.
+     */
+    findUnreadyCompletedDocumentIds(): Promise<string[]>;
     findPermanentPurgeRequestedDocumentIds(): Promise<string[]>;
     requestPermanentPurge(documentIds: string[]): Promise<EformsignPermanentPurgeRequest[]>;
     /** Returns only requests whose exact generation was still pending. */

--- a/backend/infrastructure/database/eformsign-doc-compat.ts
+++ b/backend/infrastructure/database/eformsign-doc-compat.ts
@@ -49,6 +49,7 @@ type PendingEformsignDocData = {
     documentKind?: unknown;
     employeeScheduleId?: unknown;
     templateId?: unknown;
+    permanentPurgeRequestedAt?: unknown;
     documentName?: unknown;
     documentNumber?: unknown;
     templateName?: unknown;
@@ -114,6 +115,15 @@ const PENDING_EFORMSIGN_DOC_COLUMN_GROUPS = [
             { databaseName: "sync_error_at", prismaName: "syncErrorAt" },
         ],
     },
+    {
+        // Migration: 20260730040000_add_eformsign_doc_permanent_purge_intent
+        columns: [
+            {
+                databaseName: "permanent_purge_requested_at",
+                prismaName: "permanentPurgeRequestedAt",
+            },
+        ],
+    },
 ] as const satisfies readonly { columns: readonly PendingEformsignDocColumn[] }[];
 
 export const PENDING_EFORMSIGN_DOC_COLUMN_NAMES = PENDING_EFORMSIGN_DOC_COLUMN_GROUPS.flatMap(
@@ -150,6 +160,7 @@ const PENDING_EFORMSIGN_DOC_NULLS = {
     documentKind: null,
     employeeScheduleId: null,
     templateId: null,
+    permanentPurgeRequestedAt: null,
     documentName: null,
     documentNumber: null,
     templateName: null,
@@ -200,6 +211,49 @@ export const readWithEformsignDocCompat = async <TRow>(
         }
         return read({ ...EFORMSIGN_DOC_COMPAT_READ_SELECT });
     }
+};
+
+/**
+ * Drops `pendingColumn: null` predicates from a filter so it can run against a database
+ * that does not have the column yet.
+ *
+ * Narrowing the select is only half of a compatibility read. Callers also filter on these
+ * columns — `permanentPurgeRequestedAt: null` appears in nearly every document read — and
+ * a predicate naming a missing column fails no matter what is selected, so the retry used
+ * to fail exactly like the first attempt.
+ *
+ * Only the `: null` form is dropped, and that is a semantic identity: if the column does
+ * not exist, no row can carry a value, so "is null" is true of every row. Any other
+ * comparison is left in place to fail loudly rather than be silently reinterpreted —
+ * `{ not: null }` would flip from matching nothing to matching everything.
+ */
+export const stripPendingEformsignDocPredicates = (
+    where: Prisma.eformsign_docWhereInput,
+): Prisma.eformsign_docWhereInput => {
+    const pendingNames = new Set<string>(
+        PENDING_EFORMSIGN_DOC_COLUMN_GROUPS.flatMap((group) =>
+            group.columns.map((column) => column.prismaName as string),
+        ),
+    );
+
+    const strip = (node: Prisma.eformsign_docWhereInput): Prisma.eformsign_docWhereInput => {
+        const stripped: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(node)) {
+            if (pendingNames.has(key) && value === null) {
+                continue;
+            }
+            if ((key === "AND" || key === "OR" || key === "NOT") && value !== undefined) {
+                stripped[key] = Array.isArray(value)
+                    ? value.map((entry) => strip(entry as Prisma.eformsign_docWhereInput))
+                    : strip(value as Prisma.eformsign_docWhereInput);
+                continue;
+            }
+            stripped[key] = value;
+        }
+        return stripped as Prisma.eformsign_docWhereInput;
+    };
+
+    return strip(where);
 };
 
 export const eformsignDocCompatReadSelect = (

--- a/backend/infrastructure/database/eformsign-doc-compat.ts
+++ b/backend/infrastructure/database/eformsign-doc-compat.ts
@@ -228,21 +228,34 @@ export const readWithEformsignDocCompat = async <TRow>(
  * `{ not: null }` would flip from matching nothing to matching everything.
  */
 export const stripPendingEformsignDocPredicates = (
+    error: unknown,
     where: Prisma.eformsign_docWhereInput,
 ): Prisma.eformsign_docWhereInput => {
-    const pendingNames = new Set<string>(
-        PENDING_EFORMSIGN_DOC_COLUMN_GROUPS.flatMap((group) =>
-            group.columns.map((column) => column.prismaName as string),
-        ),
-    );
+    // Only the columns the database is actually missing. A predicate on a column an
+    // earlier migration already added still means what it says, and dropping it would
+    // widen the retry — a filter excluding purge-pending rows would start including them.
+    const kept = keptPendingEformsignDocColumns(error);
+    const missingNames = PENDING_EFORMSIGN_DOC_COLUMN_GROUPS
+        .flatMap((group) => group.columns.map((column) => column.prismaName as string))
+        .filter((name) => !kept.has(name));
+    if (missingNames.length === 0) {
+        return where;
+    }
+    const missing = new Set(missingNames);
 
+    // AND is the only operator this descends into, because it is the only one where
+    // deleting a vacuously-true leaf preserves the meaning of the whole. Under OR a true
+    // leaf makes the branch true, and under NOT it makes it false; an empty object says
+    // neither, so both are left exactly as they are and fail loudly instead of quietly
+    // answering a different question. Every filter that actually needs this puts its
+    // pending predicates at the top level or in an AND chain.
     const strip = (node: Prisma.eformsign_docWhereInput): Prisma.eformsign_docWhereInput => {
         const stripped: Record<string, unknown> = {};
         for (const [key, value] of Object.entries(node)) {
-            if (pendingNames.has(key) && value === null) {
+            if (missing.has(key) && value === null) {
                 continue;
             }
-            if ((key === "AND" || key === "OR" || key === "NOT") && value !== undefined) {
+            if (key === "AND" && value !== undefined && value !== null) {
                 stripped[key] = Array.isArray(value)
                     ? value.map((entry) => strip(entry as Prisma.eformsign_docWhereInput))
                     : strip(value as Prisma.eformsign_docWhereInput);
@@ -258,20 +271,35 @@ export const stripPendingEformsignDocPredicates = (
 
 export const eformsignDocCompatReadSelect = (
     error: unknown,
+    // The caller's own projection, so a compatibility retry reads no more than the query
+    // it is standing in for. Widening to every surviving pending column would have pulled
+    // detailPayload into list reads — the one column EFORMSIGN_DOC_DOMAIN_READ_SELECT
+    // exists to keep out of them.
+    desiredSelect: Prisma.eformsign_docSelect = EFORMSIGN_DOC_DOMAIN_READ_SELECT,
 ): Prisma.eformsign_docSelect => {
     // Prisma sometimes raises P2022 with no column metadata and nothing nameable in the
     // message. That says a pending column is missing without saying which, so a read drops
     // to the floor — the assumption that cannot be wrong. Writes throw in the same
     // situation instead, because silently dropping data a caller asked to store is worse
     // than failing; a read losing columns it could have kept is recoverable.
-    const keptGroupCount = Math.max(findEformsignDocGroupIndex(error), 0);
+    const kept = keptPendingEformsignDocColumns(error);
     const select: Prisma.eformsign_docSelect = { ...EFORMSIGN_DOC_COMPAT_READ_SELECT };
-    for (const group of PENDING_EFORMSIGN_DOC_COLUMN_GROUPS.slice(0, keptGroupCount)) {
-        for (const column of group.columns) {
-            select[column.prismaName] = true;
+    for (const [column, wanted] of Object.entries(desiredSelect)) {
+        if (wanted && kept.has(column)) {
+            select[column as keyof Prisma.eformsign_docSelect] = true;
         }
     }
     return select;
+};
+
+/** Pending columns from migrations that ran before the one the error names. */
+const keptPendingEformsignDocColumns = (error: unknown): Set<string> => {
+    const keptGroupCount = Math.max(findEformsignDocGroupIndex(error), 0);
+    return new Set(
+        PENDING_EFORMSIGN_DOC_COLUMN_GROUPS
+            .slice(0, keptGroupCount)
+            .flatMap((group) => group.columns.map((column) => column.prismaName as string)),
+    );
 };
 
 /**

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -811,7 +811,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
 
             const doc = await readWithEformsignDocCompat(error, (select) =>
                 this.prismaService.eformsign_doc.findFirst({
-                    where: stripPendingEformsignDocPredicates(where),
+                    where: stripPendingEformsignDocPredicates(error, where),
                     select,
                 }));
             return doc ? EformsignDocMapper.toDomain(toCompatDomainRow(doc)) : null;
@@ -832,7 +832,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
 
             const docs = await readWithEformsignDocCompat(error, (select) =>
                 this.prismaService.eformsign_doc.findMany({
-                    where: stripPendingEformsignDocPredicates(where),
+                    where: stripPendingEformsignDocPredicates(error, where),
                     select,
                 }));
             return docs.map((doc) => EformsignDocMapper.toDomain(toCompatDomainRow(doc)));

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -1,8 +1,9 @@
 import { Injectable } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
 import {
+    EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES,
     UNASSIGNED_FORWARD_STATUS_CODES_AFTER_REVIEW_STAGE,
-    UNASSIGNED_REVIEW_STAGE_STATUS_CODES,
+    UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES,
     UNASSIGNED_TERMINAL_STATUS_CODES,
 } from "domain/constants/eformsign-doc-status.constants";
 import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
@@ -16,6 +17,7 @@ import {
     EformsignDocStaleUpdateError,
     EformsignDocUnscopedResult,
     IEformsignDocRepository,
+    UpsertEformsignDocByDocumentIdOptions,
     UpsertUnassignedEformsignDocOptions,
 } from "domain/repositories/eformsign-doc.repository.interface";
 import {
@@ -35,6 +37,29 @@ const isUniqueConstraintError = (error: unknown): boolean =>
     && (error as { code?: unknown }).code === "P2002";
 
 const DELETED_EFORMSIGN_STATUS_TYPES = ["047", "049", "099"];
+const COMPLETED_EFORMSIGN_STATUS_TYPES = [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES];
+const MIRROR_LIST_NON_COMPLETED_WHERE: Prisma.eformsign_docWhereInput = {
+    statusType: { notIn: COMPLETED_EFORMSIGN_STATUS_TYPES },
+};
+const MIRROR_LIST_VISIBILITY_WHERE: Prisma.eformsign_docWhereInput = {
+    OR: [
+        MIRROR_LIST_NON_COMPLETED_WHERE,
+        {
+            statusType: { in: COMPLETED_EFORMSIGN_STATUS_TYPES },
+            syncStatus: "ready",
+        },
+    ],
+};
+const RETRYABLE_MIRROR_SYNC_STATUSES = ["pending", "partial", "failed"] as const;
+
+const combineStatusGuards = (
+    guards: Prisma.eformsign_docWhereInput[],
+): Prisma.eformsign_docWhereInput => {
+    if (guards.length === 1) {
+        return guards[0] ?? {};
+    }
+    return guards.length > 1 ? { AND: guards } : {};
+};
 
 const toUnscopedResult = (
     documentId: string,
@@ -242,11 +267,26 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
         });
     }
 
+    async findAllVisibleInMirror(branchid: string): Promise<EformsignDocEntity[]> {
+        return this.findManyVisibleInMirror({ branchId: branchid });
+    }
+
     async findAllForHeadquarters(branchid: string): Promise<EformsignDocEntity[]> {
         // Mirrors the scan filter the API path uses: headquarters keeps everything except
         // what another branch owns, so an unclaimed document (branchId null) stays in.
         return this.findManyDomain({
             permanentPurgeRequestedAt: null,
+            OR: [
+                { branchId: branchid },
+                { branchId: null },
+            ],
+        });
+    }
+
+    async findAllVisibleInMirrorForHeadquarters(
+        branchid: string,
+    ): Promise<EformsignDocEntity[]> {
+        return this.findManyVisibleInMirror({
             OR: [
                 { branchId: branchid },
                 { branchId: null },
@@ -543,17 +583,26 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
         return { document: updated, applied: true };
     }
 
-    async upsertByDocumentId(branchid: string, doc: EformsignDocEntity): Promise<EformsignDocEntity> {
+    async upsertByDocumentId(
+        branchid: string,
+        doc: EformsignDocEntity,
+        options?: UpsertEformsignDocByDocumentIdOptions,
+    ): Promise<EformsignDocEntity> {
         const create = {
             ...EformsignDocMapper.toPrismaCreate(doc),
             branchId: branchid,
         };
-        const update: Partial<ReturnType<typeof EformsignDocMapper.toPrismaUpdate>> & {
-            branchId: string;
-        } = {
-            ...EformsignDocMapper.toPrismaUpdate(doc),
-            branchId: branchid,
-        };
+        const update: Partial<ReturnType<typeof EformsignDocMapper.toPrismaUpdate>>
+            & { branchId: string } = options?.preserveExistingMirrorProjection
+                ? {
+                    branchId: branchid,
+                    clientId: doc.clientId,
+                    documentKind: doc.documentKind,
+                }
+                : {
+                    ...EformsignDocMapper.toPrismaUpdate(doc),
+                    branchId: branchid,
+                };
         delete update.documentId;
 
         return this.conditionalUpsertByDocumentId({
@@ -591,6 +640,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
         };
         const update = {
             statusType: doc.statusType,
+            ...(options?.markMirrorPending ? { syncStatus: "pending" as const } : {}),
             ...(options?.updateStatusDetail === false ? {} : { statusDetail: doc.statusDetail }),
             stepType: doc.stepType,
             stepIndex: doc.stepIndex,
@@ -611,7 +661,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                 : {}),
         };
 
-        const statusGuards: Prisma.eformsign_docWhereInput[] = [
+        const baseStatusGuards: Prisma.eformsign_docWhereInput[] = [
             ...(UNASSIGNED_TERMINAL_STATUS_CODES.has(doc.statusType)
                 ? []
                 : [{
@@ -625,19 +675,58 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                     OR: [
                         {
                             statusType: {
-                                notIn: [...UNASSIGNED_REVIEW_STAGE_STATUS_CODES],
+                                notIn: [...UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES],
                             },
                         },
                         { statusType: doc.statusType },
                     ],
                 }]),
         ];
-        let statusGuard: Prisma.eformsign_docWhereInput = {};
-        if (statusGuards.length === 1) {
-            statusGuard = statusGuards[0] ?? {};
-        } else if (statusGuards.length > 1) {
-            statusGuard = { AND: statusGuards };
-        }
+        const statusGuards: Prisma.eformsign_docWhereInput[] = [
+            ...baseStatusGuards,
+            ...(options?.markMirrorPending
+                ? [{
+                    // The detail attempt is the publication owner. A list status can
+                    // intentionally lag behind a completion webhook, so it must never
+                    // authorize a same-generation ready/syncing row to move back to
+                    // pending. Same-generation repair is limited to retryable attempts
+                    // or a detail that itself is still at the review stage.
+                    OR: [
+                        { detailSourceUpdatedDate: null },
+                        { detailSourceUpdatedDate: { lt: doc.updatedDate } },
+                        {
+                            AND: [
+                                { detailSourceUpdatedDate: doc.updatedDate },
+                                {
+                                    OR: [
+                                        {
+                                            syncStatus: {
+                                                in: [...RETRYABLE_MIRROR_SYNC_STATUSES],
+                                            },
+                                        },
+                                        ...(UNASSIGNED_FORWARD_STATUS_CODES_AFTER_REVIEW_STAGE
+                                            .has(doc.statusType)
+                                            ? UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES
+                                                .map((statusType) => ({
+                                                    detailPayload: {
+                                                        path: [
+                                                            "current_status",
+                                                            "status_type",
+                                                        ],
+                                                        equals: statusType,
+                                                    },
+                                                }))
+                                            : []),
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                }]
+                : []),
+        ];
+        const statusGuard = combineStatusGuards(statusGuards);
+        const compatibilityStatusGuard = combineStatusGuards(baseStatusGuards);
 
         return this.conditionalUpsertByDocumentId({
             documentId: doc.documentId,
@@ -659,6 +748,19 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                 statusType: { notIn: DELETED_EFORMSIGN_STATUS_TYPES },
                 ...statusGuard,
             },
+            ...(options?.markMirrorPending
+                ? {
+                    // Before the mirror migration there is no detail generation or
+                    // syncStatus to fence. Keep the pre-mirror ordering/status guards
+                    // so a P2022 retry never references columns that do not exist.
+                    compatibilityStaleGuard: {
+                        updatedDate: { lte: doc.updatedDate },
+                        permanentPurgeRequestedAt: null,
+                        statusType: { notIn: DELETED_EFORMSIGN_STATUS_TYPES },
+                        ...compatibilityStatusGuard,
+                    },
+                }
+                : {}),
             // Creation time is not state, so a refusal on ordering grounds must not take
             // it down with the rest. It has to be that way: a row written by create or
             // adopt carries the moment we wrote it, which is *newer* than the vendor's own
@@ -676,19 +778,25 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
         update: Prisma.eformsign_docUpdateManyMutationInput;
         allowedWhere: Prisma.eformsign_docWhereInput;
         staleGuard?: Prisma.eformsign_docWhereInput;
+        compatibilityStaleGuard?: Prisma.eformsign_docWhereInput;
         repairCreatedDateWhenStale?: Date;
     }): Promise<EformsignDocEntity> {
+        const {
+            compatibilityStaleGuard,
+            ...attemptParams
+        } = params;
         try {
-            return await this.attemptConditionalUpsertByDocumentId(params);
+            return await this.attemptConditionalUpsertByDocumentId(attemptParams);
         } catch (error) {
             if (!isPendingEformsignDocColumnError(error)) {
                 throw error;
             }
 
             return this.attemptConditionalUpsertByDocumentId({
-                ...params,
-                create: omitPendingEformsignDocColumns(params.create, error),
-                update: omitPendingEformsignDocColumns(params.update, error),
+                ...attemptParams,
+                create: omitPendingEformsignDocColumns(attemptParams.create, error),
+                update: omitPendingEformsignDocColumns(attemptParams.update, error),
+                staleGuard: compatibilityStaleGuard ?? attemptParams.staleGuard,
             }, error);
         }
     }
@@ -829,6 +937,34 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
             const docs = await readWithEformsignDocCompat(error, (select) =>
                 this.prismaService.eformsign_doc.findMany({ where, select }));
             return docs.map((doc) => EformsignDocMapper.toDomain(toCompatDomainRow(doc)));
+        }
+    }
+
+    private async findManyVisibleInMirror(
+        scopeWhere: Prisma.eformsign_docWhereInput,
+    ): Promise<EformsignDocEntity[]> {
+        try {
+            return await this.findManyDomain({
+                permanentPurgeRequestedAt: null,
+                AND: [
+                    scopeWhere,
+                    MIRROR_LIST_VISIBILITY_WHERE,
+                ],
+            });
+        } catch (error) {
+            if (!isPendingEformsignDocColumnError(error)) {
+                throw error;
+            }
+
+            // During a code-first rollout sync_status may not exist yet. Without it,
+            // no completed document can be proven to contain both required PDFs.
+            return this.findManyDomain({
+                permanentPurgeRequestedAt: null,
+                AND: [
+                    scopeWhere,
+                    MIRROR_LIST_NON_COMPLETED_WHERE,
+                ],
+            });
         }
     }
 }

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -21,6 +21,7 @@ import {
 import {
     EFORMSIGN_DOC_DOMAIN_READ_SELECT,
     readWithEformsignDocCompat,
+    stripPendingEformsignDocPredicates,
     isPendingEformsignDocColumnError,
     omitPendingEformsignDocColumns,
     toCompatDomainRow,
@@ -809,7 +810,10 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
             }
 
             const doc = await readWithEformsignDocCompat(error, (select) =>
-                this.prismaService.eformsign_doc.findFirst({ where, select }));
+                this.prismaService.eformsign_doc.findFirst({
+                    where: stripPendingEformsignDocPredicates(where),
+                    select,
+                }));
             return doc ? EformsignDocMapper.toDomain(toCompatDomainRow(doc)) : null;
         }
     }
@@ -827,7 +831,10 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
             }
 
             const docs = await readWithEformsignDocCompat(error, (select) =>
-                this.prismaService.eformsign_doc.findMany({ where, select }));
+                this.prismaService.eformsign_doc.findMany({
+                    where: stripPendingEformsignDocPredicates(where),
+                    select,
+                }));
             return docs.map((doc) => EformsignDocMapper.toDomain(toCompatDomainRow(doc)));
         }
     }

--- a/backend/infrastructure/database/repositories/sb.eformsign-document-mirror.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-document-mirror.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
 
+import { EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES } from "domain/constants/eformsign-doc-status.constants";
 import {
     EformsignDocumentFileType,
     EformsignDocumentFileMetadata,
@@ -14,6 +15,7 @@ import {
     SaveEformsignDocumentFileParams,
 } from "domain/repositories/eformsign-document-mirror.repository.interface";
 import { EformsignApiDocumentResponse } from "domain/repositories/eformsign.client.interface";
+import { isPendingEformsignDocColumnError } from "infrastructure/database/eformsign-doc-compat";
 import { PrismaService } from "infrastructure/database/prisma.service";
 
 const MAX_SYNC_ERROR_LENGTH = 2_000;
@@ -132,6 +134,32 @@ implements IEformsignDocumentMirrorRepository {
             select: { documentId: true },
         });
         return rows.map((row) => row.documentId);
+    }
+
+    async findUnreadyCompletedDocumentIds(): Promise<string[]> {
+        try {
+            const rows = await this.prisma.eformsign_doc.findMany({
+                where: {
+                    statusType: { in: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES] },
+                    syncStatus: { not: "ready" },
+                },
+                select: { documentId: true },
+            });
+            return rows.map((row) => row.documentId);
+        } catch (error) {
+            if (!isPendingEformsignDocColumnError(error)) {
+                throw error;
+            }
+
+            // A database without sync_status cannot prove any completed row ready.
+            const rows = await this.prisma.eformsign_doc.findMany({
+                where: {
+                    statusType: { in: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES] },
+                },
+                select: { documentId: true },
+            });
+            return rows.map((row) => row.documentId);
+        }
     }
 
     async findPermanentPurgeRequestedDocumentIds(): Promise<string[]> {

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Controller, Post, Get, Delete, Body, Query, Param, HttpException, HttpStatus, UseGuards, Res, ServiceUnavailableException } from "@nestjs/common";
+import { BadRequestException, Controller, Post, Get, Head, Delete, Body, Query, Param, HttpException, HttpStatus, UseGuards, Res, ServiceUnavailableException } from "@nestjs/common";
 import { EformsignService } from "../../application/services/eformsign.service";
 import { EformsignDocService } from "../../application/services/eformsign-doc.service";
 import { AreaTemplateService } from "../../application/services/area-template.service";
@@ -791,6 +791,52 @@ export class EformsignController {
                 });
             }
             return document;
+        } catch (error) {
+            throwHttpOrInternalError(error);
+        }
+    }
+
+    /**
+     * Read document PDF metadata without loading the stored bytes.
+     */
+    @Head("documents/:documentId/download_files")
+    async headDocumentFile(
+        @CurrentTenant() tenant: { branchId?: string },
+        @Param("documentId") documentId: string,
+        @Query("fileType") fileType: string | undefined,
+        @Res() res: Response,
+    ) {
+        try {
+            const parsedFileType = parseDownloadFileType(fileType);
+            const allowedDocuments = await this.filterDocumentsByBranch(
+                tenant.branchId ?? "",
+                [{ id: documentId }],
+            );
+            if (allowedDocuments.length === 0) {
+                throw new HttpException(
+                    { error: "Document access forbidden" },
+                    HttpStatus.FORBIDDEN,
+                );
+            }
+            const file = await this.documentMirrorService.getStoredFileMetadata(
+                documentId,
+                parsedFileType,
+            );
+            if (!file) {
+                throw new ServiceUnavailableException({
+                    error: "Document file is waiting for local synchronization",
+                    documentId,
+                    fileType: parsedFileType,
+                });
+            }
+
+            res.status(file.status);
+            res.set({
+                "Content-Type": file.contentType,
+                ...(file.contentDisposition ? { "Content-Disposition": file.contentDisposition } : {}),
+                "Content-Length": String(file.byteSize),
+            });
+            res.end();
         } catch (error) {
             throwHttpOrInternalError(error);
         }

--- a/backend/test/infrastructure/eformsign-doc-compat.spec.ts
+++ b/backend/test/infrastructure/eformsign-doc-compat.spec.ts
@@ -3,6 +3,7 @@ import {
     eformsignDocCompatReadSelect,
     omitPendingEformsignDocColumns,
     readWithEformsignDocCompat,
+    stripPendingEformsignDocPredicates,
     toCompatDomainRow,
 } from "infrastructure/database/eformsign-doc-compat";
 
@@ -47,6 +48,23 @@ describe("eformsignDocCompatReadSelect", () => {
         ]) {
             expect(select[column as keyof typeof select]).toBeUndefined();
         }
+    });
+
+    it("keeps everything up to the newest migration when only it is missing", () => {
+        // The purge-intent migration is the newest group; a database missing only it must
+        // still return every column the four earlier migrations added.
+        const select = eformsignDocCompatReadSelect(
+            missingColumnError("permanent_purge_requested_at"),
+        );
+
+        expect(select).toMatchObject({
+            templateId: true,
+            documentName: true,
+            customerName: true,
+            detailPayload: true,
+            syncStatus: true,
+        });
+        expect(select["permanentPurgeRequestedAt" as keyof typeof select]).toBeUndefined();
     });
 
     it("falls back to the floor when the oldest migration is the missing one", () => {
@@ -107,6 +125,50 @@ describe("readWithEformsignDocCompat", () => {
         await readWithEformsignDocCompat(missingColumnError("customer_name"), read);
 
         expect(read).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("stripPendingEformsignDocPredicates", () => {
+    it("drops an is-null test for a column the database may not have", () => {
+        // Narrowing the select is only half a compatibility read: nearly every document
+        // filter carries `permanentPurgeRequestedAt: null`, and a predicate naming a
+        // missing column fails whatever is selected. Dropping it is a semantic identity —
+        // with no column, no row can carry a value, so "is null" is true of every row.
+        expect(stripPendingEformsignDocPredicates({
+            branchId: "branch-1",
+            permanentPurgeRequestedAt: null,
+        })).toEqual({ branchId: "branch-1" });
+    });
+
+    it("reaches into AND, OR and NOT", () => {
+        expect(stripPendingEformsignDocPredicates({
+            AND: [
+                { branchId: "branch-1" },
+                { permanentPurgeRequestedAt: null },
+                { OR: [{ templateId: null }, { documentId: "doc-1" }] },
+            ],
+        })).toEqual({
+            AND: [
+                { branchId: "branch-1" },
+                {},
+                { OR: [{}, { documentId: "doc-1" }] },
+            ],
+        });
+    });
+
+    it("leaves any comparison other than is-null alone", () => {
+        // `{ not: null }` means the opposite, and without the column it would flip from
+        // matching nothing to matching everything. Better to fail loudly than to answer
+        // a different question than the caller asked.
+        const where = { permanentPurgeRequestedAt: { not: null } };
+
+        expect(stripPendingEformsignDocPredicates(where)).toEqual(where);
+    });
+
+    it("leaves a filter with no pending columns untouched", () => {
+        const where = { branchId: "branch-1", documentId: "doc-1" };
+
+        expect(stripPendingEformsignDocPredicates(where)).toEqual(where);
     });
 });
 

--- a/backend/test/infrastructure/eformsign-doc-compat.spec.ts
+++ b/backend/test/infrastructure/eformsign-doc-compat.spec.ts
@@ -61,10 +61,29 @@ describe("eformsignDocCompatReadSelect", () => {
             templateId: true,
             documentName: true,
             customerName: true,
-            detailPayload: true,
-            syncStatus: true,
         });
         expect(select["permanentPurgeRequestedAt" as keyof typeof select]).toBeUndefined();
+    });
+
+    it("never widens past the projection the caller asked for", () => {
+        // The list select deliberately leaves detailPayload out — it is unbounded JSON and
+        // a page view would read one per row. A retry that selected every surviving pending
+        // column would have quietly reintroduced it for the whole deployment window.
+        const select = eformsignDocCompatReadSelect(
+            missingColumnError("permanent_purge_requested_at"),
+        );
+
+        expect(select["detailPayload" as keyof typeof select]).toBeUndefined();
+        expect(select["syncStatus" as keyof typeof select]).toBeUndefined();
+    });
+
+    it("still returns a pending column when the caller does want it", () => {
+        const select = eformsignDocCompatReadSelect(
+            missingColumnError("permanent_purge_requested_at"),
+            { documentId: true, detailPayload: true },
+        );
+
+        expect(select).toMatchObject({ detailPayload: true });
     });
 
     it("falls back to the floor when the oldest migration is the missing one", () => {
@@ -134,26 +153,46 @@ describe("stripPendingEformsignDocPredicates", () => {
         // filter carries `permanentPurgeRequestedAt: null`, and a predicate naming a
         // missing column fails whatever is selected. Dropping it is a semantic identity —
         // with no column, no row can carry a value, so "is null" is true of every row.
-        expect(stripPendingEformsignDocPredicates({
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
             branchId: "branch-1",
             permanentPurgeRequestedAt: null,
         })).toEqual({ branchId: "branch-1" });
     });
 
-    it("reaches into AND, OR and NOT", () => {
-        expect(stripPendingEformsignDocPredicates({
+    it("reaches into AND, where deleting a true leaf changes nothing", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
             AND: [
                 { branchId: "branch-1" },
                 { permanentPurgeRequestedAt: null },
-                { OR: [{ templateId: null }, { documentId: "doc-1" }] },
             ],
         })).toEqual({
             AND: [
                 { branchId: "branch-1" },
                 {},
-                { OR: [{}, { documentId: "doc-1" }] },
             ],
         });
+    });
+
+    it.each([
+        ["OR", { OR: [{ templateId: null }, { documentId: "doc-1" }] }],
+        ["NOT", { NOT: { templateId: null } }],
+    ])("leaves %s alone rather than changing what it means", (_operator, where) => {
+        // An empty object is not the true this leaf stood for. Under OR a true leaf makes
+        // the whole branch true, so dropping it would narrow the query to the other terms;
+        // under NOT it makes the branch false, so dropping it would widen to everything.
+        // Both are silently wrong answers, and a loud failure is the better one.
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), where))
+            .toEqual(where);
+    });
+
+    it("keeps a predicate whose column an earlier migration already added", () => {
+        // Only the missing group and later ones are vacuous. `templateId` shipped with the
+        // first group, so when a later migration is the missing one it is still there —
+        // dropping its predicate would widen the retry past what the caller asked for.
+        expect(stripPendingEformsignDocPredicates(
+            missingColumnError("permanent_purge_requested_at"),
+            { templateId: null, permanentPurgeRequestedAt: null },
+        )).toEqual({ templateId: null });
     });
 
     it("leaves any comparison other than is-null alone", () => {
@@ -162,13 +201,13 @@ describe("stripPendingEformsignDocPredicates", () => {
         // a different question than the caller asked.
         const where = { permanentPurgeRequestedAt: { not: null } };
 
-        expect(stripPendingEformsignDocPredicates(where)).toEqual(where);
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), where)).toEqual(where);
     });
 
     it("leaves a filter with no pending columns untouched", () => {
         const where = { branchId: "branch-1", documentId: "doc-1" };
 
-        expect(stripPendingEformsignDocPredicates(where)).toEqual(where);
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), where)).toEqual(where);
     });
 });
 

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -79,6 +79,7 @@ describe("EformsignController (Integration)", () => {
     const documentMirrorService = {
         getStoredDetail: jest.fn(),
         getStoredFile: jest.fn(),
+        getStoredFileMetadata: jest.fn(),
         markDocumentsDeleted: jest.fn(),
         purgeDocuments: jest.fn(),
         requestPermanentPurge: jest.fn(),
@@ -94,6 +95,7 @@ describe("EformsignController (Integration)", () => {
         shadowCompareService.compareInBackground.mockClear();
         documentMirrorService.getStoredDetail.mockReset();
         documentMirrorService.getStoredFile.mockReset();
+        documentMirrorService.getStoredFileMetadata.mockReset();
         documentMirrorService.markDocumentsDeleted.mockReset();
         documentMirrorService.purgeDocuments.mockReset();
         documentMirrorService.requestPermanentPurge.mockReset();
@@ -215,6 +217,7 @@ describe("EformsignController (Integration)", () => {
             async (documentId: string) => ({ id: documentId }),
         );
         documentMirrorService.getStoredFile.mockResolvedValue(null);
+        documentMirrorService.getStoredFileMetadata.mockResolvedValue(null);
         documentMirrorService.markDocumentsDeleted.mockResolvedValue(undefined);
         documentMirrorService.purgeDocuments.mockResolvedValue(undefined);
         documentMirrorService.requestPermanentPurge.mockImplementation(
@@ -620,6 +623,31 @@ describe("EformsignController (Integration)", () => {
             .get("/api/documents/doc-1/download_files?accessToken=access-token&fileType=zip");
 
         expect(response.status).toBe(400);
+        expect(documentMirrorService.getStoredFile).not.toHaveBeenCalled();
+    });
+
+    it("serves document PDF metadata for HEAD without loading stored bytes", async () => {
+        eformsignDocService.findAll.mockResolvedValue([
+            { documentId: "branch-1-doc" },
+        ] as any);
+        documentMirrorService.getStoredFileMetadata.mockResolvedValue({
+            status: 200,
+            contentType: "application/pdf",
+            contentDisposition: "inline",
+            byteSize: 321,
+        });
+
+        const response = await request(app.getHttpServer())
+            .head("/api/documents/branch-1-doc/download_files?fileType=document");
+
+        expect(response.status).toBe(200);
+        expect(response.headers["content-type"]).toContain("application/pdf");
+        expect(response.headers["content-length"]).toBe("321");
+        expect(response.text).toBeUndefined();
+        expect(documentMirrorService.getStoredFileMetadata).toHaveBeenCalledWith(
+            "branch-1-doc",
+            "document",
+        );
         expect(documentMirrorService.getStoredFile).not.toHaveBeenCalled();
     });
 

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -86,6 +86,7 @@ describe("EformsignController (Integration)", () => {
     };
     const permanentPurgeLookup = {
         findListExcludedDocumentIds: jest.fn().mockResolvedValue([]),
+        findUnreadyCompletedDocumentIds: jest.fn().mockResolvedValue([]),
         findPermanentPurgeRequestedDocumentIds: jest.fn().mockResolvedValue([]),
     };
 
@@ -99,6 +100,8 @@ describe("EformsignController (Integration)", () => {
         documentMirrorService.clearPermanentPurgeRequest.mockReset();
         permanentPurgeLookup.findListExcludedDocumentIds.mockReset();
         permanentPurgeLookup.findListExcludedDocumentIds.mockResolvedValue([]);
+        permanentPurgeLookup.findUnreadyCompletedDocumentIds.mockReset();
+        permanentPurgeLookup.findUnreadyCompletedDocumentIds.mockResolvedValue([]);
         permanentPurgeLookup.findPermanentPurgeRequestedDocumentIds.mockReset();
         permanentPurgeLookup.findPermanentPurgeRequestedDocumentIds.mockResolvedValue([]);
         const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -701,8 +704,8 @@ describe("EformsignController (Integration)", () => {
     describe("local source-of-truth document reads", () => {
         let mirrorApp: INestApplication;
         const mirrorRepository = {
-            findAll: jest.fn().mockResolvedValue([]),
-            findAllForHeadquarters: jest.fn().mockResolvedValue([]),
+            findAllVisibleInMirror: jest.fn().mockResolvedValue([]),
+            findAllVisibleInMirrorForHeadquarters: jest.fn().mockResolvedValue([]),
         };
 
         const createMirrorRow = (overrides: {
@@ -744,8 +747,8 @@ describe("EformsignController (Integration)", () => {
         };
 
         beforeEach(async () => {
-            mirrorRepository.findAll.mockResolvedValue([]);
-            mirrorRepository.findAllForHeadquarters.mockResolvedValue([]);
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([]);
+            mirrorRepository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([]);
             const fixture = await Test.createTestingModule({
                 controllers: [EformsignController],
                 providers: [
@@ -792,7 +795,7 @@ describe("EformsignController (Integration)", () => {
         });
 
         it("paginates the mirror without calling eformsign", async () => {
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-old", createdDate: "2026-07-01T00:00:00.000Z" }),
                 createMirrorRow({ documentId: "doc-new", createdDate: "2026-07-02T00:00:00.000Z" }),
             ]);
@@ -813,10 +816,10 @@ describe("EformsignController (Integration)", () => {
             expect(shadowCompareService.compareInBackground).not.toHaveBeenCalled();
         });
 
-        it("keeps paging over one generation when the list changes underneath", async () => {
-            // 페이지 사이에 문서가 목록에서 빠지면, 매 요청 새로 만들던 시절에는 나머지가
-            // 한 칸씩 당겨져 마지막 문서를 영영 못 보게 된다. 스냅샷 세대가 그걸 막는다.
-            mirrorRepository.findAll.mockResolvedValue([
+        it("changes the generation when the local mirror list moves between pages", async () => {
+            // 페이지 사이에 로컬 미러가 바뀌면 새 세대를 발행한다. 클라이언트는 이 신호를
+            // 보고 첫 페이지부터 다시 읽으므로 이동한 문서를 조용히 건너뛰지 않는다.
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-1", createdDate: "2026-07-03T00:00:00.000Z" }),
                 createMirrorRow({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
             ]);
@@ -824,22 +827,25 @@ describe("EformsignController (Integration)", () => {
             const first = await request(mirrorApp.getHttpServer())
                 .get("/api/documents?accessToken=access-token&limit=1&skip=0");
             expect(first.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-1"]);
+            expect(typeof first.body.snapshot_version).toBe("string");
 
-            // 첫 페이지의 문서가 사라져도 두 번째 페이지는 같은 세대에서 잘린다.
-            mirrorRepository.findAll.mockResolvedValue([
+            // 첫 페이지의 문서가 사라지면 stale 세대를 재사용하지 않고 새 세대를 돌려준다.
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
             ]);
             const second = await request(mirrorApp.getHttpServer())
                 .get("/api/documents?accessToken=access-token&limit=1&skip=1");
 
-            expect(second.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-2"]);
+            expect(second.body.documents).toEqual([]);
             expect(second.body.has_more).toBe(false);
+            expect(typeof second.body.snapshot_version).toBe("string");
+            expect(second.body.snapshot_version).not.toBe(first.body.snapshot_version);
         });
 
         it("reports the generation so the client can notice the list moved", async () => {
             // 클라이언트는 뒤 페이지의 snapshot_version이 다르면 페이지네이션을 리셋한다.
             // 이 값을 빼면 목록이 아래에서 밀려도 신호가 없어 문서를 조용히 건너뛴다.
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-1" }),
             ]);
 
@@ -850,7 +856,7 @@ describe("EformsignController (Integration)", () => {
         });
 
         it("answers each tab from status codes", async () => {
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-open", statusType: "060" }),
                 createMirrorRow({ documentId: "doc-done", statusType: "050" }),
                 createMirrorRow({ documentId: "doc-gone", statusType: "080" }),
@@ -872,7 +878,7 @@ describe("EformsignController (Integration)", () => {
         });
 
         it("keeps a stale tombstone in unfiltered all reads but fences it from deletion-aware filters", async () => {
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-tombstone", statusType: "060" }),
             ]);
 
@@ -890,7 +896,7 @@ describe("EformsignController (Integration)", () => {
 
             // Simulate a failed invalidation: the cached entry remains pre-delete, but
             // the durable local row is now a deletion tombstone.
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-tombstone", statusType: "049" }),
             ]);
             permanentPurgeLookup.findListExcludedDocumentIds.mockResolvedValue([
@@ -918,7 +924,7 @@ describe("EformsignController (Integration)", () => {
         });
 
         it("shows the customer name on the page it returns", async () => {
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-1", customerName: "최고객" }),
             ]);
 
@@ -932,7 +938,7 @@ describe("EformsignController (Integration)", () => {
 
         it("reads the headquarters scope, including unclaimed documents", async () => {
             branchFindUnique.mockResolvedValue({ slug: "incheon" });
-            mirrorRepository.findAllForHeadquarters.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-unclaimed" }),
             ]);
 
@@ -940,7 +946,8 @@ describe("EformsignController (Integration)", () => {
                 .get("/api/documents?accessToken=access-token");
 
             expect(response.status).toBe(200);
-            expect(mirrorRepository.findAllForHeadquarters).toHaveBeenCalledWith("branch-1");
+            expect(mirrorRepository.findAllVisibleInMirrorForHeadquarters)
+                .toHaveBeenCalledWith("branch-1");
             expect(response.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-unclaimed"]);
         });
 
@@ -950,10 +957,10 @@ describe("EformsignController (Integration)", () => {
             // 이 값을 쓰지 않는다(단건 조회로 넘어간다). 틀린 이름을 보여주는 것보다
             // 비워 두는 편이 낫고, 웹훅이 한 번이라도 닿으면 진짜 고객명이 채워진다.
             branchFindUnique.mockResolvedValue({ slug: "incheon" });
-            mirrorRepository.findAllForHeadquarters.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-unclaimed", customerName: null }),
             ]);
-            mirrorRepository.findAll.mockResolvedValue([]);
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([]);
 
             const response = await request(mirrorApp.getHttpServer())
                 .get("/api/documents?accessToken=access-token");
@@ -962,7 +969,7 @@ describe("EformsignController (Integration)", () => {
         });
 
         it("still names a branch-owned document from its recipient", async () => {
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-owned", customerName: null }),
             ]);
 
@@ -978,10 +985,10 @@ describe("EformsignController (Integration)", () => {
             // 표시용과 검색용은 분리돼 있다. 서빙 경로는 findAll(branchId)로 검색 코퍼스를
             // 만들어 미배정 문서의 수신자명을 찾지 못하므로, 여기서도 찾으면 안 된다.
             branchFindUnique.mockResolvedValue({ slug: "incheon" });
-            mirrorRepository.findAllForHeadquarters.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-unclaimed", customerName: null }),
             ]);
-            mirrorRepository.findAll.mockResolvedValue([]);
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([]);
 
             const response = await request(mirrorApp.getHttpServer())
                 .get("/api/documents?accessToken=access-token&search=%EC%86%A1%EC%A7%84%ED%98%B8");
@@ -990,7 +997,7 @@ describe("EformsignController (Integration)", () => {
         });
 
         it("counts statuses from the same generation the list pages over", async () => {
-            mirrorRepository.findAll.mockResolvedValue([
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-1", statusType: "060" }),
                 createMirrorRow({ documentId: "doc-2", statusType: "050" }),
             ]);

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -816,9 +816,9 @@ describe("EformsignController (Integration)", () => {
             expect(shadowCompareService.compareInBackground).not.toHaveBeenCalled();
         });
 
-        it("changes the generation when the local mirror list moves between pages", async () => {
-            // 페이지 사이에 로컬 미러가 바뀌면 새 세대를 발행한다. 클라이언트는 이 신호를
-            // 보고 첫 페이지부터 다시 읽으므로 이동한 문서를 조용히 건너뛰지 않는다.
+        it("keeps the cached generation stable when the local mirror moves between pages", async () => {
+            // 이미 배포된 클라이언트는 snapshot_version을 해석하지 않을 수 있다.
+            // 캐시 hit에서 live 목록으로 바꾸지 않아 offset이 같은 세대를 계속 걷게 한다.
             mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-1", createdDate: "2026-07-03T00:00:00.000Z" }),
                 createMirrorRow({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
@@ -828,18 +828,21 @@ describe("EformsignController (Integration)", () => {
                 .get("/api/documents?accessToken=access-token&limit=1&skip=0");
             expect(first.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-1"]);
             expect(typeof first.body.snapshot_version).toBe("string");
+            const callsAfterFirstPage = mirrorRepository.findAllVisibleInMirror.mock.calls.length;
 
-            // 첫 페이지의 문서가 사라지면 stale 세대를 재사용하지 않고 새 세대를 돌려준다.
+            // 첫 페이지 뒤에 live 목록이 바뀌어도 두 번째 페이지는 저장된 세대의 doc-2다.
             mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
                 createMirrorRow({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
             ]);
             const second = await request(mirrorApp.getHttpServer())
                 .get("/api/documents?accessToken=access-token&limit=1&skip=1");
 
-            expect(second.body.documents).toEqual([]);
+            expect(second.body.documents.map((d: { id: string }) => d.id)).toEqual(["doc-2"]);
             expect(second.body.has_more).toBe(false);
-            expect(typeof second.body.snapshot_version).toBe("string");
-            expect(second.body.snapshot_version).not.toBe(first.body.snapshot_version);
+            expect(second.body.snapshot_version).toBe(first.body.snapshot_version);
+            expect(mirrorRepository.findAllVisibleInMirror).toHaveBeenCalledTimes(
+                callsAfterFirstPage,
+            );
         });
 
         it("reports the generation so the client can notice the list moved", async () => {

--- a/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
@@ -99,11 +99,15 @@ describe("SbEformsignDocRepository", () => {
         });
         expect(eformsignDocModel.findMany.mock.calls[0][0].select)
             .not.toHaveProperty("detailPayload");
+        // The retry drops `permanentPurgeRequestedAt: null` from the filter. A predicate
+        // naming a column the database does not have fails whatever is selected, so
+        // narrowing the select alone left the retry failing exactly like the first
+        // attempt. Dropping an "is null" test for a non-existent column changes nothing:
+        // with no column, no row can carry a value.
         expect(eformsignDocModel.findMany).toHaveBeenNthCalledWith(2, {
             where: {
                 clientId: 55,
                 branchId: "branch-1",
-                permanentPurgeRequestedAt: null,
             },
             select: expect.objectContaining({
                 documentId: true,
@@ -182,7 +186,6 @@ describe("SbEformsignDocRepository", () => {
             where: {
                 documentId: "doc-1",
                 branchId: "branch-1",
-                permanentPurgeRequestedAt: null,
             },
             select: expect.objectContaining({
                 documentId: true,

--- a/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
@@ -1,8 +1,10 @@
 import { SbEformsignDocRepository } from "infrastructure/database/repositories/sb.eformsign-doc.repository";
 import { PrismaService } from "infrastructure/database/prisma.service";
 import {
+    EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES,
     UNASSIGNED_FORWARD_STATUS_CODES_AFTER_REVIEW_STAGE,
     UNASSIGNED_REVIEW_STAGE_STATUS_CODES,
+    UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES,
     UNASSIGNED_TERMINAL_STATUS_CODES,
 } from "domain/constants/eformsign-doc-status.constants";
 import { EformsignDocEntity } from "domain/entities/eformsign-doc.entity";
@@ -162,6 +164,118 @@ describe("SbEformsignDocRepository", () => {
                 ],
             },
         }));
+    });
+
+    it("shows completed branch documents only after the mirror is ready", async () => {
+        eformsignDocModel.findMany.mockResolvedValue([legacyRow]);
+
+        await expect(repository.findAllVisibleInMirror("branch-1")).resolves.toHaveLength(1);
+
+        const completedStatuses = [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES];
+        expect(eformsignDocModel.findMany).toHaveBeenCalledWith(expect.objectContaining({
+            where: {
+                permanentPurgeRequestedAt: null,
+                AND: [
+                    { branchId: "branch-1" },
+                    {
+                        OR: [
+                            { statusType: { notIn: completedStatuses } },
+                            {
+                                statusType: { in: completedStatuses },
+                                syncStatus: "ready",
+                            },
+                        ],
+                    },
+                ],
+            },
+        }));
+    });
+
+    it("applies the same completed-ready gate to headquarters and unclaimed rows", async () => {
+        eformsignDocModel.findMany.mockResolvedValue([legacyRow]);
+
+        await expect(repository.findAllVisibleInMirrorForHeadquarters("branch-1"))
+            .resolves.toHaveLength(1);
+
+        const completedStatuses = [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES];
+        expect(eformsignDocModel.findMany).toHaveBeenCalledWith(expect.objectContaining({
+            where: {
+                permanentPurgeRequestedAt: null,
+                AND: [
+                    {
+                        OR: [
+                            { branchId: "branch-1" },
+                            { branchId: null },
+                        ],
+                    },
+                    {
+                        OR: [
+                            { statusType: { notIn: completedStatuses } },
+                            {
+                                statusType: { in: completedStatuses },
+                                syncStatus: "ready",
+                            },
+                        ],
+                    },
+                ],
+            },
+        }));
+    });
+
+    it.each([
+        {
+            label: "branch",
+            read: (subject: SbEformsignDocRepository) =>
+                subject.findAllVisibleInMirror("branch-1"),
+            scope: { branchId: "branch-1" },
+        },
+        {
+            label: "headquarters",
+            read: (subject: SbEformsignDocRepository) =>
+                subject.findAllVisibleInMirrorForHeadquarters("branch-1"),
+            scope: {
+                OR: [
+                    { branchId: "branch-1" },
+                    { branchId: null },
+                ],
+            },
+        },
+    ])("fails closed for completed $label rows when sync_status is not deployed", async ({
+        read,
+        scope,
+    }) => {
+        const missingSyncStatus = Object.assign(
+            new Error("The column `eformsign_doc.sync_status` does not exist"),
+            {
+                code: "P2022",
+                meta: { column: "eformsign_doc.sync_status" },
+            },
+        );
+        eformsignDocModel.findMany.mockImplementation(async (query: {
+            where?: unknown;
+        }) => {
+            if (JSON.stringify(query.where).includes("syncStatus")) {
+                throw missingSyncStatus;
+            }
+            return [legacyRow];
+        });
+
+        await expect(read(repository)).resolves.toHaveLength(1);
+
+        expect(eformsignDocModel.findMany).toHaveBeenLastCalledWith({
+            where: {
+                permanentPurgeRequestedAt: null,
+                AND: [
+                    scope,
+                    {
+                        statusType: {
+                            notIn: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES],
+                        },
+                    },
+                ],
+            },
+            select: expect.any(Object),
+        });
     });
 
     it("retries document reads when Prisma reports P2022 without column metadata", async () => {
@@ -573,6 +687,62 @@ describe("SbEformsignDocRepository", () => {
         expect(eformsignDocModel.create).not.toHaveBeenCalled();
     });
 
+    it("updates only ownership when adoption must preserve an existing ready projection", async () => {
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 1 });
+        eformsignDocModel.findFirst.mockResolvedValue({
+            ...legacyRow,
+            branchId: "branch-1",
+            documentKind: "contract",
+            employeeScheduleId: null,
+            templateId: "template-1",
+        });
+
+        await repository.upsertByDocumentId("branch-1", createEntity(), {
+            preserveExistingMirrorProjection: true,
+        });
+
+        expect(eformsignDocModel.updateMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: {
+                    branchId: "branch-1",
+                    clientId: 55,
+                    documentKind: null,
+                },
+            }),
+        );
+        const update = eformsignDocModel.updateMany.mock.calls[0][0].data;
+        expect(update).not.toHaveProperty("statusType");
+        expect(update).not.toHaveProperty("statusDetail");
+        expect(update).not.toHaveProperty("updatedDate");
+        expect(update).not.toHaveProperty("stepType");
+        expect(update).not.toHaveProperty("templateId");
+        expect(update).not.toHaveProperty("expired");
+        expect(update).not.toHaveProperty("syncStatus");
+    });
+
+    it("still creates a complete pending projection for a newly adopted document", async () => {
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 0 });
+        eformsignDocModel.create.mockResolvedValue({
+            ...legacyRow,
+            branchId: "branch-1",
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: null,
+        });
+
+        await repository.upsertByDocumentId("branch-1", createEntity(), {
+            preserveExistingMirrorProjection: true,
+        });
+
+        expect(eformsignDocModel.create).toHaveBeenCalledWith({
+            data: expect.objectContaining({
+                documentId: "doc-1",
+                branchId: "branch-1",
+                statusType: "050",
+            }),
+        });
+    });
+
     it("retries the conditional documentId update and read without pending columns", async () => {
         eformsignDocModel.updateMany
             .mockRejectedValueOnce(pendingColumnError)
@@ -774,6 +944,197 @@ describe("SbEformsignDocRepository", () => {
         expect(args.data).not.toHaveProperty("snapshotChunkIndex");
     });
 
+    it("atomically withdraws a completed projection before mirror files are synchronized", async () => {
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 1 });
+        eformsignDocModel.findFirst.mockResolvedValue({
+            ...legacyRow,
+            branchId: "branch-1",
+        });
+
+        await repository.upsertUnassignedByDocumentId(createEntity(), {
+            allowAssignedUpdate: true,
+            markMirrorPending: true,
+        });
+
+        const update = eformsignDocModel.updateMany.mock.calls[0][0];
+        expect(update.data)
+            .toEqual(expect.objectContaining({ statusType: "050", syncStatus: "pending" }));
+        const staleGuard = update.where.AND[1];
+        expect(staleGuard.OR).toContainEqual({
+            detailSourceUpdatedDate: { lt: legacyRow.updatedDate },
+        });
+        expect(staleGuard.OR).toContainEqual({
+            AND: expect.arrayContaining([
+                { detailSourceUpdatedDate: legacyRow.updatedDate },
+                {
+                    OR: expect.arrayContaining([
+                        { syncStatus: { in: ["pending", "partial", "failed"] } },
+                        {
+                            detailPayload: {
+                                path: ["current_status", "status_type"],
+                                equals: "062",
+                            },
+                        },
+                        {
+                            detailPayload: {
+                                path: ["current_status", "status_type"],
+                                equals: "doc_reject_reviewer",
+                            },
+                        },
+                    ]),
+                },
+            ]),
+        });
+        expect(JSON.stringify(staleGuard)).not.toContain(
+            JSON.stringify({
+                statusType: {
+                    notIn: [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES],
+                },
+            }),
+        );
+    });
+
+    it.each(["072", "050"])(
+        "allows a same-generation review-stage row to advance to terminal status %s",
+        async (statusType) => {
+            eformsignDocModel.updateMany.mockResolvedValue({ count: 1 });
+            eformsignDocModel.findFirst.mockResolvedValue({
+                ...legacyRow,
+                statusType,
+                branchId: "branch-1",
+            });
+            const incoming = EformsignDocEntity.reconstitute({
+                ...legacyRow,
+                statusType,
+                documentKind: null,
+                employeeScheduleId: null,
+                templateId: null,
+            });
+
+            await repository.upsertUnassignedByDocumentId(incoming, {
+                allowAssignedUpdate: true,
+                markMirrorPending: true,
+            });
+
+            const staleGuard = eformsignDocModel.updateMany.mock.calls[0][0].where.AND[1];
+            expect(staleGuard.OR).toContainEqual({
+                AND: expect.arrayContaining([
+                    { detailSourceUpdatedDate: legacyRow.updatedDate },
+                    {
+                        OR: expect.arrayContaining([
+                            {
+                                detailPayload: {
+                                    path: ["current_status", "status_type"],
+                                    equals: "062",
+                                },
+                            },
+                            {
+                                detailPayload: {
+                                    path: ["current_status", "status_type"],
+                                    equals: "071",
+                                },
+                            },
+                        ]),
+                    },
+                ]),
+            });
+        },
+    );
+
+    it("refuses a same-generation retry of an already terminal status", async () => {
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 0 });
+        eformsignDocModel.create.mockRejectedValue(
+            Object.assign(new Error("Unique constraint failed"), { code: "P2002" }),
+        );
+        eformsignDocModel.count.mockResolvedValue(1);
+
+        await expect(repository.upsertUnassignedByDocumentId(createEntity(), {
+            allowAssignedUpdate: true,
+            markMirrorPending: true,
+        })).rejects.toBeInstanceOf(EformsignDocStaleUpdateError);
+
+        const staleGuard = eformsignDocModel.updateMany.mock.calls[0][0].where.AND[1];
+        expect(staleGuard.OR).toEqual([
+            { detailSourceUpdatedDate: null },
+            { detailSourceUpdatedDate: { lt: legacyRow.updatedDate } },
+            {
+                AND: expect.arrayContaining([
+                    { detailSourceUpdatedDate: legacyRow.updatedDate },
+                    {
+                        OR: expect.arrayContaining([
+                            { syncStatus: { in: ["pending", "partial", "failed"] } },
+                        ]),
+                    },
+                ]),
+            },
+        ]);
+    });
+
+    it("refuses a same-generation terminal row moving back to review stage", async () => {
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 0 });
+        eformsignDocModel.create.mockRejectedValue(
+            Object.assign(new Error("Unique constraint failed"), { code: "P2002" }),
+        );
+        eformsignDocModel.count.mockResolvedValue(1);
+        const incoming = EformsignDocEntity.reconstitute({
+            ...legacyRow,
+            statusType: "062",
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: null,
+        });
+
+        await expect(repository.upsertUnassignedByDocumentId(incoming, {
+            allowAssignedUpdate: true,
+            markMirrorPending: true,
+        })).rejects.toBeInstanceOf(EformsignDocStaleUpdateError);
+
+        const staleGuard = eformsignDocModel.updateMany.mock.calls[0][0].where.AND[1];
+        expect(staleGuard.AND[1].OR).toEqual(expect.arrayContaining([
+            { detailSourceUpdatedDate: null },
+            { detailSourceUpdatedDate: { lt: legacyRow.updatedDate } },
+            {
+                AND: expect.arrayContaining([
+                    { detailSourceUpdatedDate: legacyRow.updatedDate },
+                    {
+                        OR: expect.arrayContaining([
+                            { syncStatus: { in: ["pending", "partial", "failed"] } },
+                        ]),
+                    },
+                ]),
+            },
+        ]));
+    });
+
+    it("allows a newer terminal generation regardless of the stored completion status", async () => {
+        const newerUpdatedDate = new Date("2026-07-02T00:00:00.000Z");
+        eformsignDocModel.updateMany.mockResolvedValue({ count: 1 });
+        eformsignDocModel.findFirst.mockResolvedValue({
+            ...legacyRow,
+            updatedDate: newerUpdatedDate,
+            statusType: "072",
+            branchId: "branch-1",
+        });
+        const incoming = EformsignDocEntity.reconstitute({
+            ...legacyRow,
+            updatedDate: newerUpdatedDate,
+            statusType: "072",
+            documentKind: null,
+            employeeScheduleId: null,
+            templateId: null,
+        });
+
+        await repository.upsertUnassignedByDocumentId(incoming, {
+            allowAssignedUpdate: true,
+            markMirrorPending: true,
+        });
+
+        const staleGuard = eformsignDocModel.updateMany.mock.calls[0][0].where.AND[1];
+        expect(staleGuard.OR).toContainEqual({
+            detailSourceUpdatedDate: { lt: newerUpdatedDate },
+        });
+    });
+
     it("creates a newly discovered document with every local-only field unassigned", async () => {
         eformsignDocModel.updateMany.mockResolvedValue({ count: 0 });
         eformsignDocModel.create.mockResolvedValue({
@@ -886,6 +1247,10 @@ describe("SbEformsignDocRepository", () => {
         ["062", "063"],
         ["071", "060"],
         ["071", "063"],
+        ["62", "060"],
+        ["71", "060"],
+        ["doc_accept_participant", "060"],
+        ["doc_reject_reviewer", "060"],
     ])(
         "blocks review-stage status %s from transitioning backward to %s in the updateMany predicate",
         async (storedStatus, incomingStatus) => {
@@ -916,7 +1281,7 @@ describe("SbEformsignDocRepository", () => {
                     OR: [
                         {
                             statusType: {
-                                notIn: [...UNASSIGNED_REVIEW_STAGE_STATUS_CODES],
+                                notIn: [...UNASSIGNED_REVIEW_STAGE_STATUS_STORAGE_VALUES],
                             },
                         },
                         { statusType: incomingStatus },
@@ -1208,6 +1573,34 @@ describe("SbEformsignDocRepository", () => {
                 select: expect.objectContaining({ documentId: true }),
             }),
         );
+    });
+
+    it("removes mirror-only predicates when a pending-column retry uses the legacy schema", async () => {
+        eformsignDocModel.updateMany
+            .mockRejectedValueOnce(pendingColumnError)
+            .mockResolvedValueOnce({ count: 1 });
+        eformsignDocModel.findFirst
+            .mockRejectedValueOnce(pendingColumnError)
+            .mockResolvedValueOnce(legacyRow);
+
+        await repository.upsertUnassignedByDocumentId(createEntity(), {
+            markMirrorPending: true,
+        });
+
+        const retry = eformsignDocModel.updateMany.mock.calls[1][0];
+        expect(retry.where.AND[0]).toEqual({
+            documentId: "doc-1",
+            branchId: null,
+        });
+        expect(retry.where.AND[1]).toEqual(expect.objectContaining({
+            updatedDate: { lte: legacyRow.updatedDate },
+            permanentPurgeRequestedAt: null,
+            statusType: { notIn: ["047", "049", "099"] },
+        }));
+        expect(JSON.stringify(retry.where)).not.toMatch(
+            /detailSourceUpdatedDate|detailPayload|syncStatus/,
+        );
+        expect(retry.data).not.toHaveProperty("syncStatus");
     });
 
     it("refuses a stale mirror update without reporting an ownership conflict", async () => {

--- a/backend/test/repositories/sb.eformsign-document-mirror.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-document-mirror.repository.spec.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@prisma/client";
 
+import { EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES } from "domain/constants/eformsign-doc-status.constants";
 import { SbEformsignDocumentMirrorRepository } from "infrastructure/database/repositories/sb.eformsign-document-mirror.repository";
 
 describe("SbEformsignDocumentMirrorRepository", () => {
@@ -14,6 +15,43 @@ describe("SbEformsignDocumentMirrorRepository", () => {
             return Promise.all(operation as Promise<unknown>[]);
         });
     }
+
+    it("finds unready completed rows and hides every completed row before sync_status exists", async () => {
+        const missingSyncStatus = Object.assign(
+            new Error("The column `eformsign_doc.sync_status` does not exist"),
+            {
+                code: "P2022",
+                meta: { column: "eformsign_doc.sync_status" },
+            },
+        );
+        const findMany = jest.fn()
+            .mockResolvedValueOnce([{ documentId: "syncing-document" }])
+            .mockRejectedValueOnce(missingSyncStatus)
+            .mockResolvedValueOnce([{ documentId: "legacy-completed-document" }]);
+        const repository = new SbEformsignDocumentMirrorRepository({
+            eformsign_doc: { findMany },
+        } as never);
+
+        await expect(repository.findUnreadyCompletedDocumentIds())
+            .resolves.toEqual(["syncing-document"]);
+        await expect(repository.findUnreadyCompletedDocumentIds())
+            .resolves.toEqual(["legacy-completed-document"]);
+
+        const completedValues = [...EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES];
+        expect(findMany).toHaveBeenNthCalledWith(1, {
+            where: {
+                statusType: { in: completedValues },
+                syncStatus: { not: "ready" },
+            },
+            select: { documentId: true },
+        });
+        expect(findMany).toHaveBeenNthCalledWith(3, {
+            where: {
+                statusType: { in: completedValues },
+            },
+            select: { documentId: true },
+        });
+    });
 
     it("returns a file only when it belongs to the current non-purged detail", async () => {
         const file = {

--- a/backend/test/services/eformsign-document-mirror.service.spec.ts
+++ b/backend/test/services/eformsign-document-mirror.service.spec.ts
@@ -175,7 +175,9 @@ describe("EformsignDocumentMirrorService", () => {
     it("persists every non-secret detail value and both PDF files", async () => {
         const detail = richDetail();
         const repository = {
-            findState: jest.fn().mockResolvedValue(null),
+            findState: jest.fn()
+                .mockResolvedValueOnce(null)
+                .mockResolvedValue({ branchId: "branch-1" }),
             findFile: jest.fn(),
             saveDetail: jest.fn().mockResolvedValue(true),
             saveFile: jest.fn().mockResolvedValue(true),
@@ -199,12 +201,17 @@ describe("EformsignDocumentMirrorService", () => {
                 body: PDF,
             }),
         };
+        const snapshots = {
+            bumpVersion: jest.fn().mockResolvedValue(1),
+            bumpCompanyEpoch: jest.fn().mockResolvedValue(undefined),
+        };
         const service = new EformsignDocumentMirrorService(
             client as never,
             repository as never,
             mirrorUsecase as never,
             linkByPhoneUsecase as never,
             vendorService as never,
+            snapshots as never,
         );
 
         const result = await service.syncDocumentWithToken(
@@ -267,6 +274,7 @@ describe("EformsignDocumentMirrorService", () => {
             "ready",
             null,
         );
+        expect(snapshots.bumpVersion).toHaveBeenCalledTimes(2);
     });
 
     it("reports ownership changes when ready mirror reconciliation links a branchless document", async () => {
@@ -866,11 +874,17 @@ describe("EformsignDocumentMirrorService", () => {
     it("fails a completed mirror when its current-version audit trail is unavailable", async () => {
         const detail = richDetail();
         const repository = {
-            findState: jest.fn().mockResolvedValue(null),
+            findState: jest.fn()
+                .mockResolvedValueOnce(null)
+                .mockResolvedValue({ branchId: "branch-1" }),
             saveDetail: jest.fn().mockResolvedValue(true),
             saveFile: jest.fn().mockResolvedValue(true),
             markSyncFinished: jest.fn().mockResolvedValue(true),
             markSyncFailed: jest.fn().mockResolvedValue(undefined),
+        };
+        const snapshots = {
+            bumpVersion: jest.fn().mockResolvedValue(1),
+            bumpCompanyEpoch: jest.fn().mockResolvedValue(undefined),
         };
         const service = new EformsignDocumentMirrorService(
             { getDocument: jest.fn().mockResolvedValue(detail) } as never,
@@ -892,6 +906,7 @@ describe("EformsignDocumentMirrorService", () => {
                         body: Buffer.alloc(0),
                     }),
             } as never,
+            snapshots as never,
         );
 
         await expect(service.syncDocumentWithToken("token", "doc-1", { force: true }))
@@ -904,6 +919,7 @@ describe("EformsignDocumentMirrorService", () => {
             expect.any(Date),
             expect.stringContaining("audit_trail"),
         );
+        expect(snapshots.bumpVersion).toHaveBeenCalledTimes(1);
     });
 
     it("does not reconcile a completion after a newer same-version generation wins finish CAS", async () => {

--- a/backend/test/services/eformsign-document-mirror.service.spec.ts
+++ b/backend/test/services/eformsign-document-mirror.service.spec.ts
@@ -1502,6 +1502,49 @@ describe("EformsignDocumentMirrorService", () => {
         }));
     });
 
+    it("returns current stored PDF metadata without reading the PDF bytes", async () => {
+        const sourceUpdatedDate = new Date(UPDATED_AT);
+        const repository = {
+            findState: jest.fn().mockResolvedValue({
+                documentId: "doc-1",
+                branchId: "branch-1",
+                detailPayload: richDetail(),
+                detailSourceUpdatedDate: sourceUpdatedDate,
+                detailSyncedAt: sourceUpdatedDate,
+                syncStatus: "ready",
+                syncError: null,
+                permanentPurgeRequestedAt: null,
+                files: [{
+                    fileType: "document",
+                    contentType: "application/pdf",
+                    contentDisposition: "inline",
+                    byteSize: PDF.length,
+                    sha256: "hash",
+                    sourceUpdatedDate,
+                    syncedAt: sourceUpdatedDate,
+                }],
+            }),
+            findFile: jest.fn(),
+        };
+        const service = new EformsignDocumentMirrorService(
+            {} as never,
+            repository as never,
+            {} as never,
+            {} as never,
+            {} as never,
+        );
+
+        await expect(service.getStoredFileMetadata("doc-1", "document"))
+            .resolves.toEqual({
+                status: 200,
+                contentType: "application/pdf",
+                contentDisposition: "inline",
+                byteSize: PDF.length,
+            });
+        expect(repository.findState).toHaveBeenCalledWith("doc-1");
+        expect(repository.findFile).not.toHaveBeenCalled();
+    });
+
     it("repairs an integrity-failed current version with both PDFs", async () => {
         const detail = richDetail();
         const previousAttempt = new Date(UPDATED_AT);

--- a/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
+++ b/backend/test/services/eformsign-list-shadow-compare.service.spec.ts
@@ -92,12 +92,15 @@ function createQuery(overrides: Partial<ListShadowCompareQuery> = {}): ListShado
 }
 
 describe("EformsignListShadowCompareService", () => {
-    let repository: { findAll: jest.Mock; findAllForHeadquarters: jest.Mock };
+    let repository: {
+        findAllVisibleInMirror: jest.Mock;
+        findAllVisibleInMirrorForHeadquarters: jest.Mock;
+    };
 
     beforeEach(() => {
         repository = {
-            findAll: jest.fn().mockResolvedValue([]),
-            findAllForHeadquarters: jest.fn().mockResolvedValue([]),
+            findAllVisibleInMirror: jest.fn().mockResolvedValue([]),
+            findAllVisibleInMirrorForHeadquarters: jest.fn().mockResolvedValue([]),
         };
     });
 
@@ -139,7 +142,7 @@ describe("EformsignListShadowCompareService", () => {
             service.compareInBackground(createQuery(), servedFrom([]));
             await settle();
 
-            expect(repository.findAll).not.toHaveBeenCalled();
+            expect(repository.findAllVisibleInMirror).not.toHaveBeenCalled();
         },
     );
 
@@ -148,7 +151,7 @@ describe("EformsignListShadowCompareService", () => {
             createMirrorDocument({ documentId: "doc-2", createdDate: "2026-07-02T00:00:00.000Z" }),
             createMirrorDocument({ documentId: "doc-1", createdDate: "2026-07-01T00:00:00.000Z" }),
         ];
-        repository.findAll.mockResolvedValue(documents);
+        repository.findAllVisibleInMirror.mockResolvedValue(documents);
         const service = createService("true");
         const logger = spyOnLogger(service);
 
@@ -161,7 +164,7 @@ describe("EformsignListShadowCompareService", () => {
 
     it("names the documents each side is missing", async () => {
         const shared = createMirrorDocument({ documentId: "doc-1" });
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             shared,
             createMirrorDocument({ documentId: "doc-3" }),
         ]);
@@ -188,7 +191,7 @@ describe("EformsignListShadowCompareService", () => {
             documentId: "doc-b",
             createdDate: "2026-07-02T00:00:00.000Z",
         });
-        repository.findAll.mockResolvedValue([a, b]);
+        repository.findAllVisibleInMirror.mockResolvedValue([a, b]);
         const service = createService("true");
         const logger = spyOnLogger(service);
 
@@ -211,7 +214,7 @@ describe("EformsignListShadowCompareService", () => {
             documentId: "doc-b",
             createdDate: "2026-07-02T00:00:00.000Z",
         });
-        repository.findAll.mockResolvedValue([a, b]);
+        repository.findAllVisibleInMirror.mockResolvedValue([a, b]);
         const service = createService("true");
         const logger = spyOnLogger(service);
 
@@ -228,7 +231,7 @@ describe("EformsignListShadowCompareService", () => {
     it("reports documents whose values differ even when the list itself matches", async () => {
         // Membership and order can agree while the row serves a different status, and the
         // UI reads that directly — it drives the pill and which actions are offered.
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-1", statusType: "060" }),
         ]);
         const service = createService("true");
@@ -245,7 +248,7 @@ describe("EformsignListShadowCompareService", () => {
 
     it("applies the same template filter the served list did", async () => {
         const kept = createMirrorDocument({ documentId: "doc-keep", templateId: "template-1" });
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             kept,
             createMirrorDocument({ documentId: "doc-drop", templateId: "template-9" }),
         ]);
@@ -263,7 +266,7 @@ describe("EformsignListShadowCompareService", () => {
 
     it("matches 초성 against the recipient name, the way the served search does", async () => {
         const song = createMirrorDocument({ documentId: "doc-song", stepRecipientName: "송진호" });
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             song,
             createMirrorDocument({ documentId: "doc-park", stepRecipientName: "박수신" }),
         ]);
@@ -281,7 +284,7 @@ describe("EformsignListShadowCompareService", () => {
         // The vendor list is fetched without include_fields, so the served search never
         // sees a customer name on the document and matches the recipient name instead.
         // Searching the mirror's own column would find documents the served path cannot.
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({
                 documentId: "doc-hidden",
                 customerName: "최고객",
@@ -302,14 +305,14 @@ describe("EformsignListShadowCompareService", () => {
     it("searches headquarters recipient names from branch-owned rows only", async () => {
         // The served path builds its recipient-name corpus from findAll(branchId), so an
         // unassigned document's recipient name is not searchable there.
-        repository.findAllForHeadquarters.mockResolvedValue([
+        repository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([
             createMirrorDocument({
                 documentId: "doc-unassigned",
                 documentName: null,
                 stepRecipientName: "박수신",
             }),
         ]);
-        repository.findAll.mockResolvedValue([]);
+        repository.findAllVisibleInMirror.mockResolvedValue([]);
         const service = createService("true");
         const logger = spyOnLogger(service);
 
@@ -325,7 +328,7 @@ describe("EformsignListShadowCompareService", () => {
 
     it("reads the headquarters corpus from the method that includes unclaimed rows", async () => {
         const hqDocument = createMirrorDocument({ documentId: "doc-hq" });
-        repository.findAllForHeadquarters.mockResolvedValue([hqDocument]);
+        repository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([hqDocument]);
         const service = createService("true");
         spyOnLogger(service);
 
@@ -335,10 +338,10 @@ describe("EformsignListShadowCompareService", () => {
         );
         await settle();
 
-        expect(repository.findAllForHeadquarters).toHaveBeenCalledWith("branch-1");
+        expect(repository.findAllVisibleInMirrorForHeadquarters).toHaveBeenCalledWith("branch-1");
         // findAll is still consulted, but only for the recipient-name search corpus the
         // served path builds the same way — not for which documents the list contains.
-        expect(repository.findAll).toHaveBeenCalledWith("branch-1");
+        expect(repository.findAllVisibleInMirror).toHaveBeenCalledWith("branch-1");
     });
 
     it("stands in for the vendor inbox with local status categories on the tab endpoints", async () => {
@@ -346,7 +349,7 @@ describe("EformsignListShadowCompareService", () => {
         // document sat in — the switch has to answer them from status codes. Comparing
         // that substitution is the only way to learn whether it lands the same content.
         const drafting = createMirrorDocument({ documentId: "doc-open", statusType: "060" });
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             drafting,
             createMirrorDocument({ documentId: "doc-done", statusType: "050" }),
         ]);
@@ -367,7 +370,7 @@ describe("EformsignListShadowCompareService", () => {
         // The list renders updated_date as the signed date, so a mirror that is right
         // about membership and status can still show users the wrong day.
         const mirrored = createMirrorDocument({ documentId: "doc-1" });
-        repository.findAll.mockResolvedValue([mirrored]);
+        repository.findAllVisibleInMirror.mockResolvedValue([mirrored]);
         const service = createService("true");
         const logger = spyOnLogger(service);
 
@@ -393,7 +396,7 @@ describe("EformsignListShadowCompareService", () => {
             documentId: "doc-2026",
             createdDate: "2026-07-20T00:00:00.000Z",
         });
-        repository.findAll.mockResolvedValue([older, newer]);
+        repository.findAllVisibleInMirror.mockResolvedValue([older, newer]);
         const service = createService("true");
         const logger = spyOnLogger(service);
 
@@ -409,7 +412,7 @@ describe("EformsignListShadowCompareService", () => {
     it("keeps the search term itself out of the log", async () => {
         // Searches are customer names often enough that the term does not belong in a
         // centralised log, and a raw value could break the log line apart.
-        repository.findAll.mockResolvedValue([]);
+        repository.findAllVisibleInMirror.mockResolvedValue([]);
         const service = createService("true");
         const logger = spyOnLogger(service);
 
@@ -429,7 +432,7 @@ describe("EformsignListShadowCompareService", () => {
         // Every list request would otherwise load the whole branch mirror and sort it,
         // competing with the served requests for the same connection pool.
         let release: (() => void) | undefined;
-        repository.findAll.mockImplementation(() => new Promise((resolve) => {
+        repository.findAllVisibleInMirror.mockImplementation(() => new Promise((resolve) => {
             release = () => resolve([]);
         }));
         const service = createService("true");
@@ -439,7 +442,7 @@ describe("EformsignListShadowCompareService", () => {
         service.compareInBackground(createQuery(), served);
         service.compareInBackground(createQuery(), served);
         service.compareInBackground(createQuery(), served);
-        expect(repository.findAll).toHaveBeenCalledTimes(1);
+        expect(repository.findAllVisibleInMirror).toHaveBeenCalledTimes(1);
 
         release?.();
         await settle();
@@ -452,7 +455,7 @@ describe("EformsignListShadowCompareService", () => {
     it("never lets a comparison failure escape into the request", async () => {
         // The response has already been sent by the time this runs; throwing here would
         // become an unhandled rejection, not an error the caller could do anything with.
-        repository.findAll.mockRejectedValue(new Error("mirror unavailable"));
+        repository.findAllVisibleInMirror.mockRejectedValue(new Error("mirror unavailable"));
         const service = createService("true");
         const logger = spyOnLogger(service);
 

--- a/backend/test/services/eformsign-mirror-list.service.spec.ts
+++ b/backend/test/services/eformsign-mirror-list.service.spec.ts
@@ -58,19 +58,22 @@ function createQuery(overrides: Partial<MirrorListQuery> = {}): MirrorListQuery 
 }
 
 describe("EformsignMirrorListService", () => {
-    let repository: { findAll: jest.Mock; findAllForHeadquarters: jest.Mock };
+    let repository: {
+        findAllVisibleInMirror: jest.Mock;
+        findAllVisibleInMirrorForHeadquarters: jest.Mock;
+    };
     let service: EformsignMirrorListService;
 
     beforeEach(() => {
         repository = {
-            findAll: jest.fn().mockResolvedValue([]),
-            findAllForHeadquarters: jest.fn().mockResolvedValue([]),
+            findAllVisibleInMirror: jest.fn().mockResolvedValue([]),
+            findAllVisibleInMirrorForHeadquarters: jest.fn().mockResolvedValue([]),
         };
         service = new EformsignMirrorListService(repository as never);
     });
 
     it("returns documents newest first, tie-broken by id", async () => {
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-b", createdDate: "2026-07-01T00:00:00.000Z" }),
             createMirrorDocument({ documentId: "doc-c", createdDate: "2026-07-02T00:00:00.000Z" }),
             createMirrorDocument({ documentId: "doc-a", createdDate: "2026-07-01T00:00:00.000Z" }),
@@ -82,18 +85,19 @@ describe("EformsignMirrorListService", () => {
     });
 
     it("reads the headquarters scope from the method that includes unclaimed rows", async () => {
-        repository.findAllForHeadquarters.mockResolvedValue([
+        repository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-hq" }),
         ]);
 
         const { documents } = await service.buildList(createQuery({ isHeadquarters: true }));
 
-        expect(repository.findAllForHeadquarters).toHaveBeenCalledWith("branch-1");
+        expect(repository.findAllVisibleInMirrorForHeadquarters)
+            .toHaveBeenCalledWith("branch-1");
         expect(documents.map((document) => document.id)).toEqual(["doc-hq"]);
     });
 
     it("selects a tab by status rather than by vendor inbox", async () => {
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-open", statusType: "060" }),
             createMirrorDocument({ documentId: "doc-done", statusType: "050" }),
             createMirrorDocument({ documentId: "doc-gone", statusType: "080" }),
@@ -111,7 +115,7 @@ describe("EformsignMirrorListService", () => {
     it("puts a deleted document in the rejected tab, where the desktop shows it", async () => {
         // 047/049 land in the "unknown" category, which also holds every unrecognised
         // status — those belong in 진행 중, and only the deleted ones in 기간 만료.
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-deleted", statusType: "049" }),
             createMirrorDocument({ documentId: "doc-strange", statusType: "999" }),
         ]);
@@ -124,7 +128,7 @@ describe("EformsignMirrorListService", () => {
     });
 
     it("applies template include and exclude across a comma-separated list", async () => {
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-1", templateId: "t-1" }),
             createMirrorDocument({ documentId: "doc-2", templateId: "t-2" }),
             createMirrorDocument({ documentId: "doc-3", templateId: "t-9" }),
@@ -142,7 +146,7 @@ describe("EformsignMirrorListService", () => {
     });
 
     it("excludes deleted documents only when asked", async () => {
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-live", statusType: "060" }),
             createMirrorDocument({ documentId: "doc-deleted", statusType: "047" }),
             createMirrorDocument({ documentId: "doc-deleted-legacy", statusType: "099" }),
@@ -156,7 +160,7 @@ describe("EformsignMirrorListService", () => {
     });
 
     it("searches the recipient name, including by 초성", async () => {
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({ documentId: "doc-song", stepRecipientName: "송진호" }),
             createMirrorDocument({ documentId: "doc-park", stepRecipientName: "박수신" }),
         ]);
@@ -172,7 +176,7 @@ describe("EformsignMirrorListService", () => {
         // The API path's search index is built before enrichment, so a customer name never
         // reaches it. Matching one here would change what the search finds the moment the
         // source switches — a feature change smuggled in as a migration.
-        repository.findAll.mockResolvedValue([
+        repository.findAllVisibleInMirror.mockResolvedValue([
             createMirrorDocument({
                 documentId: "doc-1",
                 customerName: "최고객",
@@ -189,14 +193,14 @@ describe("EformsignMirrorListService", () => {
     it("only searches recipient names the branch owns", async () => {
         // Headquarters sees unclaimed documents, but the API path builds its recipient-name
         // corpus from findAll(branchId), so their names are not searchable there.
-        repository.findAllForHeadquarters.mockResolvedValue([
+        repository.findAllVisibleInMirrorForHeadquarters.mockResolvedValue([
             createMirrorDocument({
                 documentId: "doc-unassigned",
                 documentName: "무관한 제목",
                 stepRecipientName: "박수신",
             }),
         ]);
-        repository.findAll.mockResolvedValue([]);
+        repository.findAllVisibleInMirror.mockResolvedValue([]);
 
         const { documents } = await service.buildList(
             createQuery({ isHeadquarters: true, search: "박수신" }),
@@ -211,8 +215,8 @@ describe("enrichMirrorPage", () => {
 
     it("fills in the customer name the list renders", async () => {
         const service = new EformsignMirrorListService({
-            findAll: jest.fn().mockResolvedValue([entity]),
-            findAllForHeadquarters: jest.fn(),
+            findAllVisibleInMirror: jest.fn().mockResolvedValue([entity]),
+            findAllVisibleInMirrorForHeadquarters: jest.fn(),
         } as never);
         const { documents } = await service.buildList(createQuery());
 
@@ -236,8 +240,8 @@ describe("enrichMirrorPage", () => {
             stepRecipientName: "송진호",
         });
         const service = new EformsignMirrorListService({
-            findAll: jest.fn().mockResolvedValue([titled, named]),
-            findAllForHeadquarters: jest.fn(),
+            findAllVisibleInMirror: jest.fn().mockResolvedValue([titled, named]),
+            findAllVisibleInMirrorForHeadquarters: jest.fn(),
         } as never);
         const { documents } = await service.buildList(createQuery());
 
@@ -259,8 +263,8 @@ describe("enrichMirrorPage", () => {
             stepRecipientName: "수신자",
         });
         const service = new EformsignMirrorListService({
-            findAll: jest.fn().mockResolvedValue([sentinel]),
-            findAllForHeadquarters: jest.fn(),
+            findAllVisibleInMirror: jest.fn().mockResolvedValue([sentinel]),
+            findAllVisibleInMirrorForHeadquarters: jest.fn(),
         } as never);
         const { documents } = await service.buildList(createQuery());
 

--- a/backend/test/usecases/eformsign-doc/adopt-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/adopt-eformsign-doc.usecase.spec.ts
@@ -9,10 +9,12 @@ describe("AdoptEformsignDocUsecase", () => {
         const now = Date.parse("2026-07-03T00:00:00.000Z");
         jest.spyOn(Date, "now").mockReturnValue(now);
         const create = { execute: jest.fn().mockResolvedValue({ documentId: "doc-1" }) };
+        const mirror = { syncDocumentWithToken: jest.fn().mockResolvedValue(undefined) };
         const usecase = new AdoptEformsignDocUsecase(
             { execute: jest.fn().mockResolvedValue({ oauth_token: { access_token: "token" } }) } as never,
             { execute: jest.fn().mockResolvedValue({
                 id: "doc-1",
+                updated_date: 1_751_500_800_000,
                 document_name: "계약서 - 고객",
                 template: { id: "template-1", name: "표준 계약서" },
                 creator: { name: "생성자" },
@@ -33,6 +35,7 @@ describe("AdoptEformsignDocUsecase", () => {
             }) } as never,
             create as never,
             { findByPhone: jest.fn() } as never,
+            mirror as never,
         );
 
         await usecase.execute("branch-1", { documentId: "doc-1", clientId: 7 });
@@ -42,6 +45,7 @@ describe("AdoptEformsignDocUsecase", () => {
         expect(create.execute).toHaveBeenNthCalledWith(2, "branch-1", expect.objectContaining({
             documentId: "doc-1",
             clientId: 7,
+            preserveExistingMirrorProjection: true,
             templateName: "표준 계약서",
             customerName: "김고객",
             creatorName: "생성자",
@@ -49,10 +53,55 @@ describe("AdoptEformsignDocUsecase", () => {
             stepRecipientTypes: ["01", "06"],
             expiredDate: new Date(now + 3 * 24 * 60 * 60 * 1000),
         }));
+        expect(mirror.syncDocumentWithToken).toHaveBeenNthCalledWith(
+            2,
+            "token",
+            "doc-1",
+            { expectedUpdatedDate: 1_751_500_800_000 },
+        );
+        expect(create.execute.mock.invocationCallOrder[0]!).toBeLessThan(
+            mirror.syncDocumentWithToken.mock.invocationCallOrder[0]!,
+        );
+    });
+
+    it.each([
+        ["doc_complete", "003"],
+        ["50", "050"],
+    ])("normalizes persisted vendor status %s to %s", async (rawStatus, expectedStatus) => {
+        const create = { execute: jest.fn().mockResolvedValue({ documentId: "doc-status" }) };
+        const mirror = { syncDocumentWithToken: jest.fn().mockResolvedValue(undefined) };
+        const usecase = new AdoptEformsignDocUsecase(
+            { execute: jest.fn().mockResolvedValue({ oauth_token: { access_token: "token" } }) } as never,
+            { execute: jest.fn().mockResolvedValue({
+                id: "doc-status",
+                document_name: "계약서",
+                template: { id: "template-1", name: "표준 계약서" },
+                current_status: {
+                    status_type: rawStatus,
+                    status_doc_detail: "완료",
+                    step_type: "05",
+                    step_index: "1",
+                    step_name: "완료",
+                    step_recipients: [],
+                    expired_date: 0,
+                },
+            }) } as never,
+            create as never,
+            { findByPhone: jest.fn() } as never,
+            mirror as never,
+        );
+
+        await usecase.execute("branch-1", { documentId: "doc-status", clientId: 7 });
+
+        expect(create.execute).toHaveBeenCalledWith(
+            "branch-1",
+            expect.objectContaining({ statusType: expectedStatus }),
+        );
     });
 
     it("preserves no-expiry semantics when adopting a document with zero remaining days", async () => {
         const create = { execute: jest.fn().mockResolvedValue({ documentId: "doc-no-expiry" }) };
+        const mirror = { syncDocumentWithToken: jest.fn().mockResolvedValue(undefined) };
         const usecase = new AdoptEformsignDocUsecase(
             { execute: jest.fn().mockResolvedValue({ oauth_token: { access_token: "token" } }) } as never,
             { execute: jest.fn().mockResolvedValue({
@@ -72,6 +121,7 @@ describe("AdoptEformsignDocUsecase", () => {
             }) } as never,
             create as never,
             { findByPhone: jest.fn() } as never,
+            mirror as never,
         );
 
         await usecase.execute("branch-1", { documentId: "doc-no-expiry", clientId: 7 });
@@ -82,5 +132,35 @@ describe("AdoptEformsignDocUsecase", () => {
                 expiredDate: new Date("9999-12-31T23:59:59.999Z"),
             }),
         );
+    });
+
+    it("fails adoption when the adopted document cannot be mirrored", async () => {
+        const mirrorError = new Error("mirror failed");
+        const usecase = new AdoptEformsignDocUsecase(
+            { execute: jest.fn().mockResolvedValue({ oauth_token: { access_token: "token" } }) } as never,
+            { execute: jest.fn().mockResolvedValue({
+                id: "doc-complete",
+                updated_date: 1_751_500_800_000,
+                document_name: "완료 계약서",
+                template: { id: "template-1", name: "표준 계약서" },
+                current_status: {
+                    status_type: "003",
+                    status_doc_detail: "완료",
+                    step_type: "05",
+                    step_index: "1",
+                    step_name: "완료",
+                    step_recipients: [],
+                    expired_date: 0,
+                },
+            }) } as never,
+            { execute: jest.fn().mockResolvedValue({ documentId: "doc-complete" }) } as never,
+            { findByPhone: jest.fn() } as never,
+            { syncDocumentWithToken: jest.fn().mockRejectedValue(mirrorError) } as never,
+        );
+
+        await expect(usecase.execute("branch-1", {
+            documentId: "doc-complete",
+            clientId: 7,
+        })).rejects.toBe(mirrorError);
     });
 });

--- a/backend/test/usecases/eformsign-doc/adopt-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/adopt-eformsign-doc.usecase.spec.ts
@@ -1,3 +1,5 @@
+import { Logger } from "@nestjs/common";
+
 import { AdoptEformsignDocUsecase } from "application/usecases/eformsign-doc/adopt-eformsign-doc.usecase";
 
 describe("AdoptEformsignDocUsecase", () => {
@@ -134,8 +136,13 @@ describe("AdoptEformsignDocUsecase", () => {
         );
     });
 
-    it("fails adoption when the adopted document cannot be mirrored", async () => {
+    it("keeps adoption successful when post-commit mirroring must be retried", async () => {
         const mirrorError = new Error("mirror failed");
+        const createResult = {
+            documentId: "doc-complete",
+            warnings: ["client_link_failed" as const],
+        };
+        const warn = jest.spyOn(Logger.prototype, "warn").mockImplementation();
         const usecase = new AdoptEformsignDocUsecase(
             { execute: jest.fn().mockResolvedValue({ oauth_token: { access_token: "token" } }) } as never,
             { execute: jest.fn().mockResolvedValue({
@@ -153,7 +160,7 @@ describe("AdoptEformsignDocUsecase", () => {
                     expired_date: 0,
                 },
             }) } as never,
-            { execute: jest.fn().mockResolvedValue({ documentId: "doc-complete" }) } as never,
+            { execute: jest.fn().mockResolvedValue(createResult) } as never,
             { findByPhone: jest.fn() } as never,
             { syncDocumentWithToken: jest.fn().mockRejectedValue(mirrorError) } as never,
         );
@@ -161,6 +168,13 @@ describe("AdoptEformsignDocUsecase", () => {
         await expect(usecase.execute("branch-1", {
             documentId: "doc-complete",
             clientId: 7,
-        })).rejects.toBe(mirrorError);
+        })).resolves.toMatchObject({
+            documentId: "doc-complete",
+            warnings: ["client_link_failed", "mirror_sync_failed"],
+        });
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("local mirror remains incomplete"));
+        expect(warn.mock.calls.flat().join(" ")).not.toContain("will retry");
+        expect(warn.mock.calls.flat().join(" ")).not.toContain("doc-complete");
+        expect(warn.mock.calls.flat().join(" ")).not.toContain(mirrorError.message);
     });
 });

--- a/backend/test/usecases/eformsign-doc/create-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/create-eformsign-doc.usecase.spec.ts
@@ -127,6 +127,21 @@ describe("CreateEformsignDocUsecase", () => {
         expect(eformsignDocRepository.upsertByDocumentId).toHaveBeenCalledTimes(1);
     });
 
+    it("keeps an existing ready projection intact while adoption assigns ownership", async () => {
+        const client = createClient(7, "010-1234-5678");
+        clientRepository.findById.mockResolvedValue(client);
+
+        await usecase.execute(branchId, createParams({
+            preserveExistingMirrorProjection: true,
+        }));
+
+        expect(eformsignDocRepository.upsertByDocumentId).toHaveBeenCalledWith(
+            branchId,
+            expect.objectContaining({ clientId: 7, documentId }),
+            { preserveExistingMirrorProjection: true },
+        );
+    });
+
     it("falls back to the supplied client when recipient phone has no client match", async () => {
         const client = createClient(7, "010-0000-0000");
         clientRepository.findById.mockResolvedValue(client);

--- a/backend/test/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/mirror-unassigned-eformsign-doc.usecase.spec.ts
@@ -402,7 +402,7 @@ describe("MirrorUnassignedEformsignDocUsecase", () => {
 
         expect(repository.upsertUnassignedByDocumentId).toHaveBeenCalledWith(
             expect.objectContaining({ statusType: "050", expired: false }),
-            expect.not.objectContaining({ updateExpired: false }),
+            expect.objectContaining({ markMirrorPending: true }),
         );
     });
 

--- a/backend/test/usecases/eformsign-doc/service-record-case-snapshot.spec.ts
+++ b/backend/test/usecases/eformsign-doc/service-record-case-snapshot.spec.ts
@@ -148,7 +148,7 @@ function setup() {
         created_date: Date.now(),
         updated_date: Date.now(),
         current_status: {
-            status_type: "070",
+            status_type: "doc_accept_reviewer",
             status_doc_type: "진행중",
             status_doc_detail: "검토 요청",
             step_type: "06",
@@ -375,6 +375,7 @@ describe("client-owned service record snapshot", () => {
                 creatorName: "검토자",
                 lastEditorName: "최종 편집자",
                 stepRecipientTypes: "01",
+                statusType: "072",
             }),
             update: expect.objectContaining({
                 documentName: chunk.documentName,
@@ -383,7 +384,7 @@ describe("client-owned service record snapshot", () => {
                 creatorName: "검토자",
                 lastEditorName: "최종 편집자",
                 stepRecipientTypes: "01",
-                statusType: "070",
+                statusType: "072",
                 statusDetail: "검토 요청",
                 stepType: "06",
                 stepIndex: "2",

--- a/frontend/src/app/api/eformsign/documents/[documentId]/preview/__tests__/route.test.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/preview/__tests__/route.test.ts
@@ -9,10 +9,12 @@ import { GET, HEAD } from "../route";
 jest.mock("@/lib/api/server", () => ({
   serverAPIClient: {
     get: jest.fn(),
+    head: jest.fn(),
   },
 }));
 
 const mockServerGet = serverAPIClient.get as jest.Mock;
+const mockServerHead = serverAPIClient.head as jest.Mock;
 const context = { params: Promise.resolve({ documentId: "doc-1" }) };
 
 function createRequest(method: "GET" | "HEAD"): NextRequest {
@@ -30,6 +32,7 @@ function createRequest(method: "GET" | "HEAD"): NextRequest {
 describe("eformsign document preview route", () => {
   beforeEach(() => {
     mockServerGet.mockReset();
+    mockServerHead.mockReset();
   });
 
   it("returns PDF bytes for GET", async () => {
@@ -48,10 +51,12 @@ describe("eformsign document preview route", () => {
   });
 
   it("returns only PDF metadata for HEAD", async () => {
-    mockServerGet.mockResolvedValue({
+    mockServerHead.mockResolvedValue({
       status: 200,
-      headers: { "content-type": "application/pdf" },
-      data: new Uint8Array([1, 2, 3]),
+      headers: {
+        "content-type": "application/pdf",
+        "content-length": "3",
+      },
     });
 
     const response = await HEAD(createRequest("HEAD"), context);
@@ -60,13 +65,13 @@ describe("eformsign document preview route", () => {
     expect(response.headers.get("Content-Type")).toBe("application/pdf");
     expect(response.headers.get("Content-Length")).toBe("3");
     expect((await response.arrayBuffer()).byteLength).toBe(0);
-    expect(mockServerGet).toHaveBeenCalledWith(
+    expect(mockServerHead).toHaveBeenCalledWith(
       "/api/documents/doc-1/download_files",
       expect.objectContaining({
         params: { fileType: "document" },
-        responseType: "arraybuffer",
       }),
     );
+    expect(mockServerGet).not.toHaveBeenCalled();
   });
 
   it("does not contact the backend for an unauthenticated HEAD request", async () => {
@@ -80,10 +85,11 @@ describe("eformsign document preview route", () => {
     expect(response.status).toBe(401);
     expect((await response.arrayBuffer()).byteLength).toBe(0);
     expect(mockServerGet).not.toHaveBeenCalled();
+    expect(mockServerHead).not.toHaveBeenCalled();
   });
 
   it("preserves a backend access denial for HEAD without returning its body", async () => {
-    mockServerGet.mockRejectedValue(
+    mockServerHead.mockRejectedValue(
       Object.assign(new Error("forbidden"), {
         response: {
           status: 403,
@@ -102,7 +108,7 @@ describe("eformsign document preview route", () => {
   });
 
   it("preserves retry metadata for a pending local PDF without forwarding cookies", async () => {
-    mockServerGet.mockRejectedValue(
+    mockServerHead.mockRejectedValue(
       Object.assign(new Error("not ready"), {
         response: {
           status: 503,
@@ -125,7 +131,7 @@ describe("eformsign document preview route", () => {
   });
 
   it("returns a bodyless bad-gateway response for a HEAD transport failure", async () => {
-    mockServerGet.mockRejectedValue(new Error("connection refused"));
+    mockServerHead.mockRejectedValue(new Error("connection refused"));
 
     const response = await HEAD(createRequest("HEAD"), context);
 

--- a/frontend/src/app/api/eformsign/documents/[documentId]/preview/__tests__/route.test.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/preview/__tests__/route.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+import { GET, HEAD } from "../route";
+
+jest.mock("@/lib/api/server", () => ({
+  serverAPIClient: {
+    get: jest.fn(),
+  },
+}));
+
+const mockServerGet = serverAPIClient.get as jest.Mock;
+const context = { params: Promise.resolve({ documentId: "doc-1" }) };
+
+function createRequest(method: "GET" | "HEAD"): NextRequest {
+  return new NextRequest(
+    "http://localhost/api/eformsign/documents/doc-1/preview",
+    {
+      method,
+      headers: {
+        cookie: "auth_token=auth-token",
+      },
+    },
+  );
+}
+
+describe("eformsign document preview route", () => {
+  beforeEach(() => {
+    mockServerGet.mockReset();
+  });
+
+  it("returns PDF bytes for GET", async () => {
+    const pdf = new Uint8Array([1, 2, 3]);
+    mockServerGet.mockResolvedValue({
+      status: 200,
+      headers: { "content-type": "application/pdf" },
+      data: pdf,
+    });
+
+    const response = await GET(createRequest("GET"), context);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Length")).toBe("3");
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(pdf);
+  });
+
+  it("returns only PDF metadata for HEAD", async () => {
+    mockServerGet.mockResolvedValue({
+      status: 200,
+      headers: { "content-type": "application/pdf" },
+      data: new Uint8Array([1, 2, 3]),
+    });
+
+    const response = await HEAD(createRequest("HEAD"), context);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/pdf");
+    expect(response.headers.get("Content-Length")).toBe("3");
+    expect((await response.arrayBuffer()).byteLength).toBe(0);
+    expect(mockServerGet).toHaveBeenCalledWith(
+      "/api/documents/doc-1/download_files",
+      expect.objectContaining({
+        params: { fileType: "document" },
+        responseType: "arraybuffer",
+      }),
+    );
+  });
+
+  it("does not contact the backend for an unauthenticated HEAD request", async () => {
+    const request = new NextRequest(
+      "http://localhost/api/eformsign/documents/doc-1/preview",
+      { method: "HEAD" },
+    );
+
+    const response = await HEAD(request, context);
+
+    expect(response.status).toBe(401);
+    expect((await response.arrayBuffer()).byteLength).toBe(0);
+    expect(mockServerGet).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/api/eformsign/documents/[documentId]/preview/__tests__/route.test.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/preview/__tests__/route.test.ts
@@ -81,4 +81,56 @@ describe("eformsign document preview route", () => {
     expect((await response.arrayBuffer()).byteLength).toBe(0);
     expect(mockServerGet).not.toHaveBeenCalled();
   });
+
+  it("preserves a backend access denial for HEAD without returning its body", async () => {
+    mockServerGet.mockRejectedValue(
+      Object.assign(new Error("forbidden"), {
+        response: {
+          status: 403,
+          headers: { "content-type": "application/json" },
+          data: { error: "sensitive backend detail" },
+        },
+      }),
+    );
+
+    const response = await HEAD(createRequest("HEAD"), context);
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect((await response.arrayBuffer()).byteLength).toBe(0);
+  });
+
+  it("preserves retry metadata for a pending local PDF without forwarding cookies", async () => {
+    mockServerGet.mockRejectedValue(
+      Object.assign(new Error("not ready"), {
+        response: {
+          status: 503,
+          headers: {
+            "content-type": "application/json",
+            "retry-after": "30",
+            "set-cookie": "backend-session=secret",
+          },
+          data: { error: "waiting for local synchronization" },
+        },
+      }),
+    );
+
+    const response = await HEAD(createRequest("HEAD"), context);
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("30");
+    expect(response.headers.get("Set-Cookie")).toBeNull();
+    expect((await response.arrayBuffer()).byteLength).toBe(0);
+  });
+
+  it("returns a bodyless bad-gateway response for a HEAD transport failure", async () => {
+    mockServerGet.mockRejectedValue(new Error("connection refused"));
+
+    const response = await HEAD(createRequest("HEAD"), context);
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect((await response.arrayBuffer()).byteLength).toBe(0);
+  });
 });

--- a/frontend/src/app/api/eformsign/documents/[documentId]/preview/route.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/preview/route.ts
@@ -8,12 +8,18 @@ import {
 
 type RouteParams = { params: Promise<{ documentId: string }> };
 
-export async function GET(request: NextRequest, { params }: RouteParams) {
+async function proxyPreview(
+  request: NextRequest,
+  { params }: RouteParams,
+  includeBody: boolean,
+) {
   try {
     const authToken = getAuthToken(request);
 
     if (!authToken) {
-      return unauthorizedResponse("Authentication required. Please log in.");
+      return includeBody
+        ? unauthorizedResponse("Authentication required. Please log in.")
+        : new NextResponse(null, { status: 401 });
     }
 
     const { documentId } = await params;
@@ -30,11 +36,18 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const contentType = String(response.headers["content-type"] ?? "application/octet-stream");
 
     if (contentType.includes("application/json")) {
+      if (!includeBody) {
+        return new NextResponse(null, {
+          status: response.status,
+          headers: { "Content-Type": contentType },
+        });
+      }
+
       const payload = JSON.parse(Buffer.from(response.data).toString("utf-8"));
       return NextResponse.json(payload, { status: response.status });
     }
 
-    return new NextResponse(response.data, {
+    return new NextResponse(includeBody ? response.data : null, {
       status: response.status,
       headers: {
         "Content-Type": contentType,
@@ -45,9 +58,21 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       },
     });
   } catch (error) {
+    if (!includeBody) {
+      return new NextResponse(null, { status: 500 });
+    }
+
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Failed to preview eformsign document" },
       { status: 500 }
     );
   }
+}
+
+export async function GET(request: NextRequest, context: RouteParams) {
+  return proxyPreview(request, context, true);
+}
+
+export async function HEAD(request: NextRequest, context: RouteParams) {
+  return proxyPreview(request, context, false);
 }

--- a/frontend/src/app/api/eformsign/documents/[documentId]/preview/route.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/preview/route.ts
@@ -60,29 +60,45 @@ async function proxyPreview(
     const { documentId } = await params;
     const attachment = request.nextUrl.searchParams.get("attachment") === "true";
 
-    const response = await serverAPIClient.get(`/api/documents/${documentId}/download_files`, {
+    const upstreamPath = `/api/documents/${documentId}/download_files`;
+    const upstreamConfig = {
       params: {
         fileType: "document",
       },
       headers: getAuthHeaders(authToken),
-      responseType: "arraybuffer",
-    });
+    };
+    const response = includeBody
+      ? await serverAPIClient.get(upstreamPath, {
+          ...upstreamConfig,
+          responseType: "arraybuffer",
+        })
+      : await serverAPIClient.head(upstreamPath, upstreamConfig);
 
     const contentType = String(response.headers["content-type"] ?? "application/octet-stream");
 
-    if (contentType.includes("application/json")) {
-      if (!includeBody) {
-        return new NextResponse(null, {
-          status: response.status,
-          headers: { "Content-Type": contentType },
-        });
-      }
+    if (!includeBody) {
+      const contentLength = response.headers["content-length"];
+      return new NextResponse(null, {
+        status: response.status,
+        headers: {
+          "Content-Type": contentType,
+          "Content-Disposition": attachment
+            ? `attachment; filename="${documentId}.pdf"`
+            : "inline",
+          ...(contentLength !== undefined
+            ? { "Content-Length": String(contentLength) }
+            : {}),
+          "Cache-Control": "no-store",
+        },
+      });
+    }
 
+    if (contentType.includes("application/json")) {
       const payload = JSON.parse(Buffer.from(response.data).toString("utf-8"));
       return NextResponse.json(payload, { status: response.status });
     }
 
-    return new NextResponse(includeBody ? response.data : null, {
+    return new NextResponse(response.data, {
       status: response.status,
       headers: {
         "Content-Type": contentType,

--- a/frontend/src/app/api/eformsign/documents/[documentId]/preview/route.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/preview/route.ts
@@ -3,10 +3,45 @@ import { serverAPIClient } from "@/lib/api/server";
 import {
   getAuthHeaders,
   getAuthToken,
+  getUpstreamErrorStatus,
   unauthorizedResponse,
 } from "@/lib/api/route-utils";
 
 type RouteParams = { params: Promise<{ documentId: string }> };
+type UpstreamErrorWithHeaders = {
+  response?: {
+    headers?: Record<string, unknown>;
+  };
+};
+
+const HEAD_ERROR_HEADER_ALLOWLIST = [
+  "content-type",
+  "retry-after",
+  "www-authenticate",
+] as const;
+
+function headErrorResponse(error: unknown): NextResponse {
+  const upstreamHeaders = (
+    error && typeof error === "object"
+      ? (error as UpstreamErrorWithHeaders).response?.headers
+      : undefined
+  );
+  const headers = new Headers();
+
+  for (const name of HEAD_ERROR_HEADER_ALLOWLIST) {
+    const value = upstreamHeaders?.[name];
+    if (typeof value === "string" || typeof value === "number") {
+      headers.set(name, String(value));
+    }
+  }
+
+  headers.set("Cache-Control", "no-store");
+
+  return new NextResponse(null, {
+    status: getUpstreamErrorStatus(error, 502),
+    headers,
+  });
+}
 
 async function proxyPreview(
   request: NextRequest,
@@ -59,7 +94,7 @@ async function proxyPreview(
     });
   } catch (error) {
     if (!includeBody) {
-      return new NextResponse(null, { status: 500 });
+      return headErrorResponse(error);
     }
 
     return NextResponse.json(

--- a/frontend/src/components/app/contracts/ContractCreationForm.test.tsx
+++ b/frontend/src/components/app/contracts/ContractCreationForm.test.tsx
@@ -25,6 +25,18 @@ describe("ContractCreationForm compensation flows", () => {
     expect(branch).not.toContain("openDocument(");
   });
 
+  it("should not report adoption success while the local mirror is incomplete", () => {
+    const branch = source.slice(
+      source.indexOf('headless.reason === "local_persist_failed"'),
+      source.indexOf('headless.reason === "remote_unconfirmed"'),
+    );
+    expect(branch).toContain('adopted.warnings?.includes("mirror_sync_failed")');
+    expect(branch).toContain("전자문서와 PDF 동기화가 완료되지 않았습니다.");
+    expect(branch).toContain("markCreationProgressFailed()");
+    expect(branch.indexOf('adopted.warnings?.includes("mirror_sync_failed")'))
+      .toBeLessThan(branch.indexOf("setIsCreationSuccessOpen(true)"));
+  });
+
   it("should request approval and retry duplicate pending documents with force true", () => {
     const branch = source.slice(
       source.indexOf('headless.reason === "duplicate_pending_document"'),

--- a/frontend/src/components/app/contracts/ContractCreationForm.test.tsx
+++ b/frontend/src/components/app/contracts/ContractCreationForm.test.tsx
@@ -33,6 +33,13 @@ describe("ContractCreationForm compensation flows", () => {
     expect(branch).toContain('adopted.warnings?.includes("mirror_sync_failed")');
     expect(branch).toContain("전자문서와 PDF 동기화가 완료되지 않았습니다.");
     expect(branch).toContain("markCreationProgressFailed()");
+    const warningBranch = branch.slice(
+      branch.indexOf('adopted.warnings?.includes("mirror_sync_failed")'),
+      branch.indexOf("markCreationProgressFailed()"),
+    );
+    expect(warningBranch).toContain(
+      "queryClient.invalidateQueries({ queryKey: eformsignQueryKeys.documents() })",
+    );
     expect(branch.indexOf('adopted.warnings?.includes("mirror_sync_failed")'))
       .toBeLessThan(branch.indexOf("setIsCreationSuccessOpen(true)"));
   });

--- a/frontend/src/components/app/contracts/ContractCreationForm.tsx
+++ b/frontend/src/components/app/contracts/ContractCreationForm.tsx
@@ -859,6 +859,7 @@ export const ContractCreationForm = ({
                 finalClientId,
               );
               if (adopted.warnings?.includes("mirror_sync_failed")) {
+                queryClient.invalidateQueries({ queryKey: eformsignQueryKeys.documents() });
                 setSubmitError(
                   "문서는 생성·전송되었지만 전자문서와 PDF 동기화가 완료되지 않았습니다. "
                   + "새 계약서를 다시 만들지 말고 잠시 후 전자문서 목록에서 확인해 주세요.",

--- a/frontend/src/components/app/contracts/ContractCreationForm.tsx
+++ b/frontend/src/components/app/contracts/ContractCreationForm.tsx
@@ -854,7 +854,18 @@ export const ContractCreationForm = ({
 
           if (headless.reason === "local_persist_failed" && headless.remoteDocumentId) {
             try {
-              await eformsignApi.adoptDocument(headless.remoteDocumentId, finalClientId);
+              const adopted = await eformsignApi.adoptDocument(
+                headless.remoteDocumentId,
+                finalClientId,
+              );
+              if (adopted.warnings?.includes("mirror_sync_failed")) {
+                setSubmitError(
+                  "문서는 생성·전송되었지만 전자문서와 PDF 동기화가 완료되지 않았습니다. "
+                  + "새 계약서를 다시 만들지 말고 잠시 후 전자문서 목록에서 확인해 주세요.",
+                );
+                markCreationProgressFailed();
+                return;
+              }
               setCreationProgress({ step: "sent", completed: true, failed: false });
               queryClient.invalidateQueries({ queryKey: eformsignQueryKeys.documents() });
               setIsCreationSuccessOpen(true);

--- a/frontend/src/hooks/__tests__/useInfiniteContracts.excludeDeleted.test.tsx
+++ b/frontend/src/hooks/__tests__/useInfiniteContracts.excludeDeleted.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { eformsignApi } from "@/services/api";
@@ -20,6 +20,14 @@ function wrapper({ children }: { children: ReactNode }) {
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function wrapperFor(queryClient: QueryClient) {
+  return function QueryWrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
 }
 
 function emptyPage() {
@@ -56,4 +64,167 @@ describe("useInfiniteContracts — the All tab and deletion tombstones", () => {
       expect.objectContaining({ excludeDeleted: true }),
     );
   });
+
+  it("restarts desktop offset pagination when the semantic snapshot changes", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const documents = Array.from({ length: 20 }, (_, index) => ({
+      id: `document-${index + 1}`,
+      created_date: 100 - index,
+      current_status: { status_type: "060" },
+    }));
+    const firstPage = {
+      documents,
+      total_rows: 21,
+      limit: 20,
+      skip: 0,
+      has_more: true,
+      snapshot_version: "1:100",
+    };
+    const conflictingPage = {
+      documents: [{
+        id: "document-21",
+        created_date: 79,
+        current_status: { status_type: "060" },
+      }],
+      total_rows: 20,
+      limit: 20,
+      skip: 20,
+      has_more: false,
+      snapshot_version: "1:100:fvisibility",
+    };
+    mockedApi.getAllDocuments
+      .mockResolvedValueOnce(firstPage as never)
+      .mockResolvedValueOnce(conflictingPage as never)
+      .mockResolvedValue(firstPage as never);
+    const resetQueries = jest.spyOn(queryClient, "resetQueries");
+    const { result } = renderHook(
+      () => useInfiniteContracts({ filterType: null }),
+      { wrapper: wrapperFor(queryClient) },
+    );
+
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(resetQueries).toHaveBeenCalledTimes(1));
+    expect(resetQueries).toHaveBeenCalledWith({
+      queryKey: expect.arrayContaining(["infinite", "all"]),
+      exact: true,
+    });
+  });
+
+  it("re-arms the desktop drift guard after pagination becomes coherent", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const documents = Array.from({ length: 20 }, (_, index) => ({
+      id: `document-${index + 1}`,
+      created_date: 100 - index,
+      current_status: { status_type: "060" },
+    }));
+    const firstPage = {
+      documents,
+      total_rows: 21,
+      limit: 20,
+      skip: 0,
+      has_more: true,
+      snapshot_version: "1:100",
+    };
+    const conflictingPage = {
+      documents: [{
+        id: "document-21",
+        created_date: 79,
+        current_status: { status_type: "060" },
+      }],
+      total_rows: 21,
+      limit: 20,
+      skip: 20,
+      has_more: false,
+    };
+    mockedApi.getAllDocuments
+      .mockResolvedValueOnce(firstPage as never)
+      .mockResolvedValueOnce(conflictingPage as never)
+      .mockResolvedValueOnce(firstPage as never)
+      .mockResolvedValueOnce(conflictingPage as never)
+      .mockResolvedValue(firstPage as never);
+    const resetQueries = jest.spyOn(queryClient, "resetQueries");
+    const { result } = renderHook(
+      () => useInfiniteContracts({ filterType: null }),
+      { wrapper: wrapperFor(queryClient) },
+    );
+
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+    await waitFor(() => expect(resetQueries).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockedApi.getAllDocuments).toHaveBeenCalledTimes(3));
+
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(resetQueries).toHaveBeenCalledTimes(2));
+  });
+
+  it.each([
+    ["the later page omits it", "1:100", undefined],
+    ["the first page omits it", undefined, "1:100"],
+  ])(
+    "restarts desktop offset pagination when %s",
+    async (_description, firstSnapshotVersion, laterSnapshotVersion) => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0 } },
+      });
+      const documents = Array.from({ length: 20 }, (_, index) => ({
+        id: `document-${index + 1}`,
+        created_date: 100 - index,
+        current_status: { status_type: "060" },
+      }));
+      const firstPage = {
+        documents,
+        total_rows: 21,
+        limit: 20,
+        skip: 0,
+        has_more: true,
+        ...(firstSnapshotVersion === undefined
+          ? {}
+          : { snapshot_version: firstSnapshotVersion }),
+      };
+      const laterPage = {
+        documents: [{
+          id: "document-21",
+          created_date: 79,
+          current_status: { status_type: "060" },
+        }],
+        total_rows: 21,
+        limit: 20,
+        skip: 20,
+        has_more: false,
+        ...(laterSnapshotVersion === undefined
+          ? {}
+          : { snapshot_version: laterSnapshotVersion }),
+      };
+      mockedApi.getAllDocuments
+        .mockResolvedValueOnce(firstPage as never)
+        .mockResolvedValueOnce(laterPage as never)
+        .mockResolvedValue(firstPage as never);
+      const resetQueries = jest.spyOn(queryClient, "resetQueries");
+      const { result } = renderHook(
+        () => useInfiniteContracts({ filterType: null }),
+        { wrapper: wrapperFor(queryClient) },
+      );
+
+      await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+      await act(async () => {
+        await result.current.fetchNextPage();
+      });
+
+      await waitFor(() => expect(resetQueries).toHaveBeenCalledTimes(1));
+    },
+  );
 });

--- a/frontend/src/hooks/useInfiniteContracts.ts
+++ b/frontend/src/hooks/useInfiniteContracts.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { useMemo } from "react";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef } from "react";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { eformsignApi } from "@/services/api";
 import { EformsignDocument, EformsignDocumentsResponse } from "@/lib/eformsign/types";
 import { eformsignQueryKeys } from "@/hooks/useEformsignDocuments";
@@ -11,6 +11,7 @@ import { UNKNOWN_CUSTOMER_NAME, customerName } from "@/lib/eformsign/display-nam
 const PAGE_SIZE = 20;
 const EMPTY_DOCUMENTS: EformsignDocument[] = [];
 const EMPTY_EXCLUDED_NAMES: readonly string[] = [];
+const UNVERSIONED_SNAPSHOT_GENERATION = "<unversioned>";
 
 // Filter documents by actual status code. Used as a safety net for the merged
 // "전체" endpoint; per-status endpoints are already filtered server-side.
@@ -91,8 +92,18 @@ export function useInfiniteContracts({
   excludedNames = EMPTY_EXCLUDED_NAMES,
   templateFilter,
 }: UseInfiniteContractsOptions = {}) {
+  const queryClient = useQueryClient();
+  const templateId = templateFilter?.templateId;
+  const templateMatch = templateFilter?.templateMatch;
+  const queryKey = useMemo(
+    () => infiniteContractsQueryKeys.documents(
+      filterType,
+      templateId && templateMatch ? { templateId, templateMatch } : undefined,
+    ),
+    [filterType, templateId, templateMatch],
+  );
   const query = useInfiniteQuery<EformsignDocumentsResponse>({
-    queryKey: infiniteContractsQueryKeys.documents(filterType, templateFilter),
+    queryKey,
     initialPageParam: 0,
     queryFn: async ({ pageParam }) => {
       const skip = typeof pageParam === "number" ? pageParam : 0;
@@ -127,6 +138,45 @@ export function useInfiniteContracts({
     gcTime: 1000 * 60 * 60, // 1 hour
     refetchOnWindowFocus: false,
   });
+
+  // Offset pagination is valid only while every page belongs to the same effective
+  // mirror generation. A live readiness/tombstone fence can change membership even
+  // when Valkey invalidation fails, so restart from page 1 when a later page reports
+  // a different semantic snapshot generation. Presence is part of that
+  // generation: mixing a cache-backed versioned page with an unversioned
+  // cache-bypass page is no safer than mixing two different versions.
+  const pages = query.data?.pages;
+  const baseSnapshotVersion = pages?.[0]?.snapshot_version;
+  const baseSnapshotGeneration = pages?.length
+    ? (baseSnapshotVersion ?? UNVERSIONED_SNAPSHOT_GENERATION)
+    : undefined;
+  const conflictingSnapshotGeneration = useMemo(() => {
+    if (!pages || baseSnapshotGeneration === undefined) return undefined;
+    return pages
+      .slice(1)
+      .map((page) =>
+        page.snapshot_version ?? UNVERSIONED_SNAPSHOT_GENERATION)
+      .find((generation) => generation !== baseSnapshotGeneration);
+  }, [pages, baseSnapshotGeneration]);
+  const lastSnapshotResetRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (baseSnapshotGeneration === undefined) return;
+    if (conflictingSnapshotGeneration === undefined) {
+      lastSnapshotResetRef.current = null;
+      return;
+    }
+    const signature =
+      `${queryKey.join("|")}::${baseSnapshotGeneration}->${conflictingSnapshotGeneration}`;
+    if (lastSnapshotResetRef.current === signature) return;
+    lastSnapshotResetRef.current = signature;
+    void queryClient.resetQueries({ queryKey, exact: true });
+  }, [
+    baseSnapshotGeneration,
+    conflictingSnapshotGeneration,
+    queryClient,
+    queryKey,
+  ]);
 
   // Flatten loaded pages into a single document list, deduping by id.
   // The backend's getAllDocuments only dedupes within a single response, so a

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -260,7 +260,14 @@ export const eformsignApi = {
         });
         return data;
     },
-    adoptDocument: async (documentId: string, clientId?: number): Promise<{ id?: number; documentId: string }> => {
+    adoptDocument: async (
+        documentId: string,
+        clientId?: number,
+    ): Promise<{
+        id?: number;
+        documentId: string;
+        warnings?: Array<"client_link_failed" | "mirror_sync_failed">;
+    }> => {
         const { data } = await api.post('/eformsign-docs/adopt', { documentId, clientId });
         return data;
     },

--- a/mobile/src/app/(shell)/(auth)/register/page.test.tsx
+++ b/mobile/src/app/(shell)/(auth)/register/page.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { authApi } from "@/services/api";
+
+import RegisterPage from "./page";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/services/api", () => ({
+  authApi: {
+    checkEmailExists: jest.fn(),
+    register: jest.fn(),
+  },
+}));
+
+const mockCheckEmailExists = jest.mocked(authApi.checkEmailExists);
+
+describe("RegisterPage", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockCheckEmailExists.mockReset();
+    mockCheckEmailExists.mockResolvedValue({ exists: false, linkable: false });
+  });
+
+  it("advances to the profile step when the account fields are valid", async () => {
+    const user = userEvent.setup();
+
+    render(<RegisterPage />);
+
+    await user.type(screen.getByLabelText("이메일"), "new.user@example.com");
+    await user.type(screen.getByLabelText("이름"), "테스트");
+    await user.type(screen.getByLabelText("비밀번호"), "Password1!");
+    await user.type(screen.getByLabelText("비밀번호 확인"), "Password1!");
+
+    await waitFor(() => {
+      expect(mockCheckEmailExists).toHaveBeenCalledWith("new.user@example.com");
+    });
+
+    await user.click(screen.getByRole("button", { name: "다음" }));
+
+    expect(await screen.findByLabelText("전화번호")).toBeInTheDocument();
+  });
+});

--- a/mobile/src/app/(shell)/(auth)/register/page.tsx
+++ b/mobile/src/app/(shell)/(auth)/register/page.tsx
@@ -215,8 +215,10 @@ export default function RegisterPage() {
     const result = registerSchema.safeParse(getCombinedFormData());
     if (!result.success) {
       const fieldErrors = collectFieldErrors(result.error.issues, ACCOUNT_FIELDS);
-      setErrors(fieldErrors);
-      return;
+      if (Object.keys(fieldErrors).length > 0) {
+        setErrors(fieldErrors);
+        return;
+      }
     }
 
     setErrors({});

--- a/mobile/src/app/(shell)/contracts/new/page.test.ts
+++ b/mobile/src/app/(shell)/contracts/new/page.test.ts
@@ -13,6 +13,13 @@ describe("mobile contract creation compensation flow", () => {
     expect(branch).toContain("전자문서와 PDF 동기화가 완료되지 않았습니다.");
     expect(branch).toContain("completed: false");
     expect(branch).toContain("failed: true");
+    const warningBranch = branch.slice(
+      branch.indexOf('adopted.warnings?.includes("mirror_sync_failed")'),
+      branch.indexOf("return;", branch.indexOf('adopted.warnings?.includes("mirror_sync_failed")')),
+    );
+    expect(warningBranch).toContain(
+      "queryClient.invalidateQueries({ queryKey: eformsignQueryKeys.documents() })",
+    );
     expect(branch.indexOf('adopted.warnings?.includes("mirror_sync_failed")'))
       .toBeLessThan(branch.indexOf('router.push("/contracts")'));
   });

--- a/mobile/src/app/(shell)/contracts/new/page.test.ts
+++ b/mobile/src/app/(shell)/contracts/new/page.test.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs";
+
+const source = fs.readFileSync(require.resolve("./page"), "utf8");
+
+describe("mobile contract creation compensation flow", () => {
+  it("does not navigate after adoption leaves the local mirror incomplete", () => {
+    const branch = source.slice(
+      source.indexOf('headless.reason === "local_persist_failed"'),
+      source.indexOf('headless.reason === "remote_unconfirmed"'),
+    );
+
+    expect(branch).toContain('adopted.warnings?.includes("mirror_sync_failed")');
+    expect(branch).toContain("전자문서와 PDF 동기화가 완료되지 않았습니다.");
+    expect(branch).toContain("completed: false");
+    expect(branch).toContain("failed: true");
+    expect(branch.indexOf('adopted.warnings?.includes("mirror_sync_failed")'))
+      .toBeLessThan(branch.indexOf('router.push("/contracts")'));
+  });
+});

--- a/mobile/src/app/(shell)/contracts/new/page.tsx
+++ b/mobile/src/app/(shell)/contracts/new/page.tsx
@@ -846,6 +846,7 @@ export default function ContractCreationPage() {
               finalClientId,
             );
             if (adopted.warnings?.includes("mirror_sync_failed")) {
+              queryClient.invalidateQueries({ queryKey: eformsignQueryKeys.documents() });
               setProgressErrorHint(
                 "문서는 생성·전송되었지만 전자문서와 PDF 동기화가 완료되지 않았습니다. "
                 + "새 계약서를 다시 만들지 말고 잠시 후 전자문서 목록에서 확인해 주세요.",

--- a/mobile/src/app/(shell)/contracts/new/page.tsx
+++ b/mobile/src/app/(shell)/contracts/new/page.tsx
@@ -841,7 +841,22 @@ export default function ContractCreationPage() {
 
         if (headless.reason === "local_persist_failed" && headless.remoteDocumentId) {
           try {
-            await eformsignApi.adoptDocument(headless.remoteDocumentId, finalClientId);
+            const adopted = await eformsignApi.adoptDocument(
+              headless.remoteDocumentId,
+              finalClientId,
+            );
+            if (adopted.warnings?.includes("mirror_sync_failed")) {
+              setProgressErrorHint(
+                "문서는 생성·전송되었지만 전자문서와 PDF 동기화가 완료되지 않았습니다. "
+                + "새 계약서를 다시 만들지 말고 잠시 후 전자문서 목록에서 확인해 주세요.",
+              );
+              setCreationProgress((current) => ({
+                step: current.step ?? "client-started",
+                completed: false,
+                failed: true,
+              }));
+              return;
+            }
             startNavigation();
             setCreationProgress({ step: "sent", completed: true, failed: false });
             queryClient.invalidateQueries({ queryKey: eformsignQueryKeys.documents() });

--- a/mobile/src/hooks/__tests__/useInfiniteContracts.test.tsx
+++ b/mobile/src/hooks/__tests__/useInfiniteContracts.test.tsx
@@ -348,7 +348,7 @@ describe("useInfiniteContracts", () => {
     expect(result.current.loadedCount).toBe(9);
   });
 
-  it("resets once on snapshot drift and suppresses the same mismatch after refetch", async () => {
+  it("re-arms the snapshot drift guard after a coherent refetch", async () => {
     const firstPage = createPage({
       ids: documentIds(1, 9),
       totalRows: 15,
@@ -369,7 +369,8 @@ describe("useInfiniteContracts", () => {
       .mockResolvedValueOnce(firstPage)
       .mockResolvedValueOnce(conflictingPage)
       .mockResolvedValueOnce(firstPage)
-      .mockResolvedValueOnce(conflictingPage);
+      .mockResolvedValueOnce(conflictingPage)
+      .mockResolvedValue(firstPage);
     const resetQueriesSpy = jest.spyOn(queryClient, "resetQueries");
 
     const { result } = renderHook(() => useInfiniteContracts(), {
@@ -394,11 +395,52 @@ describe("useInfiniteContracts", () => {
     await act(async () => {
       await result.current.fetchNextPage();
     });
-    await waitFor(() => expect(mockedGetAllDocuments).toHaveBeenCalledTimes(4));
-
-    expect(resetQueriesSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(resetQueriesSpy).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockedGetAllDocuments).toHaveBeenCalledTimes(5));
     resetQueriesSpy.mockRestore();
   });
+
+  it.each([
+    ["the later page omits it", "1:100", undefined],
+    ["the first page omits it", undefined, "1:100"],
+  ])(
+    "resets mobile offset pagination when %s",
+    async (_description, firstSnapshotVersion, laterSnapshotVersion) => {
+      const firstPage = createPage({
+        ids: documentIds(1, 9),
+        totalRows: 15,
+        limit: 9,
+        skip: 0,
+        hasMore: true,
+        snapshotVersion: firstSnapshotVersion,
+      });
+      const laterPage = createPage({
+        ids: documentIds(10, 6),
+        totalRows: 15,
+        limit: 6,
+        skip: 9,
+        hasMore: false,
+        snapshotVersion: laterSnapshotVersion,
+      });
+      mockedGetAllDocuments
+        .mockResolvedValueOnce(firstPage)
+        .mockResolvedValueOnce(laterPage)
+        .mockResolvedValue(firstPage);
+      const resetQueriesSpy = jest.spyOn(queryClient, "resetQueries");
+
+      const { result } = renderHook(() => useInfiniteContracts(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+      await act(async () => {
+        await result.current.fetchNextPage();
+      });
+
+      await waitFor(() => expect(resetQueriesSpy).toHaveBeenCalledTimes(1));
+      resetQueriesSpy.mockRestore();
+    },
+  );
 
   it("keeps loaded documents and exposes a load-more error when the next page fails", async () => {
     mockedGetAllDocuments

--- a/mobile/src/hooks/useInfiniteContracts.ts
+++ b/mobile/src/hooks/useInfiniteContracts.ts
@@ -16,6 +16,7 @@ export const CONTRACTS_NEXT_PAGE_SIZE = 6;
 
 export const CONTRACTS_PAGE_STALE_TIME = 1000 * 60 * 5; // 5 minutes
 export const CONTRACTS_PAGE_GC_TIME = 1000 * 60 * 60; // 1 hour
+const UNVERSIONED_SNAPSHOT_GENERATION = "<unversioned>";
 
 /** Offset page cursor sent to `GET /eformsign/documents`. */
 export interface ContractsPageParam {
@@ -195,34 +196,46 @@ export function useInfiniteContracts({
 
   // --- snapshot_version drift guard -----------------------------------------
   // Offset pagination is only coherent against a stable snapshot. If the backend
-  // reports a different snapshot for a later page, the underlying list changed
-  // mid-pagination and the loaded pages may hold duplicates or gaps — restart
-  // from page 1. The field is optional (absent when the cache is bypassed), which
-  // simply means "no signal".
+  // reports a different snapshot generation for a later page, the underlying
+  // list changed mid-pagination and the loaded pages may hold duplicates or gaps
+  // — restart from page 1. Versioned and unversioned pages are distinct
+  // generations because omission means the backend bypassed the snapshot cache.
   const baseSnapshotVersion = pages?.[0]?.snapshot_version;
-  const conflictingSnapshotVersion = useMemo(() => {
-    if (!pages || !baseSnapshotVersion) return undefined;
+  const baseSnapshotGeneration = pages?.length
+    ? (baseSnapshotVersion ?? UNVERSIONED_SNAPSHOT_GENERATION)
+    : undefined;
+  const conflictingSnapshotGeneration = useMemo(() => {
+    if (!pages || baseSnapshotGeneration === undefined) return undefined;
     return pages
       .slice(1)
-      .find((page) => page.snapshot_version && page.snapshot_version !== baseSnapshotVersion)
-      ?.snapshot_version;
-  }, [pages, baseSnapshotVersion]);
+      .map((page) => page.snapshot_version ?? UNVERSIONED_SNAPSHOT_GENERATION)
+      .find((generation) => generation !== baseSnapshotGeneration);
+  }, [pages, baseSnapshotGeneration]);
 
-  // Loop guard: at most one reset per (query key, base -> conflicting) pair. A
-  // repeat of the exact same mismatch after a reset is swallowed rather than
-  // resetting forever.
+  // Loop guard: reset a given mismatch once while it remains present. Re-arm
+  // after the pages become coherent so a later recurrence is handled too.
   const lastSnapshotResetRef = useRef<string | null>(null);
   const queryKey = options.queryKey;
 
   useEffect(() => {
-    if (!baseSnapshotVersion || !conflictingSnapshotVersion) return;
+    if (baseSnapshotGeneration === undefined) return;
+    if (conflictingSnapshotGeneration === undefined) {
+      lastSnapshotResetRef.current = null;
+      return;
+    }
 
-    const signature = `${queryKey.join("|")}::${baseSnapshotVersion}->${conflictingSnapshotVersion}`;
+    const signature =
+      `${queryKey.join("|")}::${baseSnapshotGeneration}->${conflictingSnapshotGeneration}`;
     if (lastSnapshotResetRef.current === signature) return;
     lastSnapshotResetRef.current = signature;
 
     void queryClient.resetQueries({ queryKey, exact: true });
-  }, [baseSnapshotVersion, conflictingSnapshotVersion, queryClient, queryKey]);
+  }, [
+    baseSnapshotGeneration,
+    conflictingSnapshotGeneration,
+    queryClient,
+    queryKey,
+  ]);
 
   return {
     // Spreading opts out of react-query's tracked-props optimization (every

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -335,7 +335,14 @@ export const eformsignApi = {
         });
         return data;
     },
-    adoptDocument: async (documentId: string, clientId?: number): Promise<{ id?: number; documentId: string }> => {
+    adoptDocument: async (
+        documentId: string,
+        clientId?: number,
+    ): Promise<{
+        id?: number;
+        documentId: string;
+        warnings?: Array<"client_link_failed" | "mirror_sync_failed">;
+    }> => {
         const { data } = await api.post('/eformsign-docs/adopt', { documentId, clientId });
         return data;
     },


### PR DESCRIPTION
## Summary
- Promote the current verified `preview` state to production.
- Include eformsign mirror correctness/performance fixes from PRs #439, #441, #442, and #443.
- Include mobile registration step navigation fix from PR #444.

## Preview evidence
- Preview merge commit: `c25d1ed4da715495a818df7df8a1ec3988b309b7`.
- All preview branch backend/frontend/mobile/security CI passed.
- Railway and all three Vercel deployments completed successfully.
- Preview DB patch workflow run 30527158563 passed.
- Full preview eformsign backfill completed: fetched 425, updated 30, failed 0.
- Final readiness passed: ready=true with all missing/unfinished counters at 0.
- Live `https://preview.m.admin.babyjamjam.com/register` verification passed: the enabled `mobile_auth_register_form_actions_next-button` advanced from 1/3 to 2/3 with no browser errors; no account was submitted.

## Review
- PR #440 current-HEAD Codex review found no major issues.
- All seven prior review threads are resolved.

## Operational note
- Preview backfill emitted non-blocking auxiliary client reconciliation/end-date warnings for a PostgreSQL `uuid = text` comparison. Document mirror completion and readiness remained green; follow this separately before treating those auxiliary paths as clean operational evidence.

## Production plan
- Merge only after current-HEAD CI, deployments, and Codex review pass.
- After the exact merge SHA deploys, run the production eformsign backfill/readiness gate and verify the production registration transition without submitting an account.

## Rollback
- Revert this merge through a main-targeted revert PR and redeploy the previous production version. Additive mirror data remains in place.