### PR TITLE
release: contracts register-client flow + status visual fixes

### DIFF
--- a/backend/application/services/client.service.ts
+++ b/backend/application/services/client.service.ts
@@ -143,6 +143,11 @@ export interface ClientActionRequired {
 /** The latest contract signal the document-status/active-document checks read. */
 interface LatestContractSignal {
     statusType: string;
+    permanentPurgeRequestedAt: Date | null;
+    documentId: string;
+    stepType: string | null;
+    stepName: string | null;
+    detailPayload: unknown;
 }
 
 export interface ClientActionRequiredAlert extends ClientActionRequired {
@@ -587,8 +592,6 @@ export class ClientService {
         const contractDocs = await this.prismaService.eformsign_doc.findMany({
             where: {
                 clientId: { in: clientIds },
-                permanentPurgeRequestedAt: null,
-                statusType: { notIn: [...DELETED_DOCUMENT_STATUS_TYPES] },
                 serviceRecordCaseId: null,
                 // Contract lifecycle status is an indexed projection that commits before
                 // detail/PDF artifacts finish. Do not filter it by artifact syncStatus:
@@ -604,7 +607,12 @@ export class ClientService {
             ],
             select: {
                 clientId: true,
+                documentId: true,
                 statusType: true,
+                stepType: true,
+                stepName: true,
+                detailPayload: true,
+                permanentPurgeRequestedAt: true,
                 documentKind: true,
                 serviceRecordCaseId: true,
                 templateId: true,
@@ -619,6 +627,11 @@ export class ClientService {
             if (!latestContractMap.has(doc.clientId)) {
                 latestContractMap.set(doc.clientId, {
                     statusType: doc.statusType,
+                    permanentPurgeRequestedAt: doc.permanentPurgeRequestedAt,
+                    documentId: doc.documentId,
+                    stepType: doc.stepType,
+                    stepName: doc.stepName,
+                    detailPayload: doc.detailPayload,
                 });
             }
         }
@@ -635,7 +648,9 @@ export class ClientService {
         return new Map(
             [...latestContractMap].map(([clientId, contract]) => [
                 clientId,
-                ACTIVE_DOCUMENT_STATUSES.has(this.mapStatusTypeToDocumentStatus(contract.statusType)),
+                contract.permanentPurgeRequestedAt == null
+                && !DELETED_DOCUMENT_STATUS_TYPES.has(contract.statusType.trim().padStart(3, "0"))
+                && ACTIVE_DOCUMENT_STATUSES.has(this.mapStatusTypeToDocumentStatus(contract.statusType)),
             ]),
         );
     }
@@ -1176,7 +1191,9 @@ export class ClientService {
                 clientsNeedingUpdate.push({ id: client.id, newStatus: computedStatus });
             }
             const latestContract = latestContractMap.get(client.id);
-            const documentStatus = this.mapStatusTypeToDocumentStatus(latestContract?.statusType);
+            const documentStatus = latestContract?.permanentPurgeRequestedAt != null
+                ? "deleted"
+                : this.mapStatusTypeToDocumentStatus(latestContract?.statusType);
             const hasActiveContractDocument = ACTIVE_DOCUMENT_STATUSES.has(documentStatus);
             const contractSignals = {
                 serviceStatus: computedStatus,
@@ -1693,7 +1710,7 @@ export class ClientService {
         const nextMonthStart = new Date(now.getFullYear(), now.getMonth() + 1, 1);
         const nextMonthEnd = new Date(now.getFullYear(), now.getMonth() + 2, 0, 23, 59, 59);
 
-        const [activeClients, contractsNotSent, pendingSignatureDocRows, upcomingThisMonth, upcomingNextMonth] =
+        const [activeClients, contractsNotSent, branchClients, upcomingThisMonth, upcomingNextMonth] =
             await Promise.all([
                 this.prismaService.client.count({
                     where: { serviceStatus: SERVICE_STATUS.ACTIVE, branchId: branchid },
@@ -1706,22 +1723,8 @@ export class ClientService {
                     },
                 }),
                 this.prismaService.client.findMany({
-                    where: {
-                        eDocId: { not: null },
-                        eformsignDocByEDocId: { statusType: { not: '050' } },
-                        branchId: branchid,
-                    },
-                    select: {
-                        eformsignDocByEDocId: {
-                            select: {
-                                documentId: true,
-                                statusType: true,
-                                stepType: true,
-                                stepName: true,
-                                detailPayload: true,
-                            },
-                        },
-                    },
+                    where: { branchId: branchid },
+                    select: { id: true },
                 }),
                 this.prismaService.client.count({
                     where: {
@@ -1741,9 +1744,16 @@ export class ClientService {
 
         // 대시보드의 "검토 필요 문서"는 계약서 목록과 같은 규칙으로 센다: 제공기관
         // 검토 단계에 있고 검토 창(계약 종료 영업일 1일 전~)이 열린 문서만.
-        const contractsPendingSignature = pendingSignatureDocRows.filter((row) => {
-            const doc = row.eformsignDocByEDocId;
-            if (!doc) return false;
+        const latestContracts = await this.findLatestContractByClientId(
+            branchClients.map((client) => client.id),
+        );
+        const contractsPendingSignature = [...latestContracts.values()].filter((doc) => {
+            if (
+                doc.permanentPurgeRequestedAt != null
+                || DELETED_DOCUMENT_STATUS_TYPES.has(doc.statusType.trim().padStart(3, "0"))
+            ) {
+                return false;
+            }
             const endDate = doc.detailPayload && typeof doc.detailPayload === "object"
                 ? extractEformsignContractEndDate(doc.detailPayload as unknown as EformsignApiDocumentResponse)
                 : null;

--- a/backend/application/services/eformsign-document-mirror.service.ts
+++ b/backend/application/services/eformsign-document-mirror.service.ts
@@ -12,7 +12,10 @@ import {
     LinkMirroredEformsignDocByPhoneUsecase,
 } from "application/usecases/eformsign-doc/link-mirrored-eformsign-doc-by-phone.usecase";
 import { ReconcileCompletedMirroredEformsignDocUsecase } from "application/usecases/eformsign-doc/reconcile-completed-mirrored-eformsign-doc.usecase";
-import { EFORMSIGN_COMPLETED_STATUS_CODES } from "domain/constants/eformsign-doc-status.constants";
+import {
+    EFORMSIGN_COMPLETED_STATUS_CODES,
+    isUnassignedReviewStageStatus,
+} from "domain/constants/eformsign-doc-status.constants";
 import {
     EFORMSIGN_DOCUMENT_MIRROR_REPOSITORY,
     EformsignDocumentFileType,
@@ -215,10 +218,14 @@ export class EformsignDocumentMirrorService {
             && candidate.sourceUpdatedDate.getTime()
                 === state.detailSourceUpdatedDate.getTime(),
         );
+        const canReadReviewStageDocument = fileType === "document"
+            && isUnassignedReviewStageStatus(
+                state?.detailPayload?.current_status?.status_type,
+            );
         if (
             !state?.detailPayload
             || !state.detailSourceUpdatedDate
-            || state.syncStatus !== "ready"
+            || (state.syncStatus !== "ready" && !canReadReviewStageDocument)
             || Boolean(state.permanentPurgeRequestedAt)
             || !file
         ) {

--- a/backend/application/services/eformsign-mirror-list.service.ts
+++ b/backend/application/services/eformsign-mirror-list.service.ts
@@ -15,6 +15,10 @@ import {
     type TemplateMatch,
 } from "application/utils/eformsign-document-list";
 import {
+    resolveEformsignDocDisplayStatus,
+    type EformsignDocDisplayStatus,
+} from "application/utils/eformsign-doc-display-status";
+import {
     eformsignListDocFromMirror,
     MIRROR_CUSTOMER_NAME_KEY,
     MIRROR_RECIPIENT_NAME_KEY,
@@ -36,6 +40,7 @@ export interface MirrorListQuery {
     statusCategory?: DocumentStatusCategory;
     search?: string;
     excludeDeleted?: boolean;
+    displayStatus?: EformsignDocDisplayStatus;
 }
 
 export interface MirrorListResult {
@@ -151,7 +156,11 @@ export class EformsignMirrorListService {
             scopeFiltered,
             query.statusCategory,
         );
-        const searchFiltered = filterBySearch(statusFiltered, query.search);
+        const displayStatusFiltered = query.displayStatus === undefined
+            ? statusFiltered
+            : statusFiltered.filter((document) =>
+                resolveEformsignDocDisplayStatus(document) === query.displayStatus);
+        const searchFiltered = filterBySearch(displayStatusFiltered, query.search);
 
         return { documents: sortDocumentsByCreatedDate(searchFiltered) };
     }

--- a/backend/application/services/service-record-lifecycle.service.ts
+++ b/backend/application/services/service-record-lifecycle.service.ts
@@ -298,6 +298,14 @@ export class ServiceRecordLifecycleService {
         if (params.endDate === null && record.days.length > 0) {
             throw new ConflictException({ code: "SERVICE_RECORD_END_DATE_REQUIRED" });
         }
+        if (
+            params.endDate !== undefined
+            && params.endDate !== null
+            && record.days.some((day) =>
+                day.locked && isoDate(day.serviceDate)! > isoDate(params.endDate)!)
+        ) {
+            throw new ConflictException({ code: "SERVICE_RECORD_END_DATE_BEFORE_LOCKED_SESSION" });
+        }
         if (params.duration === null && record.days.length > 0) {
             throw new ConflictException({ code: "SERVICE_RECORD_DURATION_REQUIRED" });
         }

--- a/backend/application/usecases/eformsign-doc/get-contract-client-candidate.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/get-contract-client-candidate.usecase.ts
@@ -1,0 +1,116 @@
+import { Injectable } from "@nestjs/common";
+
+import {
+    extractEformsignContractClientCandidate,
+    formatNormalizedKoreanPhone,
+    toEformsignDocumentDetail,
+} from "application/utils/eformsign-contract-client-candidate";
+import { PrismaService } from "infrastructure/database/prisma.service";
+
+/**
+ * Byte-identical copy of EformsignContractClientCandidateResponse in
+ * packages/shared/src/types/eformsign.ts. The backend build cannot import
+ * workspace TypeScript; change both declarations together.
+ */
+export interface EformsignContractClientCandidateResponse {
+    documentId: string;
+    extracted: boolean;
+    name: string | null;
+    phone: string | null;
+    address: string | null;
+    birthday: string | null;
+    dueDate: string | null;
+    startDate: string | null;
+    endDate: string | null;
+    type: string | null;
+    duration: number | null;
+    fullPrice: string | null;
+    grant: string | null;
+    actualPrice: string | null;
+    careCenter: boolean | null;
+    voucherClient: boolean;
+    breastPump: boolean;
+}
+
+/**
+ * 미연결 계약서에서 고객 등록 폼 프리필용 후보를 읽어온다.
+ * 자동 등록(LinkMirroredEformsignDocByPhoneUsecase)과 같은 추출 유틸·별칭 테이블을
+ * 사용한다. 자동 등록은 customerPhone ?? candidate ?? legacy SMS를 전화 키로
+ * 추가 사용하지만, 이 엔드포인트는 그 과정을 수행하지 않는다.
+ * 추출 실패 폴백에서는 문서 컬럼의 이름을 채우지 않고 신뢰할 수 있는
+ * customerPhone만 사용한다.
+ * Caller MUST apply the branch guard (see EformsignController.getDocumentClientCandidate)
+ * before calling; this method performs no tenant scoping.
+ */
+@Injectable()
+export class GetContractClientCandidateUsecase {
+    constructor(private readonly prisma: PrismaService) {}
+
+    async execute(
+        documentId: string,
+    ): Promise<EformsignContractClientCandidateResponse | null> {
+        const document = await this.prisma.eformsign_doc.findUnique({
+            where: { documentId },
+            select: {
+                documentId: true,
+                detailPayload: true,
+                customerName: true,
+                customerPhone: true,
+            },
+        });
+        if (!document) return null;
+
+        const detail = toEformsignDocumentDetail(document.detailPayload);
+        const candidate = detail
+            ? extractEformsignContractClientCandidate(detail)
+            : null;
+        if (!candidate) {
+            return {
+                documentId: document.documentId,
+                extracted: false,
+                name: null,
+                phone: document.customerPhone
+                    ? formatNormalizedKoreanPhone(document.customerPhone)
+                    : null,
+                address: null,
+                birthday: null,
+                dueDate: null,
+                startDate: null,
+                endDate: null,
+                type: null,
+                duration: null,
+                fullPrice: null,
+                grant: null,
+                actualPrice: null,
+                careCenter: null,
+                voucherClient: false,
+                breastPump: false,
+            };
+        }
+
+        return {
+            documentId: document.documentId,
+            extracted: true,
+            name: candidate.name,
+            phone: formatNormalizedKoreanPhone(candidate.phone),
+            address: candidate.address,
+            birthday: candidate.birthday,
+            dueDate: toDateOnly(candidate.dueDate),
+            startDate: toDateOnly(candidate.startDate),
+            endDate: toDateOnly(candidate.endDate),
+            type: candidate.type,
+            duration: candidate.duration,
+            fullPrice: candidate.fullPrice,
+            grant: candidate.grant,
+            actualPrice: candidate.actualPrice,
+            careCenter: candidate.careCenter,
+            voucherClient: candidate.voucherClient,
+            breastPump: candidate.breastPump,
+        };
+    }
+}
+
+// 추출기가 만드는 Date는 UTC 자정 기준(Date.UTC)이므로 toISOString 절단이 안전하다.
+function toDateOnly(date: Date | null): string | null {
+    return date ? date.toISOString().slice(0, 10) : null;
+}

--- a/backend/application/usecases/eformsign-doc/index.ts
+++ b/backend/application/usecases/eformsign-doc/index.ts
@@ -5,6 +5,7 @@ export * from "./find-eformsign-docs-by-client-id.usecase";
 export * from "./list-eformsign-docs.usecase";
 export * from "./list-other-branch-document-ids.usecase";
 export * from "./list-eformsign-doc-display-fields.usecase";
+export * from "./get-contract-client-candidate.usecase";
 
 // Local DB use cases - Write
 export * from "./create-eformsign-doc.usecase";

--- a/backend/application/usecases/eformsign-doc/link-mirrored-eformsign-doc-by-phone.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/link-mirrored-eformsign-doc-by-phone.usecase.ts
@@ -8,6 +8,7 @@ import { SystemSettingService } from "application/services/system-setting.servic
 import {
     extractEformsignContractClientCandidate,
     formatNormalizedKoreanPhone,
+    toEformsignDocumentDetail,
 } from "application/utils/eformsign-contract-client-candidate";
 import { extractPhoneCandidates, normalizePhone } from "application/utils/normalize-phone";
 import {
@@ -144,7 +145,7 @@ export class LinkMirroredEformsignDocByPhoneUsecase {
             return result;
         }
 
-        const detail = toDocumentDetail(document.detailPayload);
+        const detail = toEformsignDocumentDetail(document.detailPayload);
         const candidate = detail
             ? extractEformsignContractClientCandidate(detail)
             : null;
@@ -310,7 +311,7 @@ export class LinkMirroredEformsignDocByPhoneUsecase {
                         if (this.isServiceRecord(document)) return { status: "skipped" };
                         if (document.clientId !== null) return { status: "already_linked" };
 
-                        const detail = toDocumentDetail(document.detailPayload);
+                        const detail = toEformsignDocumentDetail(document.detailPayload);
                         const candidate = detail
                             ? extractEformsignContractClientCandidate(detail)
                             : null;
@@ -721,12 +722,6 @@ export class LinkMirroredEformsignDocByPhoneUsecase {
             );
         }
     }
-}
-
-function toDocumentDetail(value: Prisma.JsonValue | null): EformsignApiDocumentResponse | null {
-    return typeof value === "object" && value !== null && !Array.isArray(value)
-        ? value as unknown as EformsignApiDocumentResponse
-        : null;
 }
 
 function singleLegacyPhone(value: string, hasDetail: boolean): string | null {

--- a/backend/application/utils/eformsign-contract-client-candidate.ts
+++ b/backend/application/utils/eformsign-contract-client-candidate.ts
@@ -1,3 +1,5 @@
+import { Prisma } from "@prisma/client";
+
 import {
     documentCustomerNameValue,
     isRecord,
@@ -23,6 +25,14 @@ export interface EformsignContractClientCandidate {
     careCenter: boolean | null;
     voucherClient: boolean;
     breastPump: boolean;
+}
+
+export function toEformsignDocumentDetail(
+    value: Prisma.JsonValue | null,
+): EformsignApiDocumentResponse | null {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+        ? (value as unknown as EformsignApiDocumentResponse)
+        : null;
 }
 
 const FIELD_ID_KEYS = [

--- a/backend/application/utils/eformsign-doc-display-status.ts
+++ b/backend/application/utils/eformsign-doc-display-status.ts
@@ -32,8 +32,19 @@ const SUBTRACT_BUSINESS_DAY_SEARCH_LIMIT = 30;
 function parseYmdToUtc(ymd: string): Date | null {
     const match = YMD_PATTERN.exec(ymd);
     if (!match) return null;
-    const parsed = new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])));
-    return Number.isNaN(parsed.getTime()) ? null : parsed;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const parsed = new Date(Date.UTC(year, month - 1, day));
+    if (
+        Number.isNaN(parsed.getTime())
+        || parsed.getUTCFullYear() !== year
+        || parsed.getUTCMonth() !== month - 1
+        || parsed.getUTCDate() !== day
+    ) {
+        return null;
+    }
+    return parsed;
 }
 
 /** Step back `days` Korean business days (weekends AND KR holidays skipped). */

--- a/backend/domain/constants/eformsign-doc-status.constants.ts
+++ b/backend/domain/constants/eformsign-doc-status.constants.ts
@@ -1,3 +1,5 @@
+import { normalizeEformsignStatusCode } from "domain/utils/eformsign-status-code";
+
 export const EFORMSIGN_COMPLETED_STATUS_CODES: ReadonlySet<string> = new Set([
     "003",
     "012",
@@ -64,6 +66,14 @@ export const TERMINAL_STATUS_CODES = new Set<string>([
  * re-mirrors a document that already has a local row.
  */
 export const UNASSIGNED_REVIEW_STAGE_STATUS_CODES = new Set<string>(["062", "071"]);
+
+export function isUnassignedReviewStageStatus(
+    statusType: string | number | null | undefined,
+): boolean {
+    return UNASSIGNED_REVIEW_STAGE_STATUS_CODES.has(
+        normalizeEformsignStatusCode(statusType),
+    );
+}
 
 /**
  * Canonical review-stage codes plus raw values written by older vendor-ingestion paths.

--- a/backend/infrastructure/database/repositories/sb.eformsign-document-mirror.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.eformsign-document-mirror.repository.ts
@@ -4,6 +4,7 @@ import { Prisma } from "@prisma/client";
 import {
     EFORMSIGN_COMPLETED_STATUS_STORAGE_VALUES,
     UNASSIGNED_TERMINAL_STATUS_CODES,
+    isUnassignedReviewStageStatus,
 } from "domain/constants/eformsign-doc-status.constants";
 import {
     EformsignDocumentFileType,
@@ -98,9 +99,14 @@ implements IEformsignDocumentMirrorRepository {
             },
         });
         const row = document?.files[0];
+        const canReadReviewStageDocument = fileType === "document"
+            && isUnassignedReviewStageStatus(
+                (document?.detailPayload as EformsignApiDocumentResponse | null)
+                    ?.current_status?.status_type,
+            );
         if (!document?.detailPayload
             || !document.detailSourceUpdatedDate
-            || document.syncStatus !== "ready"
+            || (document.syncStatus !== "ready" && !canReadReviewStageDocument)
             || Boolean(document.permanentPurgeRequestedAt)
             || !row
             || row.sourceUpdatedDate.getTime() !== document.detailSourceUpdatedDate.getTime()) {

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -128,6 +128,12 @@ function parseTemplateMatch(value: string | undefined): TemplateMatch {
     throw new BadRequestException("templateMatch must be include or exclude");
 }
 
+function parseDisplayStatus(value: string | undefined): EformsignDocDisplayStatus | undefined {
+    if (value === undefined || value === "") return undefined;
+    if (value === "signed" || value === "review") return value;
+    throw new BadRequestException("displayStatus must be signed or review");
+}
+
 function shouldExcludeSnapshotTombstones(
     scope: string,
     excludeDeleted: boolean | undefined,
@@ -211,6 +217,7 @@ export class EformsignController {
         statusCategory?: DocumentStatusCategory;
         search?: string;
         excludeDeleted?: boolean;
+        displayStatus?: EformsignDocDisplayStatus;
     }) {
         // Through the same snapshot the API path uses. Not for the vendor calls it saves —
         // there are none here — but because pagination has to walk one generation: a
@@ -468,6 +475,7 @@ export class EformsignController {
         @Query("statusCategory") statusCategoryValue?: string,
         @Query("search") search?: string,
         @Query("excludeDeleted") excludeDeletedValue?: string,
+        @Query("displayStatus") displayStatusValue?: string,
     ) {
         try {
             const parsedLimit = parseInteger(limit, "limit", { defaultValue: 100, min: 1, max: 100 });
@@ -475,6 +483,7 @@ export class EformsignController {
             const templateMatch = parseTemplateMatch(templateMatchValue);
             const statusCategory = parseStatusCategory(statusCategoryValue);
             const excludeDeleted = excludeDeletedValue === "true";
+            const displayStatus = parseDisplayStatus(displayStatusValue);
             const branchId = tenant.branchId ?? "";
 
             const isHeadquarters = await this.isHeadquartersBranch(branchId);
@@ -489,6 +498,7 @@ export class EformsignController {
                 statusCategory,
                 search,
                 excludeDeleted,
+                displayStatus,
             });
         } catch (error) {
             throwHttpOrInternalError(error);

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -30,6 +30,7 @@ import {
 } from "application/services/eformsign-mirror-list.service";
 import { EformsignDocumentMirrorService } from "application/services/eformsign-document-mirror.service";
 import { EformsignPermanentPurgeRequest } from "domain/repositories/eformsign-document-mirror.repository.interface";
+import { GetContractClientCandidateUsecase } from "application/usecases/eformsign-doc/get-contract-client-candidate.usecase";
 import {
     EformsignApiError,
     isEformsignDocumentAbsentError,
@@ -197,6 +198,7 @@ export class EformsignController {
         private readonly documentSnapshotService: EformsignDocumentSnapshotService,
         private readonly mirrorListService: EformsignMirrorListService,
         private readonly documentMirrorService: EformsignDocumentMirrorService,
+        private readonly getContractClientCandidateUsecase: GetContractClientCandidateUsecase,
     ) { }
 
     /**
@@ -828,6 +830,42 @@ export class EformsignController {
                 });
             }
             return document;
+        } catch (error) {
+            throwHttpOrInternalError(error);
+        }
+    }
+
+    /**
+     * Client-registration candidate extracted from a contract's stored detail.
+     * Mirrors the auto-registration extraction so manual and automatic
+     * registration always agree on the pre-filled values.
+     */
+    @Get("documents/:documentId/client-candidate")
+    async getDocumentClientCandidate(
+        @CurrentTenant() tenant: { branchId?: string },
+        @Param("documentId") documentId: string,
+    ) {
+        try {
+            const allowedDocuments = await this.filterDocumentsByBranch(
+                tenant.branchId ?? "",
+                [{ id: documentId }],
+            );
+            if (allowedDocuments.length === 0) {
+                throw new HttpException(
+                    { error: "Document access forbidden" },
+                    HttpStatus.FORBIDDEN,
+                );
+            }
+
+            const candidate =
+                await this.getContractClientCandidateUsecase.execute(documentId);
+            if (!candidate) {
+                throw new HttpException(
+                    { error: "Document not found" },
+                    HttpStatus.NOT_FOUND,
+                );
+            }
+            return candidate;
         } catch (error) {
             throwHttpOrInternalError(error);
         }

--- a/backend/module/eformsign-doc.module.ts
+++ b/backend/module/eformsign-doc.module.ts
@@ -23,6 +23,7 @@ import {
     MirrorUnassignedEformsignDocUsecase,
     BackfillEformsignDocsUsecase,
     LinkMirroredEformsignDocByPhoneUsecase,
+    GetContractClientCandidateUsecase,
 } from "application/usecases/eformsign-doc";
 import { EFORMSIGN_DOC_REPOSITORY } from "domain/repositories/eformsign-doc.repository.interface";
 import { EFORMSIGN_CLIENT_REPOSITORY } from "domain/repositories/eformsign.client.interface";
@@ -92,6 +93,7 @@ import { ReconcileCompletedMirroredEformsignDocUsecase } from "application/useca
         AdoptEformsignDocUsecase,
         MirrorUnassignedEformsignDocUsecase,
         LinkMirroredEformsignDocByPhoneUsecase,
+        GetContractClientCandidateUsecase,
         ReconcileCompletedMirroredEformsignDocUsecase,
         BackfillEformsignDocsUsecase,
         // Services
@@ -147,6 +149,7 @@ import { ReconcileCompletedMirroredEformsignDocUsecase } from "application/useca
         EformsignMirrorReadinessService,
         ReconcileCompletedMirroredEformsignDocUsecase,
         LinkMirroredEformsignDocByPhoneUsecase,
+        GetContractClientCandidateUsecase,
     ],
 })
 export class EformsignDocModule {}

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { AreaTemplateService } from "application/services/area-template.service";
 import { EformsignDocService } from "application/services/eformsign-doc.service";
 import { EformsignService } from "application/services/eformsign.service";
+import { GetContractClientCandidateUsecase } from "application/usecases/eformsign-doc/get-contract-client-candidate.usecase";
 import { PrismaService } from "infrastructure/database/prisma.service";
 import { JwtGuard } from "infrastructure/auth/jwt.guard";
 import { TenantGuard } from "infrastructure/tenant";
@@ -54,6 +55,10 @@ describe("EformsignController (Integration)", () => {
         | "findDisplayFieldsByDocumentIds"
     >>;
     let assignmentGuard: jest.Mocked<Pick<ContractClientAssignmentGuardService, "assertAssignedProvider">>;
+    let getContractClientCandidateUsecase: jest.Mocked<Pick<
+        GetContractClientCandidateUsecase,
+        "execute"
+    >>;
     let branchFindUnique: jest.Mock;
 
     const authGuard = {
@@ -158,6 +163,10 @@ describe("EformsignController (Integration)", () => {
                         assertAssignedProvider: jest.fn().mockResolvedValue({ scheduleId: 1 }),
                     },
                 },
+                {
+                    provide: GetContractClientCandidateUsecase,
+                    useValue: { execute: jest.fn() },
+                },
                 // 실제 구현을 그대로 쓴다. VALKEY_URL이 없는 테스트 환경에서는 프로세스
                 // 로컬 in-memory 스토어로 동작하고, 인스턴스는 테스트마다 새로 만들어진다.
                 EformsignDocumentSnapshotService,
@@ -196,6 +205,7 @@ describe("EformsignController (Integration)", () => {
         areaTemplateService = moduleFixture.get(AreaTemplateService);
         eformsignDocService = moduleFixture.get(EformsignDocService);
         assignmentGuard = moduleFixture.get(ContractClientAssignmentGuardService);
+        getContractClientCandidateUsecase = moduleFixture.get(GetContractClientCandidateUsecase);
         branchFindUnique = (moduleFixture.get(PrismaService) as unknown as { branch: { findUnique: jest.Mock } }).branch.findUnique;
         // default: a non-incheon branch, so per-branch filtering applies
         branchFindUnique.mockResolvedValue({ slug: "gimpo" });
@@ -792,6 +802,51 @@ describe("EformsignController (Integration)", () => {
         expect(eformsignService.getDocumentById).not.toHaveBeenCalled();
     });
 
+    it("forbids a foreign-branch document client candidate without calling the usecase", async () => {
+        eformsignDocService.findAll.mockResolvedValue([
+            { documentId: "branch-1-doc" },
+        ] as any);
+
+        const response = await request(app.getHttpServer())
+            .get("/api/documents/other-branch-doc/client-candidate");
+
+        expect(response.status).toBe(403);
+        expect(getContractClientCandidateUsecase.execute).not.toHaveBeenCalled();
+    });
+
+    it("returns the client candidate for an allowed document", async () => {
+        const candidate = {
+            documentId: "branch-1-doc",
+            extracted: true,
+            name: "홍길동",
+            phone: "010-1234-5678",
+            address: "서울시 강남구",
+            birthday: "900101",
+            dueDate: "2026-07-20",
+            startDate: "2026-08-10",
+            endDate: "2026-08-24",
+            type: "A-가형",
+            duration: 10,
+            fullPrice: "1234000",
+            grant: "900000",
+            actualPrice: "334000",
+            careCenter: true,
+            voucherClient: true,
+            breastPump: false,
+        };
+        eformsignDocService.findAll.mockResolvedValue([
+            { documentId: "branch-1-doc" },
+        ] as any);
+        getContractClientCandidateUsecase.execute.mockResolvedValue(candidate);
+
+        const response = await request(app.getHttpServer())
+            .get("/api/documents/branch-1-doc/client-candidate");
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(candidate);
+        expect(getContractClientCandidateUsecase.execute).toHaveBeenCalledWith("branch-1-doc");
+    });
+
     describe("local source-of-truth document reads", () => {
         let mirrorApp: INestApplication;
         const mirrorRepository = {
@@ -856,6 +911,10 @@ describe("EformsignController (Integration)", () => {
                     {
                         provide: ContractClientAssignmentGuardService,
                         useValue: { assertAssignedProvider: jest.fn() },
+                    },
+                    {
+                        provide: GetContractClientCandidateUsecase,
+                        useValue: { execute: jest.fn() },
                     },
                     EformsignDocumentSnapshotService,
                     {

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -797,12 +797,15 @@ describe("EformsignController (Integration)", () => {
         const mirrorRepository = {
             findAllVisibleInMirror: jest.fn().mockResolvedValue([]),
             findAllVisibleInMirrorForHeadquarters: jest.fn().mockResolvedValue([]),
+            findContractEndDatesByDocumentIds: jest.fn().mockResolvedValue(new Map()),
         };
 
         const createMirrorRow = (overrides: {
             documentId: string;
             createdDate?: string;
             statusType?: string;
+            stepType?: string;
+            stepName?: string;
             customerName?: string | null;
         }) => {
             const createdDate = new Date(overrides.createdDate ?? "2026-07-01T00:00:00.000Z");
@@ -822,9 +825,9 @@ describe("EformsignController (Integration)", () => {
                 updatedDate: createdDate,
                 statusType: overrides.statusType ?? "060",
                 statusDetail: "서명 요청됨",
-                stepType: "01",
+                stepType: overrides.stepType ?? "01",
                 stepIndex: "1",
-                stepName: "이용자 서명",
+                stepName: overrides.stepName ?? "이용자 서명",
                 stepRecipientType: "05",
                 stepRecipientName: "송진호",
                 stepRecipientSms: "01012345678",
@@ -969,6 +972,41 @@ describe("EformsignController (Integration)", () => {
             expect(eformsignService.getInProgressDocuments).not.toHaveBeenCalled();
             expect(eformsignService.getCompletedDocuments).not.toHaveBeenCalled();
             expect(eformsignService.getRejectedDocuments).not.toHaveBeenCalled();
+        });
+
+        it("filters display status before slicing the page", async () => {
+            mirrorRepository.findAllVisibleInMirror.mockResolvedValue([
+                createMirrorRow({
+                    documentId: "newer-pending",
+                    createdDate: "2026-07-03T00:00:00.000Z",
+                    statusType: "060",
+                }),
+                createMirrorRow({
+                    documentId: "older-review",
+                    createdDate: "2026-07-02T00:00:00.000Z",
+                    statusType: "070",
+                    stepType: "06",
+                    stepName: "제공기관 확인",
+                }),
+            ]);
+
+            const response = await request(mirrorApp.getHttpServer())
+                .get("/api/documents?displayStatus=review&limit=1&skip=0");
+
+            expect(response.status).toBe(200);
+            expect(response.body.documents.map((doc: { id: string }) => doc.id)).toEqual([
+                "older-review",
+            ]);
+            expect(response.body.total_rows).toBe(1);
+            expect(response.body.has_more).toBe(false);
+        });
+
+        it("rejects unsupported display-status filters", async () => {
+            const response = await request(mirrorApp.getHttpServer())
+                .get("/api/documents?displayStatus=unexpected");
+
+            expect(response.status).toBe(400);
+            expect(response.body.message).toBe("displayStatus must be signed or review");
         });
 
         it("keeps a stale tombstone in unfiltered all reads but fences it from deletion-aware filters", async () => {

--- a/backend/test/repositories/sb.eformsign-document-mirror.repository.spec.ts
+++ b/backend/test/repositories/sb.eformsign-document-mirror.repository.spec.ts
@@ -96,6 +96,26 @@ describe("SbEformsignDocumentMirrorRepository", () => {
                         files: [file],
                     })
                     .mockResolvedValueOnce({
+                        detailPayload: {
+                            id: "doc-1",
+                            current_status: { status_type: "062" },
+                        },
+                        detailSourceUpdatedDate: detailVersion,
+                        syncStatus: "partial",
+                        permanentPurgeRequestedAt: null,
+                        files: [file],
+                    })
+                    .mockResolvedValueOnce({
+                        detailPayload: {
+                            id: "doc-1",
+                            current_status: { status_type: "062" },
+                        },
+                        detailSourceUpdatedDate: detailVersion,
+                        syncStatus: "partial",
+                        permanentPurgeRequestedAt: null,
+                        files: [{ ...file, fileType: "audit_trail" }],
+                    })
+                    .mockResolvedValueOnce({
                         detailPayload: { id: "doc-1" },
                         detailSourceUpdatedDate: detailVersion,
                         syncStatus: "ready",
@@ -112,6 +132,10 @@ describe("SbEformsignDocumentMirrorRepository", () => {
         await expect(repository.findFile("doc-1", "document")).resolves.toBeNull();
         await expect(repository.findFile("doc-1", "document")).resolves.toBeNull();
         await expect(repository.findFile("doc-1", "document")).resolves.toBeNull();
+        await expect(repository.findFile("doc-1", "document")).resolves.toMatchObject({
+            content: Buffer.from("pdf"),
+        });
+        await expect(repository.findFile("doc-1", "audit_trail")).resolves.toBeNull();
         await expect(repository.findFile("doc-1", "document")).resolves.toBeNull();
     });
 

--- a/backend/test/services/client.service.spec.ts
+++ b/backend/test/services/client.service.spec.ts
@@ -73,6 +73,7 @@ describe("ClientService", () => {
                 ),
             },
             client: {
+                count: jest.fn().mockResolvedValue(0),
                 update: jest.fn(),
                 updateMany: jest.fn().mockResolvedValue({ count: 1 }),
                 findUnique: jest.fn().mockResolvedValue(null),
@@ -1901,8 +1902,6 @@ describe("ClientService", () => {
                 expect(prismaService.eformsign_doc.findMany).toHaveBeenCalledWith({
                     where: {
                         clientId: { in: [1] },
-                        permanentPurgeRequestedAt: null,
-                        statusType: { notIn: ["047", "049", "099"] },
                         serviceRecordCaseId: null,
                         OR: [
                             { documentKind: "contract" },
@@ -1915,7 +1914,12 @@ describe("ClientService", () => {
                     ],
                     select: {
                         clientId: true,
+                        documentId: true,
                         statusType: true,
+                        stepType: true,
+                        stepName: true,
+                        detailPayload: true,
+                        permanentPurgeRequestedAt: true,
                         documentKind: true,
                         serviceRecordCaseId: true,
                         templateId: true,
@@ -1938,6 +1942,20 @@ describe("ClientService", () => {
                 // "060"/requested is itself an active document, so no badge either way.
                 expect(result?.documentStatus).toBe("requested");
                 expect(result?.badges.some((badge) => badge.key === "contract_required")).toBe(false);
+            });
+
+            it("should not fall back to an older completed contract when the newest contract is deleted", async () => {
+                const client = createWaitingClient("2026-07-16", "deleted-document");
+                listClientsUsecase.execute.mockResolvedValue([client]);
+                prismaService.eformsign_doc.findMany.mockResolvedValue([
+                    { clientId: 1, statusType: "049", permanentPurgeRequestedAt: null },
+                    { clientId: 1, statusType: "003", permanentPurgeRequestedAt: null },
+                ]);
+
+                const [result] = await service.findAll(branchId);
+
+                expect(result?.documentStatus).toBe("deleted");
+                expect(result?.badges.some((badge) => badge.key === "contract_required")).toBe(true);
             });
 
             it("should ignore legacy service-record rows when choosing the latest contract", async () => {
@@ -1996,8 +2014,6 @@ describe("ClientService", () => {
                 expect(prismaService.eformsign_doc.findMany).toHaveBeenCalledWith({
                     where: {
                         clientId: { in: [1] },
-                        permanentPurgeRequestedAt: null,
-                        statusType: { notIn: ["047", "049", "099"] },
                         serviceRecordCaseId: null,
                         OR: [
                             { documentKind: "contract" },
@@ -2010,7 +2026,12 @@ describe("ClientService", () => {
                     ],
                     select: {
                         clientId: true,
+                        documentId: true,
                         statusType: true,
+                        stepType: true,
+                        stepName: true,
+                        detailPayload: true,
+                        permanentPurgeRequestedAt: true,
                         documentKind: true,
                         serviceRecordCaseId: true,
                         templateId: true,
@@ -2766,6 +2787,31 @@ describe("ClientService", () => {
             // Assert
             expect(result.data).toHaveLength(0);
             expect(result.total).toBe(0);
+        });
+    });
+
+    describe("getStats", () => {
+        it("counts review-needed state from each client's latest contract instead of the pinned eDocId", async () => {
+            prismaService.client.count.mockResolvedValue(0);
+            prismaService.client.findMany.mockResolvedValue([{ id: 1 }]);
+            prismaService.eformsign_doc.findMany.mockResolvedValue([
+                {
+                    clientId: 1,
+                    documentId: "latest-contract",
+                    statusType: "070",
+                    stepType: "06",
+                    stepName: "제공기관 확인",
+                    detailPayload: null,
+                    permanentPurgeRequestedAt: null,
+                    documentKind: "contract",
+                    serviceRecordCaseId: null,
+                    templateId: null,
+                },
+            ]);
+
+            const result = await service.getStats(branchId);
+
+            expect(result.contractsPendingSignature).toBe(1);
         });
     });
 

--- a/backend/test/services/eformsign-document-mirror.service.spec.ts
+++ b/backend/test/services/eformsign-document-mirror.service.spec.ts
@@ -1598,6 +1598,48 @@ describe("EformsignDocumentMirrorService", () => {
         expect(repository.findFile).not.toHaveBeenCalled();
     });
 
+    it("returns current document PDF metadata during the unassigned review stage", async () => {
+        const sourceUpdatedDate = new Date(UPDATED_AT);
+        const detail = richDetail();
+        detail.current_status.status_type = "062";
+        const repository = {
+            findState: jest.fn().mockResolvedValue({
+                documentId: "doc-1",
+                branchId: "branch-1",
+                detailPayload: detail,
+                detailSourceUpdatedDate: sourceUpdatedDate,
+                detailSyncedAt: sourceUpdatedDate,
+                syncStatus: "partial",
+                syncError: "audit trail unavailable before provider review",
+                permanentPurgeRequestedAt: null,
+                files: [{
+                    fileType: "document",
+                    contentType: "application/pdf",
+                    contentDisposition: "inline",
+                    byteSize: PDF.length,
+                    sha256: "hash",
+                    sourceUpdatedDate,
+                    syncedAt: sourceUpdatedDate,
+                }],
+            }),
+            findFile: jest.fn(),
+        };
+        const service = new EformsignDocumentMirrorService(
+            {} as never,
+            repository as never,
+            {} as never,
+            {} as never,
+            {} as never,
+        );
+
+        await expect(service.getStoredFileMetadata("doc-1", "document"))
+            .resolves.toMatchObject({
+                status: 200,
+                contentType: "application/pdf",
+                byteSize: PDF.length,
+            });
+    });
+
     it("repairs an integrity-failed current version with both PDFs", async () => {
         const detail = richDetail();
         const previousAttempt = new Date(UPDATED_AT);

--- a/backend/test/services/service-record-lifecycle.service.spec.ts
+++ b/backend/test/services/service-record-lifecycle.service.spec.ts
@@ -504,6 +504,26 @@ describe("ServiceRecordLifecycleService", () => {
         })).resolves.toBeUndefined();
     });
 
+    it("rejects shortening the period before a locked service day", async () => {
+        const prisma = {
+            service_record_case: {
+                findUnique: jest.fn().mockResolvedValue({
+                    status: SERVICE_RECORD_CASE_STATUS.IN_PROGRESS,
+                    startDate: date("2026-07-01"),
+                    endDate: date("2026-07-20"),
+                    requiredSessionCount: 10,
+                    days: [{ serviceDate: date("2026-07-12"), locked: true }],
+                }),
+            },
+        };
+        const service = new ServiceRecordLifecycleService(prisma as unknown as PrismaService);
+
+        await expectConflict(
+            service.validatePeriodChange({ clientId: 1, endDate: date("2026-07-11") }),
+            "SERVICE_RECORD_END_DATE_BEFORE_LOCKED_SESSION",
+        );
+    });
+
     it("does not allow clearing or reducing the contracted session count after recording starts", async () => {
         const prisma = {
             service_record_case: {

--- a/backend/test/usecases/eformsign-doc/get-contract-client-candidate.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/get-contract-client-candidate.usecase.spec.ts
@@ -1,0 +1,184 @@
+import { GetContractClientCandidateUsecase } from "application/usecases/eformsign-doc/get-contract-client-candidate.usecase";
+import { PrismaService } from "infrastructure/database/prisma.service";
+
+describe("GetContractClientCandidateUsecase", () => {
+    const findUnique = jest.fn();
+    const prisma = {
+        eformsign_doc: { findUnique },
+    } as unknown as PrismaService;
+
+    let usecase: GetContractClientCandidateUsecase;
+
+    beforeEach(() => {
+        usecase = new GetContractClientCandidateUsecase(prisma);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("문서가 없으면 null을 반환한다", async () => {
+        findUnique.mockResolvedValue(null);
+        await expect(usecase.execute("doc-missing")).resolves.toBeNull();
+        expect(findUnique).toHaveBeenCalledWith({
+            where: { documentId: "doc-missing" },
+            select: {
+                documentId: true,
+                detailPayload: true,
+                customerName: true,
+                customerPhone: true,
+            },
+        });
+    });
+
+    it("detail payload에서 후보를 추출해 직렬화한다", async () => {
+        findUnique.mockResolvedValue({
+            documentId: "doc-1",
+            customerName: null,
+            customerPhone: null,
+            detailPayload: {
+                id: "doc-1",
+                fields: [
+                    { id: "이용자 성명", value: "홍길동", type: "text" },
+                    { id: "이용자 연락처", value: "010-1234-5678", type: "text" },
+                    { id: "이용자 주소", value: "서울시 강남구", type: "text" },
+                    { id: "이용자 생년월일", value: "900101", type: "text" },
+                    { id: "출산 예정일", value: "2026-07-20", type: "text" },
+                    { id: "계약 시작일", value: "2026-08-10", type: "text" },
+                    { id: "계약 종료일", value: "2026-08-24", type: "text" },
+                    { id: "바우처 유형", value: "A-가형", type: "text" },
+                    { id: "바우처 기간", value: "10일", type: "text" },
+                    { id: "총 서비스 금액", value: "1,234,000원", type: "text" },
+                    { id: "정부지원금", value: "900,000원", type: "text" },
+                    { id: "본인부담금", value: "334,000원", type: "text" },
+                    { id: "산후조리원 이용", value: "예", type: "text" },
+                    { id: "바우처 여부", value: "예", type: "text" },
+                    { id: "유축기", value: "아니오", type: "text" },
+                ],
+                recipients: [{
+                    recipient_type: "02",
+                    name: "홍길동",
+                    sms: "010-1234-5678",
+                }],
+            },
+        });
+
+        const result = await usecase.execute("doc-1");
+
+        expect(result).toEqual({
+            documentId: "doc-1",
+            extracted: true,
+            name: "홍길동",
+            phone: "010-1234-5678",
+            address: "서울시 강남구",
+            birthday: "900101",
+            dueDate: "2026-07-20",
+            startDate: "2026-08-10",
+            endDate: "2026-08-24",
+            type: "A-가형",
+            duration: 10,
+            fullPrice: "1234000",
+            grant: "900000",
+            actualPrice: "334000",
+            careCenter: true,
+            voucherClient: true,
+            breastPump: false,
+        });
+    });
+
+    it("payload가 없으면 문서 컬럼 폴백을 반환한다", async () => {
+        findUnique.mockResolvedValue({
+            documentId: "doc-2",
+            customerName: "김산모",
+            customerPhone: "01098765432",
+            detailPayload: null,
+        });
+
+        const result = await usecase.execute("doc-2");
+
+        expect(result).toEqual({
+            documentId: "doc-2",
+            extracted: false,
+            name: null,
+            phone: "010-9876-5432",
+            address: null,
+            birthday: null,
+            dueDate: null,
+            startDate: null,
+            endDate: null,
+            type: null,
+            duration: null,
+            fullPrice: null,
+            grant: null,
+            actualPrice: null,
+            careCenter: null,
+            voucherClient: false,
+            breastPump: false,
+        });
+    });
+
+    it("detail payload가 있어도 고객 후보를 추출하지 못하면 전화만 폴백한다", async () => {
+        findUnique.mockResolvedValue({
+            documentId: "doc-3",
+            customerName: "관리사 이름",
+            customerPhone: "01011112222",
+            detailPayload: {
+                fields: [{ id: "이용자 성명", value: "홍길동" }],
+                recipients: [{ recipient_type: "01", name: "관리사", sms: "01033334444" }],
+            },
+        });
+
+        const result = await usecase.execute("doc-3");
+
+        expect(result).toEqual({
+            documentId: "doc-3",
+            extracted: false,
+            name: null,
+            phone: "010-1111-2222",
+            address: null,
+            birthday: null,
+            dueDate: null,
+            startDate: null,
+            endDate: null,
+            type: null,
+            duration: null,
+            fullPrice: null,
+            grant: null,
+            actualPrice: null,
+            careCenter: null,
+            voucherClient: false,
+            breastPump: false,
+        });
+    });
+
+    it("detail payload가 배열이면 문서 컬럼 폴백을 반환한다", async () => {
+        findUnique.mockResolvedValue({
+            documentId: "doc-4",
+            customerName: "직원 이름",
+            customerPhone: "01055556666",
+            detailPayload: [],
+        });
+
+        const result = await usecase.execute("doc-4");
+
+        expect(result).toEqual({
+            documentId: "doc-4",
+            extracted: false,
+            name: null,
+            phone: "010-5555-6666",
+            address: null,
+            birthday: null,
+            dueDate: null,
+            startDate: null,
+            endDate: null,
+            type: null,
+            duration: null,
+            fullPrice: null,
+            grant: null,
+            actualPrice: null,
+            careCenter: null,
+            voucherClient: false,
+            breastPump: false,
+        });
+    });
+});

--- a/backend/test/utils/eformsign-doc-display-status.spec.ts
+++ b/backend/test/utils/eformsign-doc-display-status.spec.ts
@@ -57,6 +57,8 @@ describe("isContractReviewWindowOpen (backend copy)", () => {
         expect(isContractReviewWindowOpen(undefined, kstNoon("2026-08-01"))).toBe(true);
         expect(isContractReviewWindowOpen("", kstNoon("2026-08-01"))).toBe(true);
         expect(isContractReviewWindowOpen("nonsense", kstNoon("2026-08-01"))).toBe(true);
+        expect(isContractReviewWindowOpen("2026-02-31", kstNoon("2026-02-01"))).toBe(true);
+        expect(isContractReviewWindowOpen("2026-13-01", kstNoon("2026-02-01"))).toBe(true);
     });
 });
 

--- a/docs/superpowers/plans/2026-08-03-register-client-from-contract.md
+++ b/docs/superpowers/plans/2026-08-03-register-client-from-contract.md
@@ -1,0 +1,858 @@
+# 계약서 상세 more-menu → 고객 등록 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 계약서 상세 패널 more-menu에 "고객 등록" 항목을 추가해, 미연결(clientId 없음) 계약서에서 계약 상세를 프리필한 ClientFormDialog로 고객을 등록할 수 있게 한다.
+
+**Architecture:** 백엔드에 조회 전용 후보 엔드포인트(`GET /api/documents/:documentId/client-candidate`)를 추가하고, 기존 검증된 추출 유틸 `extractEformsignContractClientCandidate()`를 재사용한다. 프론트는 프록시 라우트 + api 메서드 + 훅으로 후보를 받아 `ClientFormDialog`의 새 `prefill` prop(생성 모드 전용)에 넣는다. 등록 후 연결은 기존 전화번호 기반 자동 연결(`client.service.ts` → `linkContractDocumentsByPhone`)이 담당하므로 연결 로직 변경은 없다.
+
+**Tech Stack:** NestJS + Prisma (backend), Next.js App Router + TanStack Query (frontend), Jest (양쪽), pnpm monorepo (`packages/shared` 공유 타입).
+
+**Spec:** `docs/superpowers/specs/2026-08-03-register-client-from-contract-design.md`
+
+## Global Constraints
+
+- 계약서 연결 로직(백엔드 phone-link)은 변경하지 않는다. `eDocId`를 생성 DTO에 직접 넣지 않는다.
+- 메뉴 항목은 미연결 계약서(`documentClientSummary?.clientId`가 없음)에서만, 그리고 산모 계약서 섹션에서만 표시한다 (서비스 제공기록지 섹션 제외).
+- 후보 추출이 실패해도 폼은 열려야 한다 (customerName/customerPhone 폴백).
+- data-component 네이밍 컨벤션 준수 (기존 `${dataComponent}_header_stepper-actions_more-menu_content_*` 패턴 따름).
+- 커밋 메시지 트레일러: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` + `Claude-Session: https://claude.ai/code/session_01WWoR7ZzVPvhtHDS6H9n9ga`
+- 검증 명령: backend `npm run type-check` + `npx jest test/usecases/eformsign-doc/get-contract-client-candidate.usecase.spec.ts`, frontend `npm run type-check` + `npx jest src/lib/client/__tests__/contract-client-prefill.test.ts` (각 워크스페이스 디렉토리에서 실행).
+
+---
+
+### Task 1: 공유 타입 + 백엔드 후보 usecase + 컨트롤러 엔드포인트
+
+- **Tier**: standard
+- **Sandbox**: local
+- **Paths**: `packages/shared/src/types/eformsign.ts`, `backend/application/usecases/eformsign-doc/get-contract-client-candidate.usecase.ts`, `backend/application/usecases/eformsign-doc/index.ts`, `backend/module/eformsign-doc.module.ts`, `backend/interface/controllers/eformsign.controller.ts`, `backend/test/usecases/eformsign-doc/get-contract-client-candidate.usecase.spec.ts`
+- **Depends**: —
+
+**Files:**
+- Modify: `packages/shared/src/types/eformsign.ts` (line 228 뒤, `EformsignDocClientSummary` 다음)
+- Create: `backend/application/usecases/eformsign-doc/get-contract-client-candidate.usecase.ts`
+- Modify: `backend/application/usecases/eformsign-doc/index.ts` (barrel export 추가)
+- Modify: `backend/module/eformsign-doc.module.ts` (providers + exports에 usecase 추가 — `LinkMirroredEformsignDocByPhoneUsecase`가 등록된 위치 참조: providers ~line 94, exports ~line 149)
+- Modify: `backend/interface/controllers/eformsign.controller.ts` (constructor ~line 191-200, 신규 라우트는 `getDocumentById` 뒤 ~line 835)
+- Test: `backend/test/usecases/eformsign-doc/get-contract-client-candidate.usecase.spec.ts`
+
+**Interfaces:**
+- Consumes: `extractEformsignContractClientCandidate(document)`, `formatNormalizedKoreanPhone(phone)` (`backend/application/utils/eformsign-contract-client-candidate.ts:404, 526`), `PrismaService`
+- Produces: 공유 타입 `EformsignContractClientCandidateResponse` (Task 2, 3이 import), usecase `GetContractClientCandidateUsecase.execute(documentId: string): Promise<EformsignContractClientCandidateResponse | null>`, HTTP `GET /api/documents/:documentId/client-candidate` (JwtGuard + TenantGuard, 지점 스코프)
+
+- [ ] **Step 1: 공유 응답 타입 추가**
+
+`packages/shared/src/types/eformsign.ts`의 `EformsignDocClientSummary`(lines 222-228) 바로 뒤에 추가:
+
+```typescript
+/**
+ * 계약서 detail payload에서 추출한 고객 등록 후보.
+ * extracted=false면 추출 실패 폴백 — 문서 컬럼의 이름/전화만 담긴다.
+ * 날짜는 모두 YYYY-MM-DD, phone은 대시 포함 표기(예: 010-1234-5678).
+ */
+export interface EformsignContractClientCandidateResponse {
+    documentId: string;
+    extracted: boolean;
+    name: string | null;
+    phone: string | null;
+    address: string | null;
+    birthday: string | null;
+    dueDate: string | null;
+    startDate: string | null;
+    endDate: string | null;
+    type: string | null;
+    duration: number | null;
+    fullPrice: string | null;
+    grant: string | null;
+    actualPrice: string | null;
+    careCenter: boolean | null;
+    voucherClient: boolean;
+    breastPump: boolean;
+}
+```
+
+- [ ] **Step 2: 실패하는 usecase 테스트 작성**
+
+`backend/test/usecases/eformsign-doc/get-contract-client-candidate.usecase.spec.ts` 생성 (기존 패턴 참조: `backend/test/usecases/system-setting/get-setting.usecase.spec.ts`):
+
+```typescript
+import { GetContractClientCandidateUsecase } from "application/usecases/eformsign-doc/get-contract-client-candidate.usecase";
+import { PrismaService } from "infrastructure/database/prisma.service";
+
+describe("GetContractClientCandidateUsecase", () => {
+    const findUnique = jest.fn();
+    const prisma = {
+        eformsign_doc: { findUnique },
+    } as unknown as PrismaService;
+
+    let usecase: GetContractClientCandidateUsecase;
+
+    beforeEach(() => {
+        usecase = new GetContractClientCandidateUsecase(prisma);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("문서가 없으면 null을 반환한다", async () => {
+        findUnique.mockResolvedValue(null);
+        await expect(usecase.execute("doc-missing")).resolves.toBeNull();
+        expect(findUnique).toHaveBeenCalledWith({
+            where: { documentId: "doc-missing" },
+            select: {
+                documentId: true,
+                detailPayload: true,
+                customerName: true,
+                customerPhone: true,
+            },
+        });
+    });
+
+    it("detail payload에서 후보를 추출해 직렬화한다", async () => {
+        findUnique.mockResolvedValue({
+            documentId: "doc-1",
+            customerName: null,
+            customerPhone: null,
+            detailPayload: {
+                id: "doc-1",
+                fields: [
+                    { id: "이용자 성명", value: "홍길동", type: "text" },
+                    { id: "이용자 연락처", value: "010-1234-5678", type: "text" },
+                    { id: "이용자 주소", value: "서울시 강남구", type: "text" },
+                    { id: "계약 시작일", value: "2026-08-10", type: "text" },
+                    { id: "계약 종료일", value: "2026-08-24", type: "text" },
+                    { id: "바우처 기간", value: "10일", type: "text" },
+                ],
+            },
+        });
+
+        const result = await usecase.execute("doc-1");
+
+        expect(result).toMatchObject({
+            documentId: "doc-1",
+            extracted: true,
+            name: "홍길동",
+            phone: "010-1234-5678",
+            address: "서울시 강남구",
+            startDate: "2026-08-10",
+            endDate: "2026-08-24",
+            duration: 10,
+        });
+    });
+
+    it("payload가 없으면 문서 컬럼 폴백을 반환한다", async () => {
+        findUnique.mockResolvedValue({
+            documentId: "doc-2",
+            customerName: "김산모",
+            customerPhone: "01098765432",
+            detailPayload: null,
+        });
+
+        const result = await usecase.execute("doc-2");
+
+        expect(result).toEqual({
+            documentId: "doc-2",
+            extracted: false,
+            name: "김산모",
+            phone: "010-9876-5432",
+            address: null,
+            birthday: null,
+            dueDate: null,
+            startDate: null,
+            endDate: null,
+            type: null,
+            duration: null,
+            fullPrice: null,
+            grant: null,
+            actualPrice: null,
+            careCenter: null,
+            voucherClient: false,
+            breastPump: false,
+        });
+    });
+});
+```
+
+주의: 두 번째 테스트의 payload 필드 별칭이 추출기와 안 맞으면 `backend/test/utils/eformsign-contract-client-candidate.spec.ts`의 기존 픽스처에서 통과하는 필드 구조를 복사해 맞출 것 (추출기 별칭 테이블: `backend/application/utils/eformsign-contract-client-candidate.ts:68-96`). 단언하는 키(name/phone/address/startDate/endDate/duration)는 유지한다.
+
+- [ ] **Step 3: 테스트 실패 확인**
+
+Run: `cd backend && npx jest test/usecases/eformsign-doc/get-contract-client-candidate.usecase.spec.ts`
+Expected: FAIL — "Cannot find module .../get-contract-client-candidate.usecase"
+
+- [ ] **Step 4: usecase 구현**
+
+`backend/application/usecases/eformsign-doc/get-contract-client-candidate.usecase.ts` 생성:
+
+```typescript
+import { Injectable } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { EformsignContractClientCandidateResponse } from "@babyjamjam/shared/types/eformsign";
+
+import {
+    extractEformsignContractClientCandidate,
+    formatNormalizedKoreanPhone,
+} from "application/utils/eformsign-contract-client-candidate";
+import { EformsignApiDocumentResponse } from "domain/repositories/eformsign.client.interface";
+import { PrismaService } from "infrastructure/database/prisma.service";
+
+/**
+ * 미연결 계약서에서 고객 등록 폼 프리필용 후보를 읽어온다.
+ * 자동 등록(LinkMirroredEformsignDocByPhoneUsecase)과 동일한 추출 유틸을 사용해
+ * 수동 등록과 자동 등록의 추출 결과가 항상 일치하도록 한다.
+ */
+@Injectable()
+export class GetContractClientCandidateUsecase {
+    constructor(private readonly prisma: PrismaService) {}
+
+    async execute(
+        documentId: string,
+    ): Promise<EformsignContractClientCandidateResponse | null> {
+        const document = await this.prisma.eformsign_doc.findUnique({
+            where: { documentId },
+            select: {
+                documentId: true,
+                detailPayload: true,
+                customerName: true,
+                customerPhone: true,
+            },
+        });
+        if (!document) return null;
+
+        const detail = toDocumentDetail(document.detailPayload);
+        const candidate = detail
+            ? extractEformsignContractClientCandidate(detail)
+            : null;
+        if (!candidate) {
+            return {
+                documentId: document.documentId,
+                extracted: false,
+                name: document.customerName,
+                phone: document.customerPhone
+                    ? formatNormalizedKoreanPhone(document.customerPhone)
+                    : null,
+                address: null,
+                birthday: null,
+                dueDate: null,
+                startDate: null,
+                endDate: null,
+                type: null,
+                duration: null,
+                fullPrice: null,
+                grant: null,
+                actualPrice: null,
+                careCenter: null,
+                voucherClient: false,
+                breastPump: false,
+            };
+        }
+
+        return {
+            documentId: document.documentId,
+            extracted: true,
+            name: candidate.name,
+            phone: formatNormalizedKoreanPhone(candidate.phone),
+            address: candidate.address,
+            birthday: candidate.birthday,
+            dueDate: toDateOnly(candidate.dueDate),
+            startDate: toDateOnly(candidate.startDate),
+            endDate: toDateOnly(candidate.endDate),
+            type: candidate.type,
+            duration: candidate.duration,
+            fullPrice: candidate.fullPrice,
+            grant: candidate.grant,
+            actualPrice: candidate.actualPrice,
+            careCenter: candidate.careCenter,
+            voucherClient: candidate.voucherClient,
+            breastPump: candidate.breastPump,
+        };
+    }
+}
+
+// 추출기가 만드는 Date는 UTC 자정 기준(Date.UTC)이므로 toISOString 절단이 안전하다.
+function toDateOnly(date: Date | null): string | null {
+    return date ? date.toISOString().slice(0, 10) : null;
+}
+
+function toDocumentDetail(
+    value: Prisma.JsonValue | null,
+): EformsignApiDocumentResponse | null {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+        ? (value as unknown as EformsignApiDocumentResponse)
+        : null;
+}
+```
+
+`@babyjamjam/shared` import가 백엔드 tsconfig에서 해석되지 않으면 (기존 사용례 `backend/domain/utils/eformsign-status-code.ts` 참조) 그 파일이 쓰는 import 형식을 그대로 따른다.
+
+- [ ] **Step 5: barrel export + 모듈 등록**
+
+`backend/application/usecases/eformsign-doc/index.ts`에 export 추가:
+
+```typescript
+export * from "./get-contract-client-candidate.usecase";
+```
+
+`backend/module/eformsign-doc.module.ts`: barrel import 목록(line 4-25 부근)에 `GetContractClientCandidateUsecase` 추가, providers 배열(LinkMirroredEformsignDocByPhoneUsecase 근처)과 exports 배열에 각각 추가.
+
+- [ ] **Step 6: 테스트 통과 확인**
+
+Run: `cd backend && npx jest test/usecases/eformsign-doc/get-contract-client-candidate.usecase.spec.ts`
+Expected: PASS (3 tests)
+
+- [ ] **Step 7: 컨트롤러 라우트 추가**
+
+`backend/interface/controllers/eformsign.controller.ts`:
+
+constructor(lines 191-200)에 주입 추가:
+
+```typescript
+private readonly getContractClientCandidateUsecase: GetContractClientCandidateUsecase,
+```
+
+import 추가 (기존 usecase import 위치 참조):
+
+```typescript
+import { GetContractClientCandidateUsecase } from "application/usecases/eformsign-doc/get-contract-client-candidate.usecase";
+```
+
+`getDocumentById`(lines 806-834) 바로 뒤에 라우트 추가 — 지점 스코프 가드는 `getDocumentById`와 동일한 `filterDocumentsByBranch` 패턴:
+
+```typescript
+    /**
+     * Client-registration candidate extracted from a contract's stored detail.
+     * Mirrors the auto-registration extraction so manual and automatic
+     * registration always agree on the pre-filled values.
+     */
+    @Get("documents/:documentId/client-candidate")
+    async getDocumentClientCandidate(
+        @CurrentTenant() tenant: { branchId?: string },
+        @Param("documentId") documentId: string,
+    ) {
+        try {
+            const allowedDocuments = await this.filterDocumentsByBranch(
+                tenant.branchId ?? "",
+                [{ id: documentId }],
+            );
+            if (allowedDocuments.length === 0) {
+                throw new HttpException(
+                    { error: "Document access forbidden" },
+                    HttpStatus.FORBIDDEN,
+                );
+            }
+
+            const candidate =
+                await this.getContractClientCandidateUsecase.execute(documentId);
+            if (!candidate) {
+                throw new HttpException(
+                    { error: "Document not found" },
+                    HttpStatus.NOT_FOUND,
+                );
+            }
+            return candidate;
+        } catch (error) {
+            throwHttpOrInternalError(error);
+        }
+    }
+```
+
+`EformsignController`는 `app.module.ts:87`에 등록되어 있고 `eformsign-doc.module.ts`의 exports를 통해 usecase가 주입된다 — app.module이 해당 모듈을 import하는지 확인하고, 아니면 `app.module.ts` providers에 `GetContractClientCandidateUsecase`를 직접 추가한다 (`EformsignMirrorListService` 등록 방식과 동일).
+
+- [ ] **Step 8: 백엔드 타입체크 + 커밋**
+
+Run: `cd backend && npm run type-check`
+Expected: 에러 없음
+
+```bash
+git add packages/shared/src/types/eformsign.ts backend/application/usecases/eformsign-doc/ backend/module/eformsign-doc.module.ts backend/interface/controllers/eformsign.controller.ts backend/app.module.ts backend/test/usecases/eformsign-doc/
+git commit -m "feat(eformsign): add contract client-candidate endpoint"
+```
+
+---
+
+### Task 2: 프론트 플러밍 — 프록시 라우트 + api 메서드 + 훅
+
+- **Tier**: standard
+- **Sandbox**: local
+- **Paths**: `frontend/src/app/api/eformsign/documents/[documentId]/client-candidate/route.ts`, `frontend/src/services/api.ts`, `frontend/src/hooks/useEformsignDocuments.ts`
+- **Depends**: Task 1
+
+**Files:**
+- Create: `frontend/src/app/api/eformsign/documents/[documentId]/client-candidate/route.ts`
+- Modify: `frontend/src/services/api.ts` (`getDocument` lines 178-181 근처)
+- Modify: `frontend/src/hooks/useEformsignDocuments.ts` (`eformsignQueryKeys` lines 26-30 + 훅 추가)
+
+**Interfaces:**
+- Consumes: Task 1의 `EformsignContractClientCandidateResponse` (`@babyjamjam/shared/types/eformsign`), 백엔드 `GET /api/documents/:documentId/client-candidate`
+- Produces: `eformsignApi.getDocumentClientCandidate(documentId: string): Promise<EformsignContractClientCandidateResponse>`, `useContractClientCandidate(documentId: string | null)` 훅 (TanStack Query, `enabled: documentId !== null`), query key `["eformsign-documents", "client-candidate", documentId]`
+
+- [ ] **Step 1: 프록시 라우트 생성**
+
+`frontend/src/app/api/eformsign/documents/[documentId]/client-candidate/route.ts` — 기존 `frontend/src/app/api/eformsign/documents/[documentId]/route.ts` 패턴 그대로:
+
+```typescript
+import { NextRequest } from "next/server";
+import { proxyLocalGetRequest } from "@/lib/api/route-utils";
+
+type RouteParams = { params: Promise<{ documentId: string }> };
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { documentId } = await params;
+
+  return proxyLocalGetRequest(
+    request,
+    `/api/documents/${documentId}/client-candidate`,
+    "fetch eformsign contract client candidate"
+  );
+}
+```
+
+- [ ] **Step 2: api 메서드 추가**
+
+`frontend/src/services/api.ts`의 `getDocument`(lines 178-181) 바로 뒤:
+
+```typescript
+  getDocumentClientCandidate: async (documentId: string) => {
+    const { data } = await api.get(
+      `/eformsign/documents/${documentId}/client-candidate`
+    );
+    return data as EformsignContractClientCandidateResponse;
+  },
+```
+
+파일 상단 import에 `EformsignContractClientCandidateResponse` 추가 (기존 `@babyjamjam/shared/types/eformsign` import line 24에 합류).
+
+- [ ] **Step 3: 훅 추가**
+
+`frontend/src/hooks/useEformsignDocuments.ts` — `eformsignQueryKeys`(lines 26-30)에 키 추가:
+
+```typescript
+  clientCandidate: (documentId: string) =>
+    ["eformsign-documents", "client-candidate", documentId] as const,
+```
+
+파일 하단에 훅 추가:
+
+```typescript
+/** 미연결 계약서의 고객 등록 프리필 후보. documentId가 null이면 조회하지 않는다. */
+export function useContractClientCandidate(documentId: string | null) {
+  return useQuery({
+    queryKey: eformsignQueryKeys.clientCandidate(documentId ?? ""),
+    queryFn: () => eformsignApi.getDocumentClientCandidate(documentId!),
+    enabled: documentId !== null,
+    staleTime: 0,
+    retry: 1,
+  });
+}
+```
+
+필요 import(`useQuery`, `eformsignApi`)는 이 파일에 이미 존재 — 없으면 추가.
+
+- [ ] **Step 4: 타입체크 + 커밋**
+
+Run: `cd frontend && npm run type-check`
+Expected: 에러 없음
+
+```bash
+git add frontend/src/app/api/eformsign/documents/ frontend/src/services/api.ts frontend/src/hooks/useEformsignDocuments.ts
+git commit -m "feat(contracts): add client-candidate fetch plumbing"
+```
+
+---
+
+### Task 3: ClientFormDialog prefill/notice prop + 후보→프리필 매핑 헬퍼
+
+- **Tier**: standard
+- **Sandbox**: local
+- **Paths**: `frontend/src/components/app/clients/ClientFormDialog.tsx`, `frontend/src/lib/client/contract-client-prefill.ts`, `frontend/src/lib/client/__tests__/contract-client-prefill.test.ts`
+- **Depends**: Task 1 (공유 타입만 — Task 2와 병렬 가능, Paths 비중첩)
+
+**Files:**
+- Modify: `frontend/src/components/app/clients/ClientFormDialog.tsx` (props lines 56-63, `ClientFormData` line 72, 초기화 useEffect lines 556-628, 헤더 영역)
+- Create: `frontend/src/lib/client/contract-client-prefill.ts`
+- Test: `frontend/src/lib/client/__tests__/contract-client-prefill.test.ts`
+
+**Interfaces:**
+- Consumes: `EformsignContractClientCandidateResponse` (Task 1), 기존 `ClientFormData`/`CreateClientDto` (`frontend/src/features/clients/types/index.ts:83-107`)
+- Produces: `export type ClientFormData` (ClientFormDialog에서 export), `ClientFormDialogProps`에 `prefill?: Partial<ClientFormData>` + `notice?: string` 추가, `contractCandidateToClientPrefill(candidate: EformsignContractClientCandidateResponse): Partial<ClientFormData>` (Task 4가 사용)
+
+- [ ] **Step 1: 실패하는 매핑 헬퍼 테스트 작성**
+
+`frontend/src/lib/client/__tests__/contract-client-prefill.test.ts`:
+
+```typescript
+import { contractCandidateToClientPrefill } from "@/lib/client/contract-client-prefill";
+import type { EformsignContractClientCandidateResponse } from "@babyjamjam/shared/types/eformsign";
+
+const base: EformsignContractClientCandidateResponse = {
+    documentId: "doc-1",
+    extracted: true,
+    name: "홍길동",
+    phone: "010-1234-5678",
+    address: "서울시 강남구",
+    birthday: "900101",
+    dueDate: "2026-09-01",
+    startDate: "2026-08-10",
+    endDate: "2026-08-24",
+    type: "A형",
+    duration: 10,
+    fullPrice: "1000000",
+    grant: "800000",
+    actualPrice: "200000",
+    careCenter: true,
+    voucherClient: true,
+    breastPump: false,
+};
+
+describe("contractCandidateToClientPrefill", () => {
+    it("후보의 모든 필드를 폼 프리필로 매핑한다", () => {
+        expect(contractCandidateToClientPrefill(base)).toEqual({
+            name: "홍길동",
+            phone: "010-1234-5678",
+            address: "서울시 강남구",
+            birthday: "900101",
+            dueDate: "2026-09-01",
+            startDate: "2026-08-10",
+            endDate: "2026-08-24",
+            type: "A형",
+            duration: 10,
+            fullPrice: "1000000",
+            grant: "800000",
+            actualPrice: "200000",
+            careCenter: true,
+            voucherClient: true,
+            breastPump: false,
+        });
+    });
+
+    it("null 필드는 폼 기본값 형태(빈 문자열/false)로 치환하고 undefined 키를 만들지 않는다", () => {
+        const result = contractCandidateToClientPrefill({
+            ...base,
+            extracted: false,
+            name: "김산모",
+            phone: null,
+            address: null,
+            birthday: null,
+            dueDate: null,
+            startDate: null,
+            endDate: null,
+            type: null,
+            duration: null,
+            fullPrice: null,
+            grant: null,
+            actualPrice: null,
+            careCenter: null,
+            voucherClient: false,
+            breastPump: false,
+        });
+        expect(result).toEqual({
+            name: "김산모",
+            phone: "",
+            address: "",
+            birthday: "",
+            dueDate: "",
+            startDate: "",
+            endDate: "",
+            type: "",
+            duration: null,
+            fullPrice: "",
+            grant: "",
+            actualPrice: "",
+            careCenter: false,
+            voucherClient: false,
+            breastPump: false,
+        });
+    });
+});
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `cd frontend && npx jest src/lib/client/__tests__/contract-client-prefill.test.ts`
+Expected: FAIL — "Cannot find module '@/lib/client/contract-client-prefill'"
+
+- [ ] **Step 3: 매핑 헬퍼 구현**
+
+`frontend/src/lib/client/contract-client-prefill.ts`:
+
+```typescript
+import type { EformsignContractClientCandidateResponse } from "@babyjamjam/shared/types/eformsign";
+import type { ClientFormData } from "@/components/app/clients/ClientFormDialog";
+
+/**
+ * 계약서 후보 응답을 ClientFormDialog 생성 모드 프리필로 변환한다.
+ * 폼 상태는 빈 문자열/false 기본값을 쓰므로 null을 그대로 넘기지 않는다.
+ */
+export function contractCandidateToClientPrefill(
+    candidate: EformsignContractClientCandidateResponse,
+): Partial<ClientFormData> {
+    return {
+        name: candidate.name ?? "",
+        phone: candidate.phone ?? "",
+        address: candidate.address ?? "",
+        birthday: candidate.birthday ?? "",
+        dueDate: candidate.dueDate ?? "",
+        startDate: candidate.startDate ?? "",
+        endDate: candidate.endDate ?? "",
+        type: candidate.type ?? "",
+        duration: candidate.duration,
+        fullPrice: candidate.fullPrice ?? "",
+        grant: candidate.grant ?? "",
+        actualPrice: candidate.actualPrice ?? "",
+        careCenter: candidate.careCenter ?? false,
+        voucherClient: candidate.voucherClient,
+        breastPump: candidate.breastPump,
+    };
+}
+```
+
+`ClientFormData`가 아직 export되지 않았으므로 Step 4를 먼저 적용해야 컴파일된다 (같은 태스크 안에서 순서만 주의).
+
+- [ ] **Step 4: ClientFormDialog에 prefill/notice prop 추가**
+
+`frontend/src/components/app/clients/ClientFormDialog.tsx`:
+
+(a) line 72의 타입에 `export` 추가:
+
+```typescript
+export type ClientFormData = Omit<CreateClientDto, "primaryEmployeeId"> & { primaryEmployeeId: number | null };
+```
+
+(b) props 인터페이스(lines 56-63)에 추가:
+
+```typescript
+export interface ClientFormDialogProps {
+    "data-component"?: string;
+    open: boolean;
+    onClose: () => void;
+    client?: Client | null;
+    /** 생성 모드 초기값. client가 있으면(수정 모드) 무시된다. */
+    prefill?: Partial<ClientFormData>;
+    /** 다이얼로그 상단에 표시할 안내 문구 (예: 계약서 연동 주의사항). */
+    notice?: string;
+    onSuccess?: (client: Client) => void;
+}
+```
+
+컴포넌트 시그니처의 구조분해에 `prefill`, `notice` 추가.
+
+(c) 초기화 useEffect(lines 556-628)의 생성 모드 분기(lines 588-612)에서 prefill 적용:
+
+```typescript
+            if (!nextFormData) {
+                nextFormData = {
+                    name: prefillName || "",
+                    birthday: "",
+                    dueDate: "",
+                    birthDate: "",
+                    address: "",
+                    phone: "",
+                    primaryEmployeeId: null,
+                    secondaryEmployeeId: null,
+                    type: "",
+                    duration: null,
+                    fullPrice: "",
+                    grant: "",
+                    actualPrice: "",
+                    startDate: "",
+                    endDate: "",
+                    careCenter: false,
+                    voucherClient: false,
+                    breastPump: false,
+                    serviceStatus: "pre_booking",
+                    applyMessageAutomation: true,
+                    ...prefill,
+                };
+                nextPricesManuallyEdited = Boolean(
+                    prefill?.fullPrice || prefill?.grant || prefill?.actualPrice,
+                );
+                clearPrefillName();
+            }
+```
+
+useEffect 의존성 배열(line 628)에 `prefill` 추가:
+
+```typescript
+    }, [clearPrefillName, client, open, prefillName, prefill]);
+```
+
+(d) notice 렌더링 — 다이얼로그 헤더/설명 영역(DialogHeader 또는 DialogDescription 근처, 4단계 스테퍼 위)에 추가:
+
+```tsx
+{notice && (
+    <p className="text-sm text-v3-text-muted" role="note">
+        {notice}
+    </p>
+)}
+```
+
+배치는 기존 헤더 구조에 맞춰 조정하되, 모든 스텝에서 보이는 위치(스텝 콘텐츠 밖)에 둘 것.
+
+- [ ] **Step 5: 테스트 통과 + 타입체크 확인**
+
+Run: `cd frontend && npx jest src/lib/client/__tests__/contract-client-prefill.test.ts && npm run type-check`
+Expected: PASS (2 tests), 타입 에러 없음
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add frontend/src/components/app/clients/ClientFormDialog.tsx frontend/src/lib/client/contract-client-prefill.ts frontend/src/lib/client/__tests__/contract-client-prefill.test.ts
+git commit -m "feat(clients): support create-mode prefill in ClientFormDialog"
+```
+
+---
+
+### Task 4: contracts 페이지 통합 — 메뉴 항목 + 다이얼로그 + 무효화
+
+- **Tier**: standard
+- **Sandbox**: local
+- **Paths**: `frontend/src/app/(protected)/contracts/page.tsx`
+- **Depends**: Task 2, Task 3
+
+**Files:**
+- Modify: `frontend/src/app/(protected)/contracts/page.tsx`
+  - ContractDetailPanel props (lines 1070-1094)
+  - more-menu JSX (lines 1803-1842)
+  - 산모 계약서 섹션의 ContractDetailPanel 사용처 (line 853 부근)
+  - 페이지 레벨 상태/다이얼로그 (MaternityContractDialog 렌더 위치 참조)
+
+**Interfaces:**
+- Consumes: `useContractClientCandidate` (Task 2), `contractCandidateToClientPrefill` + `ClientFormDialog`의 `prefill`/`notice` prop (Task 3), 기존 `documentClientSummary` prop, query keys `["eformsign-client-names"]`, `["eformsign-documents"]`
+- Produces: 사용자 가시 기능 — more-menu "고객 등록" 항목 (data-component `${dataComponent}_header_stepper-actions_more-menu_content_register-client`)
+
+- [ ] **Step 1: ContractDetailPanel에 onRegisterClient prop 추가**
+
+ContractDetailPanel의 props(lines 1070-1094)에 추가:
+
+```typescript
+  onRegisterClient?: (documentId: string) => void;
+```
+
+구조분해에 `onRegisterClient` 추가. 표시 조건 변수를 more-menu JSX 위에 정의:
+
+```typescript
+  const canRegisterClient = Boolean(
+    onRegisterClient && !documentClientSummary?.clientId,
+  );
+```
+
+(`documentClientSummary`가 아직 로드 전이면 undefined → 항목이 보였다가 로드 후 사라질 수 있다. 요약 쿼리가 로딩 중인지 패널에서 알 수 없으므로, 미연결 판정은 `!documentClientSummary?.clientId`로 통일한다 — 요약 없음 = 미연결로 취급. 잘못 눌러도 등록 폼이 열릴 뿐 파괴적 동작은 없다.)
+
+- [ ] **Step 2: more-menu에 항목 추가**
+
+more-menu 래핑 조건(line 1803)을 확장하고 항목 추가:
+
+```tsx
+{(canReRequest || onDeleteRequest || canRegisterClient) && (
+  <DropdownMenu>
+    {/* ...기존 트리거 유지... */}
+    <DropdownMenuContent
+      data-component={`${dataComponent}_header_stepper-actions_more-menu_content`}
+      /* ...기존 props 유지... */
+    >
+      {canRegisterClient && (
+        <DropdownMenuItem
+          data-component={`${dataComponent}_header_stepper-actions_more-menu_content_register-client`}
+          onSelect={() => onRegisterClient?.(doc.id)}
+        >
+          고객 등록
+        </DropdownMenuItem>
+      )}
+      {canRegisterClient && (canReRequest || onDeleteRequest) && <DropdownMenuSeparator />}
+      {/* ...기존 재요청/삭제 항목 유지... */}
+    </DropdownMenuContent>
+  </DropdownMenu>
+)}
+```
+
+- [ ] **Step 3: 페이지 레벨 상태 + 다이얼로그 연결**
+
+산모 계약서 섹션을 렌더하는 컴포넌트(ContractDetailPanel을 line 853에서 쓰는 곳)에서:
+
+```typescript
+const [registerClientDocumentId, setRegisterClientDocumentId] = useState<string | null>(null);
+const registerCandidateQuery = useContractClientCandidate(registerClientDocumentId);
+const registerClientPrefill = useMemo(
+  () => (registerCandidateQuery.data
+    ? contractCandidateToClientPrefill(registerCandidateQuery.data)
+    : undefined),
+  [registerCandidateQuery.data],
+);
+const queryClient = useQueryClient(); // 이미 있으면 재사용
+```
+
+ContractDetailPanel(line 853 사용처, 산모 계약서 섹션만 — line 939 서비스 제공기록지 사용처에는 넘기지 않는다)에 prop 추가:
+
+```tsx
+onRegisterClient={setRegisterClientDocumentId}
+```
+
+MaternityContractDialog 렌더 위치 근처에 다이얼로그 추가 — 후보 조회가 끝난 뒤(성공/실패 무관) 열어서, 실패 시에도 빈 폼으로 등록 가능하게 한다:
+
+```tsx
+<ClientFormDialog
+  data-component="desktop_contracts_register-client-dialog"
+  open={registerClientDocumentId !== null && !registerCandidateQuery.isFetching}
+  onClose={() => setRegisterClientDocumentId(null)}
+  prefill={registerClientPrefill}
+  notice="전화번호를 변경하면 이 계약서와 자동 연결되지 않을 수 있습니다."
+  onSuccess={() => {
+    setRegisterClientDocumentId(null);
+    void queryClient.invalidateQueries({ queryKey: ["eformsign-client-names"] });
+    void queryClient.invalidateQueries({ queryKey: ["eformsign-documents"] });
+  }}
+/>
+```
+
+import 추가: `ClientFormDialog`, `useContractClientCandidate`, `contractCandidateToClientPrefill`, 필요 시 `useQueryClient`, `useMemo`.
+
+- [ ] **Step 4: 타입체크 + 기존 프론트 테스트 확인**
+
+Run: `cd frontend && npm run type-check && npx jest src/hooks/__tests__ src/lib/client/__tests__`
+Expected: 타입 에러 없음, 테스트 PASS
+
+- [ ] **Step 5: 수동 검증 (로컬 dev)**
+
+로컬 환경(localhost — dev Railway 없음)에서:
+1. 미연결 계약서 선택 → more-menu에 "고객 등록" 표시 확인.
+2. 클릭 → ClientFormDialog가 계약서 값으로 프리필되어 열리는지 확인.
+3. 등록 → 다이얼로그 닫힘, 상세 패널에 고객명 표시 + "고객 등록" 항목 사라짐 확인 (전화번호 기반 자동 연결).
+4. 연결된 계약서에서 항목이 안 보이는지 확인.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add "frontend/src/app/(protected)/contracts/page.tsx"
+git commit -m "feat(contracts): register client from contract detail more-menu"
+```
+
+---
+
+### Task 5: 최종 검증
+
+- **Tier**: trivial
+- **Sandbox**: local
+- **Paths**: (읽기 전용 검증 — 수정 없음, 발견된 문제만 해당 파일 수정)
+- **Depends**: Task 4
+
+- [ ] **Step 1: 전체 검증 실행**
+
+```bash
+cd backend && npm run type-check && npx jest test/usecases/eformsign-doc/
+cd ../frontend && npm run type-check && npm run lint && npx jest src/lib/client/__tests__ 
+```
+
+Expected: 모두 통과. 실패 시 해당 태스크 파일로 돌아가 수정 후 재실행.
+
+- [ ] **Step 2: 스펙 대조**
+
+스펙(`docs/superpowers/specs/2026-08-03-register-client-from-contract-design.md`)의 각 요구사항이 구현됐는지 확인: 메뉴 표시 조건 / 후보 엔드포인트 + 폴백 / prefill 생성 모드 전용 / 안내 문구 / 쿼리 무효화 / 서비스 제공기록지 섹션 제외.
+
+---
+
+## 병렬 실행 배치
+
+- **Batch 1**: Task 1 (단독)
+- **Batch 2** (**Run together:** Paths 비중첩): Task 2, Task 3
+- **Batch 3**: Task 4 → Task 5

--- a/docs/superpowers/specs/2026-08-03-register-client-from-contract-design.md
+++ b/docs/superpowers/specs/2026-08-03-register-client-from-contract-design.md
@@ -1,0 +1,106 @@
+# 계약서 상세 more-menu → 고객 등록 (Register Client from Contract)
+
+- **날짜**: 2026-08-03
+- **상태**: 설계 승인됨 (사용자 확인)
+- **브랜치**: `register-client-from-contract` (off `dev`)
+
+## 배경 / 문제
+
+고객 목록에는 "계약서 없는 고객 → 계약서 생성" 드롭다운 액션이 이미 있다
+(`frontend/src/app/(protected)/clients/page.tsx:839-858` → `MaternityContractDialog`).
+반대 방향이 없다: 계약서는 존재하지만 고객 DB에 고객이 없는 경우, 계약서 상세
+패널에서 곧바로 고객을 등록할 수단이 없다.
+
+백엔드에는 이미 완결된 자동 메커니즘이 있다:
+
+- **자동 연결/자동 등록**: `LinkMirroredEformsignDocByPhoneUsecase`
+  (`backend/application/usecases/eformsign-doc/link-mirrored-eformsign-doc-by-phone.usecase.ts`)
+  는 완료 상태 계약서에 대해 전화번호 기준으로 기존 고객 연결 또는 (지점 설정
+  `clientAutoRegistrationEnabled` 활성 시) 고객 자동 생성까지 수행한다.
+- **고객 생성 시 역방향 연결**: `client.service.ts`의 `create()`가 생성 직후
+  `linkContractDocumentsByPhone()`을 호출해 동일 전화번호의 계약서를
+  `eformsign_doc.clientId` ↔ `client.eDocId` 양방향으로 연결한다.
+
+따라서 미연결 계약서가 남는 경우는 갭 케이스다: 자동등록 꺼짐, 미완료 상태,
+후보 추출 실패, 동일 전화번호 모호(ambiguous), 지점 미확정 등. 이 기능은 그
+갭을 직원이 수동으로 메우는 UI다.
+
+**불변식(사용자 확인)**: 어느 쪽이 먼저 등록되든 전화번호 조회로 즉시 연결된다.
+연결된 계약서에서는 이 메뉴 항목 자체가 보이지 않아야 한다.
+
+## 결정 사항 (사용자 답변)
+
+1. **폼 방식**: 기존 `ClientFormDialog`(4단계) 재사용, 계약서에서 프리필.
+2. **중복 처리**: 별도 UI 없음 — 동일 전화 고객이 있으면 계약서는 이미 연결돼
+   있어야 하므로(불변식) 버튼이 표시되지 않는다.
+3. **프리필 범위**: 계약 상세(detail payload)에서 최대한 추출.
+4. **접근 방식**: A안 — 백엔드 후보 추출 엔드포인트 + `ClientFormDialog`
+   prefill prop (추출 로직 단일 출처 유지).
+
+## 설계
+
+### UX 흐름
+
+1. 산모 계약서 상세 패널 more-menu(현재 "재요청"/"삭제",
+   `frontend/src/app/(protected)/contracts/page.tsx:1805-1843`)에
+   **"고객 등록"** 항목 추가.
+2. 표시 조건: `documentClientSummary?.clientId == null`
+   (`EformsignDocClientSummary`, 요약이 로드된 상태에서 미연결일 때만).
+3. 클릭 → 후보 조회(`GET .../client-candidate`) → `ClientFormDialog`가
+   생성 모드 + 프리필 상태로 오픈.
+4. 등록 성공 → 백엔드가 전화번호로 계약서 자동 연결 → 프론트는 문서
+   클라이언트 요약·문서 목록/상세 쿼리 무효화 → 메뉴 항목이 사라지고
+   상세 패널에 고객명이 표시된다.
+
+### 백엔드 (신규 1개, 기존 변경 없음)
+
+- **신규 엔드포인트**: `GET /eformsign/documents/:documentId/client-candidate`
+  - 저장된 `eformsign_doc.detailPayload`에
+    `extractEformsignContractClientCandidate()`
+    (`backend/application/utils/eformsign-contract-client-candidate.ts:404`)를
+    실행해 후보를 반환한다. 날짜(Date)는 ISO 문자열로 직렬화.
+  - **폴백**: 추출 실패(payload 없음/파싱 불가) 시 문서 컬럼
+    `customerName`/`customerPhone`만 담은 최소 후보를 반환한다 — 폼은 항상
+    열린다.
+  - 지점 스코프 가드·404 처리는 기존 문서 상세 엔드포인트와 동일한 권한 규칙.
+- **연결 로직 변경 없음**: 고객 생성 경로의 기존 phone-link가 연결을 담당한다.
+  별도 연결 API를 만들지 않는다. `eDocId`를 생성 DTO로 직접 밀어넣지 않는다
+  (문서 `clientId`와 무관하게 한쪽 포인터만 생기는 비정합 상태 방지 —
+  phone-link 경로가 양방향을 정합성 있게 세팅한다).
+
+### 프론트엔드
+
+- **more-menu 항목**: "고객 등록" DropdownMenuItem — 기존 항목과 동일 패턴,
+  data-component 네이밍 컨벤션 준수.
+- **후보 조회 훅**: `useContractClientCandidate(documentId)` — useQuery,
+  다이얼로그 오픈 요청 시에만 `enabled`.
+- **`ClientFormDialog` 변경**: 새 prop `prefill?: Partial<ClientFormData>`.
+  기존 `client` prop은 수정 모드를 트리거하므로 재사용하지 않는다. `prefill`은
+  `client == null`(생성 모드)일 때만 초기값으로 사용. 후보 → 폼 필드 매핑 시
+  날짜 포맷 정규화(`formatDateForInput` 등 기존 헬퍼) 적용.
+- **성공 후**: 문서 클라이언트 요약 쿼리 + 문서 목록/상세 쿼리 무효화.
+- **안내 문구 1줄**: "전화번호를 변경하면 이 계약서와 자동 연결되지 않을 수
+  있습니다" (연결이 전화번호 기반임을 명시).
+
+### 엣지 케이스
+
+| 상황 | 처리 |
+| --- | --- |
+| 후보 추출 실패 | 이름/전화 폴백만 프리필된 폼 오픈 (기능 차단 없음) |
+| 동일 전화 고객이 이미 존재 | 불변식상 계약서가 이미 연결됨 → 버튼 미표시, 별도 처리 없음 |
+| 등록 후 전화번호 불일치로 연결 실패 | 쿼리 무효화 후에도 버튼이 남아 미연결 상태를 즉시 인지 가능 |
+| 서비스 제공기록지 문서 | 대상 아님 — 이 메뉴는 산모 계약서 섹션에만 존재 |
+
+### 테스트
+
+- **백엔드**: 후보 엔드포인트 유닛 테스트 — 정상 추출 / 폴백 / 404 / 지점
+  스코프.
+- **프론트**: 타입체크 + 기존 계약서 페이지 테스트 패턴에 맞춘 메뉴 표시
+  조건·프리필 매핑 검증.
+
+## 비범위 (Non-goals)
+
+- 추출 유틸의 `packages/shared` 이동 (C안 — 별도 리팩토링으로 미룸).
+- 기존 고객에 계약서를 수동 연결하는 UI (불변식상 불필요).
+- 자동 등록 정책(`clientAutoRegistrationEnabled`) 변경.
+- 직원(caretaker) ID 자동 매칭, `areaId` 추출 — 계약서에 구조화된 데이터 없음.

--- a/docs/superpowers/specs/2026-08-03-register-client-from-contract-design.md
+++ b/docs/superpowers/specs/2026-08-03-register-client-from-contract-design.md
@@ -59,9 +59,11 @@
     `extractEformsignContractClientCandidate()`
     (`backend/application/utils/eformsign-contract-client-candidate.ts:404`)를
     실행해 후보를 반환한다. 날짜(Date)는 ISO 문자열로 직렬화.
-  - **폴백**: 추출 실패(payload 없음/파싱 불가) 시 문서 컬럼
-    `customerName`/`customerPhone`만 담은 최소 후보를 반환한다 — 폼은 항상
-    열린다.
+  - **폴백**: 추출 실패(payload 없음/파싱 불가) 시 문서 컬럼의
+    `customerPhone`만 담은 최소 후보를 반환한다(`extracted: false`) — 폼은 항상
+    열린다. 이름은 폴백하지 않는다: `customerName` 컬럼은 목록 표시용 일반
+    성명 필드라 관리사/직원 이름일 수 있음 (리뷰 반영, 자동 등록 추출기의
+    동일 경고 주석 근거).
   - 지점 스코프 가드·404 처리는 기존 문서 상세 엔드포인트와 동일한 권한 규칙.
 - **연결 로직 변경 없음**: 고객 생성 경로의 기존 phone-link가 연결을 담당한다.
   별도 연결 API를 만들지 않는다. `eDocId`를 생성 DTO로 직접 밀어넣지 않는다

--- a/frontend/src/app/(protected)/clients/page.test.tsx
+++ b/frontend/src/app/(protected)/clients/page.test.tsx
@@ -16,12 +16,17 @@ describe("ClientsPage deletion conflicts", () => {
 });
 
 describe("ClientsPage visual conventions", () => {
-  it("uses the standard neutral pill for overflow client statuses", () => {
-    expect(source).toContain('variant="neutral"');
+  it("renders overflow client statuses as plain text instead of a badge", () => {
     expect(source).toContain(
       'data-component="desktop_clients_sections_section-content_list-section_split-layout_list-panel_content_item_status-more"',
     );
     expect(source).toContain("+{remainingClientBadges.length}");
+    const overflowStatus = source.slice(
+      source.indexOf('data-component="desktop_clients_sections_section-content_list-section_split-layout_list-panel_content_item_status-more"') - 80,
+      source.indexOf("+{remainingClientBadges.length}") + 40,
+    );
+    expect(overflowStatus).toContain("<span");
+    expect(overflowStatus).not.toContain("StatusPill");
   });
 
   it("uses the people icon for the empty client list", () => {

--- a/frontend/src/app/(protected)/clients/page.tsx
+++ b/frontend/src/app/(protected)/clients/page.tsx
@@ -51,7 +51,6 @@ import { ClientDetailPanel } from "@/components/app/clients/ClientDetailPanel";
 import { getClientDisplayLabel } from "@/components/app/clients/client-display";
 import { TwoButtonModal } from "@/components/app/ui/TwoButtonModal";
 import { NotificationOneButtonModal } from "@/components/app/ui/NotificationOneButtonModal";
-import { StatusPill } from "@/components/app/ui/status-badge";
 import { ClientDetailModal } from "@/components/app/clients/ClientDetailModal";
 import { ServiceRecordLinkResetResultModal } from "@/components/app/clients/ServiceRecordLinkResetResultModal";
 import { ServiceScheduleChangeModal } from "@/components/app/clients/ServiceScheduleChangeModal";
@@ -773,13 +772,12 @@ export default function ClientsPage() {
                                                                 }
                                                             />
                                                             {remainingClientBadges.length > 0 ? (
-                                                                <StatusPill
+                                                                <span
                                                                     data-component="desktop_clients_sections_section-content_list-section_split-layout_list-panel_content_item_status-more"
-                                                                    variant="neutral"
-                                                                    size="sm"
+                                                                    className="shrink-0 text-[calc(10.4px*var(--glint-ui-scale,1))] font-semibold text-v3-text-muted"
                                                                 >
                                                                     +{remainingClientBadges.length}
-                                                                </StatusPill>
+                                                                </span>
                                                             ) : null}
                                                         </div>
                                                     ) : undefined}

--- a/frontend/src/app/(protected)/contracts/page.test.tsx
+++ b/frontend/src/app/(protected)/contracts/page.test.tsx
@@ -11,4 +11,9 @@ describe("ContractsPage provider summaries", () => {
     expect(source).toContain(".filter((provider) => provider.name || provider.contact)");
     expect(source).toContain('providers.length === 1 ? "제공인력"');
   });
+
+  it("derives the contract end date through split and full-field aliases", () => {
+    expect(source).toContain("formatIsoDateInput(\n    extractFieldDate(detailedDocument");
+    expect(source).toContain('full: ["계약 종료일", "계약종료일", "endDate", "contractEndDate"]');
+  });
 });

--- a/frontend/src/app/(protected)/contracts/page.tsx
+++ b/frontend/src/app/(protected)/contracts/page.tsx
@@ -25,6 +25,7 @@ import {
   Bell,
 } from "lucide-react";
 import {
+  useContractClientCandidate,
   useDeleteEformsignDocument,
 } from "@/hooks/useEformsignDocuments";
 import { useEformsignAuth } from "@/hooks/useEformsignAuth";
@@ -65,6 +66,7 @@ import {
 } from "@/components/app/v3";
 import type { StatusType } from "@/components/app/v3";
 import { TwoButtonModal } from "@/components/app/ui/TwoButtonModal";
+import { ClientFormDialog } from "@/components/app/clients/ClientFormDialog";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -103,6 +105,7 @@ import {
 import { formatIsoDateInput } from "@/lib/date/format-iso-input";
 import { useAllVoucherPriceInfos } from "@/hooks/useVoucherData";
 import { inferVoucherDurationFromAmounts } from "@/lib/voucher/duration";
+import { contractCandidateToClientPrefill } from "@/lib/client/contract-client-prefill";
 import { ContractsListItem } from "@/components/app/contracts/ContractsListItem";
 import {
   ContractReviewActionButton,
@@ -464,6 +467,7 @@ export default function ContractsPage() {
   const [hasContractCreationSession, setHasContractCreationSession] = useState(false);
   const [contractCreationActiveStep, setContractCreationActiveStep] = useState(0);
   const [deleteTargetDocumentId, setDeleteTargetDocumentId] = useState<string | null>(null);
+  const [registerClientDocumentId, setRegisterClientDocumentId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [serviceRecordActiveTab, setServiceRecordActiveTab] = useState("all");
   const [serviceRecordSearchQuery, setServiceRecordSearchQuery] = useState("");
@@ -475,14 +479,37 @@ export default function ContractsPage() {
   });
   useEformsignDocsLiveStream(isAuthenticated);
   const { toast } = useToast();
+  const queryClient = useQueryClient();
   const deleteDocument = useDeleteEformsignDocument();
+  const registerCandidateQuery = useContractClientCandidate(registerClientDocumentId);
+  const registerClientPrefill = useMemo(
+    () => (registerCandidateQuery.data
+      ? contractCandidateToClientPrefill(registerCandidateQuery.data)
+      : undefined),
+    [registerCandidateQuery.data],
+  );
+  const registerClientOpen =
+    registerClientDocumentId !== null
+    && (registerCandidateQuery.isSuccess || registerCandidateQuery.isError);
+  useEffect(() => {
+    if (registerClientDocumentId !== null && registerCandidateQuery.isError) {
+      toast({
+        variant: "destructive",
+        title: "계약 정보 불러오기 실패",
+        description: "고객 정보를 직접 입력해 주세요.",
+      });
+    }
+  }, [registerCandidateQuery.isError, registerClientDocumentId, toast]);
   const { data: serviceRecordTemplateConfig, isLoading: isServiceRecordTemplateLoading } = useQuery({
     queryKey: ["eformsign-docs", "service-record-template-id"],
     queryFn: () => eformsignApi.getServiceRecordTemplateId(),
     enabled: isAuthenticated,
     staleTime: 1000 * 60 * 60,
   });
-  const { data: documentClientSummaries = [] } = useQuery({
+  const {
+    data: documentClientSummaries = [],
+    isPending: isClientSummariesPending,
+  } = useQuery({
     queryKey: ["eformsign-client-names"],
     queryFn: () => eformsignApi.getDocumentClientNames(),
     enabled: isAuthenticated,
@@ -657,6 +684,7 @@ export default function ContractsPage() {
         setSelectedServiceRecordDocId(null);
       }
 
+      setRegisterClientDocumentId(null);
       setDeleteTargetDocumentId(null);
       toast({
         title: "문서 삭제 완료",
@@ -711,7 +739,10 @@ export default function ContractsPage() {
           data-component="desktop_contracts_sections_section-nav"
           items={NAV_SECTIONS}
           activeId={activeSection}
-          onSelect={(id) => setActiveSection(id as SectionId)}
+          onSelect={(id) => {
+            setRegisterClientDocumentId(null);
+            setActiveSection(id as SectionId);
+          }}
         />
 
         <div
@@ -775,7 +806,11 @@ export default function ContractsPage() {
                     isInteractive: !isLoading && Boolean(item),
                   };
                 }}
-                onSlotClick={(doc) => { setIsCreating(false); setSelectedDocId(doc.id); }}
+                onSlotClick={(doc) => {
+                  setIsCreating(false);
+                  setRegisterClientDocumentId(null);
+                  setSelectedDocId(doc.id);
+                }}
                 // Load more props
                 hasMore={hasNextPage}
                 onLoadMore={() => fetchNextPage()}
@@ -852,6 +887,7 @@ export default function ContractsPage() {
               document={selectedDocument}
               documentClientSummary={documentClientSummaryById.get(selectedDocument.id) ?? null}
               onDeleteRequest={handleDeleteRequest}
+              onRegisterClient={isClientSummariesPending ? undefined : setRegisterClientDocumentId}
             />
           ) : !isCreating && !hasContractCreationSession ? (
             <EmptyState icon={FileText} message="계약을 선택하면 상세 정보가 표시됩니다" />
@@ -1064,6 +1100,23 @@ export default function ContractsPage() {
         isPending={deleteDocument.isPending}
         onApprove={() => void handleDeleteConfirm()}
       />
+
+      {registerClientDocumentId !== null && (
+        <ClientFormDialog
+          data-component="desktop_contracts_modals_register-client"
+          open={registerClientOpen}
+          onClose={() => setRegisterClientDocumentId(null)}
+          prefill={registerClientPrefill}
+          notice={registerCandidateQuery.isError
+            ? "계약서에서 정보를 불러오지 못했습니다. 계약서의 전화번호와 동일하게 입력해야 자동 연결됩니다."
+            : "전화번호를 변경하면 이 계약서와 자동 연결되지 않을 수 있습니다."}
+          onSuccess={() => {
+            setRegisterClientDocumentId(null);
+            void queryClient.invalidateQueries({ queryKey: ["eformsign-client-names"] });
+            void queryClient.invalidateQueries({ queryKey: ["eformsign-documents"] });
+          }}
+        />
+      )}
     </PageSection>
   );
 }
@@ -1073,12 +1126,14 @@ function ContractDetail({
   document: doc,
   documentClientSummary,
   onDeleteRequest,
+  onRegisterClient,
   reviewAction = "finalize",
 }: {
   "data-component": string;
   document: EformsignDocument;
   documentClientSummary?: EformsignDocClientSummary | null;
   onDeleteRequest?: (documentId: string) => void;
+  onRegisterClient?: (documentId: string) => void;
   reviewAction?: ContractReviewAction;
 }) {
   const isMobile = useIsMobile();
@@ -1781,6 +1836,8 @@ function ContractDetail({
     />,
   ];
 
+  const canRegisterClient = Boolean(onRegisterClient && !documentClientSummary?.clientId);
+
   const stepperActions = (
     <div
       data-component={`${dataComponent}_header_stepper-actions`}
@@ -1800,7 +1857,7 @@ function ContractDetail({
           collapseOnHeaderOverflow
         />
       </button>
-      {(canReRequest || onDeleteRequest) && (
+      {(canReRequest || onDeleteRequest || canRegisterClient) && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -1819,6 +1876,15 @@ function ContractDetail({
             sideOffset={8}
             className="min-w-[8rem]"
           >
+            {canRegisterClient && (
+              <DropdownMenuItem
+                data-component={`${dataComponent}_header_stepper-actions_more-menu_content_register-client`}
+                onSelect={() => onRegisterClient?.(doc.id)}
+              >
+                고객 등록
+              </DropdownMenuItem>
+            )}
+            {canRegisterClient && (canReRequest || onDeleteRequest) && <DropdownMenuSeparator />}
             {canReRequest && (
               <DropdownMenuItem
                 data-component={`${dataComponent}_header_stepper-actions_more-menu_content_rerequest`}

--- a/frontend/src/app/(protected)/contracts/page.tsx
+++ b/frontend/src/app/(protected)/contracts/page.tsx
@@ -99,6 +99,7 @@ import {
 import {
   UNKNOWN_CUSTOMER_NAME,
   customerName as getEformsignCustomerName,
+  resolveDocumentCustomerName,
 } from "@/lib/eformsign/display-name";
 import { formatIsoDateInput } from "@/lib/date/format-iso-input";
 import { useAllVoucherPriceInfos } from "@/hooks/useVoucherData";
@@ -496,7 +497,7 @@ export default function ContractsPage() {
     (doc: EformsignDocument | null): string | null => {
       if (!doc) return null;
       const mappedName = documentClientSummaryById.get(doc.id)?.clientName.trim();
-      return mappedName || displayCustomerName(doc);
+      return resolveDocumentCustomerName(doc, mappedName);
     },
     [documentClientSummaryById],
   );
@@ -1094,7 +1095,7 @@ function ContractDetail({
   const detailedDocument = detailQuery.data ?? doc;
   const isBaseDetailLoading = detailQuery.isFetching || detailQuery.isPlaceholderData;
   const mappedCustomerName = documentClientSummary?.clientName.trim();
-  const customerName = mappedCustomerName || displayCustomerName(detailedDocument) || "–";
+  const customerName = resolveDocumentCustomerName(detailedDocument, mappedCustomerName) || "–";
   const isServiceRecordDocument = reviewAction === "preview";
   const serviceRecordQuery = useClientServiceRecords(documentClientSummary?.clientId ?? null, {
     enabled: isServiceRecordDocument,

--- a/frontend/src/app/(protected)/contracts/page.tsx
+++ b/frontend/src/app/(protected)/contracts/page.tsx
@@ -1103,16 +1103,14 @@ function ContractDetail({
     ?? serviceRecordQuery.data?.assignments.find((assignment) => assignment.header)?.header
     ?? null;
   const category = getStatusCategory(detailedDocument.current_status?.status_type);
-  const contractEndDateIso = (() => {
-    const year = extractDocumentFieldValue(detailedDocument, ["계약 종료 년도", "계약종료년도", "endYear"]);
-    const month = extractDocumentFieldValue(detailedDocument, ["계약 종료 월", "계약종료월", "endMonth"]);
-    const day = extractDocumentFieldValue(detailedDocument, ["계약 종료 일", "계약종료일", "endDay"]);
-    if (!year || !month || !day) return "";
-    const yearNum = parseInt(year, 10);
-    if (Number.isNaN(yearNum)) return "";
-    const yearStr = (yearNum < 100 ? 2000 + yearNum : yearNum).toString().padStart(4, "0");
-    return `${yearStr}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
-  })();
+  const contractEndDateIso = formatIsoDateInput(
+    extractFieldDate(detailedDocument, {
+      year: ["계약 종료 년도", "계약종료년도", "endYear"],
+      month: ["계약 종료 월", "계약종료월", "endMonth"],
+      day: ["계약 종료 일", "계약종료일", "endDay"],
+      full: ["계약 종료일", "계약종료일", "endDate", "contractEndDate"],
+    }) ?? "",
+  );
   const statusLabel = mapDocStatusLabel(detailedDocument.current_status, contractEndDateIso || null);
   const statusType: StatusType = contractStatusBadgeType(statusLabel);
   const [activeDetailTab, setActiveDetailTab] = useState<DetailTabKey>("document");

--- a/frontend/src/app/api/eformsign/documents/[documentId]/client-candidate/route.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/client-candidate/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { proxyLocalGetRequest } from "@/lib/api/route-utils";
+
+type RouteParams = { params: Promise<{ documentId: string }> };
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { documentId } = await params;
+
+  return proxyLocalGetRequest(
+    request,
+    `/api/documents/${documentId}/client-candidate`,
+    "fetch eformsign contract client candidate"
+  );
+}

--- a/frontend/src/app/api/eformsign/documents/[documentId]/client-candidate/route.ts
+++ b/frontend/src/app/api/eformsign/documents/[documentId]/client-candidate/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
   return proxyLocalGetRequest(
     request,
-    `/api/documents/${documentId}/client-candidate`,
+    `/api/documents/${encodeURIComponent(documentId)}/client-candidate`,
     "fetch eformsign contract client candidate"
   );
 }

--- a/frontend/src/components/app/clients/ClientDetailPanel.tsx
+++ b/frontend/src/components/app/clients/ClientDetailPanel.tsx
@@ -555,6 +555,7 @@ function ClientDetailPanelBody({
                 return {
                     ...document,
                     ...fallbackDocument,
+                    ...(fallbackDocument ? { displayStatus: null } : {}),
                 };
             });
         },

--- a/frontend/src/components/app/clients/ClientFormDialog.tsx
+++ b/frontend/src/components/app/clients/ClientFormDialog.tsx
@@ -9,6 +9,7 @@ import {
 import { useCreateClient, useUpdateClient } from "@/hooks/useClients";
 import { useClientPhoneDuplicateCheck } from "@/hooks/useClientPhoneDuplicateCheck";
 import { useOutOfPocketPriceInfos, useVoucherPriceInfos, useVoucherYears } from "@/hooks/useVoucherData";
+import type { ClientFormData } from "@/features/clients/types";
 import { EmployeeAutocomplete } from "./EmployeeAutocomplete";
 import { EmployeeFormDialog } from "@/components/app/employees/EmployeeFormDialog";
 import { useClientDialogStore } from "@/stores/client-dialog-store";
@@ -59,17 +60,21 @@ export interface ClientFormDialogProps {
     open: boolean;
     onClose: () => void;
     client?: Client | null; // null/undefined for create mode, Client for edit mode
+    /** 생성 모드에서 다이얼로그가 open 상태로 전환될 때 적용된다. 열린 뒤 참조가 바뀌어도 반영되지 않으며, client가 있으면(수정 모드) 무시된다. */
+    prefill?: Partial<ClientFormData>;
+    /** 다이얼로그 상단에 표시할 안내 문구 (예: 계약서 연동 주의사항). */
+    notice?: string;
     onSuccess?: (client: Client) => void; // Optional callback when client is created/updated
 }
 
-export interface ClientFormPanelProps extends Omit<ClientFormDialogProps, "open"> {
+export interface ClientFormPanelProps extends Omit<ClientFormDialogProps, "open" | "notice"> {
     open?: boolean;
     activeStep?: number;
     onActiveStepChange?: (step: number) => void;
     renderLayout?: (parts: { content: ReactNode; footer: ReactNode }) => ReactNode;
 }
 
-type ClientFormData = Omit<CreateClientDto, "primaryEmployeeId"> & { primaryEmployeeId: number | null };
+export type { ClientFormData };
 
 const PANEL_STEP_CONTENT_CLASS_NAME =
     "grid w-full grid-cols-1 gap-[calc(16px*var(--glint-ui-scale,1))] pb-[calc(24px*var(--glint-ui-scale,1))] md:grid-cols-2";
@@ -228,6 +233,7 @@ export function ClientFormPanel({
     open = true,
     onClose,
     client,
+    prefill,
     onSuccess,
     activeStep,
     onActiveStepChange,
@@ -240,6 +246,7 @@ export function ClientFormPanel({
             open={open}
             onClose={onClose}
             client={client}
+            prefill={prefill}
             onSuccess={onSuccess}
             activeStep={activeStep}
             onActiveStepChange={onActiveStepChange}
@@ -248,7 +255,15 @@ export function ClientFormPanel({
     );
 }
 
-export function ClientFormDialog({ "data-component": dataComponent, open, onClose, client, onSuccess }: ClientFormDialogProps) {
+export function ClientFormDialog({
+    "data-component": dataComponent,
+    open,
+    onClose,
+    client,
+    prefill,
+    notice,
+    onSuccess,
+}: ClientFormDialogProps) {
     return (
         <ClientFormContent
             surface="dialog"
@@ -256,6 +271,8 @@ export function ClientFormDialog({ "data-component": dataComponent, open, onClos
             open={open}
             onClose={onClose}
             client={client}
+            prefill={prefill}
+            notice={notice}
             onSuccess={onSuccess}
         />
     );
@@ -267,6 +284,8 @@ function ClientFormContent({
     open,
     onClose,
     client,
+    prefill,
+    notice,
     onSuccess,
     activeStep: controlledActiveStep,
     onActiveStepChange,
@@ -278,6 +297,10 @@ function ClientFormContent({
     const searchParams = useSearchParams();
     const locale = useLocale();
     const isEditMode = !!client;
+    const prefillRef = useRef(prefill);
+    useEffect(() => {
+        prefillRef.current = prefill;
+    }, [prefill]);
 
     // Read pre-filled name from Zustand store (when opened from ClientAutocomplete)
     const prefillName = useClientDialogStore((state) => state.prefillName);
@@ -607,7 +630,13 @@ function ClientFormContent({
                     breastPump: false,
                     serviceStatus: "pre_booking",
                     applyMessageAutomation: true,
+                    ...Object.fromEntries(
+                        Object.entries(prefillRef.current ?? {}).filter(([, value]) => value !== undefined),
+                    ),
                 };
+                nextPricesManuallyEdited = Boolean(
+                    prefillRef.current?.fullPrice || prefillRef.current?.grant || prefillRef.current?.actualPrice,
+                );
                 clearPrefillName();
             }
 
@@ -616,6 +645,9 @@ function ClientFormContent({
                 startDate: normalizeDateForCompactState(nextFormData.startDate),
                 endDate: normalizeDateForCompactState(nextFormData.endDate),
             };
+            if (!client && !nextFormData.endDate && nextFormData.startDate && nextFormData.duration) {
+                skipNextEndDateRecalculationRef.current = false;
+            }
             queueMicrotask(() => {
                 setFormData(nextFormData);
                 setInitializedEditClientId(client?.id ?? null);
@@ -1787,6 +1819,11 @@ function ClientFormContent({
                     contentClassName="space-y-5"
                     footer={dialogFormActions}
                 >
+                    {notice && (
+                        <p data-component={`${base}_notice`} className="text-sm text-v3-text-muted" role="note">
+                            {notice}
+                        </p>
+                    )}
                     {formContent}
                 </FormDialogShell>
             </Dialog>

--- a/frontend/src/components/app/clients/__tests__/ClientDetailPanel.employee-phone.test.tsx
+++ b/frontend/src/components/app/clients/__tests__/ClientDetailPanel.employee-phone.test.tsx
@@ -196,6 +196,7 @@ describe("ClientDetailPanel employee phones", () => {
             documentKind: "contract",
             employeeScheduleId: null,
             templateId: null,
+            displayStatus: "signed",
         }]);
         const { queryClient } = renderPanel({
             ...client,
@@ -208,6 +209,7 @@ describe("ClientDetailPanel employee phones", () => {
                 documentId: "contract-document-1",
                 statusDetail: "검토 필요",
                 stepName: "검토 필요",
+                displayStatus: null,
             }),
         ]));
     });

--- a/frontend/src/components/app/clients/__tests__/ClientFormDialog.prefill.test.tsx
+++ b/frontend/src/components/app/clients/__tests__/ClientFormDialog.prefill.test.tsx
@@ -1,0 +1,171 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import type { Client } from "@/lib/client/types";
+
+import { ClientFormDialog } from "../ClientFormDialog";
+
+let mockVoucherPriceInfos = [
+    {
+        id: 1,
+        type: "A가1형",
+        duration: "10",
+        fullPrice: "1,464,000",
+        grant: "1,002,000",
+        actualPrice: "462,000",
+    },
+];
+
+const mockOutOfPocketPriceInfos = [
+    { id: 1, duration: 5, fullPrice: "815000" },
+    { id: 2, duration: 10, fullPrice: "1620000" },
+    { id: 3, duration: 15, fullPrice: "2425000" },
+    { id: 4, duration: 20, fullPrice: "3240000" },
+];
+
+jest.mock("next/navigation", () => ({
+    useRouter: () => ({ replace: jest.fn() }),
+    useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock("@/hooks/useClients", () => ({
+    useCreateClient: () => ({ isPending: false, mutateAsync: jest.fn() }),
+    useUpdateClient: () => ({ isPending: false, mutateAsync: jest.fn() }),
+}));
+
+jest.mock("@/hooks/useVoucherData", () => ({
+    useVoucherPriceInfos: (type: string) => ({
+        data: type ? mockVoucherPriceInfos : [],
+        isLoading: false,
+    }),
+    useVoucherYears: () => ({ data: [2025, 2026], isLoading: false }),
+    useOutOfPocketPriceInfos: () => ({
+        data: mockOutOfPocketPriceInfos,
+        isLoading: false,
+        isError: false,
+    }),
+}));
+
+jest.mock("@/stores/client-dialog-store", () => {
+    const state = { prefillName: "", clearPrefillName: jest.fn() };
+
+    return {
+        useClientDialogStore: (selector: (value: typeof state) => unknown) => selector(state),
+    };
+});
+
+jest.mock("@/providers/LocaleProvider", () => ({
+    useLocale: () => "ko",
+}));
+
+jest.mock("../EmployeeAutocomplete", () => ({
+    EmployeeAutocomplete: () => <div data-testid="employee-autocomplete" />,
+}));
+
+jest.mock("@/components/app/employees/EmployeeFormDialog", () => ({
+    EmployeeFormDialog: () => null,
+}));
+
+jest.mock("@/lib/api/client", () => ({
+    api: {
+        get: jest.fn(),
+    },
+}));
+
+const createClient = (overrides: Partial<Client> = {}): Client => ({
+    id: 1,
+    name: "저장된 고객",
+    createdAt: "2026-01-01",
+    birthday: "900101",
+    dueDate: "2026-09-01",
+    birthDate: null,
+    address: "인천시 서구",
+    phone: "010-1111-2222",
+    primaryEmployee: null,
+    secondaryEmployee: null,
+    type: null,
+    duration: 10,
+    fullPrice: "1500000",
+    grant: "0",
+    actualPrice: "1500000",
+    startDate: "2026-08-01",
+    endDate: "2026-08-05",
+    careCenter: false,
+    voucherClient: false,
+    breastPump: false,
+    serviceStatus: "waiting",
+    eDocId: null,
+    hasSigned: false,
+    documentStatus: null,
+    ...overrides,
+});
+
+describe("ClientFormDialog prefill", () => {
+    beforeEach(() => {
+        mockVoucherPriceInfos = [
+            {
+                id: 1,
+                type: "A가1형",
+                duration: "10",
+                fullPrice: "1,464,000",
+                grant: "1,002,000",
+                actualPrice: "462,000",
+            },
+        ];
+    });
+
+    it("applies create-mode prefill and preserves its price when duration unlocks pricing", async () => {
+        render(
+            <ClientFormDialog
+                open
+                onClose={jest.fn()}
+                prefill={{
+                    startDate: "2026-08-10",
+                    fullPrice: "1000000",
+                    grant: "",
+                    actualPrice: "",
+                }}
+            />,
+        );
+
+        await waitFor(() => expect(screen.getByLabelText("시작일")).toHaveValue("260810"));
+
+        fireEvent.change(screen.getByLabelText("서비스 기간"), { target: { value: "10" } });
+
+        await waitFor(() => expect(screen.getByLabelText("총 서비스 금액")).toHaveValue("1,000,000"));
+    });
+
+    it("uses stored client values instead of create-mode prefill in edit mode", async () => {
+        render(
+            <ClientFormDialog
+                open
+                client={createClient()}
+                onClose={jest.fn()}
+                prefill={{
+                    startDate: "2026-08-10",
+                    fullPrice: "1000000",
+                    grant: "",
+                    actualPrice: "",
+                }}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByLabelText("시작일")).toHaveValue("260801");
+            expect(screen.getByLabelText("총 서비스 금액")).toHaveValue("1,500,000");
+        });
+        expect(screen.getByLabelText("시작일")).not.toHaveValue("260810");
+        expect(screen.getByLabelText("총 서비스 금액")).not.toHaveValue("1,000,000");
+    });
+
+    it("auto-computes the end date for create-mode start date and duration prefill", async () => {
+        render(
+            <ClientFormDialog
+                open
+                onClose={jest.fn()}
+                prefill={{ startDate: "2026-08-10", duration: 10 }}
+            />,
+        );
+
+        await waitFor(() => expect(screen.getByLabelText("종료일")).not.toHaveValue(""));
+    });
+});

--- a/frontend/src/components/app/contracts/ContractCreationForm.tsx
+++ b/frontend/src/components/app/contracts/ContractCreationForm.tsx
@@ -562,6 +562,11 @@ export const ContractCreationForm = ({
   };
 
   const handleDialogClose = () => {
+    setCreationProgress((current) =>
+      current.step !== null && !current.completed && !current.failed
+        ? { ...current, failed: true }
+        : current,
+    );
     setIsDialogOpen(false);
     setIsSubmitting(false);
   };
@@ -845,7 +850,7 @@ export const ContractCreationForm = ({
               birthday: birthday || undefined,
               address: address || null,
               dueDate: normalizedDueDate || undefined,
-              birthDate: normalizedBirthDate || undefined,
+              birthDate: normalizedBirthDate || null,
               type: voucherType || null,
               duration: parseOptionalInteger(voucherDuration),
               fullPrice: fullPrice || null,
@@ -1790,7 +1795,14 @@ export const ContractCreationForm = ({
             <DialogDescription className="sr-only">
               전자문서 작성 화면과 생성 진행 상태를 표시합니다.
             </DialogDescription>
-            <Button type="button" variant="ghost" size="icon" onClick={handleDialogClose} className="h-8 w-8">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="계약서 작성 닫기"
+              onClick={handleDialogClose}
+              className="h-8 w-8"
+            >
               <X className="h-4 w-4" />
             </Button>
           </DialogHeader>

--- a/frontend/src/components/app/contracts/ContractsListItem.tsx
+++ b/frontend/src/components/app/contracts/ContractsListItem.tsx
@@ -3,8 +3,7 @@
 import { memo } from "react";
 import { Calendar, CircleCheck, FileSignature } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
-import { AnimatedSlotListItemContent, StatusBadge, type StatusType } from "@/components/app/v3";
-import { cn } from "@/lib/utils";
+import { AnimatedSlotListItemContent, StatusBadge } from "@/components/app/v3";
 import { contractStatusBadgeType, getStatusCategory, mapDocStatusLabel } from "@/lib/eformsign/status-codes";
 import type { EformsignDocument } from "@/lib/eformsign/types";
 import { formatDateForDisplay } from "@/lib/date/format-date-for-display";
@@ -16,6 +15,32 @@ interface ContractsListItemProps {
   subtitle?: string;
   isLoading: boolean;
 }
+
+const CONTRACT_STATUS_AVATAR_CLASSES = {
+  pending: {
+    container: "bg-v3-dim-white",
+    icon: "text-v3-text-muted",
+  },
+  signed: {
+    container: "bg-v3-primary-light",
+    icon: "text-v3-primary",
+  },
+  review: {
+    container: "bg-v3-orange-light",
+    icon: "text-v3-orange",
+  },
+  completed: {
+    container: "bg-v3-green-light",
+    icon: "text-v3-green",
+  },
+  expired: {
+    container: "bg-v3-burgundy-light",
+    icon: "text-v3-burgundy",
+  },
+} as const satisfies Record<
+  ReturnType<typeof contractStatusBadgeType>,
+  { container: string; icon: string }
+>;
 
 function formatDate(timestamp: number): string {
   return formatDateForDisplay(timestamp);
@@ -56,8 +81,8 @@ function ContractsListItemComponent({
     document.contract_end_date,
     document.display_status,
   );
-  const isReviewNeeded = statusLabel === "검토 필요";
-  const statusType: StatusType = contractStatusBadgeType(statusLabel);
+  const statusType = contractStatusBadgeType(statusLabel);
+  const avatarClasses = CONTRACT_STATUS_AVATAR_CLASSES[statusType];
   const sentDate = formatDate(document.created_date);
   const signedDate =
     category === "completed" ? formatDate(document.updated_date) : null;
@@ -72,24 +97,8 @@ function ContractsListItemComponent({
     <AnimatedSlotListItemContent
       data-component={dataComponent}
       icon={FileSignature}
-      iconContainerClassName={cn(
-        category === "completed"
-          ? "bg-v3-green-light"
-          : category === "expired"
-            ? "bg-v3-burgundy-light"
-            : isReviewNeeded
-              ? "bg-v3-primary-light"
-              : "bg-v3-orange-light"
-      )}
-      iconClassName={cn(
-        category === "completed"
-          ? "text-v3-green"
-          : category === "expired"
-            ? "text-v3-burgundy"
-            : isReviewNeeded
-              ? "text-v3-primary"
-              : "text-v3-orange"
-      )}
+      iconContainerClassName={avatarClasses.container}
+      iconClassName={avatarClasses.icon}
       title={recipientName}
       titleClassName={isRecipientNamePlaceholder ? "italic text-v3-text-muted" : undefined}
       subtitle={subtitle ?? document.document_name}

--- a/frontend/src/components/app/contracts/__tests__/ContractCreationForm.iframe-fallback.test.tsx
+++ b/frontend/src/components/app/contracts/__tests__/ContractCreationForm.iframe-fallback.test.tsx
@@ -11,6 +11,7 @@
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
 
 import { useFormStore } from "@/stores/form-store";
 import { ContractCreationForm } from "../ContractCreationForm";
@@ -102,13 +103,23 @@ function seedValidContractForm(): void {
     });
 }
 
-function renderForm() {
+function renderForm(props: { onProcessingFailureChange?: (failed: boolean) => void } = {}) {
     const queryClient = new QueryClient({
         defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
     });
+    function Harness() {
+        const [activeStep, setActiveStep] = useState(CONTRACT_INFO_STEP_INDEX);
+        return (
+            <ContractCreationForm
+                activeStep={activeStep}
+                onActiveStepChange={setActiveStep}
+                onProcessingFailureChange={props.onProcessingFailureChange}
+            />
+        );
+    }
     return render(
         <QueryClientProvider client={queryClient}>
-            <ContractCreationForm activeStep={CONTRACT_INFO_STEP_INDEX} onActiveStepChange={jest.fn()} />
+            <Harness />
         </QueryClientProvider>,
     );
 }
@@ -163,5 +174,22 @@ describe("ContractCreationForm — eformsign iframe fallback on headless failure
         // Outcome is unknown on this path, so staff must still be warned about
         // duplicating a contract that may already have been sent.
         expect(screen.getByText(/전자문서 목록에서 생성 여부를 먼저 확인/)).toBeInTheDocument();
+    });
+
+    it("marks an unfinished run failed when the embedded editor is closed", async () => {
+        mockDispatchHeadless.mockResolvedValue({
+            ok: false,
+            fallbackHint: "iframe",
+            failedStep: "client-started",
+        });
+        const onProcessingFailureChange = jest.fn();
+
+        renderForm({ onProcessingFailureChange });
+        await submitAndExpectIframeOpens();
+        fireEvent.click(screen.getByRole("button", { name: "계약서 작성 닫기" }));
+
+        await waitFor(() => {
+            expect(onProcessingFailureChange).toHaveBeenLastCalledWith(true);
+        });
     });
 });

--- a/frontend/src/components/app/contracts/__tests__/ContractCreationForm.initial-client.test.tsx
+++ b/frontend/src/components/app/contracts/__tests__/ContractCreationForm.initial-client.test.tsx
@@ -322,6 +322,32 @@ describe("ContractCreationForm — initialClient mode", () => {
     );
   });
 
+  it("sends null when an existing client's 출산일 is explicitly cleared", async () => {
+    seedValidContract({ birthDate: "2026-08-05" });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <ContractCreationForm activeStep={0} onActiveStepChange={jest.fn()} />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.change(screen.getByLabelText("출산일"), { target: { value: "" } });
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <ContractCreationForm activeStep={CONTRACT_INFO_STEP_INDEX} onActiveStepChange={jest.fn()} />
+      </QueryClientProvider>,
+    );
+    mockDispatchHeadless.mockResolvedValue({ ok: true });
+    fireEvent.click(screen.getByTestId("contract-creation-submit"));
+
+    await waitFor(() => expect(mockUpdateClientMutateAsync).toHaveBeenCalled());
+    expect(mockUpdateClientMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ dto: expect.objectContaining({ birthDate: null }) }),
+    );
+  });
+
   it("signals onSubmissionStateChange(true) then (false) around a contract-creation run", async () => {
     seedValidContract();
     mockDispatchHeadless.mockResolvedValue({ ok: true });

--- a/frontend/src/components/app/contracts/__tests__/ContractsListItem.test.tsx
+++ b/frontend/src/components/app/contracts/__tests__/ContractsListItem.test.tsx
@@ -43,6 +43,35 @@ function subtitle(container: HTMLElement): Element | null {
 }
 
 describe("ContractsListItem", () => {
+  it.each([
+    ["pending", "서명 대기", "bg-v3-dim-white", "text-v3-text-muted"],
+    ["signed", "서명 완료", "bg-v3-primary-light", "text-v3-primary"],
+    ["review", "검토 필요", "bg-v3-orange-light", "text-v3-orange"],
+    ["completed", "계약 완료", "bg-v3-green-light", "text-v3-green"],
+    ["expired", "기간 만료", "bg-v3-burgundy-light", "text-v3-burgundy"],
+  ] as const)(
+    "matches the avatar tone to the %s status badge",
+    (displayStatus, statusLabel, avatarBackgroundClass, avatarIconClass) => {
+      const document = {
+        ...documentFixture(),
+        display_status: displayStatus,
+      };
+      const { container } = render(
+        <ContractsListItem
+          data-component="desktop_contracts_tests_list-item"
+          document={document}
+          customerName="송진호"
+          isLoading={false}
+        />,
+      );
+
+      expect(container.querySelector('[data-component="desktop_contracts_tests_list-item_status"]')).toHaveTextContent(statusLabel);
+      const avatar = container.querySelector('[data-component="desktop_contracts_tests_list-item_icon"]');
+      expect(avatar).toHaveClass(avatarBackgroundClass);
+      expect(avatar?.querySelector("svg")).toHaveClass(avatarIconClass);
+    },
+  );
+
   it.each([null, "", "   ", "-"])(
     "shows 이름 없음 when the recipient name is unresolved (%p)",
     (customerName) => {

--- a/frontend/src/features/clients/types/index.ts
+++ b/frontend/src/features/clients/types/index.ts
@@ -106,6 +106,8 @@ export interface CreateClientDto {
     reuseExistingClient?: boolean;
 }
 
+export type ClientFormData = Omit<CreateClientDto, "primaryEmployeeId"> & { primaryEmployeeId: number | null };
+
 // Update client DTO - Frontend sends employeeId, backend converts to scheduleId
 export interface UpdateClientDto {
     name?: string;

--- a/frontend/src/hooks/useEformsignDocuments.ts
+++ b/frontend/src/hooks/useEformsignDocuments.ts
@@ -28,7 +28,7 @@ export const eformsignQueryKeys = {
   documentsByType: (type: string) => ["eformsign-documents", type] as const,
   allDocuments: () => ["eformsign-documents", "all"] as const,
   clientCandidate: (documentId: string) =>
-    ["eformsign-documents", "client-candidate", documentId] as const,
+    ["eformsign-client-candidate", documentId] as const,
 };
 
 // Fetch all documents using unified backend endpoint (single request instead of 3)
@@ -170,7 +170,8 @@ export function useContractClientCandidate(documentId: string | null) {
     queryKey: eformsignQueryKeys.clientCandidate(documentId ?? ""),
     queryFn: () => eformsignApi.getDocumentClientCandidate(documentId!),
     enabled: documentId !== null,
-    staleTime: 0,
-    retry: 1,
+    staleTime: 1000 * 60,
+    refetchOnWindowFocus: false,
+    retry: false,
   });
 }

--- a/frontend/src/hooks/useEformsignDocuments.ts
+++ b/frontend/src/hooks/useEformsignDocuments.ts
@@ -27,6 +27,8 @@ export const eformsignQueryKeys = {
   documents: () => ["eformsign-documents"] as const,
   documentsByType: (type: string) => ["eformsign-documents", type] as const,
   allDocuments: () => ["eformsign-documents", "all"] as const,
+  clientCandidate: (documentId: string) =>
+    ["eformsign-documents", "client-candidate", documentId] as const,
 };
 
 // Fetch all documents using unified backend endpoint (single request instead of 3)
@@ -159,5 +161,16 @@ export function useDeleteEformsignDocument() {
     // before its vendor request or local cleanup reports an error. Do not
     // restore that pre-delete snapshot; the invalidated local list is the
     // source of truth for whether the document remains safely hidden.
+  });
+}
+
+/** 미연결 계약서의 고객 등록 프리필 후보. documentId가 null이면 조회하지 않는다. */
+export function useContractClientCandidate(documentId: string | null) {
+  return useQuery({
+    queryKey: eformsignQueryKeys.clientCandidate(documentId ?? ""),
+    queryFn: () => eformsignApi.getDocumentClientCandidate(documentId!),
+    enabled: documentId !== null,
+    staleTime: 0,
+    retry: 1,
   });
 }

--- a/frontend/src/lib/client/__tests__/contract-client-prefill.test.ts
+++ b/frontend/src/lib/client/__tests__/contract-client-prefill.test.ts
@@ -1,0 +1,85 @@
+import { contractCandidateToClientPrefill } from "@/lib/client/contract-client-prefill";
+import type { EformsignContractClientCandidateResponse } from "@babyjamjam/shared/types/eformsign";
+
+const base: EformsignContractClientCandidateResponse = {
+    documentId: "doc-1",
+    extracted: true,
+    name: "홍길동",
+    phone: "010-1234-5678",
+    address: "서울시 강남구",
+    birthday: "900101",
+    dueDate: "2026-09-01",
+    startDate: "2026-08-10",
+    endDate: "2026-08-24",
+    type: "A형",
+    duration: 10,
+    fullPrice: "1000000",
+    grant: "800000",
+    actualPrice: "200000",
+    careCenter: true,
+    voucherClient: true,
+    breastPump: false,
+};
+
+describe("contractCandidateToClientPrefill", () => {
+    it("후보의 모든 필드를 폼 프리필로 매핑한다", () => {
+        expect(contractCandidateToClientPrefill(base)).toEqual({
+            name: "홍길동",
+            phone: "010-1234-5678",
+            address: "서울시 강남구",
+            birthday: "900101",
+            dueDate: "2026-09-01",
+            startDate: "2026-08-10",
+            endDate: "2026-08-24",
+            type: "A형",
+            duration: 10,
+            fullPrice: "1000000",
+            grant: "800000",
+            actualPrice: "200000",
+            careCenter: true,
+            voucherClient: true,
+            breastPump: false,
+        });
+    });
+
+    it("null 필드는 폼 기본값 형태(빈 문자열/false)로 치환하고 undefined 키를 만들지 않는다", () => {
+        const result = contractCandidateToClientPrefill({
+            ...base,
+            extracted: false,
+            name: "김산모",
+            phone: null,
+            address: null,
+            birthday: null,
+            dueDate: null,
+            startDate: null,
+            endDate: null,
+            type: null,
+            duration: null,
+            fullPrice: null,
+            grant: null,
+            actualPrice: null,
+            careCenter: null,
+            voucherClient: false,
+            breastPump: false,
+        });
+        expect(result).toEqual({
+            name: "김산모",
+            phone: "",
+            address: "",
+            birthday: "",
+            dueDate: "",
+            startDate: "",
+            endDate: "",
+            type: "",
+            duration: null,
+            fullPrice: "",
+            grant: "",
+            actualPrice: "",
+            careCenter: false,
+            voucherClient: false,
+            breastPump: false,
+        });
+
+        expect(contractCandidateToClientPrefill({ ...base, name: null }).name).toBe("");
+    });
+});

--- a/frontend/src/lib/client/contract-client-prefill.ts
+++ b/frontend/src/lib/client/contract-client-prefill.ts
@@ -1,0 +1,29 @@
+import type { EformsignContractClientCandidateResponse } from "@babyjamjam/shared/types/eformsign";
+
+import type { ClientFormData } from "@/features/clients/types";
+
+/**
+ * 계약서 후보 응답을 ClientFormDialog 생성 모드 프리필로 변환한다.
+ * 폼 상태는 빈 문자열/false 기본값을 쓰므로 null을 그대로 넘기지 않는다.
+ */
+export function contractCandidateToClientPrefill(
+    candidate: EformsignContractClientCandidateResponse,
+): Partial<ClientFormData> {
+    return {
+        name: candidate.name ?? "",
+        phone: candidate.phone ?? "",
+        address: candidate.address ?? "",
+        birthday: candidate.birthday ?? "",
+        dueDate: candidate.dueDate ?? "",
+        startDate: candidate.startDate ?? "",
+        endDate: candidate.endDate ?? "",
+        type: candidate.type ?? "",
+        duration: candidate.duration,
+        fullPrice: candidate.fullPrice ?? "",
+        grant: candidate.grant ?? "",
+        actualPrice: candidate.actualPrice ?? "",
+        careCenter: candidate.careCenter ?? false,
+        voucherClient: candidate.voucherClient,
+        breastPump: candidate.breastPump,
+    };
+}

--- a/frontend/src/lib/eformsign/__tests__/display-name.test.ts
+++ b/frontend/src/lib/eformsign/__tests__/display-name.test.ts
@@ -3,6 +3,7 @@ import {
   contractDisplayName,
   customerName,
   mergeDocumentForDisplayData,
+  resolveDocumentCustomerName,
 } from "@/lib/eformsign/display-name";
 import type { EformsignDocument } from "@/lib/eformsign/types";
 
@@ -92,5 +93,17 @@ describe("contract display names", () => {
     });
 
     expect(customerName(doc)).toBe("송진호");
+  });
+
+  it("prefers the customer name embedded in the document over a stale client mapping", () => {
+    const doc = documentFixture({
+      fields: [{ id: "이용자 성명", value: "안현주" }],
+    });
+
+    expect(resolveDocumentCustomerName(doc, "인천 아이미래로")).toBe("안현주");
+  });
+
+  it("uses the client mapping only when the document has no customer name", () => {
+    expect(resolveDocumentCustomerName(documentFixture(), " 송진호 ")).toBe("송진호");
   });
 });

--- a/frontend/src/lib/eformsign/display-name.ts
+++ b/frontend/src/lib/eformsign/display-name.ts
@@ -1,3 +1,21 @@
+import type { EformsignDocument } from "@/lib/eformsign/types";
+import {
+  UNKNOWN_CUSTOMER_NAME as UNKNOWN_NAME,
+  customerName as getDocumentCustomerName,
+} from "@babyjamjam/shared/eformsign/display-name";
+
+export function resolveDocumentCustomerName(
+  document: EformsignDocument,
+  mappedCustomerName?: string | null,
+): string | null {
+  const documentCustomerName = getDocumentCustomerName(document);
+  if (documentCustomerName !== UNKNOWN_NAME) {
+    return documentCustomerName;
+  }
+
+  return mappedCustomerName?.trim() || null;
+}
+
 export {
   UNKNOWN_CUSTOMER_NAME,
   contractDisplayName,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -182,7 +182,7 @@ export const eformsignApi = {
     },
     getDocumentClientCandidate: async (documentId: string) => {
         const { data } = await api.get(
-            `/eformsign/documents/${documentId}/client-candidate`
+            `/eformsign/documents/${encodeURIComponent(documentId)}/client-candidate`
         );
         return data as EformsignContractClientCandidateResponse;
     },

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -13,6 +13,7 @@ import type { RegisterRequest } from "@babyjamjam/shared";
 import { ContractDataDto } from '@/backend/application/dto/contract.dto';
 import {
     EformsignApiListResponse,
+    EformsignContractClientCandidateResponse,
     CreateEformsignDocRecordRequest,
     EformsignAuthStatusResponse,
     EformsignDeleteDocumentsResponse,
@@ -178,6 +179,12 @@ export const eformsignApi = {
     getDocument: async (documentId: string) => {
         const { data } = await api.get(`/eformsign/documents/${documentId}`);
         return data;
+    },
+    getDocumentClientCandidate: async (documentId: string) => {
+        const { data } = await api.get(
+            `/eformsign/documents/${documentId}/client-candidate`
+        );
+        return data as EformsignContractClientCandidateResponse;
     },
     // Receipt = page 7 of the document PDF, extracted by the download_files BFF route.
     // Browser-navigable BFF URL (full /api path, used as href/download — NOT via the axios client).

--- a/mobile/src/app/(shell)/contracts/page.tsx
+++ b/mobile/src/app/(shell)/contracts/page.tsx
@@ -266,6 +266,11 @@ const FILTER_TO_STATUS_CATEGORY: Record<FilterKey, EformsignStatusCategoryParam 
   "알 수 없음": "unknown",
 };
 
+const FILTER_TO_DISPLAY_STATUS = {
+  "서명 완료": "signed",
+  "검토 필요": "review",
+} as const;
+
 const FILTER_BY_CATEGORY: Record<ContractCategory, FilterKey> = {
   drafting: "서명 대기",
   signed: "서명 완료",
@@ -1938,6 +1943,9 @@ export default function ContractsPage() {
     && (activeSection === "maternal-contracts" || serviceRecordTemplateIds.length > 0);
   const debouncedSearchQuery = useDebouncedValue(searchQuery.trim(), 300);
   const statusCategoryParam = FILTER_TO_STATUS_CATEGORY[activeFilter];
+  const displayStatusParam = activeFilter in FILTER_TO_DISPLAY_STATUS
+    ? FILTER_TO_DISPLAY_STATUS[activeFilter as keyof typeof FILTER_TO_DISPLAY_STATUS]
+    : null;
 
   const {
     documents: paginatedDocuments,
@@ -1952,6 +1960,7 @@ export default function ContractsPage() {
     isLoadMoreError,
   } = useInfiniteContracts({
     statusCategory: statusCategoryParam,
+    displayStatus: displayStatusParam,
     search: debouncedSearchQuery,
     templateId: serviceRecordTemplateId,
     templateMatch: sectionTemplateMatch,

--- a/mobile/src/components/app/mobile-redesign/MessagesSettingsPage.tsx
+++ b/mobile/src/components/app/mobile-redesign/MessagesSettingsPage.tsx
@@ -134,6 +134,7 @@ export function MessagesSettingsPage(): ReactElement {
   useEffect(() => {
     if (
       isInitialLoading ||
+      approvalQuery.isError ||
       selectedItemId === null ||
       selectedItem !== undefined
     ) {
@@ -141,7 +142,7 @@ export function MessagesSettingsPage(): ReactElement {
     }
 
     router.replace("/messages/settings", { scroll: false });
-  }, [isInitialLoading, router, selectedItem, selectedItemId]);
+  }, [approvalQuery.isError, isInitialLoading, router, selectedItem, selectedItemId]);
 
   const handleSelect = (id: string) => {
     if (id === selectedItemId) {
@@ -236,7 +237,7 @@ export function MessagesSettingsPage(): ReactElement {
             data-component={SLIDING_CARD_BASE}
             open={
               selectedItemId !== null &&
-              (selectedItem !== undefined || !isInitialLoading)
+              selectedItem !== undefined
             }
             onBack={handleBack}
             backLabel="설정"
@@ -250,6 +251,8 @@ export function MessagesSettingsPage(): ReactElement {
                 isLoading={isInitialLoading}
                 policiesError={policiesQuery.isError}
                 onRetryPolicies={() => policiesQuery.refetch()}
+                approvalError={approvalQuery.isError}
+                onRetryApproval={() => approvalQuery.refetch()}
                 isApproved={approvalQuery.data?.isApproved ?? false}
               />
             )}

--- a/mobile/src/components/app/mobile-redesign/__tests__/MessagesSettingsPage.test.tsx
+++ b/mobile/src/components/app/mobile-redesign/__tests__/MessagesSettingsPage.test.tsx
@@ -401,4 +401,22 @@ describe("MessagesSettingsPage", () => {
       expect(mockedSettingsApi.getMessageAutomationPolicies).toHaveBeenCalledTimes(2);
     });
   });
+
+  it("keeps the sender-approval deep link on screen and retries after an approval error", async () => {
+    mockedSettingsApi.getMessageSenderApproval.mockRejectedValue(
+      new Error("approval unavailable"),
+    );
+    mockSearchParams = new URLSearchParams({ item: "current-tenant" });
+    renderPage();
+
+    expect(
+      await screen.findByText("메시지 발송 신청 상태를 불러오지 못했습니다"),
+    ).toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "신청 상태 재시도" }));
+    await waitFor(() => {
+      expect(mockedSettingsApi.getMessageSenderApproval).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/mobile/src/components/app/mobile-redesign/settings/SettingsList.tsx
+++ b/mobile/src/components/app/mobile-redesign/settings/SettingsList.tsx
@@ -21,6 +21,8 @@ export interface SettingsListProps {
   isLoading: boolean;
   policiesError?: boolean;
   onRetryPolicies?: () => void;
+  approvalError?: boolean;
+  onRetryApproval?: () => void;
   isApproved: boolean;
 }
 
@@ -32,6 +34,8 @@ export function SettingsList({
   isLoading,
   policiesError = false,
   onRetryPolicies,
+  approvalError = false,
+  onRetryApproval,
   isApproved,
 }: SettingsListProps): ReactElement {
   const sub = (suffix: string) => `${dataComponent}_${suffix}`;
@@ -173,23 +177,26 @@ export function SettingsList({
               );
             })}
 
-            {policiesError ? (
+            {approvalError || policiesError ? (
               <div
-                data-component={sub("items_policies-error")}
+                data-component={sub("items_query-error")}
                 className="flex items-center justify-between gap-[calc(12px*var(--glint-ui-scale,1))] rounded-[calc(14px*var(--glint-ui-scale,1))] border-[calc(1px*var(--glint-ui-scale,1))] border-v3-border bg-v3-dim-white px-[calc(12px*var(--glint-ui-scale,1))] py-[calc(10px*var(--glint-ui-scale,1))]"
                 role="alert"
               >
                 <span
-                  data-component={sub("items_policies-error_message")}
+                  data-component={sub("items_query-error_message")}
                   className="min-w-0 text-[calc(0.68rem*var(--glint-ui-scale,1))] font-semibold leading-[calc(0.95rem*var(--glint-ui-scale,1))] text-v3-text-muted"
                 >
-                  자동 전송 정책을 불러오지 못했습니다
+                  {approvalError
+                    ? "메시지 발송 신청 상태를 불러오지 못했습니다"
+                    : "자동 전송 정책을 불러오지 못했습니다"}
                 </span>
                 <button
-                  data-component={sub("items_policies-error_retry")}
+                  data-component={sub("items_query-error_retry")}
                   type="button"
+                  aria-label={approvalError ? "신청 상태 재시도" : "재시도"}
                   className="min-h-[calc(36px*var(--glint-ui-scale,1))] shrink-0 cursor-pointer rounded-[calc(10px*var(--glint-ui-scale,1))] bg-v3-primary-light px-[calc(10px*var(--glint-ui-scale,1))] text-[calc(0.68rem*var(--glint-ui-scale,1))] font-bold text-v3-primary outline-none transition-colors active:bg-v3-primary/15 focus-visible:ring-[calc(3px*var(--glint-ui-scale,1))] focus-visible:ring-v3-primary/10"
-                  onClick={onRetryPolicies}
+                  onClick={approvalError ? onRetryApproval : onRetryPolicies}
                 >
                   재시도
                 </button>

--- a/mobile/src/hooks/__tests__/useInfiniteContracts.test.tsx
+++ b/mobile/src/hooks/__tests__/useInfiniteContracts.test.tsx
@@ -190,6 +190,22 @@ describe("useInfiniteContracts", () => {
     expect(mockedGetAllDocuments).toHaveBeenCalledTimes(1);
   });
 
+  it("includes display status in both the server request and cache key", async () => {
+    mockedGetAllDocuments.mockResolvedValue(
+      createPage({ ids: ["review-doc"], totalRows: 1, limit: 9, skip: 0, hasMore: false }),
+    );
+
+    const { result } = renderHook(
+      () => useInfiniteContracts({ statusCategory: "in-progress", displayStatus: "review" }),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await waitFor(() => expect(mockedGetAllDocuments).toHaveBeenCalledWith(
+      expect.objectContaining({ displayStatus: "review" }),
+    ));
+    expect(result.current.queryKey).toContain("review");
+  });
+
   it("falls back to offset math when has_more is absent and stops at the total boundary", async () => {
     mockedGetAllDocuments
       .mockResolvedValueOnce(
@@ -275,6 +291,7 @@ describe("useInfiniteContracts", () => {
       "paginated",
       "branch-1",
       "drafting",
+      "all-display-statuses",
       "alpha",
       "any-template",
       "include",
@@ -284,6 +301,7 @@ describe("useInfiniteContracts", () => {
       "paginated",
       "branch-1",
       "completed",
+      "all-display-statuses",
       "alpha",
       "any-template",
       "include",
@@ -293,6 +311,7 @@ describe("useInfiniteContracts", () => {
       "paginated",
       "branch-1",
       "completed",
+      "all-display-statuses",
       "beta",
       "any-template",
       "include",
@@ -302,6 +321,7 @@ describe("useInfiniteContracts", () => {
       "paginated",
       "branch-2",
       "completed",
+      "all-display-statuses",
       "beta",
       "any-template",
       "include",

--- a/mobile/src/hooks/useInfiniteContracts.ts
+++ b/mobile/src/hooks/useInfiniteContracts.ts
@@ -4,7 +4,11 @@ import { useEffect, useMemo, useRef } from "react";
 import { infiniteQueryOptions, useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 
 import { eformsignApi } from "@/services/api";
-import type { EformsignStatusCategoryParam, EformsignTemplateMatchParam } from "@/services/api";
+import type {
+  EformsignDisplayStatusParam,
+  EformsignStatusCategoryParam,
+  EformsignTemplateMatchParam,
+} from "@/services/api";
 import type { EformsignDocument, EformsignDocumentsResponse } from "@/lib/eformsign/types";
 import type { DocumentFilterType } from "@/lib/eformsign/status-codes";
 import { useGetAuthUser } from "./useGetAuthUser";
@@ -29,6 +33,8 @@ export interface InfiniteContractsQueryInput {
   branchId?: string | null;
   /** Server-side status bucket, or null/undefined for "all". */
   statusCategory?: EformsignStatusCategoryParam | null;
+  /** Server-side 서명 완료/검토 필요 split. */
+  displayStatus?: EformsignDisplayStatusParam | null;
   /** Server-side search term (chosung-aware on the backend). */
   search?: string | null;
   /**
@@ -43,12 +49,13 @@ export interface InfiniteContractsQueryInput {
 export const infiniteContractsQueryKeys = {
   /** Prefix for every paginated contracts query (useful for invalidate/remove). */
   all: () => ["eformsign-documents", "paginated"] as const,
-  list: ({ branchId, statusCategory, search, templateId, templateMatch }: InfiniteContractsQueryInput) =>
+  list: ({ branchId, statusCategory, displayStatus, search, templateId, templateMatch }: InfiniteContractsQueryInput) =>
     [
       "eformsign-documents",
       "paginated",
       branchId ?? "unknown",
       statusCategory ?? "all",
+      displayStatus ?? "all-display-statuses",
       search ?? "",
       templateId ?? "any-template",
       templateMatch ?? "include",
@@ -100,12 +107,14 @@ function getNextPageParam(
 export function infiniteContractsQueryOptions({
   branchId,
   statusCategory,
+  displayStatus,
   search,
   templateId,
   templateMatch,
 }: InfiniteContractsQueryInput) {
   const normalizedSearch = search?.trim() ?? "";
   const normalizedStatusCategory = statusCategory ?? null;
+  const normalizedDisplayStatus = displayStatus ?? null;
   const normalizedTemplateId = templateId ?? null;
   const normalizedTemplateMatch = templateMatch ?? null;
 
@@ -113,6 +122,7 @@ export function infiniteContractsQueryOptions({
     queryKey: infiniteContractsQueryKeys.list({
       branchId,
       statusCategory: normalizedStatusCategory,
+      displayStatus: normalizedDisplayStatus,
       search: normalizedSearch,
       templateId: normalizedTemplateId,
       templateMatch: normalizedTemplateMatch,
@@ -122,6 +132,7 @@ export function infiniteContractsQueryOptions({
         limit: pageParam.limit,
         skip: pageParam.skip,
         statusCategory: normalizedStatusCategory ?? undefined,
+        displayStatus: normalizedDisplayStatus ?? undefined,
         search: normalizedSearch || undefined,
         templateId: normalizedTemplateId ?? undefined,
         templateMatch: normalizedTemplateMatch ?? undefined,
@@ -149,6 +160,7 @@ export interface UseInfiniteContractsOptions extends Omit<InfiniteContractsQuery
  */
 export function useInfiniteContracts({
   statusCategory = null,
+  displayStatus = null,
   search = "",
   templateId = null,
   templateMatch = null,
@@ -159,8 +171,8 @@ export function useInfiniteContracts({
   const branchId = authUser?.branchId ?? null;
 
   const options = useMemo(
-    () => infiniteContractsQueryOptions({ branchId, statusCategory, search, templateId, templateMatch }),
-    [branchId, statusCategory, search, templateId, templateMatch],
+    () => infiniteContractsQueryOptions({ branchId, statusCategory, displayStatus, search, templateId, templateMatch }),
+    [branchId, displayStatus, statusCategory, search, templateId, templateMatch],
   );
 
   const query = useInfiniteQuery({

--- a/mobile/src/lib/dashboard/__tests__/analytics.test.ts
+++ b/mobile/src/lib/dashboard/__tests__/analytics.test.ts
@@ -133,7 +133,7 @@ describe("deriveDashboardAnalyticsFromClients", () => {
       NOW,
     );
 
-    expect(analytics.contractsPendingSignature).toBe(2);
+    expect(analytics.contractsPendingSignature).toBe(0);
   });
 
   it("derives weekly upcoming starts from service-start window", () => {

--- a/mobile/src/lib/dashboard/analytics.ts
+++ b/mobile/src/lib/dashboard/analytics.ts
@@ -1,5 +1,3 @@
-import { isContractReviewWindowOpen } from "@babyjamjam/shared/constants/eformsign-doc-status";
-
 export interface DashboardAnalytics {
   activeClients: number;
   contractsNotSent: number;
@@ -168,17 +166,9 @@ export function deriveDashboardAnalyticsFromClients(
         }
       }
 
-      // Client-side approximation of the server rule: an unfinished contract only
-      // counts as 검토 필요 once the review window (계약 종료 영업일 1일 전~) opens.
-      // Without an end date the window is treated as open, like the server does.
-      if (
-        client.eDocId
-        && client.documentStatus
-        && client.documentStatus !== "completed"
-        && isContractReviewWindowOpen(client.endDate ?? null, now)
-      ) {
-        acc.contractsPendingSignature += 1;
-      }
+      // The client projection cannot distinguish provider-review workflow state
+      // from other unfinished states. Only the dedicated server analytics payload
+      // may populate contractsPendingSignature; the offline fallback stays at zero.
 
       if (isContractIncompleteNearServiceStart(client, today)) {
         acc.contractsNotSent += 1;

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -147,6 +147,7 @@ export type EformsignStatusCategoryParam =
     | "unknown";
 
 export type EformsignTemplateMatchParam = "include" | "exclude";
+export type EformsignDisplayStatusParam = "signed" | "review";
 
 export interface GetAllDocumentsParams {
     limit?: number;
@@ -155,6 +156,8 @@ export interface GetAllDocumentsParams {
     templateMatch?: EformsignTemplateMatchParam;
     /** Server-side status bucket filter, applied before the limit/skip slice. */
     statusCategory?: EformsignStatusCategoryParam;
+    /** Provider-review display split, applied before the limit/skip slice. */
+    displayStatus?: EformsignDisplayStatusParam;
     /** Server-side (chosung-aware) name/title search, applied before the slice. */
     search?: string;
     /** Drops deleted (047/049) documents before the slice. Sent as "true" only when enabled. */
@@ -193,6 +196,7 @@ function buildDocumentListParams(
     if (params.templateId) query.templateId = params.templateId;
     if (params.templateMatch) query.templateMatch = params.templateMatch;
     if (params.statusCategory) query.statusCategory = params.statusCategory;
+    if (params.displayStatus) query.displayStatus = params.displayStatus;
 
     const search = params.search?.trim();
     if (search) query.search = search;

--- a/packages/shared/src/constants/eformsign-doc-status.test.ts
+++ b/packages/shared/src/constants/eformsign-doc-status.test.ts
@@ -57,6 +57,8 @@ describe("isContractReviewWindowOpen", () => {
         expect(isContractReviewWindowOpen(undefined, kstNoon("2026-08-01"))).toBe(true);
         expect(isContractReviewWindowOpen("", kstNoon("2026-08-01"))).toBe(true);
         expect(isContractReviewWindowOpen("nonsense", kstNoon("2026-08-01"))).toBe(true);
+        expect(isContractReviewWindowOpen("2026-02-31", kstNoon("2026-02-01"))).toBe(true);
+        expect(isContractReviewWindowOpen("2026-13-01", kstNoon("2026-02-01"))).toBe(true);
     });
 });
 

--- a/packages/shared/src/constants/eformsign-doc-status.ts
+++ b/packages/shared/src/constants/eformsign-doc-status.ts
@@ -96,8 +96,19 @@ const YMD_PATTERN = /^(\d{4})-(\d{2})-(\d{2})/;
 function parseYmdToUtc(ymd: string): Date | null {
     const match = YMD_PATTERN.exec(ymd);
     if (!match) return null;
-    const parsed = new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])));
-    return Number.isNaN(parsed.getTime()) ? null : parsed;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const parsed = new Date(Date.UTC(year, month - 1, day));
+    if (
+        Number.isNaN(parsed.getTime())
+        || parsed.getUTCFullYear() !== year
+        || parsed.getUTCMonth() !== month - 1
+        || parsed.getUTCDate() !== day
+    ) {
+        return null;
+    }
+    return parsed;
 }
 
 function isBusinessDayKr(ymd: string, date: Date): boolean {

--- a/packages/shared/src/types/eformsign.ts
+++ b/packages/shared/src/types/eformsign.ts
@@ -227,6 +227,32 @@ export interface EformsignDocClientSummary {
   providerName: string | null;
 }
 
+/**
+ * 계약서 detail payload에서 추출한 고객 등록 후보.
+ * extracted=false 폴백은 이름을 채우지 않는다 (문서 컬럼 이름은 관리사/직원명일 수
+ * 있어 신뢰 불가); phone만 폴백된다.
+ * 날짜는 모두 YYYY-MM-DD, phone은 대시 포함 표기(예: 010-1234-5678).
+ */
+export interface EformsignContractClientCandidateResponse {
+  documentId: string;
+  extracted: boolean;
+  name: string | null;
+  phone: string | null;
+  address: string | null;
+  birthday: string | null;
+  dueDate: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  type: string | null;
+  duration: number | null;
+  fullPrice: string | null;
+  grant: string | null;
+  actualPrice: string | null;
+  careCenter: boolean | null;
+  voucherClient: boolean;
+  breastPump: boolean;
+}
+
 export type EformsignDocumentKind = "contract" | "service_record_snapshot";
 
 export interface CreateEformsignDocRecordRequest {


### PR DESCRIPTION
## 요약

dev → preview 승격. 포함 변경:

### feat: 계약서 상세 more-menu "고객 등록" (신규 기능)
- 미연결 계약서(clientId 없음)의 상세 패널 more-menu에 "고객 등록" 항목 추가 (산모 계약서 섹션 한정)
- 신규 백엔드 조회 엔드포인트 `GET /api/documents/:id/client-candidate` — 자동 등록과 동일한 추출 유틸로 계약 상세에서 고객 후보(이름·생년월일·연락처·주소·기간·금액·시작/종료일) 반환, 추출 실패 시 전화번호만 폴백
- `ClientFormDialog`에 생성 모드 전용 `prefill`/`notice` prop 추가 — 프리필된 등록 폼 오픈, 등록 후 기존 전화번호 기반 자동 연결로 계약서·고객 양방향 링크
- 연결 로직 변경 없음 (읽기 전용 엔드포인트 + 기존 phone-link 재사용)

### fix (dev에서 승격 대기 중이던 변경)
- 계약 상태 비주얼/리뷰 프리뷰 정렬 (37857df8b)
- 고객 계약 상태 정합 및 리뷰 후속 (e40fcc674)

## 검증
- BE: type-check 클린, eformsign-doc 스위트 191 tests + 컨트롤러 통합 44 tests PASS (신규 usecase 5·통합 2 케이스 포함)
- FE: type-check 클린, 93 tests PASS (프리필 매퍼·RTL prefill 3케이스 신규), 프로덕션 빌드 성공
- 로컬 E2E 수동 검증 완료: 미연결 계약서 → 프리필 다이얼로그 → 등록 → DB 양방향 연결 + 메뉴 숨김 확인
- 태스크별 Codex 구현 → Opus 적대 리뷰 사이클 (테넌트 가드/PII 폴백/SSE 무효화 이슈 리뷰에서 수정 완료)

## 참고
- 설계/플랜 문서: `docs/superpowers/specs/2026-08-03-register-client-from-contract-design.md`, `docs/superpowers/plans/2026-08-03-register-client-from-contract.md`
- 선재 이슈(이번 변경 아님): 연결된 완료 계약서의 목록 고객명이 `stepRecipientName`(제공기관 계정명)으로 표시되는 기존 동작 — 별도 후속 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWoR7ZzVPvhtHDS6H9n9ga