### PR TITLE
fix(backend): preserve legacy eformsign predicate semantics

### DIFF
--- a/backend/infrastructure/database/eformsign-doc-compat.ts
+++ b/backend/infrastructure/database/eformsign-doc-compat.ts
@@ -329,10 +329,9 @@ export const stripPendingEformsignDocPredicates = (
         let removedTrue = false;
         for (const [key, value] of Object.entries(node)) {
             if (value === undefined) {
-                // Prisma omits undefined filters. If they are all that remain after a
-                // missing-column predicate is removed, this node is the true identity
-                // rather than an authored empty predicate with contextual semantics.
-                removedTrue = true;
+                // Prisma omits undefined filters, but an undefined-only logical branch
+                // still has the contextual semantics of an authored empty predicate.
+                // Only removing a known missing-column `: null` marks this node true.
                 continue;
             }
             if (missing.has(key) && value === null) {

--- a/backend/infrastructure/database/eformsign-doc-compat.ts
+++ b/backend/infrastructure/database/eformsign-doc-compat.ts
@@ -328,6 +328,13 @@ export const stripPendingEformsignDocPredicates = (
         const stripped: Record<string, unknown> = {};
         let removedTrue = false;
         for (const [key, value] of Object.entries(node)) {
+            if (value === undefined) {
+                // Prisma omits undefined filters. If they are all that remain after a
+                // missing-column predicate is removed, this node is the true identity
+                // rather than an authored empty predicate with contextual semantics.
+                removedTrue = true;
+                continue;
+            }
             if (missing.has(key) && value === null) {
                 removedTrue = true;
                 continue;

--- a/backend/infrastructure/database/eformsign-doc-compat.ts
+++ b/backend/infrastructure/database/eformsign-doc-compat.ts
@@ -243,30 +243,135 @@ export const stripPendingEformsignDocPredicates = (
     }
     const missing = new Set(missingNames);
 
-    // AND is the only operator this descends into, because it is the only one where
-    // deleting a vacuously-true leaf preserves the meaning of the whole. Under OR a true
-    // leaf makes the branch true, and under NOT it makes it false; an empty object says
-    // neither, so both are left exactly as they are and fail loudly instead of quietly
-    // answering a different question. Every filter that actually needs this puts its
-    // pending predicates at the top level or in an AND chain.
-    const strip = (node: Prisma.eformsign_docWhereInput): Prisma.eformsign_docWhereInput => {
+    type SimplifiedWhere =
+        | { kind: "true" }
+        | { kind: "false" }
+        | { kind: "where"; where: Prisma.eformsign_docWhereInput };
+
+    const isTrue = (
+        value: SimplifiedWhere,
+    ): value is Extract<SimplifiedWhere, { kind: "true" }> => value.kind === "true";
+    const isFalse = (
+        value: SimplifiedWhere,
+    ): value is Extract<SimplifiedWhere, { kind: "false" }> => value.kind === "false";
+
+    const stripLogical = (
+        operator: "AND" | "OR" | "NOT",
+        value: Prisma.eformsign_docWhereInput | Prisma.eformsign_docWhereInput[],
+    ): SimplifiedWhere => {
+        const entries = Array.isArray(value) ? value : [value];
+        const simplifiedEntries = entries.map((entry) => strip(entry));
+
+        if (operator === "AND") {
+            if (simplifiedEntries.some(isFalse)) {
+                return { kind: "false" };
+            }
+            const remaining = simplifiedEntries.filter(
+                (entry): entry is Extract<SimplifiedWhere, { kind: "where" }> => !isTrue(entry),
+            );
+            if (remaining.length === 0) {
+                return { kind: "true" };
+            }
+            return {
+                kind: "where",
+                where: {
+                    AND: Array.isArray(value)
+                        ? remaining.map((entry) => entry.where)
+                        : remaining[0]!.where,
+                },
+            };
+        }
+
+        if (operator === "OR") {
+            if (simplifiedEntries.some(isTrue)) {
+                return { kind: "true" };
+            }
+            const remaining = simplifiedEntries.filter(
+                (entry): entry is Extract<SimplifiedWhere, { kind: "where" }> => !isFalse(entry),
+            );
+            if (remaining.length === 0) {
+                return { kind: "false" };
+            }
+            return {
+                kind: "where",
+                where: {
+                    OR: remaining.map((entry) => entry.where),
+                },
+            };
+        }
+
+        if (Array.isArray(value)) {
+            // Prisma treats NOT arrays as an implicit AND of negated entries.
+            if (simplifiedEntries.some(isTrue)) {
+                return { kind: "false" };
+            }
+            const remaining = simplifiedEntries.filter(
+                (entry): entry is Extract<SimplifiedWhere, { kind: "where" }> => !isFalse(entry),
+            );
+            if (remaining.length === 0) {
+                return { kind: "true" };
+            }
+            return { kind: "where", where: { NOT: remaining.map((entry) => entry.where) } };
+        }
+
+        const [simplified] = simplifiedEntries;
+        if (isTrue(simplified!)) {
+            return { kind: "false" };
+        }
+        if (isFalse(simplified!)) {
+            return { kind: "true" };
+        }
+        return { kind: "where", where: { NOT: simplified!.where } };
+    };
+
+    const strip = (node: Prisma.eformsign_docWhereInput): SimplifiedWhere => {
         const stripped: Record<string, unknown> = {};
+        let removedTrue = false;
         for (const [key, value] of Object.entries(node)) {
             if (missing.has(key) && value === null) {
+                removedTrue = true;
                 continue;
             }
-            if (key === "AND" && value !== undefined && value !== null) {
-                stripped[key] = Array.isArray(value)
-                    ? value.map((entry) => strip(entry as Prisma.eformsign_docWhereInput))
-                    : strip(value as Prisma.eformsign_docWhereInput);
+            if (
+                (key === "AND" || key === "OR" || key === "NOT")
+                && value !== undefined
+                && value !== null
+            ) {
+                const simplified = stripLogical(
+                    key,
+                    value as Prisma.eformsign_docWhereInput | Prisma.eformsign_docWhereInput[],
+                );
+                if (isTrue(simplified)) {
+                    removedTrue = true;
+                    continue;
+                }
+                if (isFalse(simplified)) {
+                    return { kind: "false" };
+                }
+                Object.assign(stripped, simplified.where);
                 continue;
             }
             stripped[key] = value;
         }
-        return stripped as Prisma.eformsign_docWhereInput;
+        if (Object.keys(stripped).length === 0) {
+            // `{}` is context-sensitive in Prisma (`OR: [{}]` and `NOT: {}` are not
+            // interchangeable with our boolean identities). Only an empty node caused by
+            // removing a known-true predicate is the true identity this helper may erase.
+            return removedTrue
+                ? { kind: "true" }
+                : { kind: "where", where: {} };
+        }
+        return { kind: "where", where: stripped as Prisma.eformsign_docWhereInput };
     };
 
-    return strip(where);
+    const simplified = strip(where);
+    if (isTrue(simplified)) {
+        return {};
+    }
+    if (isFalse(simplified)) {
+        return { OR: [] };
+    }
+    return simplified.where;
 };
 
 export const eformsignDocCompatReadSelect = (

--- a/backend/test/infrastructure/eformsign-doc-compat.spec.ts
+++ b/backend/test/infrastructure/eformsign-doc-compat.spec.ts
@@ -181,12 +181,27 @@ describe("stripPendingEformsignDocPredicates", () => {
         })).toEqual({ branchId: "branch-1" });
     });
 
+    it("ignores undefined Prisma filters when classifying a stripped OR branch", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { templateId: null, documentId: undefined },
+                { documentId: "doc-1" },
+            ],
+        })).toEqual({});
+    });
+
     it("collapses NOT of a missing-column is-null predicate to false", () => {
         // `NOT true` is false, so the top-level sibling cannot turn this retry into an
         // unconstrained query. Prisma represents false as an empty OR.
         expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
             branchId: "branch-1",
             NOT: { templateId: null },
+        })).toEqual({ OR: [] });
+    });
+
+    it("ignores undefined Prisma filters when classifying a stripped NOT branch", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            NOT: { templateId: null, documentId: undefined },
         })).toEqual({ OR: [] });
     });
 

--- a/backend/test/infrastructure/eformsign-doc-compat.spec.ts
+++ b/backend/test/infrastructure/eformsign-doc-compat.spec.ts
@@ -159,7 +159,7 @@ describe("stripPendingEformsignDocPredicates", () => {
         })).toEqual({ branchId: "branch-1" });
     });
 
-    it("reaches into AND, where deleting a true leaf changes nothing", () => {
+    it("removes true leaves from AND without leaving an empty predicate", () => {
         expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
             AND: [
                 { branchId: "branch-1" },
@@ -168,21 +168,49 @@ describe("stripPendingEformsignDocPredicates", () => {
         })).toEqual({
             AND: [
                 { branchId: "branch-1" },
-                {},
             ],
         });
     });
 
-    it.each([
-        ["OR", { OR: [{ templateId: null }, { documentId: "doc-1" }] }],
-        ["NOT", { NOT: { templateId: null } }],
-    ])("leaves %s alone rather than changing what it means", (_operator, where) => {
-        // An empty object is not the true this leaf stood for. Under OR a true leaf makes
-        // the whole branch true, so dropping it would narrow the query to the other terms;
-        // under NOT it makes the branch false, so dropping it would widen to everything.
-        // Both are silently wrong answers, and a loud failure is the better one.
-        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), where))
-            .toEqual(where);
+    it("collapses an OR containing a missing-column is-null predicate to true", () => {
+        // `templateId: null` is true for every row when the first migration is absent.
+        // Therefore its OR is true, while its top-level sibling still constrains the read.
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            branchId: "branch-1",
+            OR: [{ templateId: null }, { documentId: "doc-1" }],
+        })).toEqual({ branchId: "branch-1" });
+    });
+
+    it("collapses NOT of a missing-column is-null predicate to false", () => {
+        // `NOT true` is false, so the top-level sibling cannot turn this retry into an
+        // unconstrained query. Prisma represents false as an empty OR.
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            branchId: "branch-1",
+            NOT: { templateId: null },
+        })).toEqual({ OR: [] });
+    });
+
+    it("drops false NOT branches inside OR instead of leaving an empty object", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { NOT: { templateId: null } },
+                { documentId: "doc-1" },
+            ],
+        })).toEqual({ OR: [{ documentId: "doc-1" }] });
+    });
+
+    it("preserves a pre-existing empty branch inside OR", () => {
+        // `{}` is not this helper's true sentinel. Prisma gives it contextual semantics,
+        // so an authored empty OR branch must remain opaque rather than collapse to true.
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [{}],
+        })).toEqual({ OR: [{}] });
+    });
+
+    it("preserves a pre-existing empty branch inside NOT", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            NOT: {},
+        })).toEqual({ NOT: {} });
     });
 
     it("keeps a predicate whose column an earlier migration already added", () => {

--- a/backend/test/infrastructure/eformsign-doc-compat.spec.ts
+++ b/backend/test/infrastructure/eformsign-doc-compat.spec.ts
@@ -190,6 +190,20 @@ describe("stripPendingEformsignDocPredicates", () => {
         })).toEqual({});
     });
 
+    it("preserves an undefined-only authored branch inside OR", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { documentId: undefined },
+                { documentId: "doc-1" },
+            ],
+        })).toEqual({
+            OR: [
+                {},
+                { documentId: "doc-1" },
+            ],
+        });
+    });
+
     it("collapses NOT of a missing-column is-null predicate to false", () => {
         // `NOT true` is false, so the top-level sibling cannot turn this retry into an
         // unconstrained query. Prisma represents false as an empty OR.
@@ -203,6 +217,12 @@ describe("stripPendingEformsignDocPredicates", () => {
         expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
             NOT: { templateId: null, documentId: undefined },
         })).toEqual({ OR: [] });
+    });
+
+    it("preserves an undefined-only authored branch inside NOT", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            NOT: { documentId: undefined },
+        })).toEqual({ NOT: {} });
     });
 
     it("drops false NOT branches inside OR instead of leaving an empty object", () => {


### PR DESCRIPTION
## Summary

- Simplify compatibility retries with explicit true/false/where states across `AND`, `OR`, and `NOT`.
- Preserve Prisma boolean identities when a missing pre-migration `IS NULL` predicate is removed.
- Keep authored empty predicates opaque so compatibility rewriting does not change their contextual Prisma semantics.

## Root cause

The compatibility helper originally descended only through `AND`. A missing-column predicate inside `OR` or `NOT` either remained in the retry and failed again, or could not be safely removed without representing its boolean identity. This completes the remaining actionable review feedback from #436.

## Database and rollout

- No schema, migration, dependency, environment-variable, authentication, or authorization change.
- Existing idempotent eformsign DB patch and fail-closed full backfill/readiness flow will be rerun for each environment after promotion to regenerate deployment evidence.
- Rollback is the squash commit revert; existing mirror tables and PDF data remain intact.

## Validation

- Focused compatibility Jest: 2 suites / 98 tests passed.
- Full backend Jest: 187 suites; 2,174 passed, 37 skipped.
- Backend TypeScript check passed.
- Backend ESLint passed with 0 errors (76 pre-existing warnings).
- Backend build passed.
- `git diff --check` passed.
- Independent code review approved the boolean identities, Prisma `NOT` array handling, authored-empty preservation, and query safety.

## Security

The rewrite remains Prisma-typed predicate data. It adds no raw SQL/string interpolation, secrets, new logging, or authorization surface.