### PR TITLE
fix: stabilize mobile Playwright flows

### DIFF
--- a/mobile/src/app/(shell)/messages/system-templates/[templateKey]/page.tsx
+++ b/mobile/src/app/(shell)/messages/system-templates/[templateKey]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { use } from 'react';
 import { FileText, Loader2, Monitor, Send, Workflow } from 'lucide-react';
 import { useRouter } from 'next/navigation';
@@ -133,7 +134,8 @@ export default function EditSystemTemplatePage({ params }: { params: Promise<{ t
           </p>
         </div>
 
-        <div
+        <Link
+          href="/messages/automation"
           data-component="mobile_messages_system-templates_template-key-detail_detail-panel_trigger-link"
           className="info-card pop-up flex items-start gap-3"
         >
@@ -144,7 +146,7 @@ export default function EditSystemTemplatePage({ params }: { params: Promise<{ t
               이 템플릿의 자동 발송 ON/OFF·발송 시점은 메시지 → 자동 전송에서 관리합니다.
             </p>
           </div>
-        </div>
+        </Link>
       </div>
     </MobileDetailSlideUp>
   );

--- a/mobile/src/app/api/auth/me/route.ts
+++ b/mobile/src/app/api/auth/me/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { serverAPIClient } from "@/lib/api/server";
-import { E2E_AUTH_USER, isE2ETest } from "@/lib/e2e";
+import { E2E_ROLE_COOKIE, getE2EAuthUser, isE2ETest } from "@/lib/e2e";
 import { getUpstreamErrorStatus, logUpstreamError, sanitizeUpstreamClientError } from "@/lib/api/route-utils";
 
 function getAuthToken(request: NextRequest): string | null {
@@ -10,7 +10,7 @@ function getAuthToken(request: NextRequest): string | null {
 export async function GET(request: NextRequest) {
     try {
         if (isE2ETest()) {
-            return NextResponse.json(E2E_AUTH_USER);
+            return NextResponse.json(getE2EAuthUser(request.cookies.get(E2E_ROLE_COOKIE)?.value));
         }
 
         const token = getAuthToken(request);

--- a/mobile/src/lib/auth/cookies.ts
+++ b/mobile/src/lib/auth/cookies.ts
@@ -3,7 +3,7 @@ import { cookies } from "next/headers";
 import { cache } from "react";
 import { jwtDecode } from "jwt-decode";
 import axios from "axios";
-import { E2E_AUTH_USER, isE2ETest } from "@/lib/e2e";
+import { E2E_ROLE_COOKIE, getE2EAuthUser, isE2ETest } from "@/lib/e2e";
 
 interface TokenPayload {
   sub: string;
@@ -30,7 +30,7 @@ export const getCurrentUser = cache(async () => {
     }
 
     if (isE2ETest()) {
-      return E2E_AUTH_USER;
+      return getE2EAuthUser(cookieStore.get(E2E_ROLE_COOKIE)?.value);
     }
 
     // Send token as Bearer token in Authorization header

--- a/mobile/src/lib/e2e.ts
+++ b/mobile/src/lib/e2e.ts
@@ -1,5 +1,7 @@
 import { IS_E2E_TEST } from "@/lib/env";
 
+export const E2E_ROLE_COOKIE = "e2e_role";
+
 export const E2E_AUTH_USER = {
   id: "e2e-user",
   name: "E2E Tester",
@@ -9,6 +11,10 @@ export const E2E_AUTH_USER = {
   branchId: "e2e-branch",
   branchName: "E2E Branch",
 } as const;
+
+export function getE2EAuthUser(role?: string) {
+  return role === "owner" ? { ...E2E_AUTH_USER, role: "owner" as const } : E2E_AUTH_USER;
+}
 
 export const E2E_VAPID_PUBLIC_KEY =
   "BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";

--- a/mobile/tests/contracts-delete.spec.ts
+++ b/mobile/tests/contracts-delete.spec.ts
@@ -124,8 +124,12 @@ test.describe("Contracts delete flow", () => {
 
     await page.locator('[data-component="mobile_contracts_detail-sheet_stack_detail-page_content_header_menu-trigger"]').click();
     await page.locator('[data-component="mobile_contracts_detail-sheet_stack_detail-page_content_header_menu_delete"]').click();
-    await expect(page.locator('[data-component="mobile_contracts_delete-confirmation_modal"]')).toBeVisible();
-    await expect(page.getByText("선택한 계약서를 삭제할까요?")).toBeVisible();
+    const deleteModal = page.locator('[data-component="mobile_contracts_delete-confirmation_modal"]');
+    await expect(deleteModal).toBeVisible();
+    await expect(deleteModal.getByRole("heading", { name: "계약서 삭제" })).toBeVisible();
+    await expect(
+      deleteModal.getByText("전자문서가 취소되어 수신자가 더 이상 서명할 수 없습니다. 복구할 수 없습니다."),
+    ).toBeVisible();
 
     await page.locator('[data-component="mobile_contracts_delete-confirmation_modal_actions"]').getByRole("button", { name: "취소" }).click();
     await expect(page.locator('[data-component="mobile_contracts_delete-confirmation_modal"]')).not.toBeVisible();

--- a/mobile/tests/messages-navigation.spec.ts
+++ b/mobile/tests/messages-navigation.spec.ts
@@ -40,7 +40,6 @@ async function enableOwnerE2EUser(page: Page) {
       name: "e2e_role",
       value: "owner",
       url: new URL(page.url()).origin,
-      path: "/",
     },
   ]);
   await page.reload();

--- a/mobile/tests/messages-navigation.spec.ts
+++ b/mobile/tests/messages-navigation.spec.ts
@@ -33,6 +33,19 @@ async function mockOwnerUser(page: Page) {
   });
 }
 
+async function enableOwnerE2EUser(page: Page) {
+  await page.goto("/messages");
+  await page.context().addCookies([
+    {
+      name: "e2e_role",
+      value: "owner",
+      url: new URL(page.url()).origin,
+      path: "/",
+    },
+  ]);
+  await page.reload();
+}
+
 test.describe("mobile messages navigation", () => {
   test.beforeEach(async ({ page }) => {
     await mockMessagesApproval(page);
@@ -40,7 +53,7 @@ test.describe("mobile messages navigation", () => {
   });
 
   test("exposes the currently available message sections as mobile destinations", async ({ page }) => {
-    await page.goto("/messages");
+    await enableOwnerE2EUser(page);
 
     const expectedDestinations = [
       ["전송하기", "/messages/new"],
@@ -56,7 +69,9 @@ test.describe("mobile messages navigation", () => {
 
     for (const [label, href] of expectedDestinations) {
       await page.goto("/messages");
-      await page.getByRole("button", { name: label }).click();
+      const destinationButton = page.getByRole("button", { name: label });
+      await expect(destinationButton).toBeEnabled({ timeout: 15000 });
+      await destinationButton.click();
       await expect(page).toHaveURL(new RegExp(`${href}$`));
     }
   });


### PR DESCRIPTION
## Summary
- Update the contract-delete Playwright assertion to the current eformsign cancellation modal copy.
- Make the owner-only message navigation E2E fixture server-observable through an E2E-only role cookie, then wait for navigation controls to be enabled.
- Turn the system-template automation guidance card into a semantic link to `/messages/automation`.

## Root causes
- The delete test asserted text removed when the product changed from deletion to vendor cancellation.
- The E2E server layout always injected the default admin user, so browser API mocks could not grant owner-only access.
- The automation guidance card had a selector but no navigation behavior.

## Validation
- mobile type-check: passed
- mobile lint: passed with existing warnings only
- mobile production build with NEXT_PUBLIC_API_BASE_URL=http://localhost:3001: passed
- focused MessageSectionNav Jest test: 6 passed
- local focused Playwright run was blocked in global setup because this environment's login endpoint returned HTTP 201 without the expected success payload; CI remains the live E2E proof.