### PR TITLE
Fix mobile message permission flow and form layout

### DIFF
--- a/mobile/src/app/(shell)/messages/MessagesPermissionGuard.tsx
+++ b/mobile/src/app/(shell)/messages/MessagesPermissionGuard.tsx
@@ -28,6 +28,7 @@ export function MessagesPermissionGuard({ children }: { children: ReactNode }) {
   const router = useRouter();
   const isSenderApprovalRoute = pathname?.startsWith("/messages/sender-approval") ?? false;
   const isReadOnlyRoute = pathname === "/messages/scheduled" || pathname === "/messages/history";
+  const isNewMessageRoute = pathname === "/messages/new";
   const isPermissionExemptRoute = isSenderApprovalRoute || isReadOnlyRoute;
 
   const { data: senderApproval, isLoading } = useQuery({
@@ -41,7 +42,8 @@ export function MessagesPermissionGuard({ children }: { children: ReactNode }) {
   const needsRequestPermission = Boolean(
     senderApproval && !senderApproval.isApproved && !senderApproval.canRequest,
   );
-  const shouldShowApprovalModal = !isPermissionExemptRoute && needsSenderApproval;
+  const shouldShowApprovalModal =
+    !isPermissionExemptRoute && !isNewMessageRoute && needsSenderApproval;
   const isPermissionCheckLoading = !isPermissionExemptRoute && isLoading;
 
   const handleApprovalModalCancel = () => {

--- a/mobile/src/app/(shell)/messages/MessagesPermissionGuard.tsx
+++ b/mobile/src/app/(shell)/messages/MessagesPermissionGuard.tsx
@@ -42,6 +42,7 @@ export function MessagesPermissionGuard({ children }: { children: ReactNode }) {
     senderApproval && !senderApproval.isApproved && !senderApproval.canRequest,
   );
   const shouldShowApprovalModal = !isPermissionExemptRoute && needsSenderApproval;
+  const isPermissionCheckLoading = !isPermissionExemptRoute && isLoading;
 
   const handleApprovalModalCancel = () => {
     router.replace("/all");
@@ -55,6 +56,19 @@ export function MessagesPermissionGuard({ children }: { children: ReactNode }) {
 
     router.push("/messages/sender-approval");
   };
+
+  if (isPermissionCheckLoading) {
+    return (
+      <div
+        data-component="mobile_messages_permission-guard_loading"
+        className="flex min-h-screen items-center justify-center"
+        role="status"
+        aria-live="polite"
+      >
+        메시지 권한 확인 중...
+      </div>
+    );
+  }
 
   return (
     <MessagesPermissionGuardContext.Provider

--- a/mobile/src/app/(shell)/messages/__tests__/MessagesPermissionGuard.test.tsx
+++ b/mobile/src/app/(shell)/messages/__tests__/MessagesPermissionGuard.test.tsx
@@ -67,6 +67,32 @@ describe("MessagesPermissionGuard", () => {
     expect(mockPush).toHaveBeenCalledWith("/messages/sender-approval");
   });
 
+  it("hides the protected message page while checking sender approval", async () => {
+    const pendingApproval = {
+      approvalStatus: "not_requested" as const,
+      isApproved: false,
+      canRequest: true,
+      requestedAt: null,
+      approvedAt: null,
+    };
+    let resolveApproval: (value: typeof pendingApproval) => void = () => undefined;
+    mockGetMessageSenderApproval.mockReturnValue(
+      new Promise<typeof pendingApproval>((resolve) => {
+        resolveApproval = resolve;
+      }),
+    );
+
+    renderGuard();
+
+    expect(await screen.findByRole("status")).toHaveTextContent("메시지 권한 확인 중...");
+    expect(screen.queryByTestId("messages-route-child")).not.toBeInTheDocument();
+
+    resolveApproval(pendingApproval);
+
+    expect(await screen.findByText("메시지 전송 권한이 필요합니다.")).toBeInTheDocument();
+    expect(screen.getByTestId("messages-route-child")).toBeInTheDocument();
+  });
+
   it("routes to /all when the approval modal cancel button is clicked", async () => {
     renderGuard();
 

--- a/mobile/src/app/(shell)/messages/__tests__/MessagesPermissionGuard.test.tsx
+++ b/mobile/src/app/(shell)/messages/__tests__/MessagesPermissionGuard.test.tsx
@@ -43,7 +43,7 @@ describe("MessagesPermissionGuard", () => {
   beforeEach(() => {
     mockPush.mockClear();
     mockReplace.mockClear();
-    mockPathname = "/messages/new";
+    mockPathname = "/messages/templates";
     mockGetMessageSenderApproval.mockReset();
     mockGetMessageSenderApproval.mockResolvedValue({
       approvalStatus: "not_requested",
@@ -91,6 +91,18 @@ describe("MessagesPermissionGuard", () => {
 
     expect(await screen.findByText("메시지 전송 권한이 필요합니다.")).toBeInTheDocument();
     expect(screen.getByTestId("messages-route-child")).toBeInTheDocument();
+  });
+
+  it("allows /messages/new without approval and keeps the approval modal closed", async () => {
+    mockPathname = "/messages/new";
+
+    renderGuard();
+
+    expect(await screen.findByTestId("messages-route-child")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockGetMessageSenderApproval).toHaveBeenCalled();
+    });
+    expect(screen.queryByText("메시지 전송 권한이 필요합니다.")).not.toBeInTheDocument();
   });
 
   it("routes to /all when the approval modal cancel button is clicked", async () => {

--- a/mobile/src/app/(shell)/messages/new/__tests__/page.test.tsx
+++ b/mobile/src/app/(shell)/messages/new/__tests__/page.test.tsx
@@ -14,6 +14,7 @@ const mockUseSystemTemplate = jest.fn();
 const mockGetMessageSenderApproval = jest.fn();
 const mockUseBankAccountInfos = jest.fn();
 const mockUseVoucherPriceInfos = jest.fn();
+const mockUseMessagesPermissionGuard = jest.fn();
 const mockClipboardWriteText = jest.fn();
 let mockSearchParams = new URLSearchParams();
 
@@ -111,6 +112,10 @@ jest.mock("@/services/api", () => ({
   },
 }));
 
+jest.mock("@/app/(shell)/messages/MessagesPermissionGuard", () => ({
+  useMessagesPermissionGuard: () => mockUseMessagesPermissionGuard(),
+}));
+
 function renderPage() {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -148,6 +153,11 @@ describe("NewMessagePage", () => {
   beforeEach(() => {
     mockPush.mockClear();
     mockGetMessageSenderApproval.mockReset();
+    mockUseMessagesPermissionGuard.mockReset();
+    mockUseMessagesPermissionGuard.mockReturnValue({
+      isLoading: false,
+      needsSenderApproval: false,
+    });
     mockGetMessageSenderApproval.mockResolvedValue({
       approvalStatus: "approved",
       isApproved: true,
@@ -544,6 +554,18 @@ describe("NewMessagePage", () => {
   it("disables immediate send until a recipient is selected", () => {
     renderPage();
 
+    expect(screen.getByRole("button", { name: "즉시 발송" })).toBeDisabled();
+  });
+
+  it("keeps the send page accessible but disables immediate send without approval", () => {
+    mockUseMessagesPermissionGuard.mockReturnValue({
+      isLoading: false,
+      needsSenderApproval: true,
+    });
+
+    renderPage();
+
+    expect(screen.getByText("새 메시지")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "즉시 발송" })).toBeDisabled();
   });
 

--- a/mobile/src/app/(shell)/messages/new/page.module.css
+++ b/mobile/src/app/(shell)/messages/new/page.module.css
@@ -62,7 +62,7 @@
 }
 
 .formCardSection {
-  padding: 0;
+  display: contents;
 }
 
 .formSection {
@@ -76,10 +76,6 @@
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-}
-
-.formSection + .formSection {
-  margin-top: 12px;
 }
 
 .formLabel {
@@ -171,16 +167,21 @@
 }
 
 .templateSelectTrigger {
+  box-sizing: border-box;
   width: 100%;
   height: 44px;
   min-height: 44px;
   justify-content: space-between;
-  border-color: hsl(var(--v3-border));
-  border-radius: 10px;
-  background: hsl(var(--v3-dim-white));
+  border: 1.5px solid hsl(var(--input));
+  border-radius: 12px;
+  background: white;
   color: hsl(var(--v3-dark));
   font-size: 0.85rem;
   font-weight: 600;
+}
+
+.templateSelectTrigger:disabled {
+  background: hsl(var(--v3-dim-white));
 }
 
 .templateSelectTrigger:focus-visible {
@@ -221,26 +222,25 @@
 }
 
 .priceInfoControls {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.formSection + .priceInfoControls {
-  margin-top: 12px;
+  display: contents;
 }
 
 .variableSelectTrigger {
+  box-sizing: border-box;
   width: 100%;
-  height: 42px;
-  min-height: 42px;
+  height: 44px;
+  min-height: 44px;
   justify-content: space-between;
-  border-color: hsl(var(--v3-border));
-  border-radius: 10px;
-  background: hsl(var(--v3-dim-white));
+  border: 1.5px solid hsl(var(--input));
+  border-radius: 12px;
+  background: white;
   color: hsl(var(--v3-dark));
   font-size: 0.85rem;
   font-weight: 600;
+}
+
+.variableSelectTrigger:disabled {
+  background: hsl(var(--v3-dim-white));
 }
 
 .variableSelectTrigger:focus-visible {

--- a/mobile/src/app/(shell)/messages/sender-approval/__tests__/page.test.tsx
+++ b/mobile/src/app/(shell)/messages/sender-approval/__tests__/page.test.tsx
@@ -8,6 +8,14 @@ const mockReplace = jest.fn();
 const mockToast = jest.fn();
 
 beforeAll(() => {
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    configurable: true,
+    value: class ResizeObserverMock {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  });
   Object.defineProperty(HTMLElement.prototype, "hasPointerCapture", {
     configurable: true,
     value: () => false,
@@ -93,6 +101,12 @@ describe("MessageSenderApprovalPage", () => {
   it("shows the settings section navigation without a back button", () => {
     const { container } = renderPage();
     const listCard = container.querySelector('[data-component="mobile_messages_sender-approval_page_screen_content_scroll_list-card"]');
+    const form = container.querySelector<HTMLFormElement>(
+      '[data-component="mobile_messages_sender-approval_page_screen_content_scroll_list-card_body_form"]',
+    );
+    const actions = container.querySelector<HTMLElement>(
+      '[data-component="mobile_messages_sender-approval_page_screen_content_scroll_list-card_body_form_actions"]',
+    );
 
     expect(screen.getByRole("button", { name: "설정" }))
       .toHaveAttribute("aria-pressed", "true");
@@ -100,6 +114,9 @@ describe("MessageSenderApprovalPage", () => {
     expect(listCard).toContainElement(
       container.querySelector('[data-component="mobile_messages_sender-approval_page_screen_content_scroll_list-card_body"]'),
     );
+    expect(form?.tagName).toBe("FORM");
+    expect(form).toContainElement(actions);
+    expect(within(form as HTMLElement).getByRole("button", { name: "신청하기" })).toHaveAttribute("type", "submit");
     expect(screen.queryByRole("button", { name: "메시지 목록으로 돌아가기" }))
       .not.toBeInTheDocument();
   });
@@ -125,7 +142,7 @@ describe("MessageSenderApprovalPage", () => {
     expect(mockReplace).toHaveBeenCalledWith("/all");
   });
 
-  it("blocks the sender approval form with a pending approval modal", async () => {
+  it("shows a disabled pending approval state in the sender approval form", async () => {
     mockGetMessageSenderApproval.mockResolvedValue({
       approvalStatus: "pending",
       isApproved: false,
@@ -136,14 +153,10 @@ describe("MessageSenderApprovalPage", () => {
 
     renderPage();
 
-    expect(await screen.findByText("메시지 발송 신청 승인 대기중 입니다.")).toBeInTheDocument();
+    const submitButton = await screen.findByRole("button", { name: "승인 대기중" });
 
-    const dialog = screen.getByRole("dialog");
-    expect(within(dialog).getByRole("button", { name: "확인" })).toBeInTheDocument();
-    expect(within(dialog).queryByRole("button", { name: "신청하기" })).not.toBeInTheDocument();
-
-    fireEvent.click(within(dialog).getByRole("button", { name: "확인" }));
-
-    expect(mockReplace).toHaveBeenCalledWith("/all");
+    expect(submitButton).toBeDisabled();
+    expect(submitButton).toHaveTextContent("승인 대기중");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 });

--- a/mobile/src/app/(shell)/messages/sender-approval/page.module.css
+++ b/mobile/src/app/(shell)/messages/sender-approval/page.module.css
@@ -32,7 +32,7 @@
   flex-direction: column;
   gap: 10px;
   overflow-y: hidden;
-  padding: 0 0 84px;
+  padding: 0;
   scrollbar-width: none;
 }
 
@@ -217,11 +217,6 @@
 }
 
 .msgActions {
-  position: absolute;
-  right: 0;
-  bottom: calc(76px * var(--glint-ui-scale, 1));
-  left: 0;
-  z-index: 20;
   display: flex;
   flex-shrink: 0;
   padding: 10px 14px 16px;

--- a/mobile/src/app/(shell)/messages/sender-approval/page.tsx
+++ b/mobile/src/app/(shell)/messages/sender-approval/page.tsx
@@ -9,7 +9,6 @@ import { Building2, Send } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { MessageSenderApprovalModal } from "@/components/app/messages/MessageSenderApprovalModal";
 import { MessageSectionNav } from "@/components/app/mobile-redesign/MessageSectionNav";
 import { ListCard } from "@/components/app/mobile-redesign/primitives";
 import { useGetAuthUser } from "@/hooks/useGetAuthUser";
@@ -91,7 +90,7 @@ function getApprovalErrorMessage(error: unknown): string {
 
 function approvalStatusLabel(approval?: MessageSenderApprovalResponse): string {
   if (approval?.approvalStatus === "approved") return "승인 완료";
-  if (approval?.approvalStatus === "pending") return "승인 대기";
+  if (approval?.approvalStatus === "pending") return "승인 대기중";
   return "승인 필요";
 }
 
@@ -110,12 +109,20 @@ function SenderApprovalForm({
   });
 
   const canRequest = approval?.canRequest ?? true;
+  const isApprovalPending = approval?.approvalStatus === "pending";
   const allAgreed = AGREEMENT_ITEMS.every((item) => agreements[item.id]);
-  const canSubmit = allAgreed && canRequest && !isLoading && !isSubmitting;
-  const submitLabel = approval?.approvalStatus === "pending" ? "다시 신청하기" : "신청하기";
+  const canSubmit = allAgreed && canRequest && !isApprovalPending && !isLoading && !isSubmitting;
+  const submitLabel = isApprovalPending ? "승인 대기중" : "신청하기";
 
   return (
-    <div data-component={SENDER_APPROVAL_FORM_BASE} className={styles.formSections}>
+    <form
+      data-component={SENDER_APPROVAL_FORM_BASE}
+      className={styles.formSections}
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (canSubmit) onSubmit();
+      }}
+    >
       <section data-component={`${SENDER_APPROVAL_FORM_BASE}_branch`} className={styles.formCardSection}>
           <div data-component={`${SENDER_APPROVAL_FORM_BASE}_branch_row`} className={styles.formSection}>
             <div data-component={`${SENDER_APPROVAL_FORM_BASE}_branch_row_label`} className={styles.labelRow}>
@@ -156,7 +163,7 @@ function SenderApprovalForm({
                   <Checkbox
                     id={item.id}
                     checked={agreements[item.id]}
-                    disabled={isLoading || isSubmitting || !canRequest}
+                    disabled={isLoading || isSubmitting || !canRequest || isApprovalPending}
                     onCheckedChange={(checked) => {
                       setAgreements((current) => ({
                         ...current,
@@ -206,18 +213,17 @@ function SenderApprovalForm({
 
       <div data-component={`${SENDER_APPROVAL_FORM_BASE}_actions`} className={styles.msgActions}>
         <Button
-          type="button"
+          type="submit"
           data-component={`${SENDER_APPROVAL_FORM_BASE}_actions_submit`}
           variant="v3"
           disabled={!canSubmit}
           className={styles.submitButton}
-          onClick={() => onSubmit()}
         >
           <Send aria-hidden="true" size={16} strokeWidth={2.5} />
           {isSubmitting ? "신청 중" : submitLabel}
         </Button>
       </div>
-    </div>
+    </form>
   );
 }
 
@@ -229,7 +235,6 @@ export default function MessageSenderApprovalPage() {
   const initialUser = useInitialUser();
   const { data: user } = useGetAuthUser({ initialData: initialUser });
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [hasSubmittedSuccessfully, setHasSubmittedSuccessfully] = useState(false);
 
   const branchName = user?.branchName ?? "현재 지점";
 
@@ -241,7 +246,6 @@ export default function MessageSenderApprovalPage() {
   const requestApprovalMutation = useMutation({
     mutationFn: settingsApi.requestMessageSenderApproval,
     onSuccess: (approval: MessageSenderApprovalResponse) => {
-      setHasSubmittedSuccessfully(true);
       queryClient.setQueryData(MESSAGE_SENDER_APPROVAL_QUERY_KEY, approval);
       setErrorMessage(null);
       toast({ description: "신청이 완료되었습니다." });
@@ -252,13 +256,6 @@ export default function MessageSenderApprovalPage() {
       setErrorMessage(getApprovalErrorMessage(error));
     },
   });
-
-  const handlePendingModalConfirm = () => {
-    router.replace("/all");
-  };
-
-  const isApprovalPending =
-    !hasSubmittedSuccessfully && approvalQuery.data?.approvalStatus === "pending";
 
   return (
     <section
@@ -299,16 +296,6 @@ export default function MessageSenderApprovalPage() {
           </div>
         </div>
       </div>
-      <MessageSenderApprovalModal
-        open={isApprovalPending}
-        isApprovalPending
-        needsRequestPermission={false}
-        onOpenChange={(open) => {
-          if (!open) handlePendingModalConfirm();
-        }}
-        onCancel={handlePendingModalConfirm}
-        onRequest={handlePendingModalConfirm}
-      />
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- Allow `/messages/new` to open without sender approval while keeping `즉시 발송` disabled.
- Show pending sender approval directly in the settings form instead of opening a modal.
- Normalize message form field spacing and select styling across templates.

## Changes

- Keep the sender approval query available on the send page, but suppress the approval modal there.
- Render the pending state as a disabled `승인 대기중` form action and disable agreement inputs while pending.
- Flatten message form section layout so field rows share one `16px` parent gap instead of mixed margins and nested gaps.
- Match message select controls to the shared input border geometry and preserve the disabled background.

## Root cause

The send route was treated like other protected message routes, and the form grouped fields into nested wrappers with separate sibling margins. Select controls also had different border geometry from the shared v3 input.

## Validation

- Mobile Jest: `messages/new` suite passed, 29 tests.
- Mobile type-check passed.
- Mobile lint passed with 0 errors; existing warnings remain.
- `git diff --check` passed.
- Browser verified price-information and service-information templates: field gaps are consistently `16px`.
- Local build compiled and completed TypeScript, then stopped during page-data collection because `NEXT_PUBLIC_API_BASE_URL` is not configured.
