### PR TITLE
[chore] Mark legacy chat stylesheet move

### DIFF
--- a/mobile/src/components/app/chat/LegacyChatPage.module.css
+++ b/mobile/src/components/app/chat/LegacyChatPage.module.css
@@ -1,3 +1,4 @@
+/* temporary move marker */
 .chatShell,
 :global(main[data-slot="main-content"]:has([data-slot="chat-page"])) {
   color: hsl(var(--v3-text));


### PR DESCRIPTION
## Summary

Preserve the local CSS-module move marker on the canonical legacy chat stylesheet path.

## Changes

- Adds the temporary move marker to `mobile/src/components/app/chat/LegacyChatPage.module.css`.
- No runtime behavior or visual styling changes.

## Test Plan

- `git diff --check` passed.
- Test, lint, and build could not start because dependencies are not installed in the fresh worktree.
- No `typecheck` script is defined.

## Related

- Target branch: `dev`
- Promotion PR: #482 (`dev` → `preview`)