### PR TITLE
fix(backend): cast eformsign UUID query bindings

### DIFF
--- a/backend/application/services/client.service.ts
+++ b/backend/application/services/client.service.ts
@@ -297,7 +297,7 @@ export class ClientService {
                     FROM eformsign_doc AS doc
                     WHERE doc.id IN (${Prisma.join(documentIdsToLock)})
                       AND (
-                          doc.branch_id = ${branchid}
+                          doc.branch_id = ${branchid}::uuid
                           OR (doc.branch_id IS NULL AND doc.client_id IS NULL)
                       )
                       AND doc.status_type NOT IN ('047', '049', '099')

--- a/backend/application/services/service-record-lifecycle.service.ts
+++ b/backend/application/services/service-record-lifecycle.service.ts
@@ -320,7 +320,7 @@ export class ServiceRecordLifecycleService {
                 SELECT id
                 FROM eformsign_doc
                 WHERE document_id = ${params.documentId}
-                  AND branch_id = ${params.branchId}
+                  AND branch_id = ${params.branchId}::uuid
                   AND detail_source_updated_date = ${params.detailSourceUpdatedDate}
                   AND detail_synced_at = ${params.detailSyncedAt}
                   AND sync_status = 'ready'
@@ -389,8 +389,8 @@ export class ServiceRecordLifecycleService {
         const cases = await tx.$queryRaw<{ id: string }[]>(Prisma.sql`
             SELECT id
             FROM service_record_case
-            WHERE id = ${trigger.serviceRecordCaseId}
-              AND branch_id = ${params.branchId}
+            WHERE id = ${trigger.serviceRecordCaseId}::uuid
+              AND branch_id = ${params.branchId}::uuid
               AND status = ${SERVICE_RECORD_CASE_STATUS.DOCUMENTS_CREATED}
             FOR UPDATE
         `);
@@ -425,8 +425,8 @@ export class ServiceRecordLifecycleService {
                         = eformsign_doc.detail_source_updated_date
                 ) AS "hasCurrentAuditTrailPdf"
             FROM eformsign_doc
-            WHERE branch_id = ${params.branchId}
-              AND service_record_case_id = ${trigger.serviceRecordCaseId}
+            WHERE branch_id = ${params.branchId}::uuid
+              AND service_record_case_id = ${trigger.serviceRecordCaseId}::uuid
               AND document_kind = ${EFORMSIGN_DOCUMENT_KIND.SERVICE_RECORD_SNAPSHOT}
             ORDER BY id ASC
             FOR UPDATE

--- a/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-doc.repository.ts
@@ -455,7 +455,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                 SELECT id, client_id AS "clientId"
                 FROM eformsign_doc
                 WHERE document_id = ${documentId}
-                  AND branch_id = ${branchid}
+                  AND branch_id = ${branchid}::uuid
                   AND permanent_purge_requested_at IS NULL
                   AND status_type NOT IN ('047', '049', '099')
                 FOR UPDATE
@@ -476,7 +476,7 @@ export class SbEformsignDocRepository implements IEformsignDocRepository {
                 SELECT id
                 FROM client
                 WHERE id IN (${Prisma.join(clientIdsToLock)})
-                  AND branch_id = ${branchid}
+                  AND branch_id = ${branchid}::uuid
                 ORDER BY id
                 FOR UPDATE
             `);

--- a/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-doc.repository.spec.ts
@@ -501,6 +501,7 @@ describe("SbEformsignDocRepository", () => {
     });
 
     it("atomically moves the document pointer from the old client to the new client", async () => {
+        const branchId = "44444444-4444-4444-4444-444444444444";
         const transaction = {
             $queryRaw: jest.fn()
                 .mockResolvedValueOnce([{ id: 1, clientId: 7 }])
@@ -515,30 +516,33 @@ describe("SbEformsignDocRepository", () => {
         const transactionalRepository = new SbEformsignDocRepository(prisma);
 
         await expect(
-            transactionalRepository.linkClientIfActive("branch-1", "doc-1", 12),
+            transactionalRepository.linkClientIfActive(branchId, "doc-1", 12),
         ).resolves.toBe(true);
 
-        const lockSql = transaction.$queryRaw.mock.calls[0][0];
-        expect(lockSql.strings.join(" ")).toContain("permanent_purge_requested_at IS NULL");
-        expect(lockSql.strings.join(" ")).toContain("status_type NOT IN ('047', '049', '099')");
-        expect(lockSql.strings.join(" ")).toContain("FOR UPDATE");
+        const [documentLockSql] = transaction.$queryRaw.mock.calls[0];
+        const [clientLockSql] = transaction.$queryRaw.mock.calls[1];
+        expect(documentLockSql.strings.join(" ")).toContain("permanent_purge_requested_at IS NULL");
+        expect(documentLockSql.strings.join(" ")).toContain("status_type NOT IN ('047', '049', '099')");
+        expect(documentLockSql.text).toMatch(/\$\d+::uuid/);
+        expect(documentLockSql.strings.join(" ")).toContain("FOR UPDATE");
+        expect(clientLockSql.text).toMatch(/\$\d+::uuid/);
         expect(transaction.client.updateMany).toHaveBeenCalledTimes(2);
         expect(transaction.client.updateMany).toHaveBeenNthCalledWith(1, {
             where: {
                 id: 7,
-                branchId: "branch-1",
+                branchId,
                 eDocId: "doc-1",
             },
             data: { eDocId: null },
         });
         expect(transaction.client.updateMany).toHaveBeenNthCalledWith(2, {
-            where: { id: 12, branchId: "branch-1" },
+            where: { id: 12, branchId },
             data: { eDocId: "doc-1" },
         });
         expect(transaction.eformsign_doc.updateMany).toHaveBeenCalledWith({
             where: {
                 id: 1,
-                branchId: "branch-1",
+                branchId,
                 permanentPurgeRequestedAt: null,
                 statusType: { notIn: ["047", "049", "099"] },
             },

--- a/backend/test/services/client.service.spec.ts
+++ b/backend/test/services/client.service.spec.ts
@@ -389,6 +389,7 @@ describe("ClientService", () => {
         });
 
         it("links every matching contract by normalized phone after manual client creation", async () => {
+            const branchId = "11111111-1111-1111-1111-111111111111";
             const mockClient = createClientEntity();
             createClientUsecase.execute.mockResolvedValue(mockClient);
             prismaService.eformsign_doc.updateMany.mockResolvedValue({ count: 2 });
@@ -507,6 +508,8 @@ describe("ClientService", () => {
             expect(mockClient.eDocId).toBe("DOC-LATEST");
             const [lockQuery] = prismaService.$queryRaw.mock.calls[0]!;
             expect(lockQuery.sql).toContain("ORDER BY doc.id");
+            expect(lockQuery.strings.join(" ")).toMatch(/doc\.branch_id\s*=\s*::uuid/);
+            expect(lockQuery.text).toMatch(/\$\d+::uuid/);
             expect(documentSnapshotService.bumpVersion).toHaveBeenCalledWith(branchId);
             expect(documentSnapshotService.bumpCompanyEpoch).toHaveBeenCalledTimes(1);
         });

--- a/backend/test/services/service-record-lifecycle.service.spec.ts
+++ b/backend/test/services/service-record-lifecycle.service.spec.ts
@@ -6,12 +6,15 @@ import {
 import { PrismaService } from "infrastructure/database/prisma.service";
 
 const date = (value: string) => new Date(`${value}T00:00:00.000Z`);
+const rawQueryBranchId = "11111111-1111-1111-1111-111111111111";
+const rawQueryCaseId = "22222222-2222-2222-2222-222222222222";
+const rawQueryDocumentId = "33333333-3333-3333-3333-333333333333";
 
 function lockedSnapshot(overrides: Record<string, unknown> = {}) {
     return {
         id: 7,
-        documentId: "snapshot-062",
-        branchId: "branch-1",
+        documentId: rawQueryDocumentId,
+        branchId: rawQueryBranchId,
         documentKind: "service_record_snapshot",
         statusType: "062",
         detailPayload: { id: "snapshot-062" },
@@ -142,10 +145,10 @@ describe("ServiceRecordLifecycleService", () => {
         const ensureSpy = jest.spyOn(service, "ensureForClient");
 
         await expect(service.syncEndDateFromMirroredContract({
-            branchId: "branch-1",
+            branchId: rawQueryBranchId,
             clientId: 1,
             endDate: date("2026-07-20"),
-            documentId: "doc-1",
+            documentId: rawQueryDocumentId,
             detailSourceUpdatedDate: new Date("2026-07-30T01:00:00.000Z"),
             detailSyncedAt: new Date("2026-07-30T01:01:00.000Z"),
         })).resolves.toBe(false);
@@ -153,6 +156,8 @@ describe("ServiceRecordLifecycleService", () => {
         expect(transactionClient.$queryRaw).toHaveBeenCalledTimes(1);
         const [fenceQuery] = transactionClient.$queryRaw.mock.calls[0] ?? [];
         const fenceSql = fenceQuery.strings.join(" ");
+        expect(fenceSql).toMatch(/branch_id\s*=\s*::uuid/);
+        expect(fenceQuery.text).toMatch(/\$\d+::uuid/);
         expect(fenceSql).toContain("permanent_purge_requested_at IS NULL");
         expect(fenceSql).toContain("file_type = 'document'");
         expect(fenceSql).toContain("file_type = 'audit_trail'");
@@ -163,12 +168,12 @@ describe("ServiceRecordLifecycleService", () => {
     it("completes a service-record case idempotently when every locked snapshot is in the completed set", async () => {
         const transactionClient = {
             eformsign_doc: {
-                findFirst: jest.fn().mockResolvedValue({ serviceRecordCaseId: "case-1" }),
+                findFirst: jest.fn().mockResolvedValue({ serviceRecordCaseId: rawQueryCaseId }),
             },
             $queryRaw: jest.fn()
-                .mockResolvedValueOnce([{ id: "case-1" }])
+                .mockResolvedValueOnce([{ id: rawQueryCaseId }])
                 .mockResolvedValueOnce([lockedSnapshot()])
-                .mockResolvedValueOnce([{ id: "case-1" }])
+                .mockResolvedValueOnce([{ id: rawQueryCaseId }])
                 .mockResolvedValueOnce([lockedSnapshot()]),
             service_record_case: {
                 updateMany: jest.fn().mockResolvedValue({ count: 1 }),
@@ -181,8 +186,8 @@ describe("ServiceRecordLifecycleService", () => {
         const service = new ServiceRecordLifecycleService(prisma as unknown as PrismaService);
 
         await expect(service.completeServiceRecordSnapshotIfReady({
-            branchId: "branch-1",
-            documentId: "snapshot-062",
+            branchId: rawQueryBranchId,
+            documentId: rawQueryDocumentId,
             mirrorVersion: {
                 detailSourceUpdatedDate: new Date("2026-07-30T01:00:00.000Z"),
                 detailSyncedAt: new Date("2026-07-30T01:01:00.000Z"),
@@ -193,8 +198,10 @@ describe("ServiceRecordLifecycleService", () => {
         const [caseLockQuery] = transactionClient.$queryRaw.mock.calls[0];
         const [snapshotLockQuery] = transactionClient.$queryRaw.mock.calls[1];
         expect(caseLockQuery.strings.join(" ")).toContain("FROM service_record_case");
+        expect(caseLockQuery.text.match(/\$\d+::uuid/g)).toHaveLength(2);
         expect(caseLockQuery.strings.join(" ")).toContain("FOR UPDATE");
         expect(snapshotLockQuery.strings.join(" ")).toContain("ORDER BY id ASC");
+        expect(snapshotLockQuery.text.match(/\$\d+::uuid/g)).toHaveLength(2);
         expect(snapshotLockQuery.strings.join(" ")).toContain("FOR UPDATE");
         expect(snapshotLockQuery.strings.join(" ")).toContain("file_type = 'document'");
         expect(snapshotLockQuery.strings.join(" ")).toContain("file_type = 'audit_trail'");
@@ -206,8 +213,8 @@ describe("ServiceRecordLifecycleService", () => {
 
         transactionClient.service_record_case.updateMany.mockResolvedValue({ count: 0 });
         await expect(service.completeServiceRecordSnapshotIfReady({
-            branchId: "branch-1",
-            documentId: "snapshot-062",
+            branchId: rawQueryBranchId,
+            documentId: rawQueryDocumentId,
         })).resolves.toBe(false);
 
         expect(transactionClient.$queryRaw).toHaveBeenCalledTimes(4);


### PR DESCRIPTION
## Summary
- Cast all scoped raw-SQL UUID bindings in eformsign client relink, contract end-date, service-record completion, and document/client lock paths.
- Keep every value parameterized through Prisma tagged templates; no schema or dependency change.
- Strengthen SQL-shape regressions with UUID fixtures and compiled `$n::uuid` assertions.

## Runtime issue
Preview backfill exposed PostgreSQL `42883` (`operator does not exist: uuid = text`). The affected requests could otherwise return success while customer contract relinking, end-date propagation, or service-record completion side effects were skipped.

## Validation
- Focused backend Jest: 3 suites / 170 tests passed.
- Full backend Jest: 187 suites / 2,171 passed / 37 skipped.
- Backend type-check: passed.
- Backend lint: 0 errors (existing warnings only).
- Backend build: passed.
- `git diff --check`: passed.
- Independent scoped review: approved all eight casts and parameter binding.

## Security
No SQL string concatenation was introduced. Values remain bound parameters; only explicit PostgreSQL UUID casts were added. No secrets, auth logic, dependencies, or schema changed.

## Rollback
Revert this commit. No database rollback is required.