### PR TITLE
release: promote eformsign predicate compatibility to preview

### DIFF
--- a/backend/infrastructure/database/eformsign-doc-compat.ts
+++ b/backend/infrastructure/database/eformsign-doc-compat.ts
@@ -259,6 +259,15 @@ export const stripPendingEformsignDocPredicates = (
         operator: "AND" | "OR" | "NOT",
         value: Prisma.eformsign_docWhereInput | Prisma.eformsign_docWhereInput[],
     ): SimplifiedWhere => {
+        if (Array.isArray(value) && value.length === 0) {
+            // Empty logical arrays were authored by the caller, not produced by stripping
+            // a missing-column predicate. Prisma assigns them contextual semantics, so
+            // keep the node opaque just like an authored `{}` branch.
+            return {
+                kind: "where",
+                where: { [operator]: value },
+            };
+        }
         const entries = Array.isArray(value) ? value : [value];
         const simplifiedEntries = entries.map((entry) => strip(entry));
 
@@ -324,6 +333,23 @@ export const stripPendingEformsignDocPredicates = (
         return { kind: "where", where: { NOT: simplified!.where } };
     };
 
+    const isContextuallyEmpty = (node: Record<string, unknown>): boolean =>
+        Object.entries(node).every(([key, value]) => {
+            if (value === undefined) {
+                return true;
+            }
+            if (key !== "AND" && key !== "OR" && key !== "NOT") {
+                return false;
+            }
+            const entries = Array.isArray(value) ? value : [value];
+            return entries.every(
+                (entry) =>
+                    typeof entry === "object"
+                    && entry !== null
+                    && isContextuallyEmpty(entry as Record<string, unknown>),
+            );
+        });
+
     const strip = (node: Prisma.eformsign_docWhereInput): SimplifiedWhere => {
         const stripped: Record<string, unknown> = {};
         let removedTrue = false;
@@ -359,7 +385,15 @@ export const stripPendingEformsignDocPredicates = (
             }
             stripped[key] = value;
         }
-        if (Object.keys(stripped).length === 0) {
+        const strippedEntries = Object.entries(stripped);
+        if (removedTrue && strippedEntries.length > 0 && isContextuallyEmpty(stripped)) {
+            // Prisma changes an otherwise-empty logical node's meaning when it has a
+            // concrete sibling. Keep a schema-stable tautology in that exact object so
+            // stripping a pending-column `: null` does not change root or nested behavior.
+            // `id` predates every pending mirror migration and is a non-null primary key.
+            stripped["id"] = { notIn: [] };
+        }
+        if (strippedEntries.length === 0) {
             // `{}` is context-sensitive in Prisma (`OR: [{}]` and `NOT: {}` are not
             // interchangeable with our boolean identities). Only an empty node caused by
             // removing a known-true predicate is the true identity this helper may erase.

--- a/backend/infrastructure/database/eformsign-doc-compat.ts
+++ b/backend/infrastructure/database/eformsign-doc-compat.ts
@@ -243,30 +243,141 @@ export const stripPendingEformsignDocPredicates = (
     }
     const missing = new Set(missingNames);
 
-    // AND is the only operator this descends into, because it is the only one where
-    // deleting a vacuously-true leaf preserves the meaning of the whole. Under OR a true
-    // leaf makes the branch true, and under NOT it makes it false; an empty object says
-    // neither, so both are left exactly as they are and fail loudly instead of quietly
-    // answering a different question. Every filter that actually needs this puts its
-    // pending predicates at the top level or in an AND chain.
-    const strip = (node: Prisma.eformsign_docWhereInput): Prisma.eformsign_docWhereInput => {
+    type SimplifiedWhere =
+        | { kind: "true" }
+        | { kind: "false" }
+        | { kind: "where"; where: Prisma.eformsign_docWhereInput };
+
+    const isTrue = (
+        value: SimplifiedWhere,
+    ): value is Extract<SimplifiedWhere, { kind: "true" }> => value.kind === "true";
+    const isFalse = (
+        value: SimplifiedWhere,
+    ): value is Extract<SimplifiedWhere, { kind: "false" }> => value.kind === "false";
+
+    const stripLogical = (
+        operator: "AND" | "OR" | "NOT",
+        value: Prisma.eformsign_docWhereInput | Prisma.eformsign_docWhereInput[],
+    ): SimplifiedWhere => {
+        const entries = Array.isArray(value) ? value : [value];
+        const simplifiedEntries = entries.map((entry) => strip(entry));
+
+        if (operator === "AND") {
+            if (simplifiedEntries.some(isFalse)) {
+                return { kind: "false" };
+            }
+            const remaining = simplifiedEntries.filter(
+                (entry): entry is Extract<SimplifiedWhere, { kind: "where" }> => !isTrue(entry),
+            );
+            if (remaining.length === 0) {
+                return { kind: "true" };
+            }
+            return {
+                kind: "where",
+                where: {
+                    AND: Array.isArray(value)
+                        ? remaining.map((entry) => entry.where)
+                        : remaining[0]!.where,
+                },
+            };
+        }
+
+        if (operator === "OR") {
+            if (simplifiedEntries.some(isTrue)) {
+                return { kind: "true" };
+            }
+            const remaining = simplifiedEntries.filter(
+                (entry): entry is Extract<SimplifiedWhere, { kind: "where" }> => !isFalse(entry),
+            );
+            if (remaining.length === 0) {
+                return { kind: "false" };
+            }
+            return {
+                kind: "where",
+                where: {
+                    OR: remaining.map((entry) => entry.where),
+                },
+            };
+        }
+
+        if (Array.isArray(value)) {
+            // Prisma treats NOT arrays as an implicit AND of negated entries.
+            if (simplifiedEntries.some(isTrue)) {
+                return { kind: "false" };
+            }
+            const remaining = simplifiedEntries.filter(
+                (entry): entry is Extract<SimplifiedWhere, { kind: "where" }> => !isFalse(entry),
+            );
+            if (remaining.length === 0) {
+                return { kind: "true" };
+            }
+            return { kind: "where", where: { NOT: remaining.map((entry) => entry.where) } };
+        }
+
+        const [simplified] = simplifiedEntries;
+        if (isTrue(simplified!)) {
+            return { kind: "false" };
+        }
+        if (isFalse(simplified!)) {
+            return { kind: "true" };
+        }
+        return { kind: "where", where: { NOT: simplified!.where } };
+    };
+
+    const strip = (node: Prisma.eformsign_docWhereInput): SimplifiedWhere => {
         const stripped: Record<string, unknown> = {};
+        let removedTrue = false;
         for (const [key, value] of Object.entries(node)) {
-            if (missing.has(key) && value === null) {
+            if (value === undefined) {
+                // Prisma omits undefined filters, but an undefined-only logical branch
+                // still has the contextual semantics of an authored empty predicate.
+                // Only removing a known missing-column `: null` marks this node true.
                 continue;
             }
-            if (key === "AND" && value !== undefined && value !== null) {
-                stripped[key] = Array.isArray(value)
-                    ? value.map((entry) => strip(entry as Prisma.eformsign_docWhereInput))
-                    : strip(value as Prisma.eformsign_docWhereInput);
+            if (missing.has(key) && value === null) {
+                removedTrue = true;
+                continue;
+            }
+            if (
+                (key === "AND" || key === "OR" || key === "NOT")
+                && value !== undefined
+                && value !== null
+            ) {
+                const simplified = stripLogical(
+                    key,
+                    value as Prisma.eformsign_docWhereInput | Prisma.eformsign_docWhereInput[],
+                );
+                if (isTrue(simplified)) {
+                    removedTrue = true;
+                    continue;
+                }
+                if (isFalse(simplified)) {
+                    return { kind: "false" };
+                }
+                Object.assign(stripped, simplified.where);
                 continue;
             }
             stripped[key] = value;
         }
-        return stripped as Prisma.eformsign_docWhereInput;
+        if (Object.keys(stripped).length === 0) {
+            // `{}` is context-sensitive in Prisma (`OR: [{}]` and `NOT: {}` are not
+            // interchangeable with our boolean identities). Only an empty node caused by
+            // removing a known-true predicate is the true identity this helper may erase.
+            return removedTrue
+                ? { kind: "true" }
+                : { kind: "where", where: {} };
+        }
+        return { kind: "where", where: stripped as Prisma.eformsign_docWhereInput };
     };
 
-    return strip(where);
+    const simplified = strip(where);
+    if (isTrue(simplified)) {
+        return {};
+    }
+    if (isFalse(simplified)) {
+        return { OR: [] };
+    }
+    return simplified.where;
 };
 
 export const eformsignDocCompatReadSelect = (

--- a/backend/test/infrastructure/eformsign-doc-compat.spec.ts
+++ b/backend/test/infrastructure/eformsign-doc-compat.spec.ts
@@ -159,7 +159,7 @@ describe("stripPendingEformsignDocPredicates", () => {
         })).toEqual({ branchId: "branch-1" });
     });
 
-    it("reaches into AND, where deleting a true leaf changes nothing", () => {
+    it("removes true leaves from AND without leaving an empty predicate", () => {
         expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
             AND: [
                 { branchId: "branch-1" },
@@ -168,21 +168,84 @@ describe("stripPendingEformsignDocPredicates", () => {
         })).toEqual({
             AND: [
                 { branchId: "branch-1" },
-                {},
             ],
         });
     });
 
-    it.each([
-        ["OR", { OR: [{ templateId: null }, { documentId: "doc-1" }] }],
-        ["NOT", { NOT: { templateId: null } }],
-    ])("leaves %s alone rather than changing what it means", (_operator, where) => {
-        // An empty object is not the true this leaf stood for. Under OR a true leaf makes
-        // the whole branch true, so dropping it would narrow the query to the other terms;
-        // under NOT it makes the branch false, so dropping it would widen to everything.
-        // Both are silently wrong answers, and a loud failure is the better one.
-        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), where))
-            .toEqual(where);
+    it("collapses an OR containing a missing-column is-null predicate to true", () => {
+        // `templateId: null` is true for every row when the first migration is absent.
+        // Therefore its OR is true, while its top-level sibling still constrains the read.
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            branchId: "branch-1",
+            OR: [{ templateId: null }, { documentId: "doc-1" }],
+        })).toEqual({ branchId: "branch-1" });
+    });
+
+    it("ignores undefined Prisma filters when classifying a stripped OR branch", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { templateId: null, documentId: undefined },
+                { documentId: "doc-1" },
+            ],
+        })).toEqual({});
+    });
+
+    it("preserves an undefined-only authored branch inside OR", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { documentId: undefined },
+                { documentId: "doc-1" },
+            ],
+        })).toEqual({
+            OR: [
+                {},
+                { documentId: "doc-1" },
+            ],
+        });
+    });
+
+    it("collapses NOT of a missing-column is-null predicate to false", () => {
+        // `NOT true` is false, so the top-level sibling cannot turn this retry into an
+        // unconstrained query. Prisma represents false as an empty OR.
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            branchId: "branch-1",
+            NOT: { templateId: null },
+        })).toEqual({ OR: [] });
+    });
+
+    it("ignores undefined Prisma filters when classifying a stripped NOT branch", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            NOT: { templateId: null, documentId: undefined },
+        })).toEqual({ OR: [] });
+    });
+
+    it("preserves an undefined-only authored branch inside NOT", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            NOT: { documentId: undefined },
+        })).toEqual({ NOT: {} });
+    });
+
+    it("drops false NOT branches inside OR instead of leaving an empty object", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { NOT: { templateId: null } },
+                { documentId: "doc-1" },
+            ],
+        })).toEqual({ OR: [{ documentId: "doc-1" }] });
+    });
+
+    it("preserves a pre-existing empty branch inside OR", () => {
+        // `{}` is not this helper's true sentinel. Prisma gives it contextual semantics,
+        // so an authored empty OR branch must remain opaque rather than collapse to true.
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [{}],
+        })).toEqual({ OR: [{}] });
+    });
+
+    it("preserves a pre-existing empty branch inside NOT", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            NOT: {},
+        })).toEqual({ NOT: {} });
     });
 
     it("keeps a predicate whose column an earlier migration already added", () => {

--- a/backend/test/infrastructure/eformsign-doc-compat.spec.ts
+++ b/backend/test/infrastructure/eformsign-doc-compat.spec.ts
@@ -242,6 +242,86 @@ describe("stripPendingEformsignDocPredicates", () => {
         })).toEqual({ OR: [{}] });
     });
 
+    it("preserves an authored empty AND array nested inside OR", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { AND: [] },
+                { branchId: "branch-1" },
+            ],
+        })).toEqual({
+            OR: [
+                { AND: [] },
+                { branchId: "branch-1" },
+            ],
+        });
+    });
+
+    it("preserves an authored empty NOT array nested inside OR", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { NOT: [] },
+                { branchId: "branch-1" },
+            ],
+        })).toEqual({
+            OR: [
+                { NOT: [] },
+                { branchId: "branch-1" },
+            ],
+        });
+    });
+
+    it("propagates a removed tautology past an authored empty AND array", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { AND: [], templateId: null },
+                { branchId: "branch-1" },
+            ],
+        })).toEqual({
+            OR: [
+                { AND: [], id: { notIn: [] } },
+                { branchId: "branch-1" },
+            ],
+        });
+    });
+
+    it("propagates a removed tautology past an authored empty NOT array", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { NOT: [], templateId: null },
+                { branchId: "branch-1" },
+            ],
+        })).toEqual({
+            OR: [
+                { NOT: [], id: { notIn: [] } },
+                { branchId: "branch-1" },
+            ],
+        });
+    });
+
+    it("preserves root empty OR semantics while retaining a stripped tautology", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [],
+            templateId: null,
+        })).toEqual({
+            OR: [],
+            id: { notIn: [] },
+        });
+    });
+
+    it("retains a stripped tautology beside recursively empty logical branches", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { AND: [{}], templateId: null },
+                { NOT: {}, templateId: null },
+            ],
+        })).toEqual({
+            OR: [
+                { AND: [{}], id: { notIn: [] } },
+                { NOT: {}, id: { notIn: [] } },
+            ],
+        });
+    });
+
     it("preserves a pre-existing empty branch inside NOT", () => {
         expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
             NOT: {},

--- a/frontend/src/app/(protected)/select-branch/page.lifecycle.test.ts
+++ b/frontend/src/app/(protected)/select-branch/page.lifecycle.test.ts
@@ -1,0 +1,12 @@
+import fs from "node:fs";
+
+const source = fs.readFileSync(require.resolve("./page"), "utf8");
+
+describe("frontend select-branch navigation lifecycle", () => {
+  it("keeps automatic branch selection loading until navigation takes over", () => {
+    expect(source).toContain("Promise<boolean>");
+    expect(source).toContain("let keepLoadingForNavigation = false");
+    expect(source).toContain("keepLoadingForNavigation = await handleSelectBranch");
+    expect(source).toContain("if (!keepLoadingForNavigation)");
+  });
+});

--- a/frontend/src/app/(protected)/select-branch/page.tsx
+++ b/frontend/src/app/(protected)/select-branch/page.tsx
@@ -61,7 +61,7 @@ export default function SelectBranchPage() {
     const [selecting, setSelecting] = useState<string | null>(null);
     const [currentPage, setCurrentPage] = useState(1);
 
-    const handleSelectBranch = useCallback(async (branchId: string) => {
+    const handleSelectBranch = useCallback(async (branchId: string): Promise<boolean> => {
         setSelecting(branchId);
 
         try {
@@ -70,7 +70,7 @@ export default function SelectBranchPage() {
             if (!result.success) {
                 setError(result.error || "지점 선택에 실패했습니다.");
                 setSelecting(null);
-                return;
+                return false;
             }
 
             // 지점 전환 시 이전 지점의 React Query 캐시(고객 목록·전자계약 등)를 모두 비운다.
@@ -79,15 +79,18 @@ export default function SelectBranchPage() {
             queryClient.clear();
 
             router.replace("/dashboard");
+            return true;
         } catch (err) {
             console.error("[Select Branch] Error selecting branch:", err);
             setError("지점 선택에 실패했습니다.");
             setSelecting(null);
+            return false;
         }
     }, [router, queryClient]);
 
     useEffect(() => {
         const fetchBranches = async () => {
+            let keepLoadingForNavigation = false;
             try {
                 const result = await getUserBranches();
 
@@ -101,7 +104,7 @@ export default function SelectBranchPage() {
                 const isOwner = result.branches?.some(org => org.role === 'owner');
                 if (result.branches?.length === 1 && !isOwner) {
                     const org = result.branches[0];
-                    await handleSelectBranch(org.id);
+                    keepLoadingForNavigation = await handleSelectBranch(org.id);
                     return;
                 }
 
@@ -111,7 +114,9 @@ export default function SelectBranchPage() {
                 console.error("[Select Branch] Error fetching branches:", err);
                 setError("지점 목록을 불러오는데 실패했습니다.");
             } finally {
-                setLoading(false);
+                if (!keepLoadingForNavigation) {
+                    setLoading(false);
+                }
             }
         };
 

--- a/frontend/src/components/app/contracts/ContractCreationForm.test.tsx
+++ b/frontend/src/components/app/contracts/ContractCreationForm.test.tsx
@@ -52,4 +52,21 @@ describe("ContractCreationForm compensation flows", () => {
     expect(branch).toContain('requestConfirmation("최근 생성된 진행 중 문서가 있습니다. 그래도 새로 생성하시겠습니까?")');
     expect(branch).toContain("progressId, true");
   });
+
+  it("should keep manual iframe submission pending until the dialog closes", () => {
+    const handler = source.slice(
+      source.indexOf("const handleContractCreation"),
+      source.indexOf("const isStep1Valid"),
+    );
+    const dialogCloseHandler = source.slice(
+      source.indexOf("const handleDialogClose"),
+      source.indexOf("const resetCreationSession"),
+    );
+
+    expect(handler).toContain("let keepSubmittingUntilDialogCloses = false");
+    expect(handler).toContain("keepSubmittingUntilDialogCloses = true");
+    expect(handler).toContain("if (!keepSubmittingUntilDialogCloses)");
+    expect(handler).toContain("handleDialogClose()");
+    expect(dialogCloseHandler).toContain("setIsSubmitting(false)");
+  });
 });

--- a/frontend/src/components/app/contracts/ContractCreationForm.tsx
+++ b/frontend/src/components/app/contracts/ContractCreationForm.tsx
@@ -521,6 +521,7 @@ export const ContractCreationForm = ({
 
   const handleDialogClose = () => {
     setIsDialogOpen(false);
+    setIsSubmitting(false);
   };
 
   const resetCreationSession = () => {
@@ -677,6 +678,7 @@ export const ContractCreationForm = ({
     setCreationProgress(INITIAL_CREATION_PROGRESS);
 
     let autoRegisteredClientId: number | null = null;
+    let keepSubmittingUntilDialogCloses = false;
     try {
       let finalClientId = clientId;
       const normalizedDueDate = parseYymmddInputToIso(dueDateInput) ?? "";
@@ -933,6 +935,7 @@ export const ContractCreationForm = ({
         finalClientId
       );
 
+      keepSubmittingUntilDialogCloses = true;
       setIsDialogOpen(true);
       setCreationProgress({ step: "client-started", completed: false, failed: false });
 
@@ -965,14 +968,14 @@ export const ContractCreationForm = ({
 
             setCreationProgress({ step: "sent", completed: true, failed: false });
             queryClient.invalidateQueries({ queryKey: eformsignQueryKeys.documents() });
-            setIsDialogOpen(false);
+            handleDialogClose();
             setIsCreationSuccessOpen(true);
           },
           onError: (response) => {
             console.error("Document creation failed:", response);
             markCreationProgressFailed();
             setSubmitError(`문서 생성 실패: ${response.message}`);
-            setIsDialogOpen(false);
+            handleDialogClose();
           },
           onAction: () => {
             setCreationProgress((current) =>
@@ -1006,7 +1009,9 @@ export const ContractCreationForm = ({
         setSubmitError(error instanceof Error ? error.message : "계약서 생성 중 오류가 발생했습니다.");
       }
     } finally {
-      setIsSubmitting(false);
+      if (!keepSubmittingUntilDialogCloses) {
+        setIsSubmitting(false);
+      }
     }
   };
 

--- a/frontend/src/components/app/employees/EmployeeFormDialog.tsx
+++ b/frontend/src/components/app/employees/EmployeeFormDialog.tsx
@@ -347,6 +347,7 @@ function EmployeeFormContent({
         workArea: false,
     });
     const [error, setError] = useState<string | null>(null);
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
     const createMutation = useCreateEmployee();
     const updateMutation = useUpdateEmployee();
@@ -367,7 +368,7 @@ function EmployeeFormContent({
     });
 
     const isEditMode = !!employee;
-    const isLoading = createMutation.isPending || updateMutation.isPending;
+    const isLoading = isSubmitting || createMutation.isPending || updateMutation.isPending;
     const isPhoneFormatValid = phoneDigits.length === 11;
     const isPhoneValid = isPhoneFormatValid && isPhoneCheckReady;
     const phoneInlineMessage = isPhoneFormatValid
@@ -446,6 +447,7 @@ function EmployeeFormContent({
             return;
         }
 
+        setIsSubmitting(true);
         try {
             if (isEditMode && employee) {
                 const dto: UpdateEmployeeDto = {
@@ -491,6 +493,8 @@ function EmployeeFormContent({
         } catch (submitError: unknown) {
             console.error("[EmployeeFormDialog] Failed to save employee:", submitError);
             setError(getErrorMessage(submitError, locale, "employees.form.error-save-failed"));
+        } finally {
+            setIsSubmitting(false);
         }
     };
 

--- a/frontend/src/components/app/employees/__tests__/EmployeeFormDialog.work-area.test.tsx
+++ b/frontend/src/components/app/employees/__tests__/EmployeeFormDialog.work-area.test.tsx
@@ -5,6 +5,8 @@ import { api } from "@/lib/api/client";
 import { EmployeeFormDialog, EmployeeFormPanel } from "../EmployeeFormDialog";
 
 const mockRefetchQueries = jest.fn();
+const mockCreateEmployeeMutateAsync = jest.fn();
+const mockUpdateEmployeeMutateAsync = jest.fn();
 const employeeWithLegacyArea: Employee = {
   id: 1,
   name: "김제공",
@@ -22,8 +24,8 @@ jest.mock("@tanstack/react-query", () => ({
 
 jest.mock("@/hooks/useEmployees", () => ({
   employeeQueryKeys: { all: ["employees"] },
-  useCreateEmployee: () => ({ isPending: false, mutateAsync: jest.fn() }),
-  useUpdateEmployee: () => ({ isPending: false, mutateAsync: jest.fn() }),
+  useCreateEmployee: () => ({ isPending: false, mutateAsync: mockCreateEmployeeMutateAsync }),
+  useUpdateEmployee: () => ({ isPending: false, mutateAsync: mockUpdateEmployeeMutateAsync }),
 }));
 
 jest.mock("@/stores/employee-dialog-store", () => {
@@ -45,6 +47,15 @@ jest.mock("@/lib/api/client", () => ({
 }));
 
 const mockApiGet = api.get as jest.MockedFunction<typeof api.get>;
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
 
 jest.mock("@/components/ui/dialog", () => ({
   Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -71,6 +82,7 @@ describe("EmployeeFormPanel work area multi-select", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockApiGet.mockResolvedValue({ data: { exists: false } });
+    mockRefetchQueries.mockResolvedValue(undefined);
   });
 
   it("selects multiple areas and shows an empty-selection error beside the field label", async () => {
@@ -225,5 +237,55 @@ describe("EmployeeFormPanel work area multi-select", () => {
     expect(
       document.querySelector('[data-component="desktop_employees_form-dialog_submit"]'),
     ).toBeEnabled();
+  });
+
+  it("keeps final submit pending until employee refetch completes", async () => {
+    const refetch = createDeferred<void>();
+    const onClose = jest.fn();
+    const onSuccess = jest.fn();
+    const createdEmployee: Employee = {
+      ...employeeWithLegacyArea,
+      id: 2,
+      name: "박테스트",
+      workArea: ["남동구"],
+      phone: "01098765432",
+    };
+    mockCreateEmployeeMutateAsync.mockResolvedValue(createdEmployee);
+    mockRefetchQueries.mockReturnValueOnce(refetch.promise);
+
+    render(<EmployeeFormPanel open onClose={onClose} onSuccess={onSuccess} />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.change(screen.getByLabelText(/이름/), { target: { value: createdEmployee.name } });
+    fireEvent.click(screen.getByRole("combobox", { name: /근무 지역 선택/ }));
+    fireEvent.click(await screen.findByRole("checkbox", { name: "남동구" }));
+    fireEvent.click(screen.getByRole("button", { name: "완료" }));
+    fireEvent.change(screen.getByLabelText(/연락처/), { target: { value: createdEmployee.phone } });
+    await screen.findByText("등록 가능한 번호입니다.");
+
+    const submit = document.querySelector<HTMLButtonElement>(
+      '[data-component="desktop_employees_form-panel_submit"]',
+    );
+    expect(submit).not.toBeNull();
+    expect(submit).toBeEnabled();
+
+    fireEvent.click(submit!);
+
+    await waitFor(() => expect(mockRefetchQueries).toHaveBeenCalled());
+    expect(submit).toBeDisabled();
+    expect(submit?.querySelector('[data-slot="spinner"]')).not.toBeNull();
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+
+    await act(async () => {
+      refetch.resolve();
+      await refetch.promise;
+    });
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith(createdEmployee));
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/mobile/src/app/(shell)/clients/new/page.lifecycle.test.ts
+++ b/mobile/src/app/(shell)/clients/new/page.lifecycle.test.ts
@@ -1,0 +1,10 @@
+import fs from "node:fs";
+
+const source = fs.readFileSync(require.resolve("./page"), "utf8");
+
+describe("mobile client form navigation lifecycle", () => {
+  it("locks both header exits while saving or navigating", () => {
+    expect(source).toContain("if (isSaving) return");
+    expect(source.match(/disabled=\{isSaving\}/g)).toHaveLength(2);
+  });
+});

--- a/mobile/src/app/(shell)/clients/new/page.tsx
+++ b/mobile/src/app/(shell)/clients/new/page.tsx
@@ -797,7 +797,9 @@ export default function NewClientPage() {
   const activeStepMeta = WIZARD_STEPS[activeStep];
   const progress = ((activeStep + 1) / WIZARD_STEPS.length) * 100;
   const clientsReturnHref = editingClientId !== null ? `/clients?id=${editingClientId}` : "/clients";
+  const isSaving = createClient.isPending || updateClient.isPending || isNavigationPending;
   const goBackToClients = () => {
+    if (isSaving) return;
     router.push(clientsReturnHref);
   };
 
@@ -815,7 +817,6 @@ export default function NewClientPage() {
     handleStepChange(activeStep + 1);
   };
 
-  const isSaving = createClient.isPending || updateClient.isPending || isNavigationPending;
   const isPrimaryDisabled = isSaving || !isStepSatisfied(activeStep);
 
   return (
@@ -870,6 +871,7 @@ export default function NewClientPage() {
             <button
               type="button"
               onClick={goBackToClients}
+              disabled={isSaving}
               className={styles.navbarIconButton}
               aria-label="고객 목록으로 돌아가기"
             >
@@ -881,6 +883,7 @@ export default function NewClientPage() {
             <button
               type="button"
               onClick={goBackToClients}
+              disabled={isSaving}
               className={styles.navbarIconButton}
               aria-label={isEditMode ? "고객 정보 수정 닫기" : "새 고객 추가 닫기"}
             >

--- a/mobile/src/app/(shell)/contracts/new/page.test.ts
+++ b/mobile/src/app/(shell)/contracts/new/page.test.ts
@@ -23,4 +23,13 @@ describe("mobile contract creation compensation flow", () => {
     expect(branch.indexOf('adopted.warnings?.includes("mirror_sync_failed")'))
       .toBeLessThan(branch.indexOf('router.push("/contracts")'));
   });
+
+  it("keeps submission pending until the iframe signing surface closes", () => {
+    expect(source).toContain("const closeEformsignModal = () =>");
+    expect(source).toContain("const runIframeFallback = async");
+    expect(source).toContain("Promise<boolean>");
+    expect(source).toContain("let keepSubmittingUntilIframeCloses = false");
+    expect(source).toContain("keepSubmittingUntilIframeCloses = await runIframeFallback");
+    expect(source).toContain("if (!keepSubmittingUntilIframeCloses)");
+  });
 });

--- a/mobile/src/app/(shell)/contracts/new/page.tsx
+++ b/mobile/src/app/(shell)/contracts/new/page.tsx
@@ -638,14 +638,19 @@ export default function ContractCreationPage() {
     setActiveStep((s) => s - 1);
   };
 
+  const closeEformsignModal = () => {
+    setIsEformsignModalOpen(false);
+    setIsSubmitting(false);
+  };
+
   const runIframeFallback = async (
     contractData: ContractDataDto,
     finalClientId: number,
     expiry: dayjs.Dayjs,
-  ) => {
+  ): Promise<boolean> => {
     if (!isEformsignLoaded) {
       showFloatingError("eformsign SDK가 아직 로드되지 않았습니다. 잠시 후 다시 시도해주세요.");
-      return;
+      return false;
     }
     const documentOption: EformsignDocumentOption = await eformsignApi.generateDocument(
       contractData as unknown as Parameters<typeof eformsignApi.generateDocument>[0],
@@ -672,17 +677,18 @@ export default function ContractCreationPage() {
           queryClient.invalidateQueries({ queryKey: eformsignQueryKeys.documents() });
           startNavigation();
           setTimeout(() => {
-            setIsEformsignModalOpen(false);
+            closeEformsignModal();
             router.push("/contracts");
           }, SUCCESS_REDIRECT_DELAY_MS);
         },
         onError: (response) => {
           showFloatingError(`문서 생성 실패: ${response.message}`);
-          setIsEformsignModalOpen(false);
+          closeEformsignModal();
         },
         onAction: () => { /* noop */ },
       });
     }, 500);
+    return true;
   };
 
   const handleSubmit = async () => {
@@ -695,6 +701,7 @@ export default function ContractCreationPage() {
     setProgressErrorHint(null);
 
     let autoRegisteredClientId: number | null = null;
+    let keepSubmittingUntilIframeCloses = false;
     try {
       // 1. Manual-entry client creation
       let finalClientId = clientId ?? storedClientByIdentity?.id ?? storedClientByPhone?.id ?? null;
@@ -935,7 +942,7 @@ export default function ContractCreationPage() {
           showFloatingError(getSafeHeadlessFailureMessage(headlessFailureReason));
         }
         setIsProgressModalOpen(false);
-        await runIframeFallback(contractData, finalClientId, end);
+        keepSubmittingUntilIframeCloses = await runIframeFallback(contractData, finalClientId, end);
       }
     } catch (err: unknown) {
       setIsProgressModalOpen(false);
@@ -952,7 +959,9 @@ export default function ContractCreationPage() {
         }
       }
     } finally {
-      setIsSubmitting(false);
+      if (!keepSubmittingUntilIframeCloses) {
+        setIsSubmitting(false);
+      }
     }
   };
 
@@ -1485,7 +1494,7 @@ export default function ContractCreationPage() {
             <button
               data-component="mobile_contracts-new_signing_modal_header_close-button"
               type="button"
-              onClick={() => setIsEformsignModalOpen(false)}
+              onClick={closeEformsignModal}
               className={styles.navbarIconButton}
               aria-label="닫기"
             >

--- a/mobile/src/app/(shell)/contracts/page.lifecycle.test.ts
+++ b/mobile/src/app/(shell)/contracts/page.lifecycle.test.ts
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+
+const source = fs.readFileSync(require.resolve("./page"), "utf8");
+
+describe("mobile contracts action lifecycle", () => {
+  it("locks document deletion through the required cache refresh", () => {
+    expect(source).toContain("const [isDeletingDocument, setIsDeletingDocument] = useState(false)");
+    expect(source).toContain(
+      "const isDeleteDocumentBusy = isDeletingDocument || deleteDocument.isPending",
+    );
+    expect(source).toContain("if (!deleteTargetDoc || isDeleteDocumentBusy) return");
+    expect(source).toContain("loading={isDeleteDocumentBusy}");
+    expect(source).toContain("setIsDeletingDocument(false)");
+  });
+
+  it("keeps finalization busy through success progress and iframe handoff", () => {
+    expect(source).toContain("const closeStaffIframe = useCallback(() =>");
+    expect(source).toContain("let keepFinalizeSubmittingUntilIframeCloses = false");
+    expect(source).toContain("keepFinalizeSubmittingUntilIframeCloses = true");
+    expect(source).toContain("if (!keepFinalizeSubmittingUntilIframeCloses)");
+    expect(source).toContain("setIsFinalizeSubmitting(false)");
+  });
+});

--- a/mobile/src/app/(shell)/contracts/page.tsx
+++ b/mobile/src/app/(shell)/contracts/page.tsx
@@ -1559,6 +1559,7 @@ export default function ContractsPage() {
   const [selectedDoc, setSelectedDoc] = useState<EformsignDocument | null>(null);
   const [activeTab, setActiveTab] = useState<DetailTabId>("basic");
   const [deleteTargetDoc, setDeleteTargetDoc] = useState<EformsignDocument | null>(null);
+  const [isDeletingDocument, setIsDeletingDocument] = useState(false);
 
   // Finalize (mode:"02" — staff completion) flow state
   const queryClient = useQueryClient();
@@ -1576,6 +1577,12 @@ export default function ContractsPage() {
   const [staffDocumentOption, setStaffDocumentOption] = useState<EformsignDocumentOption | null>(null);
   const [finalizeFeedback, setFinalizeFeedback] = useState<string | null>(null);
   const finalizeProgressSourceRef = useRef<EventSource | null>(null);
+  const isDeleteDocumentBusy = isDeletingDocument || deleteDocument.isPending;
+
+  const closeStaffIframe = useCallback(() => {
+    setIsStaffIframeOpen(false);
+    setIsFinalizeSubmitting(false);
+  }, []);
 
   useEffect(() => () => {
     finalizeProgressSourceRef.current?.close();
@@ -1587,7 +1594,7 @@ export default function ContractsPage() {
     const handle = setTimeout(() => {
       openDocument(staffDocumentOption, STAFF_COMPLETION_IFRAME_ID, {
         onSuccess: () => {
-          setIsStaffIframeOpen(false);
+          closeStaffIframe();
           setStaffDocumentOption(null);
           setFinalizeDoc(null);
           setFinalizeEndDateInput("");
@@ -1600,21 +1607,28 @@ export default function ContractsPage() {
           });
         },
         onError: (response) => {
-          setIsStaffIframeOpen(false);
+          closeStaffIframe();
           setStaffDocumentOption(null);
           setFinalizeFeedback(`최종 확인 실패: ${response.message ?? "알 수 없는 오류"}`);
         },
         onAction: (response) => {
           const t = response.type?.toLowerCase() ?? "";
           if (t.includes("cancel") || t.includes("close")) {
-            setIsStaffIframeOpen(false);
+            closeStaffIframe();
             setStaffDocumentOption(null);
           }
         },
       });
     }, 300);
     return () => clearTimeout(handle);
-  }, [isStaffIframeOpen, staffDocumentOption, isEformsignLoaded, openDocument, queryClient]);
+  }, [
+    closeStaffIframe,
+    isStaffIframeOpen,
+    staffDocumentOption,
+    isEformsignLoaded,
+    openDocument,
+    queryClient,
+  ]);
 
   const openFinalize = (
     doc: EformsignDocument,
@@ -1663,7 +1677,8 @@ export default function ContractsPage() {
   };
 
   const handleDeleteDocumentConfirm = async () => {
-    if (!deleteTargetDoc) return;
+    if (!deleteTargetDoc || isDeleteDocumentBusy) return;
+    setIsDeletingDocument(true);
     try {
       await deleteDocument.mutateAsync(deleteTargetDoc.id);
       await queryClient.invalidateQueries({ queryKey: ["eformsign-doc-client-names"] });
@@ -1681,6 +1696,8 @@ export default function ContractsPage() {
         variant: "destructive",
         description: requestErrorMessage(error, "계약서 삭제 중 오류가 발생했습니다."),
       });
+    } finally {
+      setIsDeletingDocument(false);
     }
   };
 
@@ -1712,6 +1729,7 @@ export default function ContractsPage() {
     const progressId = createHeadlessProgressId("finalize");
     let progressSource: EventSource | null = null;
     let headlessOk = false;
+    let keepFinalizeSubmittingUntilIframeCloses = false;
 
     try {
       progressSource = new EventSource(
@@ -1757,6 +1775,7 @@ export default function ContractsPage() {
         });
         setTimeout(() => {
           setIsFinalizeProgressOpen(false);
+          setIsFinalizeSubmitting(false);
           setFinalizeFeedback(
             `${isServiceRecordFinalize ? "제공기록지" : "계약서"}가 완료 처리되었습니다.`,
           );
@@ -1807,13 +1826,16 @@ export default function ContractsPage() {
         const option = await eformsignApi.generateStaffDocument(documentId, undefined, undefined, endDateIso);
         setStaffDocumentOption(option as EformsignDocumentOption);
         setIsStaffIframeOpen(true);
+        keepFinalizeSubmittingUntilIframeCloses = true;
       } catch (fallbackErr) {
         const msg = fallbackErr instanceof Error ? fallbackErr.message : "최종 확인 준비 중 오류가 발생했습니다.";
         setFinalizeFeedback(msg);
       }
     }
 
-    setIsFinalizeSubmitting(false);
+    if (!keepFinalizeSubmittingUntilIframeCloses) {
+      setIsFinalizeSubmitting(false);
+    }
   };
 
   // Auto-clear finalize feedback after 4s
@@ -2356,13 +2378,17 @@ export default function ContractsPage() {
         description="선택한 계약서를 삭제할까요?"
         cancelLabel="취소"
         confirmLabel="삭제"
-        loading={deleteDocument.isPending}
+        loading={isDeleteDocumentBusy}
         onOpenChange={(open) => {
-          if (!open && !deleteDocument.isPending) {
+          if (!open && !isDeleteDocumentBusy) {
             setDeleteTargetDoc(null);
           }
         }}
-        onCancel={() => setDeleteTargetDoc(null)}
+        onCancel={() => {
+          if (!isDeleteDocumentBusy) {
+            setDeleteTargetDoc(null);
+          }
+        }}
         onConfirm={handleDeleteDocumentConfirm}
       />
 
@@ -2453,7 +2479,7 @@ export default function ContractsPage() {
             <span>계약서 최종 확인</span>
             <button
               type="button"
-              onClick={() => setIsStaffIframeOpen(false)}
+              onClick={closeStaffIframe}
               className="flex h-[44px] w-[44px] items-center justify-center rounded-xl text-v3-text"
               aria-label="닫기"
             >

--- a/mobile/src/app/(shell)/employees/new/page.lifecycle.test.ts
+++ b/mobile/src/app/(shell)/employees/new/page.lifecycle.test.ts
@@ -1,0 +1,11 @@
+import fs from "node:fs";
+
+const source = fs.readFileSync(require.resolve("./page"), "utf8");
+
+describe("mobile employee form navigation lifecycle", () => {
+  it("locks both header exits while creating or navigating", () => {
+    expect(source).toContain("const isBusy = createEmployee.isPending || isNavigationPending");
+    expect(source).toContain("if (isBusy) return");
+    expect(source.match(/disabled=\{isBusy\}/g)).toHaveLength(2);
+  });
+});

--- a/mobile/src/app/(shell)/employees/new/page.tsx
+++ b/mobile/src/app/(shell)/employees/new/page.tsx
@@ -266,9 +266,9 @@ export default function NewEmployeePage() {
       ? "제공인력님의 기본 정보를 입력해주세요."
       : "근무 지역과 다음 배정 가능 여부를 선택해주세요.";
   const selectedSummary = [store.name.trim(), store.grade].filter(Boolean);
+  const isBusy = createEmployee.isPending || isNavigationPending;
   const isNextButtonDisabled =
-    createEmployee.isPending ||
-    isNavigationPending ||
+    isBusy ||
     (
       activeStep === 0 &&
       (
@@ -328,6 +328,7 @@ export default function NewEmployeePage() {
   };
 
   const handleExit = () => {
+    if (isBusy) return;
     reset();
     router.push(returnTo ?? "/employees");
   };
@@ -358,6 +359,7 @@ export default function NewEmployeePage() {
           className={styles.navbarIconButton}
           type="button"
           onClick={handleExit}
+          disabled={isBusy}
           aria-label={returnTo ? "이전 화면으로 돌아가기" : "직원 목록으로 돌아가기"}
         >
           <ChevronLeft aria-hidden="true" size={20} strokeWidth={2.5} />
@@ -369,6 +371,7 @@ export default function NewEmployeePage() {
           className={styles.navbarIconButton}
           type="button"
           onClick={handleExit}
+          disabled={isBusy}
           aria-label="닫기"
         >
           <X aria-hidden="true" size={20} strokeWidth={2.5} />
@@ -597,7 +600,7 @@ export default function NewEmployeePage() {
             onClick={handleNext}
             disabled={isNextButtonDisabled}
           >
-            {createEmployee.isPending || isNavigationPending ? "등록 중..." : isLastStep ? "✓ 등록" : "다음 →"}
+            {isBusy ? "등록 중..." : isLastStep ? "✓ 등록" : "다음 →"}
           </button>
         </div>
       </div>

--- a/mobile/src/app/(shell)/files/upload/page.lifecycle.test.ts
+++ b/mobile/src/app/(shell)/files/upload/page.lifecycle.test.ts
@@ -1,0 +1,12 @@
+import fs from "node:fs";
+
+const source = fs.readFileSync(require.resolve("./page"), "utf8");
+
+describe("mobile file upload navigation lifecycle", () => {
+  it("locks header back and cancel while uploading", () => {
+    expect(source).toContain("const handleExit = () =>");
+    expect(source).toContain("if (isUploading) return");
+    // Header back, file input, and footer cancel are all locked while the upload owns the screen.
+    expect(source.match(/disabled=\{isUploading\}/g)).toHaveLength(3);
+  });
+});

--- a/mobile/src/app/(shell)/files/upload/page.tsx
+++ b/mobile/src/app/(shell)/files/upload/page.tsx
@@ -138,6 +138,10 @@ export default function FileUploadPage() {
   const isUploading = uploadMutation.isPending || isNavigationPending;
   const progress = isUploading ? Math.round(uploadProgress) : FALLBACK_PROGRESS;
   const uploadedBytes = selectedFile ? Math.round((selectedFile.size * progress) / 100) : 0;
+  const handleExit = () => {
+    if (isUploading) return;
+    router.push("/files");
+  };
 
   const validateFile = useCallback((file: File): string | null => {
     if (!ALLOWED_TYPES.includes(file.type)) {
@@ -232,7 +236,12 @@ export default function FileUploadPage() {
       className={styles.page}
     >
       <header data-component="mobile_files-upload_screen_root_header" className={styles.detailHeader}>
-        <button type="button" className={styles.detailBack} onClick={() => router.push("/files")}>
+        <button
+          type="button"
+          className={styles.detailBack}
+          onClick={handleExit}
+          disabled={isUploading}
+        >
           <ChevronLeft size={22} strokeWidth={2.5} />
           <span>파일</span>
         </button>
@@ -438,7 +447,12 @@ export default function FileUploadPage() {
       </main>
 
       <footer data-component="mobile_files-upload_screen_root_actions" className={styles.uploadActions}>
-        <button type="button" className={`${styles.uploadBtn} ${styles.secondary}`} onClick={() => router.push("/files")}>
+        <button
+          type="button"
+          className={`${styles.uploadBtn} ${styles.secondary}`}
+          onClick={handleExit}
+          disabled={isUploading}
+        >
           취소
         </button>
         <button

--- a/mobile/src/app/(shell)/select-branch/page.lifecycle.test.ts
+++ b/mobile/src/app/(shell)/select-branch/page.lifecycle.test.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs";
+
+const source = fs.readFileSync(require.resolve("./page"), "utf8");
+
+describe("mobile select-branch navigation lifecycle", () => {
+  it("keeps automatic branch selection loading until navigation takes over", () => {
+    expect(source).toContain("Promise<boolean>");
+    expect(source).toContain("let keepLoadingForNavigation = false");
+    expect(source).toContain("keepLoadingForNavigation = await confirmSelectBranch");
+    expect(source).toContain("if (!keepLoadingForNavigation)");
+  });
+
+  it("locks logout against an in-flight branch selection", () => {
+    expect(source).toContain("const [loggingOut, setLoggingOut] = useState(false)");
+    expect(source).toContain("const isPageBusy = submitting || loggingOut");
+    expect(source).toContain("if (isPageBusy) return");
+    expect(source).toContain('disabled={isPageBusy}');
+  });
+});

--- a/mobile/src/app/(shell)/select-branch/page.tsx
+++ b/mobile/src/app/(shell)/select-branch/page.tsx
@@ -44,15 +44,17 @@ export default function SelectBranchPage() {
   const [error, setError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [loggingOut, setLoggingOut] = useState(false);
+  const isPageBusy = submitting || loggingOut;
 
-  const confirmSelectBranch = useCallback(async (branchId: string) => {
+  const confirmSelectBranch = useCallback(async (branchId: string): Promise<boolean> => {
     setSubmitting(true);
     try {
       const result = await setCurrentBranch(branchId);
       if (!result.success) {
         setError(result.error || "지점 선택에 실패했습니다.");
         setSubmitting(false);
-        return;
+        return false;
       }
 
       // The auth user query caches branchId for 30 minutes, and eformsign
@@ -70,15 +72,18 @@ export default function SelectBranchPage() {
       });
 
       router.replace("/dashboard");
+      return true;
     } catch (err) {
       console.error("[Select Branch] Error selecting branch:", err);
       setError("지점 선택에 실패했습니다.");
       setSubmitting(false);
+      return false;
     }
   }, [queryClient, router]);
 
   useEffect(() => {
     const fetchBranches = async () => {
+      let keepLoadingForNavigation = false;
       try {
         const result = await getUserBranches();
 
@@ -90,7 +95,7 @@ export default function SelectBranchPage() {
         const isOwner = result.branches?.some((org) => org.role === "owner");
         if (result.branches?.length === 1 && !isOwner) {
           const org = result.branches[0];
-          await confirmSelectBranch(org.id);
+          keepLoadingForNavigation = await confirmSelectBranch(org.id);
           return;
         }
 
@@ -101,7 +106,9 @@ export default function SelectBranchPage() {
         console.error("[Select Branch] Error fetching branches:", err);
         setError("지점 목록을 불러오는데 실패했습니다.");
       } finally {
-        setLoading(false);
+        if (!keepLoadingForNavigation) {
+          setLoading(false);
+        }
       }
     };
 
@@ -109,11 +116,19 @@ export default function SelectBranchPage() {
   }, [confirmSelectBranch]);
 
   const handleLogout = async () => {
+    if (isPageBusy) return;
+    setLoggingOut(true);
     // auth_token/refresh_token are httpOnly — document.cookie cannot clear
     // them, and the middleware bounces authenticated users straight back
     // from /login. The server action clears them properly.
-    await logout();
-    router.replace("/login");
+    try {
+      await logout();
+      router.replace("/login");
+    } catch (err) {
+      console.error("[Select Branch] Error logging out:", err);
+      setError("로그아웃에 실패했습니다.");
+      setLoggingOut(false);
+    }
   };
 
   const getRoleLabel = (role: string) => t(locale, `roles.${role}`) || t(locale, "roles.unknown");
@@ -193,8 +208,13 @@ export default function SelectBranchPage() {
           <button type="button" className="branch-btn" onClick={() => window.location.reload()}>
             새로고침
           </button>
-          <button type="button" className="logout-link" onClick={handleLogout}>
-            <span>로그아웃</span>
+          <button
+            type="button"
+            className="logout-link"
+            onClick={handleLogout}
+            disabled={isPageBusy}
+          >
+            <span>{loggingOut ? "로그아웃 중…" : "로그아웃"}</span>
           </button>
         </div>
       </div>
@@ -237,7 +257,7 @@ export default function SelectBranchPage() {
               type="button"
               className={`branch-card ${isSelected ? "selected" : ""}`}
               onClick={() => setSelectedId(branch.id)}
-              disabled={submitting}
+              disabled={isPageBusy}
               data-component={`${SELECT_BRANCH_ROW}`}
             >
               <div
@@ -266,7 +286,7 @@ export default function SelectBranchPage() {
           type="button"
           className="branch-btn"
           onClick={() => selectedId && confirmSelectBranch(selectedId)}
-          disabled={!selectedId || submitting}
+          disabled={!selectedId || isPageBusy}
         >
           {submitting
             ? "이동 중…"
@@ -274,8 +294,13 @@ export default function SelectBranchPage() {
               ? `${selectedBranch.name}으로 이동`
               : "지점을 선택하세요"}
         </button>
-        <button type="button" className="logout-link" onClick={handleLogout}>
-          <span>로그아웃</span>
+        <button
+          type="button"
+          className="logout-link"
+          onClick={handleLogout}
+          disabled={isPageBusy}
+        >
+          <span>{loggingOut ? "로그아웃 중…" : "로그아웃"}</span>
         </button>
       </div>
     </div>

--- a/mobile/src/components/app/employees/EmployeeFormDialog.lifecycle.test.ts
+++ b/mobile/src/components/app/employees/EmployeeFormDialog.lifecycle.test.ts
@@ -1,0 +1,16 @@
+import fs from "node:fs";
+
+const source = fs.readFileSync(require.resolve("./EmployeeFormDialog"), "utf8");
+
+describe("mobile EmployeeFormDialog submit lifecycle", () => {
+  it("keeps the form busy through the required employee refetch and close", () => {
+    expect(source).toContain("const [isSubmitting, setIsSubmitting] = useState(false)");
+    expect(source).toContain(
+      "const isLoading = isSubmitting || createMutation.isPending || updateMutation.isPending",
+    );
+    expect(source).toContain("setIsSubmitting(true)");
+    expect(source).toContain("await queryClient.refetchQueries");
+    expect(source).toContain("finally");
+    expect(source).toContain("setIsSubmitting(false)");
+  });
+});

--- a/mobile/src/components/app/employees/EmployeeFormDialog.tsx
+++ b/mobile/src/components/app/employees/EmployeeFormDialog.tsx
@@ -83,6 +83,7 @@ export function EmployeeFormDialog({
     const [isPhoneDuplicate, setIsPhoneDuplicate] = useState(false);
     const [hasPhoneDuplicateCheckFailed, setHasPhoneDuplicateCheckFailed] = useState(false);
     const [lastCheckedPhoneDigits, setLastCheckedPhoneDigits] = useState<string | null>(null);
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
     const createMutation = useCreateEmployee();
     const updateMutation = useUpdateEmployee();
@@ -91,7 +92,7 @@ export function EmployeeFormDialog({
     const prefillName = useEmployeeDialogStore((state) => state.prefillName);
 
     const isEditMode = !!employee;
-    const isLoading = createMutation.isPending || updateMutation.isPending;
+    const isLoading = isSubmitting || createMutation.isPending || updateMutation.isPending;
     const phoneDigits = useMemo(() => normalizePhoneNumber(formData.phone), [formData.phone]);
     const employeePhoneDigits = useMemo(() => normalizePhoneNumber(employee?.phone ?? ""), [employee?.phone]);
     const isUnchangedEmployeePhone = isEditMode && phoneDigits.length === 11 && phoneDigits === employeePhoneDigits;
@@ -297,6 +298,7 @@ export function EmployeeFormDialog({
             return;
         }
 
+        setIsSubmitting(true);
         try {
             if (isEditMode && employee) {
                 const dto: UpdateEmployeeDto = {
@@ -345,6 +347,8 @@ export function EmployeeFormDialog({
         } catch (error: unknown) {
             console.error("[EmployeeFormDialog] Failed to save employee:", error);
             setError(getErrorMessage(error, locale, "employees.form.error-save-failed"));
+        } finally {
+            setIsSubmitting(false);
         }
     };
 

--- a/mobile/src/features/system-templates/components/VersionHistory.lifecycle.test.ts
+++ b/mobile/src/features/system-templates/components/VersionHistory.lifecycle.test.ts
@@ -1,0 +1,13 @@
+import fs from "node:fs";
+
+const source = fs.readFileSync(require.resolve("./VersionHistory"), "utf8");
+
+describe("mobile VersionHistory mutation lifecycle", () => {
+  it("locks and retains the approval dialog while applying a version", () => {
+    expect(source).toContain(
+      "const isApplying = rollbackMutation.isPending || resetMutation.isPending",
+    );
+    expect(source).toContain("if (!open && !isApplying)");
+    expect(source.match(/disabled=\{isApplying\}/g)).toHaveLength(2);
+  });
+});

--- a/mobile/src/features/system-templates/components/VersionHistory.tsx
+++ b/mobile/src/features/system-templates/components/VersionHistory.tsx
@@ -46,6 +46,7 @@ export function VersionHistory({ templateKey, onRollback }: Props) {
   const { data: versions, isLoading } = useTemplateVersions(templateKey);
   const rollbackMutation = useRollbackTemplate();
   const resetMutation = useResetTemplate();
+  const isApplying = rollbackMutation.isPending || resetMutation.isPending;
 
   const { data: previewDetail, isLoading: isPreviewLoading } = useQuery<VersionDetail>({
     queryKey:
@@ -191,7 +192,14 @@ export function VersionHistory({ templateKey, onRollback }: Props) {
       </Dialog>
 
       {/* Confirm Dialog */}
-      <Dialog open={!!confirmDialog} onOpenChange={() => setConfirmDialog(null)}>
+      <Dialog
+        open={!!confirmDialog}
+        onOpenChange={(open) => {
+          if (!open && !isApplying) {
+            setConfirmDialog(null);
+          }
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
@@ -204,7 +212,11 @@ export function VersionHistory({ templateKey, onRollback }: Props) {
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmDialog(null)}>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmDialog(null)}
+              disabled={isApplying}
+            >
               취소
             </Button>
             <Button
@@ -214,6 +226,7 @@ export function VersionHistory({ templateKey, onRollback }: Props) {
                   ? handleRollback(confirmDialog.version!)
                   : handleReset()
               }
+              disabled={isApplying}
             >
               {confirmDialog?.type === 'rollback' ? '복원' : '초기화'}
             </Button>


### PR DESCRIPTION
## Summary
- Promote PR #449 from `dev` to `preview`.
- Preserve Prisma boolean identities while removing missing pre-migration predicates inside `AND`, `OR`, and `NOT`.
- Keep authored-empty and undefined-only predicates contextually intact.

## Scope
- 2 backend/test files only.
- No schema, migration, dependency, environment-variable, authentication, or authorization change.

## Source evidence
- PR #449 merged to `dev` after full CI and latest-head Codex review passed.
- Both source review threads were resolved with regressions.

## Preview gate
- Wait for current-head CI, Railway/Vercel deployment, Codex review, comments, and unresolved-thread checks.
- After merge/deploy, rerun the idempotent DB patch workflow and fail-closed eformsign backfill/readiness verification.

## Rollback
Revert the preview merge commit. Existing mirror tables and PDF data remain intact.