### PR TITLE
fix(eformsign): restore the embedded iframe fallback and split gate budgets

### DIFF
--- a/backend/application/usecases/eformsign-doc/dispatch-document-headless.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/dispatch-document-headless.usecase.ts
@@ -139,7 +139,15 @@ export class DispatchDocumentHeadlessUsecase {
                 },
             });
 
-            if (!result.ok) {
+            // The gate runner emits "creating" at the moment it clicks 전송, so a
+            // failure at or after that step means eformsign may already hold the
+            // document and only the SDK callback went missing. Those runs must not
+            // report fallbackHint:"iframe" — that reopens the editor and a second
+            // contract goes out. Only a failure that never reached the send button
+            // is safe to retry in the iframe.
+            const sendWasAttempted = latestProgressStep === "creating" || latestProgressStep === "sent";
+
+            if (!result.ok && !sendWasAttempted) {
                 this.progressService.emit(params.progressId, "failed", result.reason, latestProgressStep);
                 return {
                     ok: false,
@@ -149,6 +157,10 @@ export class DispatchDocumentHeadlessUsecase {
                     failedStep: latestProgressStep,
                 };
             }
+            // A post-send failure falls through to the same reconciliation as a run
+            // that finished without a document_id: look the document up remotely,
+            // adopt it if it exists, and otherwise surface "confirm before retrying"
+            // instead of silently reopening the editor.
 
             // The SDK success callback (`__eformsignSuccess.document_id`) is
             // the only authoritative source of the new document id — mode:"01"

--- a/backend/infrastructure/automation/eformsign-creation-gates.ts
+++ b/backend/infrastructure/automation/eformsign-creation-gates.ts
@@ -1,19 +1,29 @@
 import type { FrameLocator, Logger, Page } from "playwright-core";
 import type { Logger as NestLogger } from "@nestjs/common";
 import {
+    EFORMSIGN_GATE_DIAGNOSTIC_INTERVAL_MS,
     EFORMSIGN_GATE_POLL_MS,
     EFORMSIGN_READY_TEXT,
     REQUEST_SEND_DIALOG_SELECTOR,
     createGateErrorWithSnapshot,
     findVisibleEnabledLocator,
     findVisibleLocator,
+    getEformsignGateSnapshot,
     isSuccessLatched,
     throwIfEformsignErrorLatched,
     tryClickGateLocator,
 } from "./eformsign-gate-utils";
 import type { EformsignHeadlessProgressStep } from "application/services/eformsign-headless-progress.service";
 
-const EFORMSIGN_CREATION_GATE_TIMEOUT_MS = 60_000;
+// How long eformsign gets to render the editor far enough to expose its first
+// actionable gate button. Measured spread on the same template/client is wide —
+// 6s on a healthy run, 64s when the vendor is slow — so this budget is sized for
+// the slow end, not the median.
+const EFORMSIGN_CREATION_GATE_WAIT_TIMEOUT_MS = 70_000;
+// How long the click sequence itself gets, measured from the first successful
+// click. Kept separate from the wait budget on purpose: sharing one deadline let
+// a slow editor render starve the sequence, which needs only ~2s in practice.
+const EFORMSIGN_CREATION_GATE_ACTION_TIMEOUT_MS = 30_000;
 
 /**
  * Drive the creation iframe (mode:"01") through the deterministic gate
@@ -27,10 +37,35 @@ export async function runEformsignCreationGates(
     logger: NestLogger | Logger | Console = console,
     onProgress?: (step: EformsignHeadlessProgressStep) => void,
 ): Promise<"success-latched" | "request-send-clicked"> {
-    const deadline = Date.now() + EFORMSIGN_CREATION_GATE_TIMEOUT_MS;
+    const startedAt = Date.now();
+    let deadline = startedAt + EFORMSIGN_CREATION_GATE_WAIT_TIMEOUT_MS;
     let lastAction = "none";
     let stampConfirmCount = 0;
     let infoInsertedEmitted = false;
+    let lastDiagnosticAt = startedAt;
+    let firstActionAt: number | null = null;
+
+    // Records a *successful* gate click. The first one hands the sequence its own
+    // budget so however long the editor took to appear, the clicks still get a
+    // full window. Failed-click retries deliberately don't come through here.
+    const noteAction = (action: string): void => {
+        lastAction = action;
+        if (firstActionAt !== null) return;
+        firstActionAt = Date.now();
+        deadline = firstActionAt + EFORMSIGN_CREATION_GATE_ACTION_TIMEOUT_MS;
+    };
+
+    const emitIdleDiagnostic = async (): Promise<void> => {
+        if (Date.now() - lastDiagnosticAt < EFORMSIGN_GATE_DIAGNOSTIC_INTERVAL_MS) return;
+        lastDiagnosticAt = Date.now();
+        const snapshot = await getEformsignGateSnapshot(eformsignFrame, REQUEST_SEND_DIALOG_SELECTOR).catch(
+            (error: unknown) => `unavailable (${error instanceof Error ? error.message : String(error)})`,
+        );
+        const line =
+            `[creation-gate] waiting ${Date.now() - startedAt}ms; lastAction: ${lastAction}; ` +
+            `snapshot: ${JSON.stringify(snapshot)}`;
+        (logger as NestLogger).log?.(line) ?? console.log(line);
+    };
 
     const emitInfoInserted = () => {
         if (infoInsertedEmitted) return;
@@ -45,6 +80,8 @@ export async function runEformsignCreationGates(
             if (await isSuccessLatched(page)) {
                 return "success-latched";
             }
+
+            await emitIdleDiagnostic();
 
             const requestSendDialog = eformsignFrame.locator(REQUEST_SEND_DIALOG_SELECTOR);
 
@@ -64,7 +101,7 @@ export async function runEformsignCreationGates(
                 if (stampConfirmCount >= 3) {
                     emitInfoInserted();
                 }
-                lastAction = "clicked 회사 도장 확인";
+                noteAction("clicked 회사 도장 확인");
                 await page.waitForTimeout(250);
                 continue;
             }
@@ -104,7 +141,7 @@ export async function runEformsignCreationGates(
                     emitInfoInserted();
                     onProgress?.("creating");
                 }
-                lastAction = "clicked top-level 전송";
+                noteAction("clicked top-level 전송");
                 await page.waitForTimeout(250);
                 continue;
             }
@@ -118,7 +155,7 @@ export async function runEformsignCreationGates(
                 }
                 (logger as NestLogger).log?.("[creation-gate] clicked 다음") ??
                     console.log("[creation-gate] clicked 다음");
-                lastAction = "clicked 다음";
+                noteAction("clicked 다음");
                 await page.waitForTimeout(250);
                 continue;
             }
@@ -134,7 +171,7 @@ export async function runEformsignCreationGates(
                 }
                 (logger as NestLogger).log?.("[creation-gate] clicked 입력 시작") ??
                     console.log("[creation-gate] clicked 입력 시작");
-                lastAction = "clicked 입력 시작";
+                noteAction("clicked 입력 시작");
                 await page.waitForTimeout(250);
                 continue;
             }
@@ -157,9 +194,13 @@ export async function runEformsignCreationGates(
         );
     }
 
+    const phase = firstActionAt === null
+        ? `no gate became actionable within ${EFORMSIGN_CREATION_GATE_WAIT_TIMEOUT_MS}ms`
+        : `sequence stalled ${Date.now() - firstActionAt}ms after its first click `
+            + `(budget ${EFORMSIGN_CREATION_GATE_ACTION_TIMEOUT_MS}ms)`;
     throw await createGateErrorWithSnapshot(
         new Error(
-            `Timed out after ${EFORMSIGN_CREATION_GATE_TIMEOUT_MS}ms while advancing eformsign creation gates. ` +
+            `Timed out after ${Date.now() - startedAt}ms while advancing eformsign creation gates: ${phase}. ` +
                 `Last action: ${lastAction}`,
         ),
         eformsignFrame,

--- a/backend/infrastructure/automation/eformsign-finalize-gates.ts
+++ b/backend/infrastructure/automation/eformsign-finalize-gates.ts
@@ -1,17 +1,23 @@
 import type { FrameLocator, Page } from "playwright-core";
 import type { Logger as NestLogger } from "@nestjs/common";
 import {
+    EFORMSIGN_GATE_DIAGNOSTIC_INTERVAL_MS,
     EFORMSIGN_GATE_POLL_MS,
     FINALIZE_REQUEST_SEND_DIALOG_SELECTOR,
     createGateErrorWithSnapshot,
     findVisibleEnabledLocator,
+    getEformsignGateSnapshot,
     isSuccessLatched,
     throwIfEformsignErrorLatched,
     tryClickGateLocator,
 } from "./eformsign-gate-utils";
 import type { EformsignHeadlessProgressStep } from "application/services/eformsign-headless-progress.service";
 
-const EFORMSIGN_FINALIZE_GATE_TIMEOUT_MS = 30_000;
+// Same split as the creation gates: eformsign's editor render time varies by an
+// order of magnitude, so waiting for the first actionable gate gets its own
+// budget and must not eat into the click sequence that follows.
+const EFORMSIGN_FINALIZE_GATE_WAIT_TIMEOUT_MS = 70_000;
+const EFORMSIGN_FINALIZE_GATE_ACTION_TIMEOUT_MS = 30_000;
 
 /**
  * Drive the staff-finalize iframe (mode:"02") through its short gate sequence:
@@ -25,9 +31,32 @@ export async function runEformsignFinalizeGates(
     logger: NestLogger | Console = console,
     onProgress?: (step: EformsignHeadlessProgressStep) => void,
 ): Promise<"success-latched" | "request-send-clicked"> {
-    const deadline = Date.now() + EFORMSIGN_FINALIZE_GATE_TIMEOUT_MS;
+    const startedAt = Date.now();
+    let deadline = startedAt + EFORMSIGN_FINALIZE_GATE_WAIT_TIMEOUT_MS;
     let lastAction = "none";
     let creatingEmitted = false;
+    let lastDiagnosticAt = startedAt;
+    let firstActionAt: number | null = null;
+
+    const noteAction = (action: string): void => {
+        lastAction = action;
+        if (firstActionAt !== null) return;
+        firstActionAt = Date.now();
+        deadline = firstActionAt + EFORMSIGN_FINALIZE_GATE_ACTION_TIMEOUT_MS;
+    };
+
+    const emitIdleDiagnostic = async (): Promise<void> => {
+        if (Date.now() - lastDiagnosticAt < EFORMSIGN_GATE_DIAGNOSTIC_INTERVAL_MS) return;
+        lastDiagnosticAt = Date.now();
+        const snapshot = await getEformsignGateSnapshot(
+            eformsignFrame,
+            FINALIZE_REQUEST_SEND_DIALOG_SELECTOR,
+        ).catch((error: unknown) => `unavailable (${error instanceof Error ? error.message : String(error)})`);
+        const line =
+            `[finalize-gate] waiting ${Date.now() - startedAt}ms; lastAction: ${lastAction}; ` +
+            `snapshot: ${JSON.stringify(snapshot)}`;
+        (logger as NestLogger).log?.(line) ?? console.log(line);
+    };
 
     // Finalize prefill (서비스 종료일) is applied via the SDK options before the
     // iframe even renders, so as soon as we reach the gate loop the data is
@@ -47,6 +76,8 @@ export async function runEformsignFinalizeGates(
             if (await isSuccessLatched(page)) {
                 return "success-latched";
             }
+
+            await emitIdleDiagnostic();
 
             const requestSendDialog = eformsignFrame.locator(FINALIZE_REQUEST_SEND_DIALOG_SELECTOR);
 
@@ -78,7 +109,7 @@ export async function runEformsignFinalizeGates(
                 (logger as NestLogger).log?.("[finalize-gate] clicked top-level 전송") ??
                     console.log("[finalize-gate] clicked top-level 전송");
                 emitCreating();
-                lastAction = "clicked top-level 전송";
+                noteAction("clicked top-level 전송");
                 await page.waitForTimeout(250);
                 continue;
             }
@@ -95,7 +126,7 @@ export async function runEformsignFinalizeGates(
                 }
                 (logger as NestLogger).log?.("[finalize-gate] clicked 확인") ??
                     console.log("[finalize-gate] clicked 확인");
-                lastAction = "clicked 확인";
+                noteAction("clicked 확인");
                 await page.waitForTimeout(250);
                 continue;
             }
@@ -110,9 +141,13 @@ export async function runEformsignFinalizeGates(
         );
     }
 
+    const phase = firstActionAt === null
+        ? `no gate became actionable within ${EFORMSIGN_FINALIZE_GATE_WAIT_TIMEOUT_MS}ms`
+        : `sequence stalled ${Date.now() - firstActionAt}ms after its first click `
+            + `(budget ${EFORMSIGN_FINALIZE_GATE_ACTION_TIMEOUT_MS}ms)`;
     throw await createGateErrorWithSnapshot(
         new Error(
-            `Timed out after ${EFORMSIGN_FINALIZE_GATE_TIMEOUT_MS}ms while advancing eformsign finalize gates. ` +
+            `Timed out after ${Date.now() - startedAt}ms while advancing eformsign finalize gates: ${phase}. ` +
                 `Last action: ${lastAction}`,
         ),
         eformsignFrame,

--- a/backend/infrastructure/automation/eformsign-gate-utils.ts
+++ b/backend/infrastructure/automation/eformsign-gate-utils.ts
@@ -2,6 +2,11 @@ import type { FrameLocator, Locator, Page } from "playwright-core";
 
 export const EFORMSIGN_GATE_POLL_MS = 500;
 export const EFORMSIGN_CLICK_TIMEOUT_MS = 2_000;
+// The gate loop only logs when it clicks something, so a run that stalls waiting
+// for the editor to expose its first actionable button leaves no trace at all.
+// Emit a snapshot on this cadence while the loop is idle so a timeout report
+// shows what the iframe was actually displaying, not just the final frame.
+export const EFORMSIGN_GATE_DIAGNOSTIC_INTERVAL_MS = 5_000;
 export const EFORMSIGN_READY_TEXT = "필수 입력 항목을 모두 작성했습니다.";
 // eformsign uses two different popup IDs depending on the SDK mode:
 //   - mode "01" (creation): #requestWithInputCommentPopup

--- a/backend/interface/dto/eformsign.dto.ts
+++ b/backend/interface/dto/eformsign.dto.ts
@@ -88,20 +88,19 @@ class ContractDataRequestDto {
     @IsNotEmpty()
     startDate!: string;
 
+    // 계약 종료일은 이용자 서명 후 직원이 사후 입력하므로 발급 시점에는 비어 있는 것이
+    // 정상이다. @IsNotEmpty()를 걸어두면 종료일 미정 계약은 generate-document가
+    // 400으로 막혀 embedded iframe이 아예 열리지 않는다.
     @IsString()
-    @IsNotEmpty()
     endYear!: string;
 
     @IsString()
-    @IsNotEmpty()
     endMonth!: string;
 
     @IsString()
-    @IsNotEmpty()
     endDay!: string;
 
     @IsString()
-    @IsNotEmpty()
     endDate!: string;
 
     @IsString()
@@ -131,6 +130,21 @@ class ContractDataRequestDto {
     @IsOptional()
     @IsString()
     issuerPhone?: string;
+
+    // 접수일. generateDocumentOptions는 사용하지 않지만 계약 생성 폼이 항상 함께
+    // 보내므로 선언해 둬야 한다. 전역 파이프가 forbidNonWhitelisted이라 미선언
+    // 속성 하나만 있어도 요청 전체가 400이 된다.
+    @IsOptional()
+    @IsString()
+    receiptYear?: string;
+
+    @IsOptional()
+    @IsString()
+    receiptMonth?: string;
+
+    @IsOptional()
+    @IsString()
+    receiptDay?: string;
 }
 
 export class GenerateDocumentRequestDto {

--- a/backend/test/usecases/eformsign-doc/dispatch-document-headless.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/dispatch-document-headless.usecase.spec.ts
@@ -248,6 +248,91 @@ describe("DispatchDocumentHeadlessUsecase", () => {
         }));
     });
 
+    // A headless failure is only safe to retry in the iframe if the run never got
+    // as far as clicking 전송. Past that point eformsign may already hold the
+    // document, and reopening the editor sends a second contract.
+    describe("post-send failures", () => {
+        const buildUsecase = (overrides: {
+            dispatchCreation: jest.Mock;
+            remoteDocuments?: unknown[];
+            createDoc?: jest.Mock;
+        }) => new DispatchDocumentHeadlessUsecase(
+            { generateDocumentOptions: jest.fn().mockReturnValue({}) } as never,
+            { dispatchCreation: overrides.dispatchCreation } as never,
+            { findByArea: jest.fn().mockResolvedValue(null) } as never,
+            { execute: jest.fn().mockResolvedValue({ oauth_token: { access_token: "a", refresh_token: "r" } }) } as never,
+            { execute: overrides.createDoc ?? jest.fn().mockResolvedValue(undefined) } as never,
+            { execute: jest.fn().mockRejectedValue(new Error("not found")) } as never,
+            { emit: jest.fn() } as never,
+            { findById: jest.fn().mockResolvedValue(null) } as never,
+            { assertAssignedProvider: jest.fn().mockResolvedValue({ scheduleId: 1 }) } as never,
+            { findByClientId: jest.fn().mockResolvedValue([]) } as never,
+            { execute: jest.fn().mockResolvedValue(overrides.remoteDocuments ?? []) } as never,
+        );
+
+        const params = {
+            clientId: 7,
+            contractData: { customerName: "김고객", customerContact: "010-0000-0000" } as never,
+        };
+
+        it("still offers the iframe when the run failed before reaching 전송", async () => {
+            const dispatchCreation = jest.fn().mockImplementation(async ({ onProgress }) => {
+                onProgress?.("client-started");
+                return { ok: false, reason: "Timed out ... no gate became actionable", durationMs: 70_000 };
+            });
+
+            await expect(buildUsecase({ dispatchCreation }).execute("branch-1", params))
+                .resolves.toEqual(expect.objectContaining({
+                    ok: false,
+                    fallbackHint: "iframe",
+                    failedStep: "client-started",
+                }));
+        });
+
+        it("never offers the iframe once 전송 was already clicked", async () => {
+            const dispatchCreation = jest.fn().mockImplementation(async ({ onProgress }) => {
+                onProgress?.("client-started");
+                onProgress?.("info-inserted");
+                onProgress?.("creating"); // emitted at the moment 전송 is clicked
+                return { ok: false, reason: "eformsign SDK completed without a success callback", durationMs: 90_000 };
+            });
+
+            const result = await buildUsecase({ dispatchCreation }).execute("branch-1", params);
+
+            // Reopening the editor here is what duplicates a contract that may
+            // already have gone out, so this hint must never be "iframe".
+            expect(result).toEqual(expect.objectContaining({
+                ok: false,
+                reason: "remote_unconfirmed",
+                fallbackHint: "manual_check",
+            }));
+        });
+
+        it("adopts the document when a post-send failure turns out to have sent it", async () => {
+            const dispatchCreation = jest.fn().mockImplementation(async ({ onProgress }) => {
+                onProgress?.("creating");
+                return { ok: false, reason: "eformsign SDK completed without a success callback", durationMs: 90_000 };
+            });
+            const createDoc = jest.fn().mockResolvedValue(undefined);
+
+            const result = await buildUsecase({
+                dispatchCreation,
+                createDoc,
+                remoteDocuments: [{
+                    id: "recovered-1",
+                    created_date: Date.now(),
+                    document_name: "김고객 산모신생아건강관리서비스 계약서",
+                }],
+            }).execute("branch-1", params);
+
+            expect(result).toEqual(expect.objectContaining({ ok: true, documentId: "recovered-1" }));
+            expect(createDoc).toHaveBeenCalledWith("branch-1", expect.objectContaining({
+                documentId: "recovered-1",
+                clientId: 7,
+            }));
+        });
+    });
+
     it("rejects a recent pending duplicate and allows force", async () => {
         const dispatchCreation = jest.fn().mockResolvedValue({ ok: false, reason: "stop", durationMs: 1 });
         const repository = { findByClientId: jest.fn().mockResolvedValue([{

--- a/frontend/src/app/api/eformsign-docs/dispatch-headless/route.ts
+++ b/frontend/src/app/api/eformsign-docs/dispatch-headless/route.ts
@@ -20,9 +20,10 @@ export async function POST(request: NextRequest) {
 
         const response = await serverAPIClient.post("/eformsign-docs/dispatch-headless", body, {
             headers: { Authorization: `Bearer ${token}` },
-            // Headless dispatch can approach 90s when eformsign is slow to
-            // fire the SDK success callback; keep the proxy above that ceiling.
-            timeout: 180_000,
+            // Must sit between the backend's own budget (iframe boot 30s + gates
+            // 100s + SDK callback 30s ≈ 160s worst case) and the browser's 180s,
+            // so a slow run still resolves into a real backend verdict.
+            timeout: 170_000,
         });
 
         return NextResponse.json(response.data);

--- a/frontend/src/app/api/eformsign-docs/finalize-headless/route.ts
+++ b/frontend/src/app/api/eformsign-docs/finalize-headless/route.ts
@@ -17,7 +17,10 @@ export async function POST(request: NextRequest) {
 
         const response = await serverAPIClient.post("/eformsign-docs/finalize-headless", body, {
             headers: { Authorization: `Bearer ${token}` },
-            timeout: 60_000,
+            // Same ordering as dispatch-headless: 60s sat *below* the backend's
+            // own worst case, so a slow-but-still-working finalize was cut off
+            // here and surfaced as an unclassifiable proxy error.
+            timeout: 170_000,
         });
 
         return NextResponse.json(response.data);

--- a/frontend/src/components/app/contracts/ContractCreationForm.tsx
+++ b/frontend/src/components/app/contracts/ContractCreationForm.tsx
@@ -372,6 +372,11 @@ export const ContractCreationForm = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [allowIframeFallback, setAllowIframeFallback] = useState(false);
+  // Kept out of `submitError` on purpose: opening the iframe fallback re-enters
+  // handleContractCreation, which clears submitError. This warning has to outlive
+  // that, because it is the only thing standing between staff and a duplicate
+  // contract when the dispatch outcome is unknown.
+  const [unverifiedDispatchNotice, setUnverifiedDispatchNotice] = useState<string | null>(null);
   const [creationProgress, setCreationProgress] = useState<HeadlessProgressState>(INITIAL_CREATION_PROGRESS);
   const [dueDateInput, setDueDateInput] = useState("");
   const [startDateInput, setStartDateInput] = useState("");
@@ -529,6 +534,7 @@ export const ContractCreationForm = ({
     setIsSubmitting(false);
     setSubmitError(null);
     setAllowIframeFallback(false);
+    setUnverifiedDispatchNotice(null);
     setCreationProgress(INITIAL_CREATION_PROGRESS);
   };
 
@@ -674,6 +680,10 @@ export const ContractCreationForm = ({
 
     setIsSubmitting(true);
     setSubmitError(null);
+    // A manual run is usually the automatic iframe fallback re-entering after a
+    // failure, so it must not wipe the warning that failure just raised. Only a
+    // genuinely fresh attempt clears it.
+    if (mode !== "manual") setUnverifiedDispatchNotice(null);
     setIsDialogOpen(false);
     setCreationProgress(INITIAL_CREATION_PROGRESS);
 
@@ -804,6 +814,15 @@ export const ContractCreationForm = ({
         const progressId = createHeadlessProgressId();
         let progressSource: ReturnType<typeof createReconnectingEventSource> | null = null;
 
+        // Reopen the eformsign editor so staff are never stranded on a failed
+        // automatic run. Deferred a tick so this run's `finally` (which clears
+        // isSubmitting) lands before the manual run sets it again.
+        const openIframeFallback = () => {
+          setTimeout(() => {
+            void handleContractCreation({ mode: "manual" });
+          }, 0);
+        };
+
         try {
           setCreationProgress({ step: "client-started", completed: false, failed: false });
           progressSource = createReconnectingEventSource({
@@ -901,7 +920,8 @@ export const ContractCreationForm = ({
             "[contract-creation] headless dispatch returned ok=false",
             headless.reason,
           );
-          setAllowIframeFallback(headless.fallbackHint === "iframe");
+          const canFallBackToIframe = headless.fallbackHint === "iframe";
+          setAllowIframeFallback(canFallBackToIframe);
           setSubmitError(getSafeHeadlessFailureMessage(headless.reason));
           setCreationProgress((current) => ({
             step: headless.failedStep && isHeadlessProgressStepKey(headless.failedStep)
@@ -910,14 +930,28 @@ export const ContractCreationForm = ({
             completed: false,
             failed: true,
           }));
+          if (canFallBackToIframe) {
+            // fallbackHint:"iframe" is the backend stating it got far enough to
+            // know nothing was sent, so reopening the editor cannot duplicate.
+            openIframeFallback();
+          }
           return;
         } catch (headlessError) {
           console.warn(
             "[contract-creation] headless dispatch threw",
             headlessError,
           );
-          setSubmitError(getSafeHeadlessFailureMessage(headlessError instanceof Error ? headlessError.message : undefined));
+          // The backend's verdict never reached us, so whether the document was
+          // sent is genuinely unknown. The editor still opens so staff are never
+          // stranded, but the warning has to stay: finishing here on top of a run
+          // that actually succeeded is how a contract gets sent twice.
+          setAllowIframeFallback(true);
+          setUnverifiedDispatchNotice(
+            "자동 생성 결과를 확인하지 못했습니다. 전자문서 목록에서 생성 여부를 먼저 확인하시고, "
+            + "이미 생성되어 있다면 중복 생성하지 말고 이 창을 닫아 주세요.",
+          );
           markCreationProgressFailed();
+          openIframeFallback();
           return;
         } finally {
           progressSource?.close();
@@ -1471,7 +1505,7 @@ export const ContractCreationForm = ({
     {
       label: "전자문서 생성",
       content: (
-        <div className="flex h-full w-full items-center justify-center py-2">
+        <div className="flex h-full w-full items-stretch justify-center py-2">
           <HeadlessProgressStepper
             steps={CONTRACT_CREATION_PROGRESS_STEPS}
             progress={creationProgress}
@@ -1480,7 +1514,7 @@ export const ContractCreationForm = ({
             testIdPrefix="contract-creation-progress"
             errorHint={CONTRACT_CREATION_MANUAL_HELP}
             spinnerClassName="contract-creation-processing-spinner"
-            className="w-full max-w-[22rem]"
+            className="h-full w-full max-w-[22rem] [&>li:not(:last-child)]:flex-1"
           />
         </div>
       ),
@@ -1497,6 +1531,16 @@ export const ContractCreationForm = ({
           {(submitError || eformsignError) && (
             <Alert variant="destructive" data-component="desktop_messages_sections_contract-form-error">
               <AlertDescription>{submitError || eformsignError}</AlertDescription>
+            </Alert>
+          )}
+
+          {unverifiedDispatchNotice && (
+            <Alert
+              variant="destructive"
+              data-component="desktop_contracts_creation_unverified-dispatch-notice"
+              data-testid="contract-creation-unverified-notice"
+            >
+              <AlertDescription>{unverifiedDispatchNotice}</AlertDescription>
             </Alert>
           )}
 

--- a/frontend/src/components/app/contracts/__tests__/ContractCreationForm.iframe-fallback.test.tsx
+++ b/frontend/src/components/app/contracts/__tests__/ContractCreationForm.iframe-fallback.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * The headless dispatch is allowed to fail — what must never happen is staff
+ * being stranded on a dead processing step. These tests drive the real component
+ * through a failing dispatch and assert the eformsign editor actually opens,
+ * i.e. `openDocument(..., "eformsign_iframe", ...)` is called.
+ *
+ * Both failure shapes are covered, because they reach the fallback through
+ * different branches:
+ *   - backend answered `ok:false` + `fallbackHint:"iframe"`  (verdict known)
+ *   - the request itself threw, e.g. a client-side timeout   (verdict unknown)
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { useFormStore } from "@/stores/form-store";
+import { ContractCreationForm } from "../ContractCreationForm";
+
+const mockOpenDocument = jest.fn();
+const mockDispatchHeadless = jest.fn();
+const mockGenerateDocument = jest.fn();
+const mockAuthenticate = jest.fn();
+
+jest.mock("next/navigation", () => ({
+    useRouter: () => ({ push: jest.fn(), replace: jest.fn(), refresh: jest.fn() }),
+}));
+
+jest.mock("@/providers/LocaleProvider", () => ({
+    useLocale: () => "ko",
+}));
+
+jest.mock("@/hooks/useGetAuthUser", () => ({
+    useGetAuthUser: () => ({ data: { phone: "010-1234-5678" } }),
+}));
+
+jest.mock("@/hooks/useEformsign", () => ({
+    useEformsign: () => ({
+        isLoaded: true,
+        isLoading: false,
+        error: null,
+        openDocument: mockOpenDocument,
+    }),
+}));
+
+jest.mock("@/services/api", () => ({
+    eformsignApi: {
+        authenticate: (...args: unknown[]) => mockAuthenticate(...args),
+        dispatchHeadless: (...args: unknown[]) => mockDispatchHeadless(...args),
+        generateDocument: (...args: unknown[]) => mockGenerateDocument(...args),
+        createDocRecord: jest.fn().mockResolvedValue({}),
+        adoptDocument: jest.fn().mockResolvedValue({}),
+    },
+}));
+
+const idleMutation = () => ({ mutateAsync: jest.fn().mockResolvedValue({ id: 42 }), isPending: false });
+jest.mock("@/hooks/useClients", () => ({
+    useCreateClient: () => idleMutation(),
+    useUpdateClient: () => idleMutation(),
+    useDeleteClient: () => idleMutation(),
+}));
+
+jest.mock("@/hooks/useEmployees", () => ({
+    useEmployees: () => ({ data: [], isLoading: false }),
+}));
+
+jest.mock("@/hooks", () => ({
+    useVoucherPriceInfos: () => ({ data: [], isLoading: false }),
+    useVoucherYears: () => ({ data: [2026], isLoading: false }),
+    useAreaTemplates: () => ({ data: [], isLoading: false }),
+}));
+
+// The SSE channel is orthogonal here; a no-op source keeps the dispatch path
+// from touching EventSource, which jsdom does not implement.
+jest.mock("@/lib/sse/reconnecting-event-source", () => ({
+    createReconnectingEventSource: () => ({ close: jest.fn() }),
+}));
+
+const CONTRACT_INFO_STEP_INDEX = 3;
+
+function seedValidContractForm(): void {
+    useFormStore.setState({
+        clientId: 42,
+        isManualEntry: false,
+        name: "송진호",
+        phone: "010-6621-1878",
+        birthday: "960414",
+        dueDate: "",
+        address: "인천시 강다",
+        employeeId: 7,
+        employeeName: "김정인",
+        employeePhone: "01057871878",
+        showEmployee2: false,
+        employee2Id: null,
+        startDate: "2026-08-05",
+        endDate: "2026-08-25",
+        paymentDate: "2026-08-05",
+        fullPrice: "1000000",
+        grant: "800000",
+        actualPrice: "200000",
+        voucherType: "일반",
+        voucherDuration: "15",
+        area: "인천",
+    });
+}
+
+function renderForm() {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <ContractCreationForm activeStep={CONTRACT_INFO_STEP_INDEX} onActiveStepChange={jest.fn()} />
+        </QueryClientProvider>,
+    );
+}
+
+async function submitAndExpectIframeOpens() {
+    fireEvent.click(screen.getByTestId("contract-creation-submit"));
+
+    await waitFor(() => expect(mockDispatchHeadless).toHaveBeenCalled(), { timeout: 5000 });
+    // The manual re-entry is deferred a tick and then waits 500ms before opening,
+    // so give the assertion room rather than racing it.
+    await waitFor(() => expect(mockOpenDocument).toHaveBeenCalled(), { timeout: 5000 });
+
+    expect(mockOpenDocument).toHaveBeenCalledWith(
+        expect.anything(),
+        "eformsign_iframe",
+        expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+}
+
+describe("ContractCreationForm — eformsign iframe fallback on headless failure", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockAuthenticate.mockResolvedValue({ success: true });
+        mockGenerateDocument.mockResolvedValue({ document: { id: "tpl-1" }, user_data: {} });
+        seedValidContractForm();
+    });
+
+    it("opens the embedded iframe when the backend reports a definite failure", async () => {
+        mockDispatchHeadless.mockResolvedValue({
+            ok: false,
+            reason: "Timed out after 100000ms while advancing eformsign creation gates",
+            fallbackHint: "iframe",
+            failedStep: "client-started",
+            durationMs: 100000,
+        });
+
+        renderForm();
+        await submitAndExpectIframeOpens();
+
+        // The second run must be the manual one — otherwise we would have looped
+        // back into another headless attempt instead of opening the editor.
+        expect(mockDispatchHeadless).toHaveBeenCalledTimes(1);
+        expect(mockGenerateDocument).toHaveBeenCalled();
+    });
+
+    it("opens the embedded iframe when the dispatch request itself fails", async () => {
+        mockDispatchHeadless.mockRejectedValue(new Error("timeout of 180000ms exceeded"));
+
+        renderForm();
+        await submitAndExpectIframeOpens();
+
+        // Outcome is unknown on this path, so staff must still be warned about
+        // duplicating a contract that may already have been sent.
+        expect(screen.getByText(/전자문서 목록에서 생성 여부를 먼저 확인/)).toBeInTheDocument();
+    });
+});

--- a/frontend/src/services/__tests__/headless-dispatch-timeout.test.ts
+++ b/frontend/src/services/__tests__/headless-dispatch-timeout.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression lock for the timeout inversion that broke the iframe fallback.
+ *
+ * The headless dispatch crosses three hops, each with its own timeout:
+ *   browser axios  →  Next.js route proxy  →  Nest backend
+ *
+ * They must stay ordered backend < proxy < browser. When the proxy alone was
+ * raised to 180s and the browser was left on the shared 30s default, the browser
+ * aborted first: the backend's verdict — the thing that carries `fallbackHint`
+ * and drives the iframe fallback — never arrived, so staff were stranded on a
+ * dead processing step with a message telling them to press a button that was
+ * never rendered.
+ *
+ * The browser hop is the one that silently regresses, because omitting a
+ * per-call timeout inherits `api`'s 30s default rather than failing loudly.
+ */
+import fs from "fs";
+import path from "path";
+
+const mockPost = jest.fn();
+
+jest.mock("@/lib/api/client", () => ({
+    api: {
+        post: (...args: unknown[]) => mockPost(...args),
+        get: jest.fn(),
+    },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let eformsignApi: any;
+
+const ROUTES_DIR = path.join(__dirname, "../../app/api/eformsign-docs");
+
+function readProxyTimeout(routeFile: string): number {
+    const source = fs.readFileSync(path.join(ROUTES_DIR, routeFile, "route.ts"), "utf8");
+    const match = /timeout:\s*([\d_]+)/.exec(source);
+    if (!match) throw new Error(`no timeout found in ${routeFile}/route.ts`);
+    return Number(match[1].replace(/_/g, ""));
+}
+
+function timeoutOf(call: unknown[]): number | undefined {
+    const config = call[2] as { timeout?: number } | undefined;
+    return config?.timeout;
+}
+
+describe("headless dispatch timeout ordering", () => {
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        mockPost.mockResolvedValue({ data: { ok: true } });
+        ({ eformsignApi } = await import("../api"));
+    });
+
+    it("sends an explicit browser-side timeout for dispatch-headless", async () => {
+        await eformsignApi.dispatchHeadless({}, 1, "p-1");
+
+        const timeout = timeoutOf(mockPost.mock.calls[0]);
+        expect(timeout).toBeDefined();
+        expect(timeout).toBeGreaterThanOrEqual(180_000);
+    });
+
+    it("sends an explicit browser-side timeout for finalize-headless", async () => {
+        await eformsignApi.finalizeHeadless("doc-1", undefined, "p-1");
+
+        const timeout = timeoutOf(mockPost.mock.calls[0]);
+        expect(timeout).toBeDefined();
+        expect(timeout).toBeGreaterThanOrEqual(180_000);
+    });
+
+    it.each([
+        ["dispatch-headless", () => eformsignApi.dispatchHeadless({}, 1, "p-1")],
+        ["finalize-headless", () => eformsignApi.finalizeHeadless("doc-1", undefined, "p-1")],
+    ])("keeps the browser hop above the %s proxy hop", async (routeFile, call) => {
+        await call();
+
+        const browserTimeout = timeoutOf(mockPost.mock.calls[0]);
+        const proxyTimeout = readProxyTimeout(routeFile);
+
+        // Strictly greater: if the browser gives up first, the proxy's response —
+        // and with it the backend's fallbackHint — is thrown away.
+        expect(browserTimeout).toBeGreaterThan(proxyTimeout);
+    });
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,13 @@
 import axios from "axios";
 import { api } from "@/lib/api/client";
+/**
+ * Headless dispatch/finalize run a real browser against eformsign, so they blow
+ * far past the 30s default on `api`. The three hops must stay ordered — backend
+ * budget (≈160s worst case) < Next.js proxy (170s) < this — so the browser
+ * always ends up holding the backend's own verdict (which carries
+ * `fallbackHint`) instead of aborting first on an outcome it can't classify.
+ */
+const HEADLESS_DISPATCH_CLIENT_TIMEOUT_MS = 180_000;
 import { safeStorageSetItem } from "@/lib/safe-storage";
 import type { RegisterRequest } from "@babyjamjam/shared";
 import { ContractDataDto } from '@/backend/application/dto/contract.dto';
@@ -257,7 +265,7 @@ export const eformsignApi = {
             clientId,
             progressId,
             force,
-        });
+        }, { timeout: HEADLESS_DISPATCH_CLIENT_TIMEOUT_MS });
         return data;
     },
     adoptDocument: async (
@@ -284,7 +292,7 @@ export const eformsignApi = {
             documentId,
             prefillEndDate,
             progressId,
-        });
+        }, { timeout: HEADLESS_DISPATCH_CLIENT_TIMEOUT_MS });
         return data;
     },
     getDocumentClientNames: async (): Promise<EformsignDocClientSummary[]> => {


### PR DESCRIPTION
헤드리스 계약서 생성이 실패했고, 대신 떠야 할 embedded iframe이 열리지 않았습니다. 원인은 **서로 독립적인 4가지**였고, 각각 추론이 아니라 실제 실행으로 확인했습니다.

## 1. 홉 타임아웃 역전

프록시만 180초로 올리고 브라우저는 공유 axios 기본 **30초**를 그대로 뒀습니다. 백엔드가 65초 걸린 실행에서 브라우저가 35초 먼저 끊겨, `fallbackHint:"iframe"`을 실은 백엔드 응답이 영영 도착하지 못했습니다.

```
[POST /eformsign-docs/dispatch-headless] clientId=84       11:19:32
dispatchCreation failed: Timed out after 60000ms ...       11:20:37   ← 브라우저는 30초에 이미 포기
```

**백엔드(최악 ~160초) < 프록시(170초) < 브라우저(180초)** 순으로 정렬했습니다. finalize도 같은 역전(프록시 60초 < 백엔드 ~160초)이 있어 함께 고쳤습니다.

## 2. catch 분기에 fallback 배선 누락

`setAllowIframeFallback`이 성공 응답 경로에만 있었습니다. 결과적으로 *"재시도하거나 수동 입력을 사용해 주세요"* 를 띄우는 경로가 **정작 그 버튼을 렌더하지 않는 경로**였습니다. 이제 두 실패 형태 모두 편집기를 엽니다.

## 3. `POST /generate-document`가 항상 400 — iframe 경로는 처음부터 죽어 있었음

`ContractDataRequestDto`에 `receiptYear/Month/Day`가 선언돼 있지 않은데(계약 생성 폼은 항상 보내고, 백엔드는 쓰지도 않음) 전역 파이프가 `forbidNonWhitelisted`입니다. 핸들러 진입 **전에** 잘려서 백엔드 로그에 흔적조차 없었습니다.

동일 페이로드로 백엔드를 직접 호출해 확정:

| 케이스 | 결과 |
|---|---|
| 프론트가 보내는 그대로 | `400 — property receiptYear/receiptMonth/receiptDay should not exist` |
| `receipt*`만 제거 | **201, 정상 문서 옵션 반환** |
| 종료일 빈 값 (= 발급 시점의 정상 케이스) | `400 — endYear/endMonth/endDay/endDate should not be empty` |

종료일은 "이용자 서명 후 직원이 사후 입력"이 설계된 흐름인데(폼 주석에도 명시) `@IsNotEmpty()`가 걸려 정상 발급까지 막고 있었습니다.

## 4. 발송 후 실패도 iframe으로 유도 → 중복 발송 위험

`ok=false`면 무조건 `fallbackHint:"iframe"`이었습니다. 그런데 `waitForTerminalSdkCallback`은 30초 타임아웃 시 throw하고, 이 대기는 게이트가 **`전송`을 이미 클릭한 뒤**에 일어납니다. eformsign에 문서가 접수된 상태에서 편집기를 다시 열면 **같은 계약서가 2건** 나갑니다.

게이트가 전송 클릭 시점에 내는 `onProgress("creating")`을 판별 신호로 씁니다. `creating` 이상에서 실패하면 기존 reconciliation 경로로 보내 — 원격에 있으면 그 문서를 채택하고, 없으면 "목록 확인 후 재시도"를 안내합니다.

## 게이트 예산 분리

동일 템플릿에서 에디터 렌더 시간이 **6초 ~ 64초**로 요동친 반면 클릭 시퀀스 자체는 **~2초**면 끝납니다. 60초 하나를 둘이 공유하니 느린 렌더가 정작 해야 할 일의 예산을 잡아먹었습니다 (실패 런은 64초 대기 후 2초가 모자랐습니다).

**대기 70초 / 클릭 30초(첫 성공 클릭 시점부터 재시작)** 로 분리했습니다. 원래 59초 공백을 보이지 않게 만들었던 관측 공백도 주기적 스냅샷 로그로 메웠습니다.

그 외 계약 생성 처리 단계 stepper가 컨테이너 높이를 채우도록 수정했습니다.

## 검증

- 백엔드 **98 suites / 1085 tests**, 프론트 **145 suites / 659 tests**, `tsc`·`eslint` 통과
- **뮤테이션 테스트** — 신규 회귀 락 3종 각각 수정을 되돌리면 해당 테스트가 실제로 붉어짐
- **육안 확인** — 게이트를 강제 실패시킨 백엔드에 실 UI를 붙여 iframe이 클릭 없이 열리는 것 확인

## 알려진 잔여 리스크

- 벤더 렌더가 70초를 넘으면 여전히 실패합니다. 제거가 아니라 완화이며, 그 경우에도 iframe fallback은 동작합니다.
- `runWithSlot` 대기 큐가 무제한이라 **동시 4건 이상**(MAX_CONCURRENCY=3)이면 브라우저가 먼저 끊겨 중복 발송 창이 열립니다. 단일 지점 규모에서 발생하지 않는다고 판단해 이번 범위에서 제외했습니다. 대응책은 큐 대기 10초 제한 + `busy` 조기 반환입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQdDwycpac835dPtcEdF1i