### PR TITLE
fix(eformsign): propagate real vendor status on token refresh failure

### DIFF
--- a/backend/application/services/eformsign.service.ts
+++ b/backend/application/services/eformsign.service.ts
@@ -174,7 +174,11 @@ export class EformsignService {
 
         if (!response.ok) {
             const errorData = await response.text();
-            throw new Error(`Failed to get access token: ${response.status} - ${errorData}`);
+            throw new EformsignApiError(
+                `Failed to get access token: ${response.status} - ${errorData}`,
+                response.status,
+                extractEformsignVendorCode(errorData),
+            );
         }
 
         return await response.json();
@@ -203,7 +207,11 @@ export class EformsignService {
 
         if (!response.ok) {
             const errorData = await response.text();
-            throw new Error(`Failed to refresh token: ${response.status} - ${errorData}`);
+            throw new EformsignApiError(
+                `Failed to refresh token: ${response.status} - ${errorData}`,
+                response.status,
+                extractEformsignVendorCode(errorData),
+            );
         }
 
         return await response.json();

--- a/backend/interface/controllers/eformsign.controller.ts
+++ b/backend/interface/controllers/eformsign.controller.ts
@@ -55,6 +55,10 @@ function throwHttpOrInternalError(error: unknown): never {
         throw error;
     }
 
+    if (error instanceof EformsignApiError) {
+        throw new HttpException({ error: error.message }, error.status);
+    }
+
     const message = error instanceof Error ? error.message : "Unknown error";
     throw new HttpException(
         { error: message },
@@ -379,11 +383,7 @@ export class EformsignController {
             );
             return result;
         } catch (error) {
-            const message = error instanceof Error ? error.message : "Unknown error";
-            throw new HttpException(
-                { error: message },
-                HttpStatus.INTERNAL_SERVER_ERROR
-            );
+            throwHttpOrInternalError(error);
         }
     }
 
@@ -396,11 +396,7 @@ export class EformsignController {
             );
             return result;
         } catch (error) {
-            const message = error instanceof Error ? error.message : "Unknown error";
-            throw new HttpException(
-                { error: message },
-                HttpStatus.INTERNAL_SERVER_ERROR
-            );
+            throwHttpOrInternalError(error);
         }
     }
 

--- a/backend/test/integration/eformsign.controller.integration.spec.ts
+++ b/backend/test/integration/eformsign.controller.integration.spec.ts
@@ -267,6 +267,30 @@ describe("EformsignController (Integration)", () => {
         expect(eformsignService.refreshAccessToken).not.toHaveBeenCalled();
     });
 
+    it("propagates the vendor's real status when refresh-token fails", async () => {
+        eformsignService.refreshAccessToken.mockRejectedValue(
+            new EformsignApiError("expired refresh token", 401),
+        );
+
+        const response = await request(app.getHttpServer())
+            .post("/api/refresh-token")
+            .send({ executionTime: 1780000000000, refreshToken: "stale-token" });
+
+        expect(response.status).toBe(401);
+    });
+
+    it("propagates the vendor's real status when access-token fails", async () => {
+        eformsignService.getAccessToken.mockRejectedValue(
+            new EformsignApiError("unauthorized", 401),
+        );
+
+        const response = await request(app.getHttpServer())
+            .post("/api/access-token")
+            .send({ executionTime: 1780000000000 });
+
+        expect(response.status).toBe(401);
+    });
+
     it("rejects malformed contract data before generating document options", async () => {
         const response = await request(app.getHttpServer())
             .post("/api/generate-document")

--- a/backend/test/services/eformsign.service.spec.ts
+++ b/backend/test/services/eformsign.service.spec.ts
@@ -1,4 +1,5 @@
 import { ConfigService } from "@nestjs/config";
+import * as crypto from "crypto";
 
 import { ContractDataDto } from "application/dto/contract.dto";
 import {
@@ -7,6 +8,11 @@ import {
     EFORMSIGN_MAX_DOWNLOAD_BYTES,
     EformsignService,
 } from "application/services/eformsign.service";
+
+function generateEformsignPrivateKeyHex(): string {
+    const { privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+    return (privateKey.export({ format: "der", type: "pkcs8" }) as Buffer).toString("hex");
+}
 
 function createConfigService(overrides: Record<string, string | undefined> = {}): ConfigService {
     return {
@@ -162,6 +168,32 @@ describe("EformsignService", () => {
 
         await expect(service.cancelDocuments("access-token", ["doc-1"]))
             .rejects.toMatchObject({ status: 400, vendorCode: "4000164" });
+    });
+
+    it("surfaces a vendor rejection of an access-token request as an api error", async () => {
+        const service = new EformsignService(createConfigService({
+            EFORMSIGN_PRIVATE_KEY: generateEformsignPrivateKeyHex(),
+        }));
+        jest.spyOn(global, "fetch").mockResolvedValue(new Response(
+            JSON.stringify({ code: "4010001", ErrorMessage: "unauthorized" }),
+            { status: 401, headers: { "Content-Type": "application/json" } },
+        ));
+
+        await expect(service.getAccessToken(Date.now()))
+            .rejects.toMatchObject({ status: 401, vendorCode: "4010001" });
+    });
+
+    it("surfaces a vendor rejection of a refresh-token request as an api error", async () => {
+        const service = new EformsignService(createConfigService({
+            EFORMSIGN_PRIVATE_KEY: generateEformsignPrivateKeyHex(),
+        }));
+        jest.spyOn(global, "fetch").mockResolvedValue(new Response(
+            JSON.stringify({ code: "4010002", ErrorMessage: "expired refresh token" }),
+            { status: 401, headers: { "Content-Type": "application/json" } },
+        ));
+
+        await expect(service.refreshAccessToken(Date.now(), "stale-refresh-token"))
+            .rejects.toMatchObject({ status: 401, vendorCode: "4010002" });
     });
 
     it("aborts and cancels a mirrored PDF body that stops streaming before the deadline", async () => {

--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -80,6 +80,23 @@ function createUnauthorizedError(config: RetryableRequestConfig): AxiosError {
     } as AxiosError;
 }
 
+function createUnauthorizedErrorWithMessage(
+    config: RetryableRequestConfig,
+    errorMessage: string,
+): AxiosError {
+    return {
+        name: "AxiosError",
+        message: "Request failed with status code 401",
+        config,
+        response: {
+            status: 401,
+            data: { error: errorMessage },
+        },
+        isAxiosError: true,
+        toJSON: () => ({}),
+    } as AxiosError;
+}
+
 describe("api client network retry", () => {
     beforeEach(() => {
         mockAxios.mockClear();
@@ -186,5 +203,47 @@ describe("api client app-session refresh", () => {
 
         expect(mockAxios.__mockApi.barePost).not.toHaveBeenCalled();
         expect(mockAxios).not.toHaveBeenCalled();
+    });
+});
+
+describe("api client eformsign refresh failure classification", () => {
+    beforeEach(() => {
+        mockAxios.mockClear();
+        mockAxios.__mockApi.barePost.mockReset();
+        window.history.replaceState({}, "", "/login");
+    });
+
+    it("rejects a vendor-flavored refresh failure without starting an app-session refresh", async () => {
+        const originalRequest: RetryableRequestConfig = {
+            method: "POST",
+            url: "/refresh-access-token",
+        };
+        const error = createUnauthorizedErrorWithMessage(
+            originalRequest,
+            "Failed to refresh token: 401 - Authentication required by upstream gateway",
+        );
+
+        await expect(getResponseRejectedHandler()(error)).rejects.toBe(error);
+
+        expect(mockAxios.__mockApi.barePost).not.toHaveBeenCalled();
+        expect(mockAxios).not.toHaveBeenCalled();
+    });
+
+    it("falls back to app-session refresh when the app's own auth check rejects the refresh request", async () => {
+        mockAxios.__mockApi.barePost.mockResolvedValue({ data: { success: true } });
+        const originalRequest: RetryableRequestConfig = {
+            method: "POST",
+            url: "/refresh-access-token",
+        };
+        const error = createUnauthorizedErrorWithMessage(
+            originalRequest,
+            "Authentication required. Please log in.",
+        );
+
+        await getResponseRejectedHandler()(error);
+
+        expect(originalRequest._appAuthRetry).toBe(true);
+        expect(mockAxios.__mockApi.barePost).toHaveBeenCalledTimes(1);
+        expect(mockAxios).toHaveBeenCalledWith(originalRequest);
     });
 });

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -98,7 +98,7 @@ function isAppAuthRequiredError(error: AxiosError): boolean {
     if (!data || typeof data !== "object") return false;
     const message = (data as { error?: unknown; message?: unknown }).error
         ?? (data as { error?: unknown; message?: unknown }).message;
-    return typeof message === "string" && message.includes("Authentication required");
+    return typeof message === "string" && message.startsWith("Authentication required.");
 }
 
 function redirectToLoginOnce() {


### PR DESCRIPTION
## Summary
- `DELETE /api/eformsign/documents` returns 401 when the eformsign access-token cookie is expired; the axios interceptor then calls `POST /api/refresh-access-token`, which proxies to the backend's `POST /api/refresh-token`.
- That backend endpoint (and `POST /api/access-token`) always answered with a hard-coded 500 on any failure, masking a legitimate, recoverable 401 (e.g. an expired/already-rotated refresh token). This defeated the frontend's existing `withEformsignReauth()` fallback, which only re-authenticates on 401/403 — so contract-document deletion failed outright with a generic error instead of silently recovering.
- `eformsign.service.ts`'s `getAccessToken`/`refreshAccessToken` now throw `EformsignApiError` with the real vendor status, matching the pattern already used by `deleteDocuments`/`cancelDocuments` in the same file.
- `eformsign.controller.ts`'s shared `throwHttpOrInternalError()` helper now propagates `EformsignApiError.status`; the two token handlers use that helper instead of duplicated hard-coded-500 catch blocks (same as 10+ other handlers in the file already do).
- Hardened `isAppAuthRequiredError()` in `client.ts` (`.startsWith` instead of `.includes`) so a vendor error body that now surfaces as a 401 can't accidentally match the app's own "Authentication required." auth-check message and trigger a spurious full logout.
- No frontend behavior change was otherwise needed — `withEformsignReauth()` was already correct, it just never received the real status code to act on.

## Test plan
- [x] `pnpm --filter babyjamjam-admin-backend type-check` — clean
- [x] Backend: `eformsign.service.spec.ts` + `eformsign.controller.integration.spec.ts` — new regression tests added and pass; full backend suite (227 suites) green aside from one pre-existing, unrelated date-hardcoded flake (`prisma-agent-action.repository.spec.ts`, unaffected by this diff, also reproducible on `dev`)
- [x] Frontend: `client.test.ts` — new regression tests added and pass; confirmed the `isAppAuthRequiredError` test actually fails without the fix (reverted, confirmed red, restored)
- [x] Independent Opus 5 audit of the diff (root-cause trace, blast-radius check on other `throwHttpOrInternalError` call sites, security/info-disclosure review) — verdict: correct, safe to merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWEqotH7713oSbxkxwcMny