### PR TITLE
fix: address PR #460 audit findings across mobile and frontend

### DIFF
--- a/frontend/src/features/clients/hooks/use-clients.message-trigger-invalidation.test.ts
+++ b/frontend/src/features/clients/hooks/use-clients.message-trigger-invalidation.test.ts
@@ -23,32 +23,32 @@ describe("client mutation message job invalidation", () => {
     });
   });
 
-  it("invalidates upcoming jobs after creating a client", () => {
-    const mutation = useCreateClient() as unknown as { onSuccess: () => void };
+  it("invalidates upcoming jobs after creating a client", async () => {
+    const mutation = useCreateClient() as unknown as { onSuccess: () => Promise<void> };
 
-    mutation.onSuccess();
+    await mutation.onSuccess();
 
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: messageTriggerKeys.upcoming(),
     });
   });
 
-  it("invalidates upcoming jobs after updating a client", () => {
+  it("invalidates upcoming jobs after updating a client", async () => {
     const mutation = useUpdateClient() as unknown as {
-      onSuccess: (client: { id: number }, variables: { id: number }) => void;
+      onSuccess: (client: { id: number }, variables: { id: number }) => Promise<void>;
     };
 
-    mutation.onSuccess({ id: 42 }, { id: 42 });
+    await mutation.onSuccess({ id: 42 }, { id: 42 });
 
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: messageTriggerKeys.upcoming(),
     });
   });
 
-  it("invalidates upcoming jobs after deleting a client", () => {
-    const mutation = useDeleteClient() as unknown as { onSuccess: () => void };
+  it("invalidates upcoming jobs after deleting a client", async () => {
+    const mutation = useDeleteClient() as unknown as { onSuccess: () => Promise<void> };
 
-    mutation.onSuccess();
+    await mutation.onSuccess();
 
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: messageTriggerKeys.upcoming(),

--- a/frontend/src/features/clients/hooks/use-clients.ts
+++ b/frontend/src/features/clients/hooks/use-clients.ts
@@ -99,10 +99,10 @@ export function useCreateClient() {
 
   return useMutation({
     mutationFn: (dto: CreateClientDto) => clientsApi.create(dto).then(r => r.data),
-    onSuccess: () => {
+    onSuccess: async () => {
       // Invalidate all client queries to refresh lists
-      void queryClient.invalidateQueries({ queryKey: clientKeys.all });
-      void queryClient.invalidateQueries({ queryKey: messageTriggerKeys.upcoming() });
+      await queryClient.invalidateQueries({ queryKey: clientKeys.all });
+      await queryClient.invalidateQueries({ queryKey: messageTriggerKeys.upcoming() });
     },
   });
 }
@@ -116,15 +116,15 @@ export function useUpdateClient() {
   return useMutation({
     mutationFn: ({ id, dto }: { id: number; dto: UpdateClientDto }) =>
       clientsApi.update(id, dto).then(r => r.data),
-    onSuccess: (updatedClient, { id }) => {
+    onSuccess: async (updatedClient, { id }) => {
       queryClient.setQueriesData(
         { queryKey: clientKeys.all },
         (currentData) => updateClientCacheData(currentData, updatedClient)
       );
       queryClient.setQueryData(clientKeys.detail(id), updatedClient);
 
-      void queryClient.invalidateQueries({ queryKey: clientKeys.all });
-      void queryClient.invalidateQueries({ queryKey: messageTriggerKeys.upcoming() });
+      await queryClient.invalidateQueries({ queryKey: clientKeys.all });
+      await queryClient.invalidateQueries({ queryKey: messageTriggerKeys.upcoming() });
     },
   });
 }
@@ -137,9 +137,9 @@ export function useDeleteClient() {
 
   return useMutation({
     mutationFn: (id: number) => clientsApi.delete(id),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: clientKeys.all });
-      void queryClient.invalidateQueries({ queryKey: messageTriggerKeys.upcoming() });
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: clientKeys.all });
+      await queryClient.invalidateQueries({ queryKey: messageTriggerKeys.upcoming() });
     },
   });
 }
@@ -154,10 +154,10 @@ export function useTerminateService() {
   return useMutation({
     mutationFn: ({ id, dto }: { id: number; dto?: TerminateServiceDto }) =>
       clientsApi.terminateService(id, dto).then(r => r.data),
-    onSuccess: (_, { id }) => {
-      void queryClient.invalidateQueries({ queryKey: clientKeys.all });
-      void queryClient.invalidateQueries({ queryKey: clientKeys.detail(id) });
-      void queryClient.invalidateQueries({ queryKey: messageTriggerKeys.upcoming() });
+    onSuccess: async (_, { id }) => {
+      await queryClient.invalidateQueries({ queryKey: clientKeys.all });
+      await queryClient.invalidateQueries({ queryKey: clientKeys.detail(id) });
+      await queryClient.invalidateQueries({ queryKey: messageTriggerKeys.upcoming() });
     },
   });
 }
@@ -172,10 +172,10 @@ export function useRequestReplacement() {
   return useMutation({
     mutationFn: ({ id, dto }: { id: number; dto: RequestReplacementDto }) =>
       clientsApi.requestReplacement(id, dto).then(r => r.data),
-    onSuccess: (_, { id }) => {
-      void queryClient.invalidateQueries({ queryKey: clientKeys.all });
-      void queryClient.invalidateQueries({ queryKey: clientKeys.detail(id) });
-      void queryClient.invalidateQueries({ queryKey: messageTriggerKeys.upcoming() });
+    onSuccess: async (_, { id }) => {
+      await queryClient.invalidateQueries({ queryKey: clientKeys.all });
+      await queryClient.invalidateQueries({ queryKey: clientKeys.detail(id) });
+      await queryClient.invalidateQueries({ queryKey: messageTriggerKeys.upcoming() });
     },
   });
 }

--- a/mobile/src/app/(shell)/all/page.tsx
+++ b/mobile/src/app/(shell)/all/page.tsx
@@ -20,7 +20,6 @@ import { useMessageTemplates } from "@/hooks/use-message-templates";
 import { useUnreadCount, usePushNotification } from "@/hooks/usePushNotification";
 import { AllSettingsRedesign } from "@/components/app/mobile-redesign/AllSettingsRedesign";
 import type { MenuGroup } from "@/components/app/mobile-redesign/mockup-data";
-import { useMessageTriggerRules } from "@/features/message-triggers/hooks/use-message-triggers";
 
 /** Canonical data-component base for the /all route. */
 const ALL_PAGE_BASE = "mobile_all_page";
@@ -40,20 +39,16 @@ export default function AllMenuPage() {
   const clientsQuery = useAllClients();
   const employeesQuery = useEmployees();
   const messageTemplatesQuery = useMessageTemplates();
-  const messageTriggerRulesQuery = useMessageTriggerRules();
   const pushNotification = usePushNotification();
   const unreadCountQuery = useUnreadCount(true);
 
   const clients = safeArrayPayload(clientsQuery.data);
   const employees = safeArrayPayload(employeesQuery.data);
   const messageTemplates = safeArrayPayload(messageTemplatesQuery.data);
-  const messageTriggerRules = safeArrayPayload(messageTriggerRulesQuery.data);
-  const automationTriggerCount = messageTriggerRules.length;
   const unreadNotifCount = typeof unreadCountQuery.data === "number" ? unreadCountQuery.data : 0;
   const isClientsInitialLoading = clientsQuery.isLoading && !clientsQuery.data;
   const isEmployeesInitialLoading = employeesQuery.isLoading && !employeesQuery.data;
   const isMessageTemplatesInitialLoading = messageTemplatesQuery.isLoading && !messageTemplatesQuery.data;
-  const isMessageRulesInitialLoading = messageTriggerRulesQuery.isLoading && !messageTriggerRulesQuery.data;
   const isUnreadInitialLoading = unreadCountQuery.isLoading && unreadCountQuery.data === undefined;
 
   const menuGroups = useMemo<MenuGroup[]>(() => {
@@ -130,9 +125,8 @@ export default function AllMenuPage() {
             href: "/messages/automation",
             icon: Send,
             tone: "gold",
-            value: isMessageRulesInitialLoading ? undefined : `${automationTriggerCount}개`,
-            valueLoading: isMessageRulesInitialLoading,
-            valueSkeletonWidth: "28px",
+            disabled: true,
+            statusLabel: "출시 예정",
           },
         ],
       },
@@ -155,12 +149,10 @@ export default function AllMenuPage() {
     clients.length,
     employees.length,
     messageTemplates.length,
-    automationTriggerCount,
     unreadNotifCount,
     isClientsInitialLoading,
     isEmployeesInitialLoading,
     isMessageTemplatesInitialLoading,
-    isMessageRulesInitialLoading,
     isUnreadInitialLoading,
     pushNotification.isLoading,
     pushNotification.isSubscribed,

--- a/mobile/src/app/(shell)/messages/new/__tests__/page.test.tsx
+++ b/mobile/src/app/(shell)/messages/new/__tests__/page.test.tsx
@@ -398,6 +398,80 @@ describe("NewMessagePage", () => {
     });
   });
 
+  it("seeds the recipient chip and name variable once the deep-linked client resolves late", async () => {
+    mockSearchParams = new URLSearchParams({ clientId: "7" });
+    mockUseAllClients.mockReturnValue({ data: undefined, isLoading: true });
+
+    const { rerender } = renderPage();
+
+    await openTemplateSelect();
+    fireEvent.click(screen.getByRole("option", { name: "서비스 안내" }));
+
+    expect(screen.queryByRole("button", { name: "박서연 수신자 제거" })).not.toBeInTheDocument();
+    expect(
+      (screen.getByLabelText("메시지 본문") as HTMLTextAreaElement).value,
+    ).not.toContain("박서연");
+
+    mockUseAllClients.mockReturnValue({ data: mockClients, isLoading: false });
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <NewMessagePage />
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByRole("button", { name: "박서연 수신자 제거" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText("메시지 본문")).toHaveValue(
+        "박서연 산모님~♡\n서비스 시작일: {{serviceDate}}\n산후관리서비스 관련 안내사항을 보내드립니다 :)",
+      );
+    });
+  });
+
+  it("surfaces the missing-phone warning once a deep-linked client without a phone resolves late", async () => {
+    mockSearchParams = new URLSearchParams({ clientId: "7" });
+    mockUseAllClients.mockReturnValue({ data: undefined, isLoading: true });
+
+    const { rerender } = renderPage();
+
+    expect(screen.queryByText("선택한 고객에 등록된 연락처가 없습니다.")).not.toBeInTheDocument();
+
+    mockUseAllClients.mockReturnValue({
+      data: [{ ...mockClients[0], phone: "" }],
+      isLoading: false,
+    });
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <NewMessagePage />
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("선택한 고객에 등록된 연락처가 없습니다.")).toBeInTheDocument();
+  });
+
+  it("does not re-add a deep-linked recipient the user removed when the client list refetches", async () => {
+    mockSearchParams = new URLSearchParams({ clientId: "7" });
+    mockUseAllClients.mockReturnValue({ data: mockClients, isLoading: false });
+
+    const { rerender } = renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "박서연 수신자 제거" }));
+    expect(screen.queryByRole("button", { name: "박서연 수신자 제거" })).not.toBeInTheDocument();
+
+    mockUseAllClients.mockReturnValue({
+      data: mockClients.map((client) => ({ ...client })),
+      isLoading: false,
+    });
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <NewMessagePage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "박서연 수신자 제거" })).not.toBeInTheDocument();
+    });
+  });
+
   it("blocks submissions with more than 50 recipients", async () => {
     renderPage();
 

--- a/mobile/src/app/(shell)/messages/new/page.tsx
+++ b/mobile/src/app/(shell)/messages/new/page.tsx
@@ -518,27 +518,6 @@ function NewMessageForm({ initialBody, initialTemplateId, initialClientId, initi
   const [recipientNameInputValue, setRecipientNameInputValue] = useState("");
   const [recipients, setRecipients] = useState<RecipientChip[]>(() => initialRecipient ? [initialRecipient] : []);
 
-  useEffect(() => {
-    if (initialClient) {
-      const phone = normalizeKoreanPhoneDigits(initialClient.phone);
-      if (phone) {
-        const chip: RecipientChip = {
-          id: `client-${initialClient.id}`,
-          clientId: initialClient.id,
-          name: initialClient.name,
-          phone: formatRecipientPhone(phone),
-          initial: getRecipientInitial(initialClient.name),
-          tone: "primary",
-        };
-        queueMicrotask(() => {
-          setRecipients((prev) => {
-            if (prev.some((item) => item.clientId === initialClient.id)) return prev;
-            return [chip, ...prev];
-          });
-        });
-      }
-    }
-  }, [initialClient]);
   const [bodyOverride, setBodyOverride] = useState<string | null>(initialBody.trim() ? initialBody : null);
   const [templateVariableValues, setTemplateVariableValues] = useState<Record<string, string>>(() => {
     const values: Record<string, string> = {};
@@ -550,6 +529,39 @@ function NewMessageForm({ initialBody, initialTemplateId, initialClientId, initi
   const [errorMessage, setErrorMessage] = useState<string | null>(
     initialClient && !initialClientPhone ? CLIENT_WITHOUT_PHONE_MESSAGE : null,
   );
+
+  const seededClientIdsRef = useRef<Set<number>>(new Set());
+  useEffect(() => {
+    if (!initialClient) return;
+    if (seededClientIdsRef.current.has(initialClient.id)) return;
+    seededClientIdsRef.current.add(initialClient.id);
+
+    const phone = normalizeKoreanPhoneDigits(initialClient.phone);
+    if (phone) {
+      const chip: RecipientChip = {
+        id: `client-${initialClient.id}`,
+        clientId: initialClient.id,
+        name: initialClient.name,
+        phone: formatRecipientPhone(phone),
+        initial: getRecipientInitial(initialClient.name),
+        tone: "primary",
+      };
+      queueMicrotask(() => {
+        setRecipients((prev) => {
+          if (prev.some((item) => item.clientId === initialClient.id)) return prev;
+          return [chip, ...prev];
+        });
+      });
+    } else {
+      queueMicrotask(() => {
+        setErrorMessage((prev) => prev ?? CLIENT_WITHOUT_PHONE_MESSAGE);
+      });
+    }
+
+    queueMicrotask(() => {
+      setTemplateVariableValues((prev) => (prev.name ? prev : { ...prev, name: initialClient.name }));
+    });
+  }, [initialClient]);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [selectedTemplateId, setSelectedTemplateId] = useState<string>(initialTemplateId);
   const ignoreNextPriceInfoSelectChangeRef = useRef(false);

--- a/mobile/src/app/(shell)/messages/system-templates/[templateKey]/page.tsx
+++ b/mobile/src/app/(shell)/messages/system-templates/[templateKey]/page.tsx
@@ -2,7 +2,6 @@
 
 import { use } from 'react';
 import { FileText, Loader2, Monitor, Send, Workflow } from 'lucide-react';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { InfoCard } from '@/components/app/mobile-redesign/detail-sheet';
 import { MobileDetailSlideUp } from '@/components/app/mobile-redesign/mobile-detail-slideup';
@@ -134,19 +133,18 @@ export default function EditSystemTemplatePage({ params }: { params: Promise<{ t
           </p>
         </div>
 
-        <Link
-          href="/messages/automation"
+        <div
           data-component="mobile_messages_system-templates_template-key-detail_detail-panel_trigger-link"
-          className="info-card pop-up flex items-start gap-3 hover:bg-v3-dim-white"
+          className="info-card pop-up flex items-start gap-3"
         >
           <Workflow className="mt-0.5 h-5 w-5 shrink-0 text-v3-primary" />
           <div className="flex-1" data-component="mobile_messages_system-templates_template-key-detail_detail-panel_trigger-link_copy">
-            <p className="text-[0.85rem] font-semibold text-v3-dark">자동 발송 규칙 설정</p>
+            <p className="text-[0.85rem] font-semibold text-v3-dark">자동 발송 규칙 설정 (출시 예정)</p>
             <p className="text-[0.72rem] text-v3-text-muted">
               이 템플릿의 자동 발송 ON/OFF·발송 시점은 메시지 → 자동 전송에서 관리합니다.
             </p>
           </div>
-        </Link>
+        </div>
       </div>
     </MobileDetailSlideUp>
   );

--- a/mobile/src/components/app/clients/ClientAutocomplete.tsx
+++ b/mobile/src/components/app/clients/ClientAutocomplete.tsx
@@ -45,7 +45,7 @@ export function ClientAutocomplete({
     error = false,
     helperText,
     excludeIds = [],
-    allowManualEntry = true,
+    allowManualEntry = false,
     manualEntryLabel,
     manualEntryDescription,
     onManualEntry,

--- a/mobile/src/components/app/mobile-redesign/MessageSectionNav.tsx
+++ b/mobile/src/components/app/mobile-redesign/MessageSectionNav.tsx
@@ -43,11 +43,18 @@ export const MESSAGE_NAVIGATION_ITEMS: MessageNavigationItem[] =
     icon: MESSAGE_NAVIGATION_PRESENTATION[section.id],
   }));
 
+const DISABLED_SECTION_IDS = new Set<MessageSectionId>([
+  "scheduled",
+  "history",
+  "templates",
+  "triggers",
+]);
+
 const MESSAGE_SECTION_NAV_ITEMS = MESSAGE_NAVIGATION_ITEMS.map((item) => ({
   id: item.id,
   label: item.title,
   icon: item.icon,
-  disabled: item.id === "templates",
+  disabled: DISABLED_SECTION_IDS.has(item.id),
 }));
 
 export function MessageSectionNav({

--- a/mobile/src/components/app/mobile-redesign/__tests__/MessagesAutomationPage.test.tsx
+++ b/mobile/src/components/app/mobile-redesign/__tests__/MessagesAutomationPage.test.tsx
@@ -46,8 +46,13 @@ describe("MessagesAutomationPage", () => {
       .toHaveAttribute("aria-pressed", "true");
     expect(container.querySelector(".message-navigation-row")).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "발송 예정" }));
+    const scheduledButton = screen.getByRole("button", { name: "발송 예정" });
+    expect(scheduledButton).toBeDisabled();
+    fireEvent.click(scheduledButton);
+    expect(mockPush).not.toHaveBeenCalled();
 
-    expect(mockPush).toHaveBeenCalledWith("/messages/scheduled");
+    fireEvent.click(screen.getByRole("button", { name: "설정" }));
+
+    expect(mockPush).toHaveBeenCalledWith("/messages/sender-approval");
   });
 });

--- a/mobile/src/components/app/mobile-redesign/__tests__/MessagesDataPages.test.tsx
+++ b/mobile/src/components/app/mobile-redesign/__tests__/MessagesDataPages.test.tsx
@@ -67,8 +67,7 @@ describe("mobile message data pages", () => {
     expect(rowInfo?.querySelector(".message-data-row-title")).toHaveTextContent("김고객");
     expect(rowInfo?.querySelector(".message-data-row-subtitle")).toHaveTextContent("서비스 안내");
     expect(scheduledItem).not.toHaveTextContent("01012345678");
-    expect(screen.getByRole("button", { name: "발송 예정" }))
-      .toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "발송 예정" })).toBeDisabled();
     expect(container.querySelector('[data-component$="_content_list-card_header"] .list-title-text'))
       .toHaveTextContent("발송 예정");
     expect(container.querySelector('[data-component="mobile_messages_scheduled_page_content_list-card"]'))

--- a/mobile/src/components/app/mobile-redesign/__tests__/MessagesTriggersPage.test.tsx
+++ b/mobile/src/components/app/mobile-redesign/__tests__/MessagesTriggersPage.test.tsx
@@ -30,8 +30,7 @@ describe("MessagesTriggersPage", () => {
     expect(content?.firstElementChild).toBe(navigation);
     expect(container.querySelector('[data-component="messages-shell"]')).not.toBeInTheDocument();
     expect(container.querySelector('[data-slot="messages-page"]')).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "자동 전송" }))
-      .toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "자동 전송" })).toBeDisabled();
     expect(container.querySelector('[data-component="mobile_messages_triggers_detail-sheet_stack_list-page_shell_content_list-card_header"] .list-title-text'))
       .toHaveTextContent("자동 전송");
     expect(container.querySelector('[data-component="mobile_messages_triggers_detail-sheet_stack_list-page_shell_content_list-card"]'))

--- a/mobile/src/components/app/root/contracts-prefetch-coordinator.tsx
+++ b/mobile/src/components/app/root/contracts-prefetch-coordinator.tsx
@@ -8,7 +8,7 @@ import {
   infiniteContractsQueryOptions,
 } from "@/hooks/useInfiniteContracts";
 import { useGetAuthUser } from "@/hooks/useGetAuthUser";
-import { dashboardQueryKeys } from "@/hooks/useDashboardAnalytics";
+import { dashboardQueryKeys, fetchDashboardAnalytics } from "@/hooks/useDashboardAnalytics";
 import { clientQueryKeys } from "@/hooks/useClients";
 import { api } from "@/lib/api/client";
 import { eformsignApi } from "@/services/api";
@@ -18,35 +18,47 @@ export function ContractsPrefetchCoordinator(): null {
   const { data: user } = useGetAuthUser();
   const branchId = user?.branchId;
   const attemptedBranchIdsRef = useRef(new Set<string>());
+  const contractsAttemptedBranchIdsRef = useRef(new Set<string>());
 
   useEffect(() => {
-    if (!branchId || attemptedBranchIdsRef.current.has(branchId)) return;
+    if (
+      !branchId
+      || (
+        attemptedBranchIdsRef.current.has(branchId)
+        && contractsAttemptedBranchIdsRef.current.has(branchId)
+      )
+    ) {
+      return;
+    }
 
     let cancelled = false;
 
     const prefetchShellData = async () => {
       try {
-        attemptedBranchIdsRef.current.add(branchId);
+        if (!attemptedBranchIdsRef.current.has(branchId)) {
+          attemptedBranchIdsRef.current.add(branchId);
 
-        // Prefetch Dashboard queries in background
-        void queryClient.prefetchQuery({
-          queryKey: dashboardQueryKeys.analytics(),
-          queryFn: async () => {
-            const response = await fetch("/api/clients/analytics", { cache: "no-store" });
-            return response.json();
-          },
-          staleTime: 60_000,
-        });
+          // Prefetch Dashboard queries in background
+          void queryClient.prefetchQuery({
+            queryKey: dashboardQueryKeys.analytics(),
+            queryFn: fetchDashboardAnalytics,
+            staleTime: 60_000,
+          });
 
-        void queryClient.prefetchQuery({
-          queryKey: clientQueryKeys.list(1, 50, undefined),
-          queryFn: async () => {
-            const { data } = await api.get("/clients", { params: { page: 1, limit: 50 } });
-            return data;
-          },
-          staleTime: 60_000,
-        });
+          void queryClient.prefetchQuery({
+            queryKey: clientQueryKeys.list(1, 50, undefined),
+            queryFn: async () => {
+              const { data } = await api.get("/clients", { params: { page: 1, limit: 50 } });
+              return data;
+            },
+            staleTime: 60_000,
+          });
+        }
 
+        if (contractsAttemptedBranchIdsRef.current.has(branchId)) return;
+
+        // 인증 확인을 통과한 뒤에만 "시도함"으로 기록한다 — 신선한 세션에서 eformsign
+        // 인증보다 먼저 마운트돼 조기 반환한 경우, 다음 마운트/지점 변경에서 재시도된다.
         const authStatus = await eformsignApi.getAuthStatus();
         if (
           cancelled
@@ -54,6 +66,8 @@ export function ContractsPrefetchCoordinator(): null {
         ) {
           return;
         }
+
+        contractsAttemptedBranchIdsRef.current.add(branchId);
 
         // 계약 페이지의 기본 뷰(산모 계약서 섹션)와 완전히 같은 쿼리 키로 프리페치해야
         // 캐시가 재사용된다: 섹션은 제공기록지 template id의 exclude 필터로 표현되므로

--- a/mobile/src/components/app/ui/Autocomplete.tsx
+++ b/mobile/src/components/app/ui/Autocomplete.tsx
@@ -73,6 +73,7 @@ export function Autocomplete<T>({
     required,
     error,
     helperText,
+    emptyMessage,
     manualEntry,
     disabled = false,
     className,
@@ -122,10 +123,19 @@ export function Autocomplete<T>({
     }, [items, displayInputValue, filter, getItemLabel]);
 
     const showDropdown = !disabled && (isFocused || isToggledOpen);
-    const isDropdownVisible = showDropdown && filteredItems.length > 0;
-    const optionCount = filteredItems.length;
+    const hasQuery = displayInputValue.trim().length > 0;
+    const isDropdownVisible =
+        showDropdown &&
+        (filteredItems.length > 0 || isLoading || hasQuery || items.length === 0);
+    const optionCount = filteredItems.length + (manualEntry ? 1 : 0);
     const activeHighlightedIndex =
         highlightedIndex >= 0 && highlightedIndex < optionCount ? highlightedIndex : -1;
+    const toggleActionLabel =
+        currentInputValue.trim().length > 0 && manualEntry
+            ? "수동 입력으로 진행"
+            : showDropdown
+              ? "목록 닫기"
+              : "목록 열기";
 
     const handleSelect = (item: T) => {
         if (disabled) return;
@@ -173,16 +183,15 @@ export function Autocomplete<T>({
 
     const handleKeyDown = (e: React.KeyboardEvent) => {
         if (disabled) return;
-        if (!showDropdown) return;
-        const total = filteredItems.length + (manualEntry ? 1 : 0);
-        if (total === 0) return;
+        if (!isDropdownVisible) return;
+        if (optionCount === 0) return;
 
         if (e.key === "ArrowDown") {
             e.preventDefault();
-            setHighlightedIndex((prev) => (prev + 1) % total);
+            setHighlightedIndex((prev) => (prev + 1) % optionCount);
         } else if (e.key === "ArrowUp") {
             e.preventDefault();
-            setHighlightedIndex((prev) => (prev - 1 + total) % total);
+            setHighlightedIndex((prev) => (prev - 1 + optionCount) % optionCount);
         } else if (e.key === "Enter") {
             if (activeHighlightedIndex >= 0) {
                 e.preventDefault();
@@ -210,6 +219,7 @@ export function Autocomplete<T>({
     const inputDc = sub("input");
     const toggleDc = sub("toggle");
     const dropdownDc = sub("dropdown");
+    const addBtnDc = sub("add-button");
     const clearBtnDc = sub("clear");
     const resolvedInputId = inputId ?? name;
 
@@ -306,8 +316,8 @@ export function Autocomplete<T>({
                                 }
                             }}
                             className="flex h-[44px] w-[44px] items-center justify-center rounded-2xl text-v3-primary transition-colors hover:text-v3-primary/80 disabled:cursor-not-allowed disabled:opacity-40"
-                            aria-label="수동 입력으로 진행"
-                            title="수동 입력으로 진행"
+                            aria-label={toggleActionLabel}
+                            title={toggleActionLabel}
                             data-component={toggleDc}
                             data-slot="autocomplete-toggle"
                         >
@@ -327,6 +337,10 @@ export function Autocomplete<T>({
                         {isLoading ? (
                             <div data-component={sub("loading")} className="flex items-center justify-center py-6">
                                 <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                            </div>
+                        ) : filteredItems.length === 0 ? (
+                            <div data-component={sub("empty")} className="py-6 text-center text-sm text-muted-foreground">
+                                {emptyMessage ?? "결과 없음"}
                             </div>
                         ) : (
                             <div data-component={sub("options")} className="max-h-[200px] overflow-y-auto">
@@ -394,6 +408,62 @@ export function Autocomplete<T>({
                                     );
                                 })}
                             </div>
+                        )}
+
+                        {manualEntry && (
+                            <>
+                                <div data-component={sub("manual-divider")} className="h-px bg-v3-border" />
+                                <div
+                                    onPointerDown={(e) => {
+                                        e.preventDefault();
+                                        markSuppressedClick("manual-entry");
+                                        handleManualEntry();
+                                    }}
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        if (shouldSkipClick("manual-entry")) {
+                                            return;
+                                        }
+                                        handleManualEntry();
+                                    }}
+                                    onMouseEnter={() =>
+                                        setHighlightedIndex(filteredItems.length)
+                                    }
+                                    className={cn(
+                                        "flex flex-col w-full py-3 px-3 cursor-pointer transition-colors",
+                                        activeHighlightedIndex === filteredItems.length &&
+                                            "bg-v3-primary text-white"
+                                    )}
+                                    data-component={addBtnDc}
+                                    data-testid={addBtnDc}
+                                >
+                                    <div data-component={sub("manual-header")} className="flex items-center gap-2">
+                                        {manualEntry.icon}
+                                        <span
+                                            data-component={sub("manual-label")}
+                                            className={cn(
+                                                "text-sm font-medium",
+                                                activeHighlightedIndex !== filteredItems.length &&
+                                                    "text-primary"
+                                            )}
+                                        >
+                                            {manualEntry.label}
+                                        </span>
+                                    </div>
+                                    {manualEntry.description && (
+                                        <span
+                                            data-component={sub("manual-description")}
+                                            className={cn(
+                                                "text-xs mt-1 ml-6",
+                                                activeHighlightedIndex !== filteredItems.length &&
+                                                    "text-muted-foreground"
+                                            )}
+                                        >
+                                            {manualEntry.description}
+                                        </span>
+                                    )}
+                                </div>
+                            </>
                         )}
                     </div>
                 )}

--- a/mobile/src/hooks/useDashboardAnalytics.ts
+++ b/mobile/src/hooks/useDashboardAnalytics.ts
@@ -17,7 +17,7 @@ interface UseDashboardAnalyticsOptions {
   staleTime?: number;
 }
 
-async function fetchDashboardAnalytics(): Promise<DashboardAnalytics> {
+export async function fetchDashboardAnalytics(): Promise<DashboardAnalytics> {
   const response = await fetch("/api/clients/analytics", { cache: "no-store" });
   if (!response.ok) {
     throw new Error(`Failed to fetch dashboard analytics: ${response.status}`);

--- a/mobile/tests/employee-autocomplete.spec.ts
+++ b/mobile/tests/employee-autocomplete.spec.ts
@@ -131,6 +131,7 @@ test.describe('EmployeeAutocomplete', () => {
     await expect(page.locator(`[data-component="${PRIMARY_AUTOCOMPLETE}_dropdown"]`)).toBeVisible();
 
     await autocompleteInput.fill('xyz-nonexistent');
+    await expect(page.locator(`[data-component="${PRIMARY_AUTOCOMPLETE}_dropdown"]`)).toBeVisible();
     await expect(page.locator(`[data-component="${PRIMARY_AUTOCOMPLETE}_toggle"]`)).toBeVisible();
   });
 

--- a/mobile/tests/mobile-all-menu.spec.ts
+++ b/mobile/tests/mobile-all-menu.spec.ts
@@ -39,7 +39,6 @@ test.describe("Mobile nav: center chat + /all menu", () => {
     let releaseEmployees: () => void = () => {};
     let releaseUnreadCount: () => void = () => {};
     let releaseMessageTemplates: () => void = () => {};
-    let releaseAlimtalkRules: () => void = () => {};
     const clientsReady = new Promise<void>((resolve) => {
       releaseClients = resolve;
     });
@@ -51,9 +50,6 @@ test.describe("Mobile nav: center chat + /all menu", () => {
     });
     const messageTemplatesReady = new Promise<void>((resolve) => {
       releaseMessageTemplates = resolve;
-    });
-    const alimtalkRulesReady = new Promise<void>((resolve) => {
-      releaseAlimtalkRules = resolve;
     });
 
     await page.route("**/api/clients**", async (route) => {
@@ -88,18 +84,9 @@ test.describe("Mobile nav: center chat + /all menu", () => {
         body: JSON.stringify([{ id: "m1" }, { id: "m2" }, { id: "m3" }, { id: "m4" }, { id: "m5" }]),
       });
     });
-    await page.route("**/api/message-trigger-rules**", async (route) => {
-      await alimtalkRulesReady;
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify([{ id: "a1" }, { id: "a2" }, { id: "a3" }, { id: "a4" }]),
-      });
-    });
-
     await page.goto("/all");
     await expect(page.locator('[data-component="mobile_all_page"]')).toBeVisible();
-    await expect(page.locator('[data-component="mobile_all_page_menu_group_row_value-skeleton"]')).toHaveCount(4);
+    await expect(page.locator('[data-component="mobile_all_page_menu_group_row_value-skeleton"]')).toHaveCount(3);
     await expect(page.locator('[data-component="mobile_all_page_menu_group_row_badge-skeleton"]')).toHaveCount(1);
     await expect(
       page
@@ -128,12 +115,15 @@ test.describe("Mobile nav: center chat + /all menu", () => {
     releaseEmployees();
     releaseUnreadCount();
     releaseMessageTemplates();
-    releaseAlimtalkRules();
 
     await expect(page.locator(".menu-value", { hasText: "2명" })).toBeVisible();
     await expect(page.locator(".menu-value", { hasText: "1명" })).toBeVisible();
     await expect(page.locator(".menu-value", { hasText: "5건" })).toBeVisible();
-    await expect(page.locator(".menu-value", { hasText: "4개" })).toBeVisible();
+    await expect(
+      page
+        .locator('[data-component="mobile_all_page_menu_group_row"]', { hasText: "발송 자동화" })
+        .locator(".menu-status-pill", { hasText: "출시 예정" })
+    ).toBeVisible();
     await expect(page.locator(".menu-badge", { hasText: "3" })).toBeVisible();
     await expect(page.locator('[data-component="mobile_all_page_menu_group_row_value-skeleton"]')).toHaveCount(0);
     await expect(page.locator('[data-component="mobile_all_page_menu_group_row_badge-skeleton"]')).toHaveCount(0);


### PR DESCRIPTION
## Summary

Fixes the nine genuine defects found in the [PR #460 audit](https://github.com/jaino-song/babyjamjam-admin/pull/460#issuecomment-5148829776) of the preview→main promotion, so the release can be re-promoted clean.

### Confirmed regressions (audit scores 90–100)
- **Contracts prefetch permanently skipped on pre-auth mount** — `contracts-prefetch-coordinator.tsx` now tracks the auth-gated contracts prefetch with its own attempted-set, marked only after eformsign auth is confirmed (restores the `75479dedb` invariant). The two auth-independent shell prefetches keep their eager once-per-branch marking.
- **Deep-link seeding half-restored on `/messages/new?clientId=N`** — when the client resolves after mount, the `{{name}}` template variable and the missing-phone warning are now seeded (never clobbering user input), once per client id so a removed chip is never re-added on refetch.
- **Autocomplete keyboard navigation broken** — the option index space now matches the rendered rows: no phantom highlight, Enter works on the manual-entry row, key handling gated on actual dropdown visibility.

### Additional defects from the same audit
- Dashboard analytics prefetch reuses the guarded `fetchDashboardAnalytics` fetcher (error bodies are no longer cached as fresh data for 60s).
- Empty/loading dropdown feedback restored (`emptyMessage`, spinner); toggle button label now reflects its actual action.
- `ClientAutocomplete` `allowManualEntry` default reverted to `false` (four call sites had a dead action button).
- Five frontend `use-clients` mutation hooks converted to awaited `invalidateQueries` (submit buttons stay pending through refetch, matching the mobile twin).
- Coming-soon (출시 예정) gating completed: `MessageSectionNav` disables scheduled/history/templates/triggers, the `/all` 발송 자동화 row and the system-template automation link no longer navigate.

### Tests
- New: late-resolution seeding (name + missing-phone), removed-chip no-re-add guard.
- Updated: awaited `onSuccess` in the frontend invalidation test, disabled-tab assertions in three message page suites, Playwright spec alignment (`employee-autocomplete`, `mobile-all-menu`).

## Verification
- `pnpm -C mobile type-check` / `pnpm -C frontend type-check` — clean
- mobile jest: 156 suites green; frontend jest: 144 suites green
- eslint on all changed mobile files: 0 errors
- Reviewed by Opus pass; all blocking findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wEZ6qYbE6koacawqUNZ8t