### PR TITLE
Disable message sections while sender approval is pending

### DIFF
--- a/frontend/src/app/(protected)/messages/page.test.tsx
+++ b/frontend/src/app/(protected)/messages/page.test.tsx
@@ -22,6 +22,20 @@ describe("MessagesPage unreleased section gating", () => {
     expect(unreleasedIds).toContain('"templates"');
     expect(unreleasedIds).toContain('"triggers"');
     expect(source).toContain("const isOwner = user?.role === ROLES.owner");
-    expect(source).toContain("disabled: UNRELEASED_SECTION_IDS.has(section.id) && !isOwner");
+    expect(source).toContain("UNRELEASED_SECTION_IDS.has(section.id) && !isOwner");
+  });
+});
+
+describe("MessagesPage sender approval gating", () => {
+  it("keeps only send and settings available while sender approval is pending", () => {
+    expect(source).toContain(
+      'const SENDER_APPROVAL_EXEMPT_SECTION_IDS = new Set<MessageSectionId>(["send", "settings"]);',
+    );
+    expect(source).toContain(
+      "const isSenderApprovalRequired = senderApproval?.isApproved === false",
+    );
+    expect(source).toContain(
+      "!SENDER_APPROVAL_EXEMPT_SECTION_IDS.has(section.id)",
+    );
   });
 });

--- a/frontend/src/app/(protected)/messages/page.tsx
+++ b/frontend/src/app/(protected)/messages/page.tsx
@@ -130,7 +130,10 @@ import {
 } from "@/components/app/messages/forms/TemplateSendForm";
 import type { TemplateMessageFormLayout } from "@/components/app/messages/forms/form-components/TemplateMessageFormLayout";
 import { MessageTenantApplicationSettings } from "@/components/app/messages/MessageTenantApplicationSettings";
-import { MessageApprovalGate } from "@/components/app/messages/MessageApprovalGate";
+import {
+  MessageApprovalGate,
+  useMessageSenderApproval,
+} from "@/components/app/messages/MessageApprovalGate";
 import { TriggerRulesManager } from "@/components/app/messages/TriggerRulesManager";
 import { Button } from "@/components/ui/button";
 import {
@@ -213,6 +216,7 @@ const UNRELEASED_SECTION_IDS = new Set<MessageSectionId>([
   "templates",
   "triggers",
 ]);
+const SENDER_APPROVAL_EXEMPT_SECTION_IDS = new Set<MessageSectionId>(["send", "settings"]);
 
 const TEMPLATE_SEND_FORM_ID = "messages-template-send-form-active";
 
@@ -1575,12 +1579,16 @@ export default function MessagesPage() {
     useState<TemplateSendFormSubmitState | null>(null);
   const user = useInitialUser();
   const isOwner = user?.role === ROLES.owner;
+  const { data: senderApproval } = useMessageSenderApproval();
+  const isSenderApprovalRequired = senderApproval?.isApproved === false;
   const messageSections = useMemo(
     () => MESSAGE_SECTIONS.map((section) => ({
       ...section,
-      disabled: UNRELEASED_SECTION_IDS.has(section.id) && !isOwner,
+      disabled:
+        (isSenderApprovalRequired && !SENDER_APPROVAL_EXEMPT_SECTION_IDS.has(section.id)) ||
+        (UNRELEASED_SECTION_IDS.has(section.id) && !isOwner),
     })),
-    [isOwner],
+    [isOwner, isSenderApprovalRequired],
   );
 
   const { data: userTemplatesData, isLoading: isLoadingUserTemplates } = useMessageTemplates(1, 100);

--- a/frontend/src/components/app/messages/MessageApprovalGate.tsx
+++ b/frontend/src/components/app/messages/MessageApprovalGate.tsx
@@ -5,6 +5,18 @@ import { useQuery } from "@tanstack/react-query";
 import { settingsApi } from "@/services/api";
 import { MessageApprovalRequiredNotice } from "@/components/app/messages/MessageApprovalRequiredNotice";
 
+export const MESSAGE_SENDER_APPROVAL_QUERY_KEY = [
+  "settings",
+  "message-sender-approval",
+] as const;
+
+export function useMessageSenderApproval() {
+  return useQuery({
+    queryKey: MESSAGE_SENDER_APPROVAL_QUERY_KEY,
+    queryFn: settingsApi.getMessageSenderApproval,
+  });
+}
+
 export function MessageApprovalGate({
   children,
   dataComponent,
@@ -12,10 +24,7 @@ export function MessageApprovalGate({
   children: ReactNode;
   dataComponent: string;
 }) {
-  const { data: senderApproval, isLoading } = useQuery({
-    queryKey: ["settings", "message-sender-approval"],
-    queryFn: settingsApi.getMessageSenderApproval,
-  });
+  const { data: senderApproval, isLoading } = useMessageSenderApproval();
 
   if (isLoading || senderApproval?.isApproved) {
     return <>{children}</>;

--- a/mobile/src/components/app/mobile-redesign/MessageSectionNav.tsx
+++ b/mobile/src/components/app/mobile-redesign/MessageSectionNav.tsx
@@ -16,6 +16,7 @@ import {
   type MessageSectionId,
 } from "@babyjamjam/shared";
 
+import { useMessagesPermissionGuard } from "@/app/(shell)/messages/MessagesPermissionGuard";
 import { MobileSectionNav } from "@/components/app/mobile-redesign/primitives";
 import { useInitialUser } from "@/providers/UserProvider";
 
@@ -53,6 +54,7 @@ const UNRELEASED_SECTION_IDS = new Set<MessageSectionId>([
   "templates",
   "triggers",
 ]);
+const SENDER_APPROVAL_EXEMPT_SECTION_IDS = new Set<MessageSectionId>(["send", "settings"]);
 
 export function MessageSectionNav({
   "data-component": dataComponent,
@@ -64,6 +66,7 @@ export function MessageSectionNav({
   const router = useRouter();
   const user = useInitialUser();
   const isOwner = user?.role === "owner";
+  const { needsSenderApproval } = useMessagesPermissionGuard();
 
   const sectionNavItems = useMemo(
     () =>
@@ -71,9 +74,11 @@ export function MessageSectionNav({
         id: item.id,
         label: item.title,
         icon: item.icon,
-        disabled: UNRELEASED_SECTION_IDS.has(item.id) && !isOwner,
+        disabled:
+          (needsSenderApproval && !SENDER_APPROVAL_EXEMPT_SECTION_IDS.has(item.id)) ||
+          (UNRELEASED_SECTION_IDS.has(item.id) && !isOwner),
       })),
-    [isOwner],
+    [isOwner, needsSenderApproval],
   );
 
   const handleSectionSelect = (sectionId: MessageSectionId) => {

--- a/mobile/src/components/app/mobile-redesign/__tests__/MessageSectionNav.test.tsx
+++ b/mobile/src/components/app/mobile-redesign/__tests__/MessageSectionNav.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 
 import { MessageSectionNav } from "../MessageSectionNav";
+import { useMessagesPermissionGuard } from "@/app/(shell)/messages/MessagesPermissionGuard";
 import { useInitialUser } from "@/providers/UserProvider";
 
 jest.mock("next/navigation", () => ({
@@ -11,7 +12,12 @@ jest.mock("@/providers/UserProvider", () => ({
   useInitialUser: jest.fn(),
 }));
 
+jest.mock("@/app/(shell)/messages/MessagesPermissionGuard", () => ({
+  useMessagesPermissionGuard: jest.fn(),
+}));
+
 const mockUseInitialUser = useInitialUser as jest.Mock;
+const mockUseMessagesPermissionGuard = useMessagesPermissionGuard as jest.Mock;
 
 const UNRELEASED_LABELS = ["발송 예정", "발송 기록", "템플릿", "자동 전송"];
 const RELEASED_LABELS = ["전송하기", "설정"];
@@ -23,6 +29,11 @@ function renderNav() {
 describe("MessageSectionNav", () => {
   beforeEach(() => {
     mockUseInitialUser.mockReset();
+    mockUseMessagesPermissionGuard.mockReset();
+    mockUseMessagesPermissionGuard.mockReturnValue({
+      isLoading: false,
+      needsSenderApproval: false,
+    });
   });
 
   it.each(["admin", "manager", "user"])("disables the unreleased sections for %s", (role) => {
@@ -55,6 +66,23 @@ describe("MessageSectionNav", () => {
 
     for (const label of UNRELEASED_LABELS) {
       expect(screen.getByRole("button", { name: label })).toBeDisabled();
+    }
+  });
+
+  it("disables every section except send and settings while sender approval is pending", () => {
+    mockUseInitialUser.mockReturnValue({ role: "owner" });
+    mockUseMessagesPermissionGuard.mockReturnValue({
+      isLoading: false,
+      needsSenderApproval: true,
+    });
+
+    renderNav();
+
+    for (const label of [...UNRELEASED_LABELS, "발송 기록"]) {
+      expect(screen.getByRole("button", { name: label })).toBeDisabled();
+    }
+    for (const label of RELEASED_LABELS) {
+      expect(screen.getByRole("button", { name: label })).toBeEnabled();
     }
   });
 });


### PR DESCRIPTION
## Summary

- Disable all message section nav items except `전송하기` and `설정` while sender approval is pending.
- Apply the same behavior to desktop and mobile.
- Add regression coverage for both nav implementations.

## Root cause

The existing approval gate protected message content, but section nav disabled states only considered unreleased sections and role, so pending accounts could still access the other nav buttons.

## Validation

- Frontend full Jest: 144 suites / 654 tests passed.
- Mobile full Jest: 157 suites / 857 tests passed.
- Frontend and mobile lint/typecheck passed.
- UI architecture check passed.
- Frontend production build passed.
- Chrome verification passed on desktop and mobile pending-approval routes.
- Mobile production build could not complete because the fresh worktree has no `NEXT_PUBLIC_API_BASE_URL`.
- Security scan found no secrets or dangerous patterns in changed files; dependency audit reports an existing transitive `brace-expansion` advisory.