### PR TITLE
Unify permission-dependent loading skeletons

### DIFF
--- a/frontend/src/app/(protected)/all/page.test.tsx
+++ b/frontend/src/app/(protected)/all/page.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+
+import { useGetAuthUser } from "@/hooks/useGetAuthUser";
+
+import AllMenuPage from "./page";
+
+jest.mock("@/hooks/useGetAuthUser", () => ({
+  useGetAuthUser: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: jest.fn() }),
+}));
+
+jest.mock("@/components/app/v3/ShortcutGrid", () => ({
+  ShortcutGrid: () => <div data-component="test-shortcut-grid" />,
+}));
+
+const mockedUseGetAuthUser = jest.mocked(useGetAuthUser);
+
+describe("AllMenuPage permission loading", () => {
+  it("keeps the full menu in skeleton state until the user role is known", () => {
+    mockedUseGetAuthUser.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useGetAuthUser>);
+
+    const view = render(<AllMenuPage />);
+
+    expect(screen.getByRole("status", { name: "메뉴 권한 확인 중" })).toBeInTheDocument();
+    expect(screen.queryByText("관리자")).not.toBeInTheDocument();
+
+    mockedUseGetAuthUser.mockReturnValue({
+      data: {
+        id: "owner-1",
+        name: "오너",
+        role: "owner",
+      },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useGetAuthUser>);
+    view.rerender(<AllMenuPage />);
+
+    expect(screen.queryByRole("status", { name: "메뉴 권한 확인 중" })).not.toBeInTheDocument();
+    expect(screen.getByText("관리자")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(protected)/all/page.tsx
+++ b/frontend/src/app/(protected)/all/page.tsx
@@ -142,33 +142,57 @@ export default function AllMenuPage() {
             전체 메뉴
           </h2>
           <div data-component="desktop_all_menu_content_nav_list" className="flex flex-col gap-2">
-            {navItems.map((item, idx) => {
-              const Icon = item.icon;
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  data-component="desktop_all_menu_content_nav_list_item"
-                  className={cn(
-                    "flex items-center gap-3 px-3 py-1",
-                    "rounded-[18px]",
-                    "active:scale-[0.98] transition-all",
-                    "opacity-0 animate-v3-pop-up"
-                  )}
-                  style={{ animationDelay: `${0.35 + idx * 0.04}s`, animationFillMode: "both" }}
-                >
-                  <div data-component="desktop_all_menu_content_nav_list_item_icon" className="w-11 h-11 rounded-[14px] bg-v3-dim-white flex items-center justify-center shrink-0">
-                    <Icon className="w-5 h-5 text-v3-text-muted" strokeWidth={2.5} />
+            {isLoading ? (
+              <div
+                data-component="desktop_all_menu_content_nav_list_loading"
+                role="status"
+                aria-label="메뉴 권한 확인 중"
+                className="flex flex-col gap-2"
+              >
+                {Array.from({ length: 8 }, (_, index) => (
+                  <div
+                    key={`menu-skeleton-${index}`}
+                    data-component="desktop_all_menu_content_nav_list_loading_item"
+                    aria-hidden="true"
+                    className="flex items-center gap-3 px-3 py-1"
+                  >
+                    <Skeleton className="h-11 w-11 shrink-0" />
+                    <div className="min-w-0 flex-1 space-y-2">
+                      <Skeleton className="h-4 w-24" />
+                      <Skeleton className="h-3 w-32" />
+                    </div>
                   </div>
-                  <div data-component="desktop_all_menu_content_nav_list_item_content" className="min-w-0 flex-1 flex items-center justify-between">
-                    <p className="text-md font-extrabold text-v3-dark truncate">
-                      {item.label}
-                    </p>
-                    <p className="text-sm text-v3-text-muted truncate">{item.desc}</p>
-                  </div>
-                </Link>
-              );
-            })}
+                ))}
+              </div>
+            ) : (
+              navItems.map((item, idx) => {
+                const Icon = item.icon;
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    data-component="desktop_all_menu_content_nav_list_item"
+                    className={cn(
+                      "flex items-center gap-3 px-3 py-1",
+                      "rounded-[18px]",
+                      "active:scale-[0.98] transition-all",
+                      "opacity-0 animate-v3-pop-up"
+                    )}
+                    style={{ animationDelay: `${0.35 + idx * 0.04}s`, animationFillMode: "both" }}
+                  >
+                    <div data-component="desktop_all_menu_content_nav_list_item_icon" className="w-11 h-11 rounded-[14px] bg-v3-dim-white flex items-center justify-center shrink-0">
+                      <Icon className="w-5 h-5 text-v3-text-muted" strokeWidth={2.5} />
+                    </div>
+                    <div data-component="desktop_all_menu_content_nav_list_item_content" className="min-w-0 flex-1 flex items-center justify-between">
+                      <p className="text-md font-extrabold text-v3-dark truncate">
+                        {item.label}
+                      </p>
+                      <p className="text-sm text-v3-text-muted truncate">{item.desc}</p>
+                    </div>
+                  </Link>
+                );
+              })
+            )}
           </div>
         </section>
       </div>

--- a/frontend/src/components/app/v3/SidebarNotifications.tsx
+++ b/frontend/src/components/app/v3/SidebarNotifications.tsx
@@ -102,9 +102,13 @@ export function SidebarNotifications() {
   const [modalPosition, setModalPosition] = React.useState<{ top: number; left: number } | null>(null);
   const triggerRef = React.useRef<HTMLButtonElement | null>(null);
   const { isScrollActive, handleScroll } = useScrollActivity();
-  const { data: alerts = [] } = useClientAlerts(3);
-  const { data: savedNotifications = [] } = useNotifications(5, 0, true);
+  const { data: alerts = [], isLoading: isAlertsLoading } = useClientAlerts(3);
+  const {
+    data: savedNotifications = [],
+    isLoading: isSavedNotificationsLoading,
+  } = useNotifications(5, 0, true);
   const markAsRead = useMarkAsRead();
+  const isNotificationsLoading = isAlertsLoading || isSavedNotificationsLoading;
 
   const notifications = React.useMemo<SidebarNotificationItem[]>(() => {
     const actionItems: SidebarNotificationItem[] = alerts.map((alert) => {
@@ -247,10 +251,11 @@ export function SidebarNotifications() {
                 data-scroll-active={isScrollActive ? "true" : "false"}
                 onScroll={handleScroll}
               >
-                {notifications.length ? (
+                {isNotificationsLoading || notifications.length ? (
                   <AnimatedSlotList<SidebarNotificationItem>
                     items={notifications}
-                    isLoading={false}
+                    isLoading={isNotificationsLoading}
+                    loadingCount={6}
                     itemDataComponent="desktop_chrome_sidebar_notifications-modal_item"
                     getItemKey={(notification) => notification.id}
                     onSlotClick={(notification) => handleNotificationClick(notification)}

--- a/frontend/src/components/app/v3/__tests__/SidebarNotifications.test.tsx
+++ b/frontend/src/components/app/v3/__tests__/SidebarNotifications.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { useClientAlerts } from "@/hooks/useClientAlerts";
+import { useMarkAsRead, useNotifications } from "@/hooks/usePushNotification";
+
+import { SidebarNotifications } from "../SidebarNotifications";
+
+jest.mock("@/hooks/useClientAlerts", () => ({
+  useClientAlerts: jest.fn(),
+}));
+
+jest.mock("@/hooks/usePushNotification", () => ({
+  useMarkAsRead: jest.fn(),
+  useNotifications: jest.fn(),
+}));
+
+jest.mock("@/components/app/v3/useScrollActivity", () => ({
+  useScrollActivity: () => ({
+    isScrollActive: false,
+    handleScroll: jest.fn(),
+  }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockedUseClientAlerts = jest.mocked(useClientAlerts);
+const mockedUseMarkAsRead = jest.mocked(useMarkAsRead);
+const mockedUseNotifications = jest.mocked(useNotifications);
+
+describe("SidebarNotifications loading state", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseMarkAsRead.mockReturnValue({ mutate: jest.fn() } as unknown as ReturnType<typeof useMarkAsRead>);
+  });
+
+  it("renders notification skeletons instead of the empty state while queries are loading", () => {
+    mockedUseClientAlerts.mockReturnValue({ data: [], isLoading: true } as unknown as ReturnType<typeof useClientAlerts>);
+    mockedUseNotifications.mockReturnValue({ data: [], isLoading: true } as unknown as ReturnType<typeof useNotifications>);
+
+    const { rerender } = render(<SidebarNotifications />);
+    fireEvent.click(screen.getByRole("button", { name: "알림 열기" }));
+
+    expect(screen.queryByText("새 알림이 없습니다")).not.toBeInTheDocument();
+    expect(document.querySelectorAll('[data-component="desktop_chrome_sidebar_notifications-modal_item"]')).toHaveLength(6);
+
+    mockedUseClientAlerts.mockReturnValue({ data: [], isLoading: false } as unknown as ReturnType<typeof useClientAlerts>);
+    mockedUseNotifications.mockReturnValue({
+      data: [{
+        id: 1,
+        title: "계약 알림",
+        body: "확인이 필요합니다.",
+        data: {},
+        sentAt: "2026-08-02T00:00:00.000Z",
+        readAt: null,
+        isRead: false,
+      }],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useNotifications>);
+    rerender(<SidebarNotifications />);
+
+    expect(screen.getByText("계약 알림")).toBeInTheDocument();
+  });
+});

--- a/mobile/src/app/(shell)/prices/page.test.tsx
+++ b/mobile/src/app/(shell)/prices/page.test.tsx
@@ -2,8 +2,10 @@ import { fireEvent, render, screen } from "@testing-library/react";
 
 import PricesPage from "./page";
 
+const mockUseGetAuthUser = jest.fn();
+
 jest.mock("@/hooks/useGetAuthUser", () => ({
-  useGetAuthUser: () => ({ data: { role: "owner" } }),
+  useGetAuthUser: () => mockUseGetAuthUser(),
 }));
 
 jest.mock("@/hooks/useVoucherData", () => ({
@@ -13,13 +15,15 @@ jest.mock("@/hooks/useVoucherData", () => ({
 }));
 
 jest.mock("@/components/app/mobile-redesign/primitives", () => ({
-  ListCard: ({ actionLabel, onActionClick, children }: {
+  ListCard: ({ actionLabel, actionLoading, onActionClick, children }: {
     actionLabel?: string;
+    actionLoading?: boolean;
     onActionClick?: () => void;
     children: React.ReactNode;
   }) => (
     <div data-component="test-prices-list-card">
-      {actionLabel ? <button onClick={onActionClick}>{actionLabel}</button> : null}
+      {actionLoading ? <div data-testid="test-prices-action-skeleton" /> : null}
+      {!actionLoading && actionLabel ? <button onClick={onActionClick}>{actionLabel}</button> : null}
       {children}
     </div>
   ),
@@ -41,6 +45,25 @@ jest.mock("@/components/app/settings/VoucherPriceUploadForm", () => ({
 }));
 
 describe("mobile prices page", () => {
+  beforeEach(() => {
+    mockUseGetAuthUser.mockReturnValue({ data: { role: "owner" }, isLoading: false });
+  });
+
+  it("shows the owner action skeleton while the user role is loading", () => {
+    mockUseGetAuthUser.mockReturnValue({ data: undefined, isLoading: true });
+
+    const view = render(<PricesPage />);
+
+    expect(screen.getByTestId("test-prices-action-skeleton")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "업데이트" })).not.toBeInTheDocument();
+
+    mockUseGetAuthUser.mockReturnValue({ data: { role: "owner" }, isLoading: false });
+    view.rerender(<PricesPage />);
+
+    expect(screen.queryByTestId("test-prices-action-skeleton")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "업데이트" })).toBeInTheDocument();
+  });
+
   it("opens the functional voucher upload form for owners", () => {
     render(<PricesPage />);
 

--- a/mobile/src/app/(shell)/prices/page.tsx
+++ b/mobile/src/app/(shell)/prices/page.tsx
@@ -79,7 +79,7 @@ function formatWon(amount: number): string {
 }
 
 export default function PricesPage() {
-  const { data: authUser } = useGetAuthUser();
+  const { data: authUser, isLoading: isAuthUserLoading } = useGetAuthUser();
   const isOwner = authUser?.role === "owner";
   const { data: years = [], isLoading: isYearsLoading } = useVoucherYears();
   const sortedYears = useMemo(() => [...years].sort((a, b) => a - b), [years]);
@@ -220,6 +220,7 @@ export default function PricesPage() {
                 )
               }
               actionLabel={isOwner ? "업데이트" : undefined}
+              actionLoading={isAuthUserLoading}
               actionIcon={isOwner ? <Upload size={12} strokeWidth={3} aria-hidden="true" /> : undefined}
               onActionClick={
                 isOwner

--- a/mobile/src/components/app/mobile-redesign/ListCardHeader.tsx
+++ b/mobile/src/components/app/mobile-redesign/ListCardHeader.tsx
@@ -2,6 +2,8 @@ import Link from "next/link";
 import type { ReactNode } from "react";
 import { Plus } from "lucide-react";
 
+import { Skeleton } from "@/components/ui/skeleton";
+
 const SOURCE_COMPONENT = "ListCardHeader";
 export interface ListCardHeaderProps {
   "data-component": string;
@@ -10,6 +12,7 @@ export interface ListCardHeaderProps {
   actionLabel?: string;
   actionHref?: string;
   actionIcon?: ReactNode;
+  actionLoading?: boolean;
   actionType?: "button" | "submit";
   actionDisabled?: boolean;
   onActionClick?: () => void;
@@ -22,6 +25,7 @@ export function ListCardHeader({
   actionLabel,
   actionHref,
   actionIcon,
+  actionLoading = false,
   actionType = "button",
   actionDisabled = false,
   onActionClick,
@@ -31,7 +35,14 @@ export function ListCardHeader({
     : actionLabel?.startsWith("+")
       ? null
       : <Plus size={12} strokeWidth={3} />;
-  const action = actionLabel ? (
+  const action = actionLoading ? (
+    <Skeleton
+      role="status"
+      aria-label="권한 확인 중"
+      className="h-7 w-20 rounded-full"
+      data-component={`${dataComponent}_action-skeleton`}
+    />
+  ) : actionLabel ? (
     actionHref ? (
       <Link
         href={actionHref}

--- a/mobile/src/components/app/mobile-redesign/primitives.tsx
+++ b/mobile/src/components/app/mobile-redesign/primitives.tsx
@@ -510,6 +510,7 @@ export function ListCard({
   title,
   count,
   actionLabel,
+  actionLoading,
   actionHref,
   actionIcon,
   actionType = "button",
@@ -529,6 +530,7 @@ export function ListCard({
   title: string;
   count?: ReactNode;
   actionLabel?: string;
+  actionLoading?: boolean;
   actionHref?: string;
   actionIcon?: ReactNode;
   actionType?: "button" | "submit";
@@ -560,6 +562,7 @@ export function ListCard({
         title={title}
         count={count}
         actionLabel={actionLabel}
+        actionLoading={actionLoading}
         actionHref={actionHref}
         actionIcon={actionIcon}
         actionType={actionType}


### PR DESCRIPTION
## Summary
- Hold frontend All Menu items in a skeleton state until the auth role is resolved.
- Keep notification modal content in a loading state until both notification queries finish.
- Show a mobile prices action skeleton while owner permission is being resolved.
- Add regression tests for each loading-to-loaded transition.

## Root cause
Permission- or query-dependent items were rendered from empty/undefined data first, then inserted after the request completed. This caused late-appearing menu/actions and an incorrect empty notification state.

## Validation
- Frontend Jest: 146 suites, 655 tests passed
- Mobile Jest: 157 suites, 857 tests passed
- Frontend/mobile type-check passed
- Frontend/mobile lint passed with existing warnings only
- UI architecture gate passed
- Frontend/mobile production builds passed
- `pnpm audit --prod --audit-level=high` remains blocked by the existing backend transitive `brace-expansion` advisory; no dependencies changedn