### PR TITLE
Gate message settings list on policy loading

### DIFF
--- a/frontend/src/components/app/messages/MessageTenantApplicationSettings.tsx
+++ b/frontend/src/components/app/messages/MessageTenantApplicationSettings.tsx
@@ -216,7 +216,10 @@ export function MessageTenantApplicationSettings() {
     queryKey: ["settings", "message-sender-approval"],
     queryFn: settingsApi.getMessageSenderApproval,
   });
-  const { data: messageAutomationPolicies } = useQuery({
+  const {
+    data: messageAutomationPolicies,
+    isLoading: isMessageAutomationPoliciesLoading,
+  } = useQuery({
     queryKey: ["settings", "message-automation-policies"],
     queryFn: settingsApi.getMessageAutomationPolicies,
   });
@@ -237,9 +240,11 @@ export function MessageTenantApplicationSettings() {
   const allAgreed = ALIGO_POLICY_ITEMS.every((item) => agreements[item.id]);
   const canSubmit = allAgreed;
   const isMessageSenderApproved = messageSenderApproval?.isApproved === true;
+  const isMessageSettingsListLoading =
+    isMessageSenderApprovalLoading || isMessageAutomationPoliciesLoading;
   const listItems = useMemo<TenantApplicationListItem[]>(
     () => {
-      if (isMessageSenderApprovalLoading) {
+      if (isMessageSettingsListLoading) {
         return [];
       }
 
@@ -289,7 +294,7 @@ export function MessageTenantApplicationSettings() {
     },
     [
       canSubmit,
-      isMessageSenderApprovalLoading,
+      isMessageSettingsListLoading,
       isMessageSenderApproved,
       messageAutomationPolicies?.policies,
       clientRegistrationPolicy?.clientAutoRegistration,
@@ -433,14 +438,14 @@ export function MessageTenantApplicationSettings() {
       ruleOrder: retroactiveTriggerOrderItems.map((item) => item.id),
     });
   };
-  const emptyListMessage = isMessageSenderApprovalLoading
+  const emptyListMessage = isMessageSettingsListLoading
     ? "설정 정보를 불러오는 중입니다."
     : "표시할 설정 항목이 없습니다.";
-  const emptyDetailMessage = isMessageSenderApprovalLoading
+  const emptyDetailMessage = isMessageSettingsListLoading
     ? "설정 정보를 불러오는 중입니다."
     : "설정 항목을 선택해 주세요.";
 
-  if (isMessageSenderApprovalLoading) {
+  if (isMessageSettingsListLoading) {
     return (
       <div
         data-component="desktop_messages_sections_settings-layout"

--- a/frontend/src/components/app/messages/__tests__/MessageTenantApplicationSettings.test.tsx
+++ b/frontend/src/components/app/messages/__tests__/MessageTenantApplicationSettings.test.tsx
@@ -180,9 +180,10 @@ function mockSettingsQueries(
   isApproved: boolean,
   automationPolicies: MessageAutomationPoliciesResponse = DEFAULT_AUTOMATION_POLICIES,
   triggerRules: MessageTriggerRule[] = DEFAULT_TRIGGER_RULES,
+  options: { automationPoliciesLoading?: boolean } = {},
 ) {
-  mockedUseQuery.mockImplementation(((options: unknown) => {
-    const queryKey = getQueryKey(options);
+  mockedUseQuery.mockImplementation(((queryOptions: unknown) => {
+    const queryKey = getQueryKey(queryOptions);
 
     if (queryKey?.[0] === "settings" && queryKey[1] === "message-sender-approval") {
       return {
@@ -199,8 +200,8 @@ function mockSettingsQueries(
 
     if (queryKey?.[0] === "settings" && queryKey[1] === "message-automation-policies") {
       return {
-        data: automationPolicies,
-        isLoading: false,
+        data: options.automationPoliciesLoading ? undefined : automationPolicies,
+        isLoading: options.automationPoliciesLoading ?? false,
       } as unknown as ReturnType<typeof useQuery>;
     }
 
@@ -462,6 +463,23 @@ describe("MessageTenantApplicationSettings", () => {
     expect(screen.getByText("중복 전송 확인")).toBeInTheDocument();
     expect(screen.getByRole("switch", { name: "제공기록지 전송 자동화 규칙 활성화" })).toBeInTheDocument();
     expect(container.querySelector('[data-component="desktop_messages_sections_settings-tenant-application"]')).toBeInTheDocument();
+  });
+
+  it("waits for automation policies before rendering the settings list", () => {
+    mockSettingsQueries(true, DEFAULT_AUTOMATION_POLICIES, DEFAULT_TRIGGER_RULES, {
+      automationPoliciesLoading: true,
+    });
+
+    const view = render(<MessageTenantApplicationSettings />);
+
+    expect(screen.getAllByText("설정 정보를 불러오는 중입니다.")).toHaveLength(2);
+    expect(screen.queryByText("제공기록지 전송 자동화 규칙")).not.toBeInTheDocument();
+
+    mockSettingsQueries(true);
+    view.rerender(<MessageTenantApplicationSettings />);
+
+    expect(screen.getAllByText("제공기록지 전송 자동화 규칙").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("지난 자동 전송 처리 규칙").length).toBeGreaterThan(0);
   });
 
   it("policy switches stay disabled while unapproved and only approval-gated active policies render off", () => {


### PR DESCRIPTION
## Summary
- wait for sender approval and message automation policy queries before rendering the settings list
- keep permission-dependent settings items from appearing after the initial list render
- add a regression test for the delayed automation-policy response

## Validation
- focused MessageTenantApplicationSettings Jest test: 9 passed
- frontend Jest: 144 suites, 654 tests passed
- frontend type-check passed
- frontend lint passed with existing warnings only
- frontend build passed
- UI architecture gate passed

Related mobile fix: #464