### PR TITLE
fix(backend): preserve authored empty logical arrays

### DIFF
--- a/backend/infrastructure/database/eformsign-doc-compat.ts
+++ b/backend/infrastructure/database/eformsign-doc-compat.ts
@@ -259,6 +259,15 @@ export const stripPendingEformsignDocPredicates = (
         operator: "AND" | "OR" | "NOT",
         value: Prisma.eformsign_docWhereInput | Prisma.eformsign_docWhereInput[],
     ): SimplifiedWhere => {
+        if (Array.isArray(value) && value.length === 0) {
+            // Empty logical arrays were authored by the caller, not produced by stripping
+            // a missing-column predicate. Prisma assigns them contextual semantics, so
+            // keep the node opaque just like an authored `{}` branch.
+            return {
+                kind: "where",
+                where: { [operator]: value },
+            };
+        }
         const entries = Array.isArray(value) ? value : [value];
         const simplifiedEntries = entries.map((entry) => strip(entry));
 

--- a/backend/infrastructure/database/eformsign-doc-compat.ts
+++ b/backend/infrastructure/database/eformsign-doc-compat.ts
@@ -333,6 +333,23 @@ export const stripPendingEformsignDocPredicates = (
         return { kind: "where", where: { NOT: simplified!.where } };
     };
 
+    const isContextuallyEmpty = (node: Record<string, unknown>): boolean =>
+        Object.entries(node).every(([key, value]) => {
+            if (value === undefined) {
+                return true;
+            }
+            if (key !== "AND" && key !== "OR" && key !== "NOT") {
+                return false;
+            }
+            const entries = Array.isArray(value) ? value : [value];
+            return entries.every(
+                (entry) =>
+                    typeof entry === "object"
+                    && entry !== null
+                    && isContextuallyEmpty(entry as Record<string, unknown>),
+            );
+        });
+
     const strip = (node: Prisma.eformsign_docWhereInput): SimplifiedWhere => {
         const stripped: Record<string, unknown> = {};
         let removedTrue = false;
@@ -369,20 +386,12 @@ export const stripPendingEformsignDocPredicates = (
             stripped[key] = value;
         }
         const strippedEntries = Object.entries(stripped);
-        if (
-            removedTrue
-            && strippedEntries.length > 0
-            && strippedEntries.every(([key, value]) =>
-                (key === "AND" || key === "OR" || key === "NOT")
-                && Array.isArray(value)
-                && value.length === 0
-            )
-        ) {
-            // Prisma gives an authored empty logical array contextual semantics when it
-            // stands alone. If this same node also contained a missing-column `: null`,
-            // however, that removed predicate is the known-true branch and must still
-            // propagate through its parent logical expression.
-            return { kind: "true" };
+        if (removedTrue && strippedEntries.length > 0 && isContextuallyEmpty(stripped)) {
+            // Prisma changes an otherwise-empty logical node's meaning when it has a
+            // concrete sibling. Keep a schema-stable tautology in that exact object so
+            // stripping a pending-column `: null` does not change root or nested behavior.
+            // `id` predates every pending mirror migration and is a non-null primary key.
+            stripped["id"] = { notIn: [] };
         }
         if (strippedEntries.length === 0) {
             // `{}` is context-sensitive in Prisma (`OR: [{}]` and `NOT: {}` are not

--- a/backend/infrastructure/database/eformsign-doc-compat.ts
+++ b/backend/infrastructure/database/eformsign-doc-compat.ts
@@ -368,7 +368,23 @@ export const stripPendingEformsignDocPredicates = (
             }
             stripped[key] = value;
         }
-        if (Object.keys(stripped).length === 0) {
+        const strippedEntries = Object.entries(stripped);
+        if (
+            removedTrue
+            && strippedEntries.length > 0
+            && strippedEntries.every(([key, value]) =>
+                (key === "AND" || key === "OR" || key === "NOT")
+                && Array.isArray(value)
+                && value.length === 0
+            )
+        ) {
+            // Prisma gives an authored empty logical array contextual semantics when it
+            // stands alone. If this same node also contained a missing-column `: null`,
+            // however, that removed predicate is the known-true branch and must still
+            // propagate through its parent logical expression.
+            return { kind: "true" };
+        }
+        if (strippedEntries.length === 0) {
             // `{}` is context-sensitive in Prisma (`OR: [{}]` and `NOT: {}` are not
             // interchangeable with our boolean identities). Only an empty node caused by
             // removing a known-true predicate is the true identity this helper may erase.

--- a/backend/test/infrastructure/eformsign-doc-compat.spec.ts
+++ b/backend/test/infrastructure/eformsign-doc-compat.spec.ts
@@ -276,7 +276,12 @@ describe("stripPendingEformsignDocPredicates", () => {
                 { AND: [], templateId: null },
                 { branchId: "branch-1" },
             ],
-        })).toEqual({});
+        })).toEqual({
+            OR: [
+                { AND: [], id: { notIn: [] } },
+                { branchId: "branch-1" },
+            ],
+        });
     });
 
     it("propagates a removed tautology past an authored empty NOT array", () => {
@@ -285,7 +290,36 @@ describe("stripPendingEformsignDocPredicates", () => {
                 { NOT: [], templateId: null },
                 { branchId: "branch-1" },
             ],
-        })).toEqual({});
+        })).toEqual({
+            OR: [
+                { NOT: [], id: { notIn: [] } },
+                { branchId: "branch-1" },
+            ],
+        });
+    });
+
+    it("preserves root empty OR semantics while retaining a stripped tautology", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [],
+            templateId: null,
+        })).toEqual({
+            OR: [],
+            id: { notIn: [] },
+        });
+    });
+
+    it("retains a stripped tautology beside recursively empty logical branches", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { AND: [{}], templateId: null },
+                { NOT: {}, templateId: null },
+            ],
+        })).toEqual({
+            OR: [
+                { AND: [{}], id: { notIn: [] } },
+                { NOT: {}, id: { notIn: [] } },
+            ],
+        });
     });
 
     it("preserves a pre-existing empty branch inside NOT", () => {

--- a/backend/test/infrastructure/eformsign-doc-compat.spec.ts
+++ b/backend/test/infrastructure/eformsign-doc-compat.spec.ts
@@ -242,6 +242,34 @@ describe("stripPendingEformsignDocPredicates", () => {
         })).toEqual({ OR: [{}] });
     });
 
+    it("preserves an authored empty AND array nested inside OR", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { AND: [] },
+                { branchId: "branch-1" },
+            ],
+        })).toEqual({
+            OR: [
+                { AND: [] },
+                { branchId: "branch-1" },
+            ],
+        });
+    });
+
+    it("preserves an authored empty NOT array nested inside OR", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { NOT: [] },
+                { branchId: "branch-1" },
+            ],
+        })).toEqual({
+            OR: [
+                { NOT: [] },
+                { branchId: "branch-1" },
+            ],
+        });
+    });
+
     it("preserves a pre-existing empty branch inside NOT", () => {
         expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
             NOT: {},

--- a/backend/test/infrastructure/eformsign-doc-compat.spec.ts
+++ b/backend/test/infrastructure/eformsign-doc-compat.spec.ts
@@ -270,6 +270,24 @@ describe("stripPendingEformsignDocPredicates", () => {
         });
     });
 
+    it("propagates a removed tautology past an authored empty AND array", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { AND: [], templateId: null },
+                { branchId: "branch-1" },
+            ],
+        })).toEqual({});
+    });
+
+    it("propagates a removed tautology past an authored empty NOT array", () => {
+        expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
+            OR: [
+                { NOT: [], templateId: null },
+                { branchId: "branch-1" },
+            ],
+        })).toEqual({});
+    });
+
     it("preserves a pre-existing empty branch inside NOT", () => {
         expect(stripPendingEformsignDocPredicates(missingColumnError("document_kind"), {
             NOT: {},


### PR DESCRIPTION
## Summary
- preserve authored zero-entry logical arrays during eformsign missing-column compatibility rewrites
- prevent nested empty `AND`/`NOT` branches from collapsing an enclosing `OR` to an unconstrained filter
- add regression coverage for both contextual cases

## Validation
- `pnpm --filter ./backend exec jest --runInBand test/infrastructure/eformsign-doc-compat.spec.ts` (30 passed)
- `pnpm --filter ./backend exec jest --runInBand` (187 suites, 2,180 passed, 37 skipped)
- `pnpm --filter ./backend run type-check`
- `pnpm --filter ./backend run lint` (0 errors; pre-existing warnings)
- `pnpm --filter ./backend run build`
- security diff review: no dependency, secret, raw SQL, dynamic execution, or authorization changes

## Context
Addresses the unresolved P2 review thread on preview promotion PR #450 before promotion continues.