### PR TITLE
fix: resolve PR 484 review findings

### DIFF
--- a/backend/agent-manifest.json
+++ b/backend/agent-manifest.json
@@ -54,7 +54,7 @@
       "approvalPolicy": "strong",
       "idempotencyPolicy": "action-id",
       "sourceFile": "application/usecases/message/message-external-agent-capabilities.provider.ts",
-      "sourceDigest": "1573e6edec49a754205c7c971cfc82ac122d07844c41a6040cb1dd22d75db2d8"
+      "sourceDigest": "deff687f115119567f06b10cc23fe21eb57bebb0e842abfda60b8c615f1f200d"
     },
     {
       "name": "automation.delete",
@@ -73,7 +73,7 @@
       "approvalPolicy": "strong",
       "idempotencyPolicy": "action-id",
       "sourceFile": "application/usecases/message/message-external-agent-capabilities.provider.ts",
-      "sourceDigest": "1573e6edec49a754205c7c971cfc82ac122d07844c41a6040cb1dd22d75db2d8"
+      "sourceDigest": "deff687f115119567f06b10cc23fe21eb57bebb0e842abfda60b8c615f1f200d"
     },
     {
       "name": "automation.list",
@@ -91,7 +91,7 @@
       "flagKey": "agent.capability.automation.list",
       "sideEffect": false,
       "sourceFile": "application/usecases/message/message-external-agent-capabilities.provider.ts",
-      "sourceDigest": "1573e6edec49a754205c7c971cfc82ac122d07844c41a6040cb1dd22d75db2d8"
+      "sourceDigest": "deff687f115119567f06b10cc23fe21eb57bebb0e842abfda60b8c615f1f200d"
     },
     {
       "name": "automation.setActive",
@@ -110,7 +110,7 @@
       "approvalPolicy": "strong",
       "idempotencyPolicy": "action-id",
       "sourceFile": "application/usecases/message/message-external-agent-capabilities.provider.ts",
-      "sourceDigest": "1573e6edec49a754205c7c971cfc82ac122d07844c41a6040cb1dd22d75db2d8"
+      "sourceDigest": "deff687f115119567f06b10cc23fe21eb57bebb0e842abfda60b8c615f1f200d"
     },
     {
       "name": "automation.update",
@@ -129,7 +129,7 @@
       "approvalPolicy": "strong",
       "idempotencyPolicy": "action-id",
       "sourceFile": "application/usecases/message/message-external-agent-capabilities.provider.ts",
-      "sourceDigest": "1573e6edec49a754205c7c971cfc82ac122d07844c41a6040cb1dd22d75db2d8"
+      "sourceDigest": "deff687f115119567f06b10cc23fe21eb57bebb0e842abfda60b8c615f1f200d"
     },
     {
       "name": "bank.accounts",
@@ -347,7 +347,7 @@
       "approvalPolicy": "strong",
       "idempotencyPolicy": "provider-key",
       "sourceFile": "application/usecases/eformsign-doc/contract-external-agent-capabilities.provider.ts",
-      "sourceDigest": "f3f3652881dda9648b8d03ced4ac0046eae259866d5838d62839a1ab80909f67"
+      "sourceDigest": "5425f39e484922ff48ae8f806ba7f91bbb535474e8ac48f28753ba3e0d3cd5d3"
     },
     {
       "name": "contracts.status",
@@ -623,7 +623,7 @@
       "flagKey": "agent.capability.messages.deliveryHistory",
       "sideEffect": false,
       "sourceFile": "application/usecases/message/message-external-agent-capabilities.provider.ts",
-      "sourceDigest": "1573e6edec49a754205c7c971cfc82ac122d07844c41a6040cb1dd22d75db2d8"
+      "sourceDigest": "deff687f115119567f06b10cc23fe21eb57bebb0e842abfda60b8c615f1f200d"
     },
     {
       "name": "messages.previewSms",
@@ -641,7 +641,7 @@
       "flagKey": "agent.capability.messages.previewSms",
       "sideEffect": false,
       "sourceFile": "application/usecases/message/message-external-agent-capabilities.provider.ts",
-      "sourceDigest": "1573e6edec49a754205c7c971cfc82ac122d07844c41a6040cb1dd22d75db2d8"
+      "sourceDigest": "deff687f115119567f06b10cc23fe21eb57bebb0e842abfda60b8c615f1f200d"
     },
     {
       "name": "messages.retrySms",
@@ -660,7 +660,7 @@
       "approvalPolicy": "strong",
       "idempotencyPolicy": "action-id",
       "sourceFile": "application/usecases/message/message-external-agent-capabilities.provider.ts",
-      "sourceDigest": "1573e6edec49a754205c7c971cfc82ac122d07844c41a6040cb1dd22d75db2d8"
+      "sourceDigest": "deff687f115119567f06b10cc23fe21eb57bebb0e842abfda60b8c615f1f200d"
     },
     {
       "name": "messages.scheduleSms",
@@ -679,7 +679,7 @@
       "approvalPolicy": "strong",
       "idempotencyPolicy": "action-id",
       "sourceFile": "application/usecases/message/message-external-agent-capabilities.provider.ts",
-      "sourceDigest": "1573e6edec49a754205c7c971cfc82ac122d07844c41a6040cb1dd22d75db2d8"
+      "sourceDigest": "deff687f115119567f06b10cc23fe21eb57bebb0e842abfda60b8c615f1f200d"
     },
     {
       "name": "messages.sendSms",
@@ -698,7 +698,7 @@
       "approvalPolicy": "strong",
       "idempotencyPolicy": "action-id",
       "sourceFile": "application/usecases/message/message-external-agent-capabilities.provider.ts",
-      "sourceDigest": "1573e6edec49a754205c7c971cfc82ac122d07844c41a6040cb1dd22d75db2d8"
+      "sourceDigest": "deff687f115119567f06b10cc23fe21eb57bebb0e842abfda60b8c615f1f200d"
     },
     {
       "name": "messages.updateTemplate",

--- a/backend/application/usecases/eformsign-doc/contract-external-agent-capabilities.provider.spec.ts
+++ b/backend/application/usecases/eformsign-doc/contract-external-agent-capabilities.provider.spec.ts
@@ -38,6 +38,7 @@ describe("ContractExternalAgentCapabilitiesProvider approval-bound dispatch", ()
 
     function setup(currentClient = client(), currentTemplates = [template()]) {
         const createAndSend = { execute: jest.fn().mockResolvedValue({ success: true, documentId: "remote-1" }) };
+        const adoptEformsignDoc = { execute: jest.fn().mockResolvedValue({ documentId: "remote-1" }) };
         const getAccessToken = { execute: jest.fn().mockResolvedValue({ oauth_token: { access_token: "token" } }) };
         const fetchDocument = { execute: jest.fn() };
         const transaction = { agent_action: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) } };
@@ -47,6 +48,7 @@ describe("ContractExternalAgentCapabilitiesProvider approval-bound dispatch", ()
         const areaTemplateService = { findAll: jest.fn().mockResolvedValue(currentTemplates) };
         const provider = new ContractExternalAgentCapabilitiesProvider(
             createAndSend as never,
+            adoptEformsignDoc as never,
             getAccessToken as never,
             fetchDocument as never,
             { execute: jest.fn().mockResolvedValue(currentClient) } as never,
@@ -54,7 +56,7 @@ describe("ContractExternalAgentCapabilitiesProvider approval-bound dispatch", ()
             { findByIdForUpdate: jest.fn().mockResolvedValue(currentClient) } as never,
             prisma as never,
         );
-        return { provider, createAndSend, getAccessToken, fetchDocument, transaction, prisma, areaTemplateService };
+        return { provider, createAndSend, adoptEformsignDoc, getAccessToken, fetchDocument, transaction, prisma, areaTemplateService };
     }
 
     async function inspectDispatch(
@@ -264,11 +266,35 @@ describe("ContractExternalAgentCapabilitiesProvider approval-bound dispatch", ()
         expect(createAndSend.execute).not.toHaveBeenCalled();
     });
 
-    it("reconciles a remotely accepted in-progress document as a successful dispatch", async () => {
-        const { provider, fetchDocument } = setup();
+    it("keeps a temporary remote document uncertain instead of claiming it was dispatched", async () => {
+        const { provider, fetchDocument, adoptEformsignDoc } = setup();
         fetchDocument.execute.mockResolvedValue({
             current_status: {
                 status_type: "001",
+                status_doc_detail: "서명 요청됨",
+            },
+        });
+        const capability = provider.getCapabilities()[0]!;
+
+        await expect(capability.reconcile!(context, {
+            clientId: 7,
+            templateId: "template-1",
+        }, { remoteDocumentId: "remote-1" })).resolves.toEqual({
+            status: "uncertain",
+            reason: "Provider status does not prove contract dispatch",
+        });
+        expect(fetchDocument.execute).toHaveBeenCalledWith("token", "remote-1");
+        expect(adoptEformsignDoc.execute).toHaveBeenCalledWith("branch-a", {
+            documentId: "remote-1",
+            clientId: 7,
+        });
+    });
+
+    it("reconciles a dispatched participant request as a successful dispatch", async () => {
+        const { provider, fetchDocument } = setup();
+        fetchDocument.execute.mockResolvedValue({
+            current_status: {
+                status_type: "060",
                 status_doc_detail: "서명 요청됨",
             },
         });
@@ -285,6 +311,25 @@ describe("ContractExternalAgentCapabilitiesProvider approval-bound dispatch", ()
                 status: "서명 요청됨",
             },
         });
-        expect(fetchDocument.execute).toHaveBeenCalledWith("token", "remote-1");
+    });
+
+    it("stays uncertain when local contract projection repair fails", async () => {
+        const { provider, fetchDocument, adoptEformsignDoc } = setup();
+        fetchDocument.execute.mockResolvedValue({
+            current_status: {
+                status_type: "060",
+                status_doc_detail: "서명 요청됨",
+            },
+        });
+        adoptEformsignDoc.execute.mockRejectedValue(new Error("database unavailable"));
+        const capability = provider.getCapabilities()[0]!;
+
+        await expect(capability.reconcile!(context, {
+            clientId: 7,
+            templateId: "template-1",
+        }, { remoteDocumentId: "remote-1" })).resolves.toEqual({
+            status: "uncertain",
+            reason: "Local contract projection repair failed",
+        });
     });
 });

--- a/backend/application/usecases/eformsign-doc/contract-external-agent-capabilities.provider.spec.ts
+++ b/backend/application/usecases/eformsign-doc/contract-external-agent-capabilities.provider.spec.ts
@@ -38,6 +38,8 @@ describe("ContractExternalAgentCapabilitiesProvider approval-bound dispatch", ()
 
     function setup(currentClient = client(), currentTemplates = [template()]) {
         const createAndSend = { execute: jest.fn().mockResolvedValue({ success: true, documentId: "remote-1" }) };
+        const getAccessToken = { execute: jest.fn().mockResolvedValue({ oauth_token: { access_token: "token" } }) };
+        const fetchDocument = { execute: jest.fn() };
         const transaction = { agent_action: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) } };
         const prisma = {
             $transaction: jest.fn(async (operation: (tx: typeof transaction) => Promise<unknown>) => operation(transaction)),
@@ -45,14 +47,14 @@ describe("ContractExternalAgentCapabilitiesProvider approval-bound dispatch", ()
         const areaTemplateService = { findAll: jest.fn().mockResolvedValue(currentTemplates) };
         const provider = new ContractExternalAgentCapabilitiesProvider(
             createAndSend as never,
-            { execute: jest.fn() } as never,
-            { execute: jest.fn() } as never,
+            getAccessToken as never,
+            fetchDocument as never,
             { execute: jest.fn().mockResolvedValue(currentClient) } as never,
             areaTemplateService as never,
             { findByIdForUpdate: jest.fn().mockResolvedValue(currentClient) } as never,
             prisma as never,
         );
-        return { provider, createAndSend, transaction, prisma, areaTemplateService };
+        return { provider, createAndSend, getAccessToken, fetchDocument, transaction, prisma, areaTemplateService };
     }
 
     async function inspectDispatch(
@@ -260,5 +262,29 @@ describe("ContractExternalAgentCapabilitiesProvider approval-bound dispatch", ()
         }, clientAgentTargetVersion(client() as never))).rejects.toBeInstanceOf(AgentActionCertainFailureError);
 
         expect(createAndSend.execute).not.toHaveBeenCalled();
+    });
+
+    it("reconciles a remotely accepted in-progress document as a successful dispatch", async () => {
+        const { provider, fetchDocument } = setup();
+        fetchDocument.execute.mockResolvedValue({
+            current_status: {
+                status_type: "001",
+                status_doc_detail: "서명 요청됨",
+            },
+        });
+        const capability = provider.getCapabilities()[0]!;
+
+        await expect(capability.reconcile!(context, {
+            clientId: 7,
+            templateId: "template-1",
+        }, { remoteDocumentId: "remote-1" })).resolves.toEqual({
+            status: "succeeded",
+            result: {
+                success: true,
+                documentId: "remote-1",
+                status: "서명 요청됨",
+            },
+        });
+        expect(fetchDocument.execute).toHaveBeenCalledWith("token", "remote-1");
     });
 });

--- a/backend/application/usecases/eformsign-doc/contract-external-agent-capabilities.provider.ts
+++ b/backend/application/usecases/eformsign-doc/contract-external-agent-capabilities.provider.ts
@@ -7,9 +7,11 @@ import type { AgentCapabilityProviderContract, CapabilityDefinition } from "appl
 import type { AgentContext } from "application/agent/agent-context";
 import type { AgentFormField } from "@babyjamjam/shared";
 import { CreateAndSendContractUsecase, ContractClientSnapshot } from "./create-and-send-contract.usecase";
+import { AdoptEformsignDocUsecase } from "./adopt-eformsign-doc.usecase";
 import { GetEformsignAccessTokenUsecase } from "./get-eformsign-access-token.usecase";
 import { FetchEformsignDocFromApiUsecase } from "./fetch-eformsign-doc-from-api.usecase";
 import { EFORMSIGN_COMPLETED_STATUS_CODES, TERMINAL_STATUS_CODES } from "domain/constants/eformsign-doc-status.constants";
+import { normalizeEformsignStatusCode } from "domain/utils/eformsign-status-code";
 import { FindClientByIdUsecase } from "application/usecases/client/find-client-by-id.usecase";
 import { AreaTemplateService } from "application/services/area-template.service";
 import { clientAgentTargetVersion } from "application/usecases/client/client-agent-target";
@@ -21,6 +23,15 @@ import { recordAgentActionEffect } from "application/agent/agent-action-effect-r
 const ContractInputSchema = z.object({ clientId: z.number().int().positive(), templateId: z.string().min(1).max(200), templateName: z.string().max(200).optional() });
 const ContractOutputSchema = z.object({ success: z.boolean(), documentId: z.string().optional(), status: z.string(), uncertain: z.boolean().optional() });
 const CONTRACT_TEMPLATE_UNAVAILABLE_ERROR = "Contract template is unavailable";
+const DISPATCH_CONFIRMED_IN_PROGRESS_STATUS_CODES = new Set([
+    "010", // doc_request_approval
+    "020", // doc_request_reception
+    "030", // doc_request_outsider
+    "060", // doc_request_participant
+    "063", // doc_rerequest_participant
+    "064", // doc_open_participant
+    "070", // doc_request_reviewer
+]);
 const ContractApprovalSnapshotSchema = z.object({
     clientId: z.number().int().positive(),
     phoneLast4: z.string().min(1).max(20),
@@ -49,6 +60,7 @@ const CONTRACT_FORM_FIELDS: AgentFormField[] = [
 export class ContractExternalAgentCapabilitiesProvider implements AgentCapabilityProviderContract {
     constructor(
         private readonly createAndSend: CreateAndSendContractUsecase,
+        private readonly adoptEformsignDoc: AdoptEformsignDocUsecase,
         private readonly getAccessToken: GetEformsignAccessTokenUsecase,
         private readonly fetchDocument: FetchEformsignDocFromApiUsecase,
         private readonly findClientById: FindClientByIdUsecase,
@@ -125,27 +137,45 @@ export class ContractExternalAgentCapabilitiesProvider implements AgentCapabilit
                     }
                 },
                 revalidate: async (context, rawInput, expectedTargetVersion) => this.revalidateClient(context, rawInput, expectedTargetVersion),
-                reconcile: async (_context, _rawInput, uncertainty) => {
+                reconcile: async (context, rawInput, uncertainty) => {
                     const remoteDocumentId = typeof uncertainty?.["remoteDocumentId"] === "string" ? uncertainty["remoteDocumentId"] : undefined;
                     if (!remoteDocumentId) return { status: "uncertain" as const, reason: "Remote document identity is unavailable" };
+                    const input = ContractInputSchema.parse(rawInput);
+                    let document: Awaited<ReturnType<FetchEformsignDocFromApiUsecase["execute"]>>;
                     try {
                         const token = await this.getAccessToken.execute(Date.now());
-                        const document = await this.fetchDocument.execute(token.oauth_token.access_token, remoteDocumentId);
-                        const statusType = document.current_status.status_type;
-                        const status = document.current_status.status_doc_detail ?? statusType;
-                        if (EFORMSIGN_COMPLETED_STATUS_CODES.has(statusType)) {
-                            return { status: "succeeded" as const, result: { success: true, documentId: remoteDocumentId, status } };
-                        }
-                        if (TERMINAL_STATUS_CODES.has(statusType)) {
-                            return { status: "failed" as const, result: { success: false, documentId: remoteDocumentId, status }, reason: "Provider reported a terminal non-completed status" };
-                        }
-                        return {
-                            status: "succeeded" as const,
-                            result: { success: true, documentId: remoteDocumentId, status },
-                        };
+                        document = await this.fetchDocument.execute(token.oauth_token.access_token, remoteDocumentId);
                     } catch {
                         return { status: "uncertain" as const, reason: "Provider status lookup failed" };
                     }
+
+                    try {
+                        const repaired = await this.adoptEformsignDoc.execute(context.principal.branchId, {
+                            documentId: remoteDocumentId,
+                            clientId: input.clientId,
+                        });
+                        if (repaired.warnings?.length) {
+                            return { status: "uncertain" as const, reason: "Local contract projection repair is incomplete" };
+                        }
+                    } catch {
+                        return { status: "uncertain" as const, reason: "Local contract projection repair failed" };
+                    }
+
+                    const statusType = normalizeEformsignStatusCode(document.current_status.status_type);
+                    const status = document.current_status.status_doc_detail ?? statusType;
+                    if (EFORMSIGN_COMPLETED_STATUS_CODES.has(statusType)) {
+                        return { status: "succeeded" as const, result: { success: true, documentId: remoteDocumentId, status } };
+                    }
+                    if (TERMINAL_STATUS_CODES.has(statusType)) {
+                        return { status: "failed" as const, result: { success: false, documentId: remoteDocumentId, status }, reason: "Provider reported a terminal non-completed status" };
+                    }
+                    if (!DISPATCH_CONFIRMED_IN_PROGRESS_STATUS_CODES.has(statusType)) {
+                        return { status: "uncertain" as const, reason: "Provider status does not prove contract dispatch" };
+                    }
+                    return {
+                        status: "succeeded" as const,
+                        result: { success: true, documentId: remoteDocumentId, status },
+                    };
                 },
             },
         ];

--- a/backend/application/usecases/eformsign-doc/contract-external-agent-capabilities.provider.ts
+++ b/backend/application/usecases/eformsign-doc/contract-external-agent-capabilities.provider.ts
@@ -139,7 +139,10 @@ export class ContractExternalAgentCapabilitiesProvider implements AgentCapabilit
                         if (TERMINAL_STATUS_CODES.has(statusType)) {
                             return { status: "failed" as const, result: { success: false, documentId: remoteDocumentId, status }, reason: "Provider reported a terminal non-completed status" };
                         }
-                        return { status: "uncertain" as const, reason: "Provider document is still in progress" };
+                        return {
+                            status: "succeeded" as const,
+                            result: { success: true, documentId: remoteDocumentId, status },
+                        };
                     } catch {
                         return { status: "uncertain" as const, reason: "Provider status lookup failed" };
                     }

--- a/backend/application/usecases/message/message-external-agent-capabilities.provider.ts
+++ b/backend/application/usecases/message/message-external-agent-capabilities.provider.ts
@@ -15,7 +15,13 @@ import {
     SmsTriggerDeliveryService,
 } from "application/services/sms-trigger-delivery.service";
 import { MessageTriggerJobEntity } from "domain/entities/message-trigger-job.entity";
-import { MessageTriggerEventType, MessageTriggerOffsetType, MessageTriggerRecipientType, MessageTriggerTemplateKey } from "domain/constants/message-trigger-catalog";
+import {
+    AGENT_SMS_RULE_ID_PREFIX,
+    MessageTriggerEventType,
+    MessageTriggerOffsetType,
+    MessageTriggerRecipientType,
+    MessageTriggerTemplateKey,
+} from "domain/constants/message-trigger-catalog";
 import type { MessageTriggerRuleEntity } from "domain/entities/message-trigger-rule.entity";
 import { MESSAGE_TRIGGER_JOB_REPOSITORY, type IMessageTriggerJobRepository } from "domain/repositories/message-trigger-job.repository.interface";
 import { PhoneNumber } from "domain/value-objects/phone-number.vo";
@@ -541,7 +547,7 @@ export class MessageExternalAgentCapabilitiesProvider implements AgentCapability
     ): Promise<MessageTriggerJobEntity> {
         if (!context.actionId) throw new AgentActionUncertainError("SMS action identity is missing");
         await this.ensureSmsApprovedForExecution(context.principal.branchId);
-        const ruleId = `agent-sms:${context.principal.branchId}`;
+        const ruleId = `${AGENT_SMS_RULE_ID_PREFIX}${context.principal.branchId}`;
         await this.prisma.message_trigger_rule.upsert({
             where: { id: ruleId },
             create: {

--- a/backend/domain/constants/message-trigger-catalog.ts
+++ b/backend/domain/constants/message-trigger-catalog.ts
@@ -33,6 +33,8 @@ export enum MessageTriggerTemplateKey {
     INFO = "INFO",
 }
 
+export const AGENT_SMS_RULE_ID_PREFIX = "agent-sms:";
+
 export type SupportedTriggerProvider = "sms";
 
 // Free pairing: every SMS (system-template) trigger may fire on any client lifecycle event.

--- a/backend/infrastructure/database/repositories/sb.message-trigger-job.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.message-trigger-job.repository.ts
@@ -12,6 +12,7 @@ import {
     MessageTriggerJobStatus,
 } from "domain/entities/message-trigger-job.entity";
 import {
+    AGENT_SMS_RULE_ID_PREFIX,
     MessageTriggerRecipientType,
     MessageTriggerTemplateKey,
 } from "domain/constants/message-trigger-catalog";
@@ -359,6 +360,7 @@ export class SbMessageTriggerJobRepository implements IMessageTriggerJobReposito
                 status: "pending",
                 clientId: null,
                 employeeScheduleId: null,
+                NOT: { ruleId: { startsWith: AGENT_SMS_RULE_ID_PREFIX } },
             },
             data: {
                 status: "canceled",

--- a/backend/infrastructure/database/repositories/sb.message-trigger-job.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.message-trigger-job.repository.ts
@@ -381,6 +381,7 @@ export class SbMessageTriggerJobRepository implements IMessageTriggerJobReposito
                 clientId: null,
                 employeeScheduleId: null,
                 recipientType: MessageTriggerRecipientType.CLIENT,
+                NOT: { ruleId: { startsWith: AGENT_SMS_RULE_ID_PREFIX } },
                 OR: [
                     { status: "pending" },
                     {

--- a/backend/test/repositories/sb.message-trigger-job.repository.spec.ts
+++ b/backend/test/repositories/sb.message-trigger-job.repository.spec.ts
@@ -701,6 +701,7 @@ describe("SbMessageTriggerJobRepository", () => {
                 status: "pending",
                 clientId: null,
                 employeeScheduleId: null,
+                NOT: { ruleId: { startsWith: "agent-sms:" } },
             },
             data: {
                 status: "canceled",

--- a/backend/test/repositories/sb.message-trigger-job.repository.spec.ts
+++ b/backend/test/repositories/sb.message-trigger-job.repository.spec.ts
@@ -722,6 +722,7 @@ describe("SbMessageTriggerJobRepository", () => {
                 clientId: null,
                 employeeScheduleId: null,
                 recipientType: MessageTriggerRecipientType.CLIENT,
+                NOT: { ruleId: { startsWith: "agent-sms:" } },
                 OR: [
                     { status: "pending" },
                     {

--- a/frontend/src/app/(protected)/contracts/page.tsx
+++ b/frontend/src/app/(protected)/contracts/page.tsx
@@ -5,7 +5,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { EformsignDocClientSummary } from "@babyjamjam/shared/types/eformsign";
 import dynamic from "next/dynamic";
 import { useRouter, useSearchParams } from "next/navigation";
-import { matchesSearchQuery } from "@/lib/search/korean-search";
 import { formatDateForDisplay } from "@/lib/date/format-date-for-display";
 import {
   FileText,
@@ -35,6 +34,7 @@ import { useInfiniteContracts } from "@/hooks/useInfiniteContracts";
 import { ServiceRecordHeaderCard } from "@/features/service-records/components/ServiceRecordHeaderCard";
 import { useClientServiceRecords } from "@/features/service-records/hooks/use-service-records";
 import type { EformsignDocument, EformsignDocumentOption } from "@/lib/eformsign/types";
+import { matchesDocumentSearch } from "@/lib/eformsign/contract-search";
 import {
   DocumentFilterType,
   contractStatusBadgeType,
@@ -98,11 +98,7 @@ import {
   extractOpenEvents,
   extractReRequestEvents,
 } from "@/lib/eformsign/document-details";
-import {
-  UNKNOWN_CUSTOMER_NAME,
-  customerName as getEformsignCustomerName,
-  resolveDocumentCustomerName,
-} from "@/lib/eformsign/display-name";
+import { resolveDocumentCustomerName } from "@/lib/eformsign/display-name";
 import { formatIsoDateInput } from "@/lib/date/format-iso-input";
 import { useAllVoucherPriceInfos } from "@/hooks/useVoucherData";
 import { inferVoucherDurationFromAmounts } from "@/lib/voucher/duration";
@@ -193,20 +189,6 @@ type InfoCardRow = {
   label: string;
   value: React.ReactNode;
 };
-
-function displayCustomerName(doc: EformsignDocument | null): string | null {
-  if (!doc) return null;
-  const name = getEformsignCustomerName(doc);
-  return name === UNKNOWN_CUSTOMER_NAME ? null : name;
-}
-
-function matchesDocumentSearch(
-  doc: EformsignDocument,
-  query: string,
-  mappedCustomerName?: string | null,
-): boolean {
-  return matchesSearchQuery(query, [mappedCustomerName ?? displayCustomerName(doc), doc.document_name]);
-}
 
 function matchesDocumentStatusTab(doc: EformsignDocument, tab: string): boolean {
   if (tab === "all") return true;

--- a/frontend/src/lib/eformsign/__tests__/contract-search.test.ts
+++ b/frontend/src/lib/eformsign/__tests__/contract-search.test.ts
@@ -1,0 +1,25 @@
+import { matchesDocumentSearch } from "@/lib/eformsign/contract-search";
+import type { EformsignDocument } from "@/lib/eformsign/types";
+
+function documentFixture(fields: unknown[] = []): EformsignDocument {
+  return {
+    document_name: "산모 서비스 계약서",
+    fields,
+  } as EformsignDocument;
+}
+
+describe("contract document search", () => {
+  it("matches the customer name displayed from the document when the local mapping is stale", () => {
+    expect(
+      matchesDocumentSearch(
+        documentFixture([{ id: "이용자 성명", value: "안현주" }]),
+        "안현주",
+        "인천 아이미래로",
+      ),
+    ).toBe(true);
+  });
+
+  it("falls back to the local mapping when the document has no customer name", () => {
+    expect(matchesDocumentSearch(documentFixture(), "송진호", " 송진호 ")).toBe(true);
+  });
+});

--- a/frontend/src/lib/eformsign/contract-search.ts
+++ b/frontend/src/lib/eformsign/contract-search.ts
@@ -1,0 +1,14 @@
+import { matchesSearchQuery } from "@/lib/search/korean-search";
+import { resolveDocumentCustomerName } from "@/lib/eformsign/display-name";
+import type { EformsignDocument } from "@/lib/eformsign/types";
+
+export function matchesDocumentSearch(
+  document: EformsignDocument,
+  query: string,
+  mappedCustomerName?: string | null,
+): boolean {
+  return matchesSearchQuery(query, [
+    resolveDocumentCustomerName(document, mappedCustomerName),
+    document.document_name,
+  ]);
+}


### PR DESCRIPTION
## Summary
- Keep agent-scheduled SMS jobs out of orphan cleanup so approved jobs reach delivery.
- Reconcile an action-bound remote contract as a successful dispatch once the provider accepts it, while preserving terminal failures.
- Use the same document-first customer name resolution for contract display and search.

## Validation
- `pnpm test` — all workspace suites passed
- `pnpm lint` — no errors; existing warnings remain
- `pnpm lint:ui-architecture` — passed
- frontend/backend type checks — passed
- backend and frontend builds — passed
- mobile build — passed with the documented placeholder API URL

Follow-up for PR #484.