### PR TITLE
fix: harden the file storage subsystem

### DIFF
--- a/.github/workflows/database-patches.yml
+++ b/.github/workflows/database-patches.yml
@@ -205,6 +205,14 @@ jobs:
         working-directory: backend
         run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-agent-copilot-tables.sql
 
+      - name: Apply document category branch scope patch
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260807000000_scope_document_category_value_per_branch/migration.sql
+
+      - name: Verify document category branch scope patch
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-document-category-branch-scope.sql
+
   apply-preview:
     name: apply preview database patches
     if: >-
@@ -536,6 +544,14 @@ jobs:
         working-directory: backend
         run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/scripts/verify-agent-copilot-tables.sql
 
+      - name: Apply document category branch scope patch
+        working-directory: backend
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/migrations/20260807000000_scope_document_category_value_per_branch/migration.sql
+
+      - name: Verify document category branch scope patch
+        working-directory: backend
+        run: ./scripts/run-prisma-db-execute.sh --schema prisma/schema.prisma --file prisma/scripts/verify-document-category-branch-scope.sql
+
   apply-production:
     name: apply production database patches
     needs: [apply-preview]
@@ -846,3 +862,11 @@ jobs:
       - name: Verify agent copilot tables patch
         working-directory: backend
         run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-agent-copilot-tables.sql
+
+      - name: Apply document category branch scope patch
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/migrations/20260807000000_scope_document_category_value_per_branch/migration.sql
+
+      - name: Verify document category branch scope patch
+        working-directory: backend
+        run: pnpm exec prisma db execute --schema prisma/schema.prisma --file prisma/scripts/verify-document-category-branch-scope.sql

--- a/backend/application/services/document-category.service.ts
+++ b/backend/application/services/document-category.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from "@nestjs/common";
+import { ConflictException, Injectable } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
 import { PrismaService } from "infrastructure/database/prisma.service";
 
 export interface DocumentCategory {
@@ -40,23 +41,58 @@ export class DocumentCategoryService {
         label: string;
         color: string;
     }): Promise<DocumentCategory> {
-        const category = await this.prisma.document_category.create({
-            data: {
-                branchId: params.branchId,
-                value: params.value,
-                label: params.label,
-                color: params.color,
-                isCustom: true,
-            },
+        // Global (branch-null) categories are visible to every branch through
+        // findAll's branch-null fallback. The per-branch unique index cannot stop
+        // a branch from shadowing one (NULL branch_id never collides with a
+        // concrete branch_id), so reject the collision here — otherwise findAll
+        // would list the same value twice for this branch.
+        const globalCategory = await this.prisma.document_category.findFirst({
+            where: { value: params.value, branchId: null },
+            select: { id: true },
         });
-        return {
-            id: category.id,
-            value: category.value,
-            label: category.label,
-            color: category.color,
-            isCustom: category.isCustom,
-            createdAt: category.createdAt,
-        };
+        if (globalCategory) {
+            throw new ConflictException({
+                statusCode: 409,
+                code: "GLOBAL_CATEGORY_CONFLICT",
+                error: "Conflict",
+                field: "value",
+                message: `Category value '${params.value}' is already used by a global category`,
+            });
+        }
+
+        try {
+            const category = await this.prisma.document_category.create({
+                data: {
+                    branchId: params.branchId,
+                    value: params.value,
+                    label: params.label,
+                    color: params.color,
+                    isCustom: true,
+                },
+            });
+            return {
+                id: category.id,
+                value: category.value,
+                label: category.label,
+                color: category.color,
+                isCustom: category.isCustom,
+                createdAt: category.createdAt,
+            };
+        } catch (error) {
+            // The only unique constraint this insert can violate is the per-branch
+            // (branch_id, value) index, so name the colliding value instead of
+            // surfacing a bare 409 through PrismaExceptionFilter.
+            if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+                throw new ConflictException({
+                    statusCode: 409,
+                    code: "P2002",
+                    error: "Conflict",
+                    field: "value",
+                    message: `Category value '${params.value}' already exists in this branch`,
+                });
+            }
+            throw error;
+        }
     }
 
     async delete(branchId: string, id: string): Promise<void> {

--- a/backend/interface/controllers/document.controller.ts
+++ b/backend/interface/controllers/document.controller.ts
@@ -264,20 +264,39 @@ export class DocumentController {
         return this.toResponse(entity, storageUrl);
     }
 
+    /**
+     * Registers a row against a storage object that is already there. No client
+     * calls it — both apps upload through POST /upload — but it is reachable by
+     * anyone holding a token, so it derives what it can rather than believing
+     * the body. The storage path is still the caller's claim; that is safe
+     * because DocumentService.create refuses a path another branch owns.
+     */
     @Post()
-    async create(@CurrentTenant() tenant: { branchId?: string }, @Body() dto: CreateDocumentDto) {
+    async create(
+        @CurrentTenant() tenant: { branchId?: string; userId?: string },
+        @Body() dto: CreateDocumentDto,
+    ) {
         const branchId = tenant.branchId ?? "";
+        // Same gate as the upload route: this row's mimetype decides how the
+        // download serves it, so an unfiltered one would be the way around the
+        // inline allowlist.
+        const mimeType = normalizeMimeType(dto.mimetype) || "application/octet-stream";
+        if (!UPLOAD_ALLOWED_MIME_TYPES.has(mimeType)) {
+            throw new BadRequestException(`unsupported file type: ${mimeType}`);
+        }
 
         const entity = await this.documentService.create(branchId, {
             name: dto.name,
             description: dto.description,
             categoryId: dto.categoryId,
             tags: dto.tags,
-            mimetype: dto.mimetype,
+            mimetype: mimeType,
             filesize: dto.filesize,
             storagepath: dto.storagepath,
             branchid: branchId,
-            uploadedby: dto.uploadedby,
+            // Taken from the verified tenant, never the body — otherwise the
+            // audit trail is whatever the caller typed.
+            uploadedby: tenant.userId || "system",
         });
         return this.toResponse(entity);
     }

--- a/backend/interface/controllers/document.controller.ts
+++ b/backend/interface/controllers/document.controller.ts
@@ -10,6 +10,7 @@ import {
     UploadedFile,
     BadRequestException,
     Inject,
+    Logger,
     NotFoundException,
     Res,
     Query,
@@ -78,9 +79,100 @@ function isMissingStorageObjectError(error: unknown): boolean {
     return error.message.toLowerCase().includes("object not found");
 }
 
+/**
+ * Lowercased media-type "essence" with any parameters (`; charset=...`)
+ * stripped, so MIME checks cannot be bypassed with variants such as
+ * `TEXT/HTML; charset=utf-8`.
+ */
+function normalizeMimeType(mimetype: string | undefined | null): string {
+    return (mimetype ?? "").split(";")[0]?.trim().toLowerCase() ?? "";
+}
+
+/**
+ * MIME types that may be rendered inline on this origin: PDF plus the raster
+ * image types the preview UI actually displays. Everything else is forced into
+ * an opaque attachment download so browser-scriptable content (text/html,
+ * image/svg+xml, XML, ...) stored under any historical row can never execute
+ * with a staff session. image/svg+xml is deliberately absent - SVG can carry
+ * script, and the preview UI's image check matches every image/* type.
+ * image/jpg is a nonstandard alias of image/jpeg that the mobile upload page
+ * has always accepted; it is a harmless raster type, kept so such rows keep
+ * previewing.
+ */
+const INLINE_SAFE_MIME_TYPES: ReadonlySet<string> = new Set([
+    "application/pdf",
+    "image/png",
+    "image/jpeg",
+    "image/jpg",
+    "image/gif",
+    "image/webp",
+]);
+
+/**
+ * Defence-in-depth allowlist for uploads, deliberately broader than
+ * INLINE_SAFE_MIME_TYPES: it covers every MIME type the product itself models
+ * (the download extension map below, frontend document-preview-utils, the
+ * mobile upload page) plus office/archive/text formats staff plausibly upload
+ * through the desktop dropzone, which historically accepted any type.
+ * application/octet-stream must stay allowed: browsers derive a file's type
+ * from OS registry data, so .hwp/.hwpx - the product's flagship document
+ * format - and other locally unregistered extensions frequently arrive as
+ * application/octet-stream (or with no type at all). That is safe because
+ * nothing outside INLINE_SAFE_MIME_TYPES is ever served inline, so a
+ * mislabelled upload can only ever be downloaded, never rendered. What this
+ * list is really for is keeping browser-scriptable types (text/html,
+ * image/svg+xml, XML, JavaScript) out of storage entirely.
+ */
+const UPLOAD_ALLOWED_MIME_TYPES: ReadonlySet<string> = new Set([
+    ...INLINE_SAFE_MIME_TYPES,
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-powerpoint",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/hwp",
+    "application/haansofthwp",
+    "application/vnd.hancom.hwp",
+    "application/vnd.hancom.hwpx",
+    "application/x-hwp",
+    "application/x-hwpx",
+    "image/heic",
+    "image/heif",
+    "application/zip",
+    "application/x-zip-compressed",
+    "text/plain",
+    "text/csv",
+    "application/octet-stream",
+]);
+
+/** RFC 5987 value-chars percent-encoding: encodeURIComponent plus the characters it leaves bare that RFC 5987 does not allow. */
+function encodeRfc5987ValueChars(value: string): string {
+    return encodeURIComponent(value).replace(
+        /['()*]/g,
+        (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+    );
+}
+
+/**
+ * RFC 6266/5987 Content-Disposition value carrying an ASCII-only `filename`
+ * fallback plus a UTF-8 `filename*`, so Korean document names survive a
+ * download instead of arriving percent-encoded. Both parameters are built from
+ * restricted alphabets - the fallback replaces every non-printable-ASCII byte
+ * (including CR/LF), double quote, and backslash with "_", and the extended
+ * form is fully percent-encoded - which is what keeps this header immune to
+ * header/parameter injection through a document name.
+ */
+function buildContentDisposition(type: "inline" | "attachment", filename: string): string {
+    const asciiFallback = filename.replace(/[^\x20-\x7e]|["\\]/g, "_");
+    return `${type}; filename="${asciiFallback}"; filename*=UTF-8''${encodeRfc5987ValueChars(filename)}`;
+}
+
 @Controller("documents")
 @UseGuards(JwtGuard, TenantGuard)
 export class DocumentController {
+    private readonly logger = new Logger(DocumentController.name);
+
     constructor(
         private readonly documentService: DocumentService,
         @Inject(FILE_STORAGE_PORT)
@@ -115,6 +207,13 @@ export class DocumentController {
             );
         }
 
+        // Multer forwards the client-supplied multipart Content-Type verbatim,
+        // so gate it against the upload allowlist before anything is stored.
+        const mimeType = normalizeMimeType(file.mimetype) || "application/octet-stream";
+        if (!UPLOAD_ALLOWED_MIME_TYPES.has(mimeType)) {
+            throw new BadRequestException(`unsupported file type: ${mimeType}`);
+        }
+
         // generate unique storage path
         const lastDotIndex = file.originalname.lastIndexOf(".");
         const fileExtension =
@@ -122,7 +221,6 @@ export class DocumentController {
         const storagePath = fileExtension
             ? `${randomUUID()}.${fileExtension}`
             : randomUUID();
-        const mimeType = file.mimetype || "application/octet-stream";
         const tags = parseDocumentTags(dto.tags);
 
         // upload to storage
@@ -133,17 +231,36 @@ export class DocumentController {
         );
         const branchId = tenant.branchId ?? "";
 
-        const entity = await this.documentService.create(branchId, {
-            name: dto.name || file.originalname,
-            description: dto.description,
-            categoryId: dto.categoryId,
-            tags,
-            mimetype: mimeType,
-            filesize: file.size,
-            storagepath: storagePath,
-            branchid: branchId,
-            uploadedby: tenant.userId || "system",
-        });
+        let entity: DocumentEntity;
+        try {
+            entity = await this.documentService.create(branchId, {
+                name: dto.name || file.originalname,
+                description: dto.description,
+                categoryId: dto.categoryId,
+                tags,
+                mimetype: mimeType,
+                filesize: file.size,
+                storagepath: storagePath,
+                branchid: branchId,
+                uploadedby: tenant.userId || "system",
+            });
+        } catch (error) {
+            // The object is already in storage, so a failed insert (claimed
+            // storage path, stale category, transient DB error) would leak an
+            // orphaned object no row references and no sweep job reclaims.
+            // deleteStoragePath swallows object-not-found, so the compensation
+            // is safe to attempt blindly; if it fails too, log it and still
+            // rethrow the original error - the caller needs the real cause.
+            try {
+                await this.documentService.deleteStoragePath(storagePath);
+            } catch (cleanupError) {
+                this.logger.error(
+                    `failed to delete orphaned storage object ${storagePath} after document creation failed`,
+                    cleanupError instanceof Error ? cleanupError.stack : String(cleanupError),
+                );
+            }
+            throw error;
+        }
         return this.toResponse(entity, storageUrl);
     }
 
@@ -289,13 +406,22 @@ export class DocumentController {
              filename += getExtension(doc.mimetype) || getStorageExtension(doc.storagepath);
          }
          
-         const disposition = attachment === "true" 
-             ? `attachment; filename="${encodeURIComponent(filename)}"` 
-             : "inline";
-         
+         // Only MIME types the preview UI renders may be displayed inline;
+         // everything else becomes an opaque attachment regardless of what the
+         // caller asked for, so stored browser-scriptable content can never
+         // execute on this origin. nosniff stops an allowlisted Content-Type
+         // from being re-sniffed into something executable.
+         const normalizedMimeType = normalizeMimeType(doc.mimetype);
+         const isInlineSafe = INLINE_SAFE_MIME_TYPES.has(normalizedMimeType);
+         const asAttachment = attachment === "true" || !isInlineSafe;
+
          res.set({
-             "Content-Type": doc.mimetype,
-             "Content-Disposition": disposition,
+             "Content-Type": isInlineSafe ? normalizedMimeType : "application/octet-stream",
+             "Content-Disposition": buildContentDisposition(
+                 asAttachment ? "attachment" : "inline",
+                 filename,
+             ),
+             "X-Content-Type-Options": "nosniff",
              "Content-Length": fileBuffer.length,
          });
          res.send(fileBuffer);

--- a/backend/interface/dto/document.dto.ts
+++ b/backend/interface/dto/document.dto.ts
@@ -40,8 +40,10 @@ export class CreateDocumentDto {
     @IsString()
     branchid?: string;
 
-    @IsString()
-    uploadedby!: string;
+    // No uploadedby: the controller takes it from the verified tenant. Leaving
+    // it declared would make it a required field the handler then discards, and
+    // forbidNonWhitelisted now rejects it outright rather than accepting a
+    // value that has no effect.
 }
 
 export class UpdateDocumentDto {

--- a/backend/prisma/migrate-categories.ts
+++ b/backend/prisma/migrate-categories.ts
@@ -18,20 +18,33 @@ async function seedCategories(): Promise<Map<string, string>> {
     const categoryMap = new Map<string, string>();
 
     for (const category of DEFAULT_CATEGORIES) {
-        const result = await (prisma as any).document_category.upsert({
-            where: { value: category.value },
-            update: {
-                label: category.label,
-                color: category.color,
-                isCustom: category.isCustom,
-            },
-            create: {
-                value: category.value,
-                label: category.label,
-                color: category.color,
-                isCustom: category.isCustom,
-            },
+        // Seed rows are global (branchId: null). `value` is no longer globally
+        // unique — uniqueness is (branchId, value) plus a partial unique index on
+        // value WHERE branch_id IS NULL — and Prisma cannot address a composite
+        // unique containing NULL, so upsert-by-value is replaced with an explicit
+        // find-then-update/create against the global scope.
+        const existing = await prisma.document_category.findFirst({
+            where: { value: category.value, branchId: null },
+            select: { id: true },
         });
+        const result = existing
+            ? await prisma.document_category.update({
+                  where: { id: existing.id },
+                  data: {
+                      label: category.label,
+                      color: category.color,
+                      isCustom: category.isCustom,
+                  },
+              })
+            : await prisma.document_category.create({
+                  data: {
+                      value: category.value,
+                      label: category.label,
+                      color: category.color,
+                      isCustom: category.isCustom,
+                      branchId: null,
+                  },
+              });
         categoryMap.set(category.value, result.id);
         console.log(`  ✓ ${category.value} (${category.label}) -> ${result.id}`);
     }

--- a/backend/prisma/migrations/20260807000000_scope_document_category_value_per_branch/migration.sql
+++ b/backend/prisma/migrations/20260807000000_scope_document_category_value_per_branch/migration.sql
@@ -1,0 +1,89 @@
+-- Scope document_category.value uniqueness per branch (multi-tenancy fix).
+--
+-- Before: value was globally unique (document_category_value_key from 0_init), so
+-- no two branches could ever use the same category value. On top of that, the
+-- multi-tenancy backfill (prisma/scripts/migrate-to-multi-tenancy-clean.ts) had
+-- assigned every category — including the eight global seed categories from
+-- prisma/migrate-categories.ts — to the first branch with is_custom = true.
+-- A second branch therefore saw an empty category list (findAll returns
+-- branch_id = mine OR branch_id IS NULL, and no branch-null rows were left) and
+-- could not recreate "contract" etc. because the global unique fired. Since
+-- category_id is required on upload, that branch could not upload at all.
+--
+-- After:
+--   * value is unique per branch:    document_category_branch_id_value_key (branch_id, value)
+--   * value is unique among globals: document_category_value_global_key (value) WHERE branch_id IS NULL
+--     (partial unique index — Prisma cannot express it; schema.prisma carries a
+--     "Database note" comment on the model instead)
+--   * the eight seed categories are restored to global scope
+--     (branch_id = NULL, is_custom = false)
+--
+-- Idempotency: this file is re-executed on every push to dev/preview/main by
+-- .github/workflows/database-patches.yml, so every statement is guarded. The
+-- remediation UPDATE only touches rows still in the broken state and never flips
+-- a row onto a value that already has a global twin, so it cannot violate the
+-- partial unique index on any re-run.
+
+BEGIN;
+
+-- 1. Drop the global unique on value. 0_init created it as a plain UNIQUE INDEX
+--    (document_category_value_key); the DROP CONSTRAINT is belt-and-braces for
+--    any environment where the same name exists as a table constraint instead.
+ALTER TABLE "document_category" DROP CONSTRAINT IF EXISTS "document_category_value_key";
+DROP INDEX IF EXISTS "document_category_value_key";
+
+-- 2. Restore the eight seed categories to global scope. On the first run the old
+--    global unique guarantees at most one row per value repo-wide, so matching on
+--    the known value strings is well-defined. Guards for re-runs:
+--      * branch_id IS NOT NULL — no-op once the row is already global;
+--      * NOT EXISTS global twin — never flips a branch-owned row onto a value that
+--        already has a global row (that UPDATE would violate the partial unique
+--        index below and permanently break this patch job);
+--      * DISTINCT ON (value) — flips at most one row per value even if duplicates
+--        were created after the global unique was dropped, so the statement can
+--        never collide with itself.
+UPDATE "document_category" dc
+SET "branch_id" = NULL,
+    "is_custom" = false
+WHERE dc."id" IN (
+        SELECT DISTINCT ON ("value") "id"
+        FROM "document_category"
+        WHERE "value" IN (
+                'contract', 'invoice', 'receipt', 'report',
+                'certificate', 'form', 'notice', 'employee-contract'
+            )
+          AND "branch_id" IS NOT NULL
+        ORDER BY "value", "created_at" ASC, "id" ASC
+    )
+  AND NOT EXISTS (
+        SELECT 1
+        FROM "document_category" g
+        WHERE g."value" = dc."value"
+          AND g."branch_id" IS NULL
+    );
+
+-- Defensive normalization: a seed row that is already global but still flagged
+-- custom (should not occur — the UPDATE above sets both columns together — but
+-- costs nothing and converges the flag).
+UPDATE "document_category"
+SET "is_custom" = false
+WHERE "value" IN (
+        'contract', 'invoice', 'receipt', 'report',
+        'certificate', 'form', 'notice', 'employee-contract'
+    )
+  AND "branch_id" IS NULL
+  AND "is_custom" = true;
+
+-- 3. Per-branch uniqueness (matches @@unique([branchId, value]) in schema.prisma).
+--    Safe on first run: the old global unique implies no duplicate (branch_id, value).
+CREATE UNIQUE INDEX IF NOT EXISTS "document_category_branch_id_value_key"
+    ON "document_category"("branch_id", "value");
+
+-- 4. Global rows are not constrained by the composite unique (Postgres never
+--    treats two NULLs as equal), so keep global category values unique with a
+--    partial unique index. Safe on first run for the same reason as step 3.
+CREATE UNIQUE INDEX IF NOT EXISTS "document_category_value_global_key"
+    ON "document_category"("value")
+    WHERE "branch_id" IS NULL;
+
+COMMIT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -282,9 +282,14 @@ model document {
   @@index([branchId], map: "idx_document_branch")
 }
 
+/// Database note: partial unique index `document_category_value_global_key` on
+/// (value) WHERE branch_id IS NULL exists in the database but cannot be expressed
+/// in Prisma (created via migration/patch SQL). It keeps global (branch-null) seed
+/// category values unique; the composite unique below only covers branch-owned rows
+/// because Postgres never treats two NULL branch_id values as equal.
 model document_category {
   id        String     @id @default(dbgenerated("(gen_random_uuid())::text"))
-  value     String     @unique
+  value     String
   label     String
   color     String
   isCustom  Boolean    @default(true) @map("is_custom")
@@ -293,6 +298,7 @@ model document_category {
   documents document[]
   branch    branch?    @relation(fields: [branchId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
+  @@unique([branchId, value], map: "document_category_branch_id_value_key")
   @@index([branchId], map: "idx_document_category_branch")
 }
 

--- a/backend/prisma/scripts/migrate-to-multi-tenancy-clean.ts
+++ b/backend/prisma/scripts/migrate-to-multi-tenancy-clean.ts
@@ -254,17 +254,18 @@ async function migrate() {
     }
     console.log(`[Migration] Assigned ${categoriesUpdated} document_categories`);
 
-    const docCount = await prisma.document.count({
-      where: { orgId: null },
-    });
-    console.log(`[Migration] Found ${docCount} documents with null orgId`);
+    // Backfill every document, exactly like every other entity in this script.
+    // The old code filtered on the legacy orgId column while writing branchId, so
+    // any document that already carried a non-null orgId was silently skipped and
+    // kept branch_id = NULL — invisible to every branch forever.
+    const docCount = await prisma.document.count();
+    console.log(`[Migration] Found ${docCount} documents`);
     let docsUpdated = 0;
     skip = 0;
 
     while (skip < docCount) {
       const docs = await prisma.document.findMany({
         select: { id: true },
-        where: { orgId: null },
         skip: skip,
         take: batchSize,
       });

--- a/backend/prisma/scripts/verify-document-category-branch-scope.sql
+++ b/backend/prisma/scripts/verify-document-category-branch-scope.sql
@@ -1,0 +1,57 @@
+-- Verifies 20260807000000_scope_document_category_value_per_branch.
+-- Every assertion below is guaranteed by that migration, which runs immediately
+-- before this file in .github/workflows/database-patches.yml, so this script is
+-- safe to execute on every push in every environment.
+DO $$
+BEGIN
+    IF to_regclass('public.document_category') IS NULL THEN
+        RAISE EXCEPTION 'document_category table is missing';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND indexname = 'document_category_value_key'
+    ) THEN
+        RAISE EXCEPTION 'legacy global unique index document_category_value_key still exists; category values must be unique per branch, not globally';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND indexname = 'document_category_branch_id_value_key'
+    ) THEN
+        RAISE EXCEPTION 'per-branch unique index document_category_branch_id_value_key is missing';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND indexname = 'document_category_value_global_key'
+    ) THEN
+        RAISE EXCEPTION 'global partial unique index document_category_value_global_key is missing';
+    END IF;
+
+    -- Data invariants. Both are enforced by the two unique indexes checked above,
+    -- so they cannot fail while those indexes exist — asserted anyway so an index
+    -- drop combined with data drift cannot go unnoticed.
+    IF EXISTS (
+        SELECT "value"
+        FROM "document_category"
+        WHERE "branch_id" IS NULL
+        GROUP BY "value"
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'duplicate global (branch-null) document_category values exist';
+    END IF;
+
+    IF EXISTS (
+        SELECT "branch_id", "value"
+        FROM "document_category"
+        WHERE "branch_id" IS NOT NULL
+        GROUP BY "branch_id", "value"
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'duplicate document_category values exist within a single branch';
+    END IF;
+END $$;

--- a/backend/prisma/scripts/verify-documents-branch.sql
+++ b/backend/prisma/scripts/verify-documents-branch.sql
@@ -1,0 +1,33 @@
+-- INTENTIONALLY NOT WIRED INTO .github/workflows/database-patches.yml.
+--
+-- The multi-tenancy backfill (prisma/scripts/migrate-to-multi-tenancy-clean.ts)
+-- used to read documents through `where: { orgId: null }` while writing branch_id,
+-- so every document that already carried a non-null legacy org_id was silently
+-- skipped and kept branch_id = NULL. Such rows are invisible to every branch
+-- (all repository queries filter on branch_id), keep their storage objects billed
+-- forever, and permanently block their storage_path from reuse
+-- (existsByStoragePathOutsideBranch treats branch_id IS NULL as "outside my branch").
+--
+-- Do NOT add this file to the database-patches workflow until production has been
+-- checked with:
+--
+--     SELECT count(*) FROM document WHERE branch_id IS NULL;
+--
+-- If that count is non-zero, wiring this file up would fail the DB patch job in
+-- every environment on every push. First re-run the (now fixed) backfill script or
+-- remediate the rows manually, confirm the count reads 0, and only then add this
+-- verify step after the corresponding migration step in all three workflow jobs.
+DO $$
+BEGIN
+    IF to_regclass('public.document') IS NULL THEN
+        RAISE EXCEPTION 'document table is missing';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM "document"
+        WHERE "branch_id" IS NULL
+    ) THEN
+        RAISE EXCEPTION 'document rows with NULL branch_id exist; they are invisible to every branch and must be reassigned to a branch';
+    END IF;
+END $$;

--- a/backend/test/integration/document.controller.integration.spec.ts
+++ b/backend/test/integration/document.controller.integration.spec.ts
@@ -1,4 +1,5 @@
-import { ExecutionContext, ForbiddenException, INestApplication, Logger, ValidationPipe } from "@nestjs/common";
+import { ExecutionContext, ForbiddenException, INestApplication, Logger } from "@nestjs/common";
+import { GlobalValidationPipe } from "infrastructure/pipes/global-validation.pipe";
 import { Test, TestingModule } from "@nestjs/testing";
 import { DocumentService } from "application/services/document.service";
 import { DocumentEntity } from "domain/entities/document.entity";
@@ -93,7 +94,13 @@ describe("DocumentController (Integration)", () => {
             .compile();
 
         app = moduleFixture.createNestApplication();
-        app.useGlobalPipes(new ValidationPipe({ transform: true }));
+        // Matches main.ts. The bare pipe this used to install silently stripped
+        // undeclared body fields, so a test could not tell "the handler ignores
+        // this" from "the request is refused" — and mass-assignment hardening is
+        // exactly the difference between those two.
+        app.useGlobalPipes(
+            new GlobalValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }),
+        );
         await app.init();
 
         documentService = moduleFixture.get(DocumentService);
@@ -133,7 +140,6 @@ describe("DocumentController (Integration)", () => {
                 storagepath: "documents/contract.pdf",
                 storageurl: "https://example.test/contract.pdf",
                 branchid: "branch-2",
-                uploadedby: "user-1",
             });
 
         expect(response.status).toBe(201);
@@ -161,7 +167,6 @@ describe("DocumentController (Integration)", () => {
                 mimetype: "application/pdf",
                 filesize: 100,
                 storagepath: "documents/shared.pdf",
-                uploadedby: "user-1",
             });
 
         expect(response.status).toBe(403);
@@ -194,7 +199,12 @@ describe("DocumentController (Integration)", () => {
         expect(fileStorage.createSignedUrl).not.toHaveBeenCalled();
     });
 
-    it("should use tenant user as document uploader when uploading documents", async () => {
+    // This used to assert that a spoofed uploader was silently ignored (201).
+    // That was an artefact of the permissive pipe this suite used to install:
+    // production runs forbidNonWhitelisted, so the request never reaches the
+    // handler at all. Asserting the weaker behaviour meant the suite would have
+    // stayed green if mass-assignment hardening were switched off.
+    it("should refuse an upload that tries to name its own uploader", async () => {
         fileStorage.upload.mockResolvedValue("https://example.test/signed-contract.pdf");
         documentService.create.mockResolvedValue(createDocumentEntity("branch-1", null));
 
@@ -207,12 +217,26 @@ describe("DocumentController (Integration)", () => {
             .field("uploadedBy", "camel-attacker-user")
             .attach("file", Buffer.from("fake-file"), "contract.pdf");
 
+        expect(response.status).toBe(400);
+        expect(fileStorage.upload).not.toHaveBeenCalled();
+        expect(documentService.create).not.toHaveBeenCalled();
+    });
+
+    it("should stamp the uploader from the tenant on a clean upload", async () => {
+        fileStorage.upload.mockResolvedValue("https://example.test/signed-contract.pdf");
+        documentService.create.mockResolvedValue(createDocumentEntity("branch-1", null));
+
+        const response = await request(app.getHttpServer())
+            .post("/documents/upload")
+            .field("name", "Contract")
+            .field("categoryId", "contract")
+            .field("tags", JSON.stringify(["signed"]))
+            .attach("file", Buffer.from("fake-file"), "contract.pdf");
+
         expect(response.status).toBe(201);
         expect(documentService.create).toHaveBeenCalledWith(
             "branch-1",
-            expect.objectContaining({
-                uploadedby: "user-1",
-            }),
+            expect.objectContaining({ uploadedby: "user-1" }),
         );
     });
 
@@ -416,5 +440,67 @@ describe("DocumentController (Integration)", () => {
             "attachment; filename=\"Con_tract__.pdf\"; filename*=UTF-8''Con%22tract%0D%0A.pdf",
         );
         expect(disposition).not.toMatch(/[\r\n]/);
+    });
+
+    // POST /documents registers a row against an object that is already in
+    // storage. No client calls it, but a token is enough to reach it, so it must
+    // not take the caller's word for who uploaded the file or what it is.
+    it("should stamp POST /documents with the tenant's user, not the body's", async () => {
+        documentService.create.mockResolvedValue(createDocumentEntity("branch-1", null));
+
+        const response = await request(app.getHttpServer())
+            .post("/documents")
+            .send({
+                name: "Contract",
+                categoryId: "contract",
+                tags: [],
+                mimetype: "application/pdf",
+                filesize: 1024,
+                storagepath: "already-there.pdf",
+                uploadedby: "somebody-else",
+            });
+
+        // uploadedby is no longer part of the DTO, so forbidNonWhitelisted
+        // rejects it outright rather than accepting a value with no effect.
+        expect(response.status).toBe(400);
+        expect(documentService.create).not.toHaveBeenCalled();
+    });
+
+    it("should derive uploadedby from the tenant on POST /documents", async () => {
+        documentService.create.mockResolvedValue(createDocumentEntity("branch-1", null));
+
+        const response = await request(app.getHttpServer())
+            .post("/documents")
+            .send({
+                name: "Contract",
+                categoryId: "contract",
+                tags: [],
+                mimetype: "application/pdf",
+                filesize: 1024,
+                storagepath: "already-there.pdf",
+            });
+
+        expect(response.status).toBe(201);
+        expect(documentService.create).toHaveBeenCalledWith(
+            "branch-1",
+            expect.objectContaining({ uploadedby: "user-1" }),
+        );
+    });
+
+    it("should apply the upload allowlist to POST /documents too", async () => {
+        const response = await request(app.getHttpServer())
+            .post("/documents")
+            .send({
+                name: "Payload",
+                categoryId: "contract",
+                tags: [],
+                mimetype: "text/html",
+                filesize: 10,
+                storagepath: "already-there.html",
+            });
+
+        expect(response.status).toBe(400);
+        expect(response.body.message).toBe("unsupported file type: text/html");
+        expect(documentService.create).not.toHaveBeenCalled();
     });
 });

--- a/backend/test/integration/document.controller.integration.spec.ts
+++ b/backend/test/integration/document.controller.integration.spec.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, ForbiddenException, INestApplication, ValidationPipe } from "@nestjs/common";
+import { ExecutionContext, ForbiddenException, INestApplication, Logger, ValidationPipe } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { DocumentService } from "application/services/document.service";
 import { DocumentEntity } from "domain/entities/document.entity";
@@ -20,14 +20,15 @@ describe("DocumentController (Integration)", () => {
     function createDocumentEntity(
         orgId: string,
         storageUrl: string | null = "https://example.test/contract.pdf",
+        overrides: { name?: string; mimetype?: string } = {},
     ): DocumentEntity {
         return DocumentEntity.reconstitute(
             "doc-1",
-            "Contract",
+            overrides.name ?? "Contract",
             null,
             "contract",
             ["signed"],
-            "application/pdf",
+            overrides.mimetype ?? "application/pdf",
             100,
             "documents/contract.pdf",
             storageUrl,
@@ -71,6 +72,7 @@ describe("DocumentController (Integration)", () => {
                         findAll: jest.fn(),
                         update: jest.fn(),
                         delete: jest.fn(),
+                        deleteStoragePath: jest.fn(),
                     },
                 },
                 {
@@ -267,5 +269,152 @@ describe("DocumentController (Integration)", () => {
 
         expect(response.status).toBe(404);
         expect(response.body.message).toBe("Document file not found");
+    });
+
+    it("should reject uploads whose MIME type is not allowlisted before touching storage", async () => {
+        const response = await request(app.getHttpServer())
+            .post("/documents/upload")
+            .field("name", "Payload")
+            .field("categoryId", "contract")
+            .field("tags", JSON.stringify([]))
+            .attach("file", Buffer.from("<script>alert(1)</script>"), {
+                filename: "payload.html",
+                contentType: "text/html",
+            });
+
+        expect(response.status).toBe(400);
+        expect(response.body.message).toBe("unsupported file type: text/html");
+        expect(fileStorage.upload).not.toHaveBeenCalled();
+        expect(documentService.create).not.toHaveBeenCalled();
+    });
+
+    it("should reject parameterised MIME variants that normalize to a forbidden type", async () => {
+        const response = await request(app.getHttpServer())
+            .post("/documents/upload")
+            .field("name", "Payload")
+            .field("categoryId", "contract")
+            .attach("file", Buffer.from("<svg onload=alert(1)></svg>"), {
+                filename: "payload.svg",
+                contentType: "IMAGE/SVG+XML; charset=utf-8",
+            });
+
+        expect(response.status).toBe(400);
+        expect(response.body.message).toBe("unsupported file type: image/svg+xml");
+        expect(fileStorage.upload).not.toHaveBeenCalled();
+    });
+
+    it("should serve stored non-previewable MIME types as an opaque attachment, never inline", async () => {
+        documentService.findById.mockResolvedValue(
+            createDocumentEntity("branch-1", null, { name: "payload.html", mimetype: "text/html" }),
+        );
+        fileStorage.download.mockResolvedValue(Buffer.from("<script>alert(1)</script>"));
+
+        const response = await request(app.getHttpServer()).get("/documents/doc-1/download");
+
+        expect(response.status).toBe(200);
+        expect(response.headers["content-type"]).toBe("application/octet-stream");
+        expect(response.headers["content-disposition"]).toMatch(/^attachment; /);
+        expect(response.headers["x-content-type-options"]).toBe("nosniff");
+    });
+
+    it("should not serve image/svg+xml inline even though it is an image type", async () => {
+        documentService.findById.mockResolvedValue(
+            createDocumentEntity("branch-1", null, { name: "diagram.svg", mimetype: "image/svg+xml" }),
+        );
+        fileStorage.download.mockResolvedValue(Buffer.from('<svg onload="alert(1)"></svg>'));
+
+        const response = await request(app.getHttpServer()).get("/documents/doc-1/download");
+
+        expect(response.status).toBe(200);
+        expect(response.headers["content-type"]).toBe("application/octet-stream");
+        expect(response.headers["content-disposition"]).toMatch(/^attachment; /);
+    });
+
+    it("should keep serving PDF documents inline with nosniff protection", async () => {
+        documentService.findById.mockResolvedValue(createDocumentEntity("branch-1", null));
+        fileStorage.download.mockResolvedValue(Buffer.from("%PDF-1.4"));
+
+        const response = await request(app.getHttpServer()).get("/documents/doc-1/download");
+
+        expect(response.status).toBe(200);
+        expect(response.headers["content-type"]).toBe("application/pdf");
+        expect(response.headers["content-disposition"]).toBe(
+            "inline; filename=\"Contract.pdf\"; filename*=UTF-8''Contract.pdf",
+        );
+        expect(response.headers["x-content-type-options"]).toBe("nosniff");
+    });
+
+    it("should delete the just-uploaded storage object when document creation fails", async () => {
+        fileStorage.upload.mockResolvedValue("https://example.test/signed-contract.pdf");
+        documentService.create.mockRejectedValue(new ForbiddenException("storage path unavailable"));
+        documentService.deleteStoragePath.mockResolvedValue(undefined);
+
+        const response = await request(app.getHttpServer())
+            .post("/documents/upload")
+            .field("name", "Contract")
+            .field("categoryId", "contract")
+            .field("tags", JSON.stringify(["signed"]))
+            .attach("file", Buffer.from("fake-file"), "contract.pdf");
+
+        expect(response.status).toBe(403);
+        expect(response.body.message).toBe("storage path unavailable");
+        const uploadedPath = fileStorage.upload.mock.calls[0]?.[1];
+        expect(uploadedPath).toBeDefined();
+        expect(documentService.deleteStoragePath).toHaveBeenCalledWith(uploadedPath);
+    });
+
+    it("should rethrow the original creation error when orphan cleanup also fails", async () => {
+        const errorLogSpy = jest.spyOn(Logger.prototype, "error").mockImplementation(() => undefined);
+        try {
+            fileStorage.upload.mockResolvedValue("https://example.test/signed-contract.pdf");
+            documentService.create.mockRejectedValue(new ForbiddenException("storage path unavailable"));
+            documentService.deleteStoragePath.mockRejectedValue(new Error("storage unavailable"));
+
+            const response = await request(app.getHttpServer())
+                .post("/documents/upload")
+                .field("name", "Contract")
+                .field("categoryId", "contract")
+                .attach("file", Buffer.from("fake-file"), "contract.pdf");
+
+            expect(response.status).toBe(403);
+            expect(response.body.message).toBe("storage path unavailable");
+            expect(documentService.deleteStoragePath).toHaveBeenCalled();
+        } finally {
+            errorLogSpy.mockRestore();
+        }
+    });
+
+    it("should emit an RFC 5987 filename* so Korean document names download intact", async () => {
+        documentService.findById.mockResolvedValue(
+            createDocumentEntity("branch-1", null, { name: "서류.pdf" }),
+        );
+        fileStorage.download.mockResolvedValue(Buffer.from("%PDF-1.4"));
+
+        const response = await request(app.getHttpServer())
+            .get("/documents/doc-1/download")
+            .query({ attachment: "true" });
+
+        expect(response.status).toBe(200);
+        expect(response.headers["content-disposition"]).toBe(
+            "attachment; filename=\"__.pdf\"; filename*=UTF-8''%EC%84%9C%EB%A5%98.pdf",
+        );
+    });
+
+    it("should sanitize quotes and newlines so document names cannot break the download header", async () => {
+        documentService.findById.mockResolvedValue(
+            createDocumentEntity("branch-1", null, { name: 'Con"tract\r\n.pdf' }),
+        );
+        fileStorage.download.mockResolvedValue(Buffer.from("%PDF-1.4"));
+
+        const response = await request(app.getHttpServer())
+            .get("/documents/doc-1/download")
+            .query({ attachment: "true" });
+
+        expect(response.status).toBe(200);
+        const disposition = response.headers["content-disposition"];
+        expect(disposition).toBe(
+            "attachment; filename=\"Con_tract__.pdf\"; filename*=UTF-8''Con%22tract%0D%0A.pdf",
+        );
+        expect(disposition).not.toMatch(/[\r\n]/);
     });
 });

--- a/backend/test/services/document-category.service.spec.ts
+++ b/backend/test/services/document-category.service.spec.ts
@@ -1,3 +1,5 @@
+import { ConflictException } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
 import { DocumentCategoryService } from "application/services/document-category.service";
 import { PrismaService } from "infrastructure/database/prisma.service";
 
@@ -5,10 +7,18 @@ describe("DocumentCategoryService", () => {
     const createPrismaService = () => ({
         document_category: {
             findMany: jest.fn(),
+            findFirst: jest.fn(),
             create: jest.fn(),
             deleteMany: jest.fn(),
         },
     });
+
+    const uniqueViolation = () =>
+        new Prisma.PrismaClientKnownRequestError("duplicate", {
+            code: "P2002",
+            clientVersion: "test",
+            meta: { target: ["branch_id", "value"] },
+        });
 
     let prisma: ReturnType<typeof createPrismaService>;
     let service: DocumentCategoryService;
@@ -43,7 +53,37 @@ describe("DocumentCategoryService", () => {
         });
     });
 
+    it("should return global categories alongside the branch's own", async () => {
+        prisma.document_category.findMany.mockResolvedValue([
+            {
+                id: "global-category",
+                value: "contract",
+                label: "계약서",
+                color: "primary",
+                isCustom: false,
+                createdAt: new Date("2026-01-01T00:00:00.000Z"),
+                branchId: null,
+            },
+            {
+                id: "branch-category",
+                value: "branch-only",
+                label: "Branch Only",
+                color: "secondary",
+                isCustom: true,
+                createdAt: new Date("2026-01-02T00:00:00.000Z"),
+                branchId: "branch-1",
+            },
+        ]);
+
+        const result = await service.findAll("branch-1");
+
+        expect(result.map((c) => c.id)).toEqual(["global-category", "branch-category"]);
+        expect(result[0]).toMatchObject({ value: "contract", isCustom: false });
+        expect(result[1]).toMatchObject({ value: "branch-only", isCustom: true });
+    });
+
     it("should persist custom categories under the selected branch", async () => {
+        prisma.document_category.findFirst.mockResolvedValue(null);
         prisma.document_category.create.mockResolvedValue({
             id: "category-1",
             value: "branch-contract",
@@ -60,6 +100,10 @@ describe("DocumentCategoryService", () => {
             color: "primary",
         });
 
+        expect(prisma.document_category.findFirst).toHaveBeenCalledWith({
+            where: { value: "branch-contract", branchId: null },
+            select: { id: true },
+        });
         expect(prisma.document_category.create).toHaveBeenCalledWith({
             data: {
                 branchId: "branch-1",
@@ -71,6 +115,136 @@ describe("DocumentCategoryService", () => {
         });
     });
 
+    // value is unique per (branchId, value) — not globally — so two branches may
+    // legitimately own the same category value. The guarantee itself lives in the
+    // composite unique index of 20260807000000_scope_document_category_value_per_branch;
+    // this test pins the service contract on top of it (no cross-branch pre-check,
+    // both creates go through with their own branchId).
+    it("should let two different branches create a category with the same value", async () => {
+        prisma.document_category.findFirst.mockResolvedValue(null);
+        prisma.document_category.create
+            .mockResolvedValueOnce({
+                id: "category-a",
+                value: "onboarding",
+                label: "Onboarding",
+                color: "primary",
+                isCustom: true,
+                createdAt: new Date("2026-01-01T00:00:00.000Z"),
+            })
+            .mockResolvedValueOnce({
+                id: "category-b",
+                value: "onboarding",
+                label: "Onboarding",
+                color: "primary",
+                isCustom: true,
+                createdAt: new Date("2026-01-02T00:00:00.000Z"),
+            });
+
+        const first = await service.create({
+            branchId: "branch-1",
+            value: "onboarding",
+            label: "Onboarding",
+            color: "primary",
+        });
+        const second = await service.create({
+            branchId: "branch-2",
+            value: "onboarding",
+            label: "Onboarding",
+            color: "primary",
+        });
+
+        expect(first).toMatchObject({ id: "category-a", value: "onboarding" });
+        expect(second).toMatchObject({ id: "category-b", value: "onboarding" });
+        expect(prisma.document_category.create).toHaveBeenNthCalledWith(1, {
+            data: {
+                branchId: "branch-1",
+                value: "onboarding",
+                label: "Onboarding",
+                color: "primary",
+                isCustom: true,
+            },
+        });
+        expect(prisma.document_category.create).toHaveBeenNthCalledWith(2, {
+            data: {
+                branchId: "branch-2",
+                value: "onboarding",
+                label: "Onboarding",
+                color: "primary",
+                isCustom: true,
+            },
+        });
+    });
+
+    // Without this guard a branch could shadow a global category: the composite
+    // unique never fires against branch-null rows, findAll would then return the
+    // same value twice for that branch.
+    it("should reject a value that collides with a global category, naming the value", async () => {
+        prisma.document_category.findFirst.mockResolvedValue({ id: "global-contract" });
+
+        const promise = service.create({
+            branchId: "branch-2",
+            value: "contract",
+            label: "계약서",
+            color: "primary",
+        });
+
+        await expect(promise).rejects.toBeInstanceOf(ConflictException);
+        await expect(promise).rejects.toMatchObject({
+            status: 409,
+            response: expect.objectContaining({
+                statusCode: 409,
+                code: "GLOBAL_CATEGORY_CONFLICT",
+                error: "Conflict",
+                field: "value",
+                message: expect.stringContaining("'contract'"),
+            }),
+        });
+        expect(prisma.document_category.findFirst).toHaveBeenCalledWith({
+            where: { value: "contract", branchId: null },
+            select: { id: true },
+        });
+        expect(prisma.document_category.create).not.toHaveBeenCalled();
+    });
+
+    it("should translate a same-branch duplicate (P2002) into a conflict naming the value", async () => {
+        prisma.document_category.findFirst.mockResolvedValue(null);
+        prisma.document_category.create.mockRejectedValue(uniqueViolation());
+
+        const promise = service.create({
+            branchId: "branch-1",
+            value: "branch-contract",
+            label: "Branch Contract",
+            color: "primary",
+        });
+
+        await expect(promise).rejects.toBeInstanceOf(ConflictException);
+        await expect(promise).rejects.toMatchObject({
+            status: 409,
+            response: expect.objectContaining({
+                statusCode: 409,
+                code: "P2002",
+                error: "Conflict",
+                field: "value",
+                message: expect.stringContaining("'branch-contract'"),
+            }),
+        });
+    });
+
+    it("should rethrow non-unique-constraint errors untouched", async () => {
+        prisma.document_category.findFirst.mockResolvedValue(null);
+        const dbDown = new Error("connection refused");
+        prisma.document_category.create.mockRejectedValue(dbDown);
+
+        await expect(
+            service.create({
+                branchId: "branch-1",
+                value: "branch-contract",
+                label: "Branch Contract",
+                color: "primary",
+            }),
+        ).rejects.toBe(dbDown);
+    });
+
     it("should delete only custom categories in the selected branch", async () => {
         prisma.document_category.deleteMany.mockResolvedValue({ count: 1 });
 
@@ -79,6 +253,22 @@ describe("DocumentCategoryService", () => {
         expect(prisma.document_category.deleteMany).toHaveBeenCalledWith({
             where: {
                 id: "category-1",
+                branchId: "branch-1",
+                isCustom: true,
+            },
+        });
+    });
+
+    // A global category has branchId = NULL and isCustom = false, so the scoped
+    // deleteMany filter can never match it — count 0, nothing deleted, no error.
+    it("should not delete a global category: the branch-scoped filter cannot match it", async () => {
+        prisma.document_category.deleteMany.mockResolvedValue({ count: 0 });
+
+        await expect(service.delete("branch-1", "global-category")).resolves.toBeUndefined();
+
+        expect(prisma.document_category.deleteMany).toHaveBeenCalledWith({
+            where: {
+                id: "global-category",
                 branchId: "branch-1",
                 isCustom: true,
             },

--- a/frontend/src/app/api/file-storage/__tests__/route.test.ts
+++ b/frontend/src/app/api/file-storage/__tests__/route.test.ts
@@ -1,0 +1,460 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+
+import { serverAPIClient } from "@/lib/api/server";
+import { GET as downloadFile, HEAD as headFile } from "../files/[fileId]/download/route";
+import {
+  DELETE as deleteFile,
+  GET as getFile,
+  PUT as updateFile,
+} from "../files/[fileId]/route";
+import { GET as listFiles, POST as uploadFile } from "../files/route";
+
+jest.mock("@/lib/api/server", () => ({
+  serverAPIClient: {
+    delete: jest.fn(),
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+  },
+}));
+
+const mockDelete = serverAPIClient.delete as jest.Mock;
+const mockGet = serverAPIClient.get as jest.Mock;
+const mockPost = serverAPIClient.post as jest.Mock;
+const mockPut = serverAPIClient.put as jest.Mock;
+
+function createJsonRequest(path: string, method: string, body: BodyInit): NextRequest {
+  return new NextRequest(`http://localhost${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      cookie: "auth_token=auth-token",
+    },
+    body,
+  });
+}
+
+function createGetRequest(path: string): NextRequest {
+  return new NextRequest(`http://localhost${path}`, {
+    headers: { cookie: "auth_token=auth-token" },
+  });
+}
+
+function createUploadRequest(extraFields: Record<string, string | File> = {}): NextRequest {
+  const formData = new FormData();
+  formData.append("file", new File(["contents"], "document.txt", { type: "text/plain" }));
+  formData.append("name", "Document");
+  for (const [key, value] of Object.entries(extraFields)) {
+    formData.append(key, value);
+  }
+
+  return new NextRequest("http://localhost/api/file-storage/files", {
+    method: "POST",
+    headers: { cookie: "auth_token=auth-token" },
+    body: formData,
+  });
+}
+
+describe("file-storage API routes", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockDelete.mockReset();
+    mockGet.mockReset();
+    mockPost.mockReset();
+    mockPut.mockReset();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("preserves backend error status and sanitizes payload when listing files", async () => {
+    mockGet.mockRejectedValue({
+      response: {
+        status: 403,
+        data: { error: "document access denied" },
+      },
+    });
+
+    const response = await listFiles(createGetRequest("/api/file-storage/files"));
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "Failed to fetch documents" });
+  });
+
+  it("preserves backend status and payload when uploading files", async () => {
+    mockPost.mockResolvedValue({
+      status: 202,
+      data: { queued: true },
+    });
+
+    const response = await uploadFile(createUploadRequest());
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({ queued: true });
+  });
+
+  it("never forwards client-supplied identity fields on upload", async () => {
+    mockPost.mockResolvedValue({ status: 201, data: { id: "doc-1" } });
+
+    const response = await uploadFile(
+      createUploadRequest({ orgId: "another-tenant", uploadedBy: "attacker" }),
+    );
+
+    expect(response.status).toBe(201);
+    const forwardedFormData = mockPost.mock.calls[0][1] as FormData;
+    expect(forwardedFormData.has("orgId")).toBe(false);
+    expect(forwardedFormData.has("uploadedBy")).toBe(false);
+    expect(forwardedFormData.get("name")).toBe("Document");
+  });
+
+  it("sanitizes an upstream validation error body instead of passing it through", async () => {
+    mockPost.mockRejectedValue({
+      response: {
+        status: 400,
+        data: {
+          statusCode: 400,
+          message: ["property orgId should not exist"],
+          error: "Bad Request",
+        },
+      },
+    });
+
+    const response = await uploadFile(createUploadRequest());
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Failed to upload document" });
+  });
+
+  it("rejects non-string upload metadata before proxying", async () => {
+    const response = await uploadFile(
+      createUploadRequest({
+        categoryId: new File(["x"], "sneaky.txt", { type: "text/plain" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid upload metadata" });
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsafe file detail IDs before proxying", async () => {
+    const response = await getFile(
+      createGetRequest("/api/file-storage/files/bad%2Fid"),
+      { params: Promise.resolve({ fileId: "bad%2Fid" }) },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid file id" });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsafe update IDs before proxying", async () => {
+    const response = await updateFile(
+      createJsonRequest(
+        "/api/file-storage/files/bad%2Fid",
+        "PUT",
+        JSON.stringify({ name: "Renamed" }),
+      ),
+      { params: Promise.resolve({ fileId: "bad%2Fid" }) },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid file id" });
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsafe delete IDs before proxying", async () => {
+    const response = await deleteFile(
+      createGetRequest("/api/file-storage/files/bad%2Fid"),
+      { params: Promise.resolve({ fileId: "bad%2Fid" }) },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid file id" });
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("forwards a validated document update to the backend path", async () => {
+    mockPut.mockResolvedValue({
+      status: 200,
+      data: { id: "file_123", name: "Renamed" },
+    });
+
+    const response = await updateFile(
+      createJsonRequest(
+        "/api/file-storage/files/file_123",
+        "PUT",
+        JSON.stringify({ name: "Renamed" }),
+      ),
+      { params: Promise.resolve({ fileId: "file_123" }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ id: "file_123", name: "Renamed" });
+    expect(mockPut).toHaveBeenCalledWith(
+      "/documents/file_123",
+      { name: "Renamed" },
+      { headers: { Authorization: "Bearer auth-token" } },
+    );
+  });
+
+  it("rejects an update body with a mistyped field before proxying", async () => {
+    const response = await updateFile(
+      createJsonRequest(
+        "/api/file-storage/files/file_123",
+        "PUT",
+        JSON.stringify({ name: 123 }),
+      ),
+      { params: Promise.resolve({ fileId: "file_123" }) },
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed update JSON before proxying", async () => {
+    const response = await updateFile(
+      createJsonRequest("/api/file-storage/files/file_123", "PUT", "{bad-json"),
+      { params: Promise.resolve({ fileId: "file_123" }) },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Request body must be valid JSON",
+    });
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it("preserves backend delete error status and sanitizes payload", async () => {
+    mockDelete.mockRejectedValue({
+      response: {
+        status: 409,
+        data: { error: "document is locked" },
+      },
+    });
+
+    const response = await deleteFile(
+      createGetRequest("/api/file-storage/files/file_123"),
+      { params: Promise.resolve({ fileId: "file_123" }) },
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "Failed to delete document" });
+  });
+
+  describe("download", () => {
+    it("rejects unsafe download IDs before proxying", async () => {
+      const response = await downloadFile(
+        createGetRequest("/api/file-storage/files/bad%2Fid/download"),
+        { params: Promise.resolve({ fileId: "bad%2Fid" }) },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({ error: "Invalid file id" });
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("passes upstream download headers through, including x-content-type-options", async () => {
+      const body = new TextEncoder().encode("PDF!").buffer;
+      mockGet.mockResolvedValue({
+        status: 200,
+        data: body,
+        headers: {
+          "content-type": "application/pdf",
+          "content-disposition": 'attachment; filename="a.pdf"',
+          "x-content-type-options": "nosniff",
+          // Deliberately wrong: the proxy must size the body it actually
+          // sends, not echo a stale upstream transfer header.
+          "content-length": "999",
+        },
+      });
+
+      const response = await downloadFile(
+        createGetRequest("/api/file-storage/files/file_123/download"),
+        { params: Promise.resolve({ fileId: "file_123" }) },
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/pdf");
+      expect(response.headers.get("content-disposition")).toBe('attachment; filename="a.pdf"');
+      expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(response.headers.get("content-length")).toBe("4");
+      expect(mockGet).toHaveBeenCalledWith("/documents/file_123/download", {
+        headers: { Authorization: "Bearer auth-token" },
+        responseType: "arraybuffer",
+      });
+      await expect(response.arrayBuffer()).resolves.toEqual(body);
+    });
+
+    it("propagates attachment=true to the upstream download URL", async () => {
+      mockGet.mockResolvedValue({
+        status: 200,
+        data: new ArrayBuffer(1),
+        headers: {},
+      });
+
+      await downloadFile(
+        createGetRequest("/api/file-storage/files/file_123/download?attachment=true"),
+        { params: Promise.resolve({ fileId: "file_123" }) },
+      );
+
+      expect(mockGet).toHaveBeenCalledWith(
+        "/documents/file_123/download?attachment=true",
+        expect.anything(),
+      );
+    });
+
+    it("preserves non-404 upstream download error status and sanitizes the payload", async () => {
+      mockGet.mockRejectedValue({
+        response: {
+          status: 403,
+          data: { error: "branch mismatch for tenant t_999" },
+        },
+      });
+
+      const response = await downloadFile(
+        createGetRequest("/api/file-storage/files/file_123/download"),
+        { params: Promise.resolve({ fileId: "file_123" }) },
+      );
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual({ error: "Failed to download document" });
+    });
+
+    it("sanitizes upstream download errors while keeping the 404 mapping", async () => {
+      mockGet.mockRejectedValue({
+        response: {
+          status: 404,
+          data: { message: "Document not found in bucket s3://internal" },
+        },
+      });
+
+      const response = await downloadFile(
+        createGetRequest("/api/file-storage/files/file_123/download"),
+        { params: Promise.resolve({ fileId: "file_123" }) },
+      );
+
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toEqual({ error: "Document not found" });
+    });
+  });
+
+  describe("HEAD download preflight", () => {
+    it("keeps the HEAD metadata preflight working without fetching the body", async () => {
+      mockGet.mockResolvedValue({
+        status: 200,
+        data: { mimeType: "application/pdf", fileSize: 123 },
+        headers: {},
+      });
+
+      const response = await headFile(
+        createGetRequest("/api/file-storage/files/file_123/download"),
+        { params: Promise.resolve({ fileId: "file_123" }) },
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/pdf");
+      expect(response.headers.get("content-disposition")).toBe("inline");
+      expect(response.headers.get("content-length")).toBe("123");
+      expect(response.body).toBeNull();
+      // Metadata endpoint, not the download endpoint: HEAD must never
+      // transfer the file body upstream just to answer a preflight.
+      expect(mockGet).toHaveBeenCalledWith("/documents/file_123", {
+        headers: { Authorization: "Bearer auth-token" },
+      });
+    });
+
+    it("passes x-content-type-options through on HEAD when upstream provides it", async () => {
+      mockGet.mockResolvedValue({
+        status: 200,
+        data: { mimeType: "application/pdf", fileSize: 123 },
+        headers: { "x-content-type-options": "nosniff" },
+      });
+
+      const response = await headFile(
+        createGetRequest("/api/file-storage/files/file_123/download"),
+        { params: Promise.resolve({ fileId: "file_123" }) },
+      );
+
+      expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    });
+
+    it("rejects unsafe HEAD IDs before proxying, without a body", async () => {
+      const response = await headFile(
+        createGetRequest("/api/file-storage/files/bad%2Fid/download"),
+        { params: Promise.resolve({ fileId: "bad%2Fid" }) },
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.body).toBeNull();
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("auth rejection", () => {
+    function noAuthRequest(path: string, method = "GET"): NextRequest {
+      return new NextRequest(`http://localhost${path}`, { method });
+    }
+
+    it("rejects file listing without auth_token", async () => {
+      const response = await listFiles(noAuthRequest("/api/file-storage/files"));
+      expect(response.status).toBe(401);
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects file upload without auth_token", async () => {
+      const response = await uploadFile(noAuthRequest("/api/file-storage/files", "POST"));
+      expect(response.status).toBe(401);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("rejects file detail GET without auth_token", async () => {
+      const response = await getFile(noAuthRequest("/api/file-storage/files/file_123"), {
+        params: Promise.resolve({ fileId: "file_123" }),
+      });
+      expect(response.status).toBe(401);
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects file update without auth_token", async () => {
+      const response = await updateFile(noAuthRequest("/api/file-storage/files/file_123", "PUT"), {
+        params: Promise.resolve({ fileId: "file_123" }),
+      });
+      expect(response.status).toBe(401);
+      expect(mockPut).not.toHaveBeenCalled();
+    });
+
+    it("rejects file delete without auth_token", async () => {
+      const response = await deleteFile(noAuthRequest("/api/file-storage/files/file_123", "DELETE"), {
+        params: Promise.resolve({ fileId: "file_123" }),
+      });
+      expect(response.status).toBe(401);
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    it("rejects file download without auth_token", async () => {
+      const response = await downloadFile(
+        noAuthRequest("/api/file-storage/files/file_123/download"),
+        { params: Promise.resolve({ fileId: "file_123" }) },
+      );
+      expect(response.status).toBe(401);
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects HEAD download without auth_token, without a body", async () => {
+      const response = await headFile(
+        noAuthRequest("/api/file-storage/files/file_123/download", "HEAD"),
+        { params: Promise.resolve({ fileId: "file_123" }) },
+      );
+      expect(response.status).toBe(401);
+      expect(response.body).toBeNull();
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/app/api/file-storage/file-route-utils.ts
+++ b/frontend/src/app/api/file-storage/file-route-utils.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+
+export function isValidFileId(fileId: string): boolean {
+  return /^[A-Za-z0-9_-]+$/.test(fileId);
+}
+
+export function invalidFileIdResponse(): NextResponse {
+  return NextResponse.json({ error: "Invalid file id" }, { status: 400 });
+}
+
+export function documentPath(fileId: string, suffix = ""): string {
+  return `/documents/${encodeURIComponent(fileId)}${suffix}`;
+}

--- a/frontend/src/app/api/file-storage/files/[fileId]/download/route.ts
+++ b/frontend/src/app/api/file-storage/files/[fileId]/download/route.ts
@@ -1,94 +1,124 @@
 import { NextRequest, NextResponse } from "next/server";
+
 import { serverAPIClient } from "@/lib/api/server";
+import {
+    getAuthHeaders,
+    getAuthToken,
+    unauthorizedResponse,
+} from "@/lib/api/route-utils";
+// Deliberately the shared sanitizing errorResponse: the local
+// "@/lib/api/route-utils" binds errorResponse to legacy-message mode, which
+// forwards upstream error text to the browser. File-storage mirrors mobile's
+// sanitized error behaviour.
+import { errorResponse } from "@babyjamjam/shared/api";
+import {
+    documentPath,
+    invalidFileIdResponse,
+    isValidFileId,
+} from "../../../file-route-utils";
 
-function getAuthToken(request: NextRequest): string | null {
-    return request.cookies.get("auth_token")?.value || null;
-}
-
-function createErrorResponse(error: string, status: number, includeBody: boolean) {
-    if (!includeBody) {
-        return new NextResponse(null, { status });
-    }
-
-    return NextResponse.json({ error }, { status });
-}
-
-async function proxyDownload(
-    request: NextRequest,
-    { params }: { params: Promise<{ fileId: string }> },
-    includeBody: boolean
-) {
-    try {
-        const token = getAuthToken(request);
-        if (!token) {
-            return createErrorResponse("Unauthorized", 401, includeBody);
-        }
-
-        const { fileId } = await params;
-        const { searchParams } = new URL(request.url);
-        const attachment = searchParams.get("attachment");
-
-        if (!includeBody) {
-            const response = await serverAPIClient.get(`/documents/${fileId}`, {
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                },
-            });
-            const headers: Record<string, string> = {
-                "Content-Type": response.data?.mimeType || "application/octet-stream",
-                "Content-Disposition": "inline",
-            };
-
-            if (typeof response.data?.fileSize === "number") {
-                headers["Content-Length"] = String(response.data.fileSize);
-            }
-
-            return new NextResponse(null, { headers });
-        }
-
-        const url = attachment === "true"
-            ? `/documents/${fileId}/download?attachment=true`
-            : `/documents/${fileId}/download`;
-
-        const response = await serverAPIClient.get(url, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            },
-            responseType: "arraybuffer",
-        });
-
-        const contentLength = String(
-            response.headers["content-length"] ?? response.data.byteLength,
-        );
-
-        return new NextResponse(includeBody ? response.data : null, {
-            headers: {
-                "Content-Type": String(response.headers["content-type"] ?? "application/octet-stream"),
-                "Content-Disposition": String(response.headers["content-disposition"] ?? "inline"),
-                "Content-Length": contentLength,
-            },
-        });
-    } catch (error) {
-        if (error && typeof error === "object" && "response" in error) {
-            const axiosError = error as { response?: { status: number } };
-            if (axiosError.response?.status === 404) {
-                return createErrorResponse("Document not found", 404, includeBody);
-            }
-        }
-        return createErrorResponse("Download failed", 500, includeBody);
+// The backend decides Content-Type / Content-Disposition /
+// X-Content-Type-Options; the proxy only copies them through and never
+// invents its own values beyond the octet-stream/inline fallbacks.
+function copyNosniffHeader(
+    upstreamHeaders: Record<string, unknown> | undefined,
+    headers: Record<string, string>,
+): void {
+    const nosniff = upstreamHeaders?.["x-content-type-options"];
+    if (nosniff) {
+        headers["X-Content-Type-Options"] = String(nosniff);
     }
 }
 
 export async function GET(
     request: NextRequest,
-    context: { params: Promise<{ fileId: string }> }
+    { params }: { params: Promise<{ fileId: string }> }
 ) {
-    return proxyDownload(request, context, true);
+    try {
+        const token = getAuthToken(request);
+        if (!token) {
+            return unauthorizedResponse("Unauthorized");
+        }
+
+        const { fileId } = await params;
+        if (!isValidFileId(fileId)) {
+            return invalidFileIdResponse();
+        }
+
+        const { searchParams } = new URL(request.url);
+        const attachment = searchParams.get("attachment");
+
+        const url = documentPath(
+            fileId,
+            attachment === "true" ? "/download?attachment=true" : "/download",
+        );
+
+        const response = await serverAPIClient.get(url, {
+            headers: getAuthHeaders(token),
+            responseType: "arraybuffer",
+        });
+
+        const headers: Record<string, string> = {
+            "Content-Type": String(response.headers["content-type"] ?? "application/octet-stream"),
+            "Content-Disposition": String(response.headers["content-disposition"] ?? "inline"),
+            "Content-Length": String(response.data.byteLength),
+        };
+        copyNosniffHeader(response.headers, headers);
+
+        return new NextResponse(response.data, {
+            status: response.status,
+            headers,
+        });
+    } catch (error) {
+        if (error && typeof error === "object" && "response" in error) {
+            const axiosError = error as { response?: { status: number } };
+            if (axiosError.response?.status === 404) {
+                return NextResponse.json({ error: "Document not found" }, { status: 404 });
+            }
+        }
+        return errorResponse(error, "download document");
+    }
 }
 
+// Desktop-only: answers metadata preflights without transferring the file
+// body. Mobile has no HEAD equivalent; keep it. HEAD responses stay body-less
+// on every path, including errors.
 export async function HEAD(
     request: NextRequest,
-    context: { params: Promise<{ fileId: string }> }
+    { params }: { params: Promise<{ fileId: string }> }
 ) {
-    return proxyDownload(request, context, false);
+    try {
+        const token = getAuthToken(request);
+        if (!token) {
+            return new NextResponse(null, { status: 401 });
+        }
+
+        const { fileId } = await params;
+        if (!isValidFileId(fileId)) {
+            return new NextResponse(null, { status: 400 });
+        }
+
+        const response = await serverAPIClient.get(documentPath(fileId), {
+            headers: getAuthHeaders(token),
+        });
+
+        const headers: Record<string, string> = {
+            "Content-Type": response.data?.mimeType || "application/octet-stream",
+            "Content-Disposition": "inline",
+        };
+        if (typeof response.data?.fileSize === "number") {
+            headers["Content-Length"] = String(response.data.fileSize);
+        }
+        copyNosniffHeader(response.headers, headers);
+
+        return new NextResponse(null, { headers });
+    } catch (error) {
+        if (error && typeof error === "object" && "response" in error) {
+            const axiosError = error as { response?: { status: number } };
+            if (axiosError.response?.status === 404) {
+                return new NextResponse(null, { status: 404 });
+            }
+        }
+        return new NextResponse(null, { status: 500 });
+    }
 }

--- a/frontend/src/app/api/file-storage/files/[fileId]/route.ts
+++ b/frontend/src/app/api/file-storage/files/[fileId]/route.ts
@@ -1,9 +1,36 @@
-import { NextRequest, NextResponse } from "next/server";
-import { serverAPIClient } from "@/lib/api/server";
+import { NextRequest } from "next/server";
+import { z } from "zod";
 
-function getAuthToken(request: NextRequest): string | null {
-    return request.cookies.get("auth_token")?.value || null;
-}
+import { serverAPIClient } from "@/lib/api/server";
+import {
+    backendJsonResponse,
+    getAuthHeaders,
+    getAuthToken,
+    parseBody,
+    unauthorizedResponse,
+} from "@/lib/api/route-utils";
+// Deliberately the shared sanitizing errorResponse: the local
+// "@/lib/api/route-utils" binds errorResponse to legacy-message mode, which
+// forwards upstream error text to the browser. File-storage mirrors mobile's
+// sanitized error behaviour.
+import { errorResponse } from "@babyjamjam/shared/api";
+import {
+    documentPath,
+    invalidFileIdResponse,
+    isValidFileId,
+} from "../../file-route-utils";
+
+// Mirrors backend UpdateDocumentDto: every field is @IsOptional, so a
+// passthrough object that type-checks known fields is sufficient. The
+// backend's authoritative ValidationPipe owns the full contract.
+const updateDocumentSchema = z
+    .object({
+        name: z.string().optional(),
+        description: z.string().optional(),
+        categoryId: z.string().optional(),
+        tags: z.array(z.string()).optional(),
+    })
+    .passthrough();
 
 export async function GET(
     request: NextRequest,
@@ -11,22 +38,21 @@ export async function GET(
 ) {
     const token = getAuthToken(request);
     if (!token) {
-        return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+        return unauthorizedResponse("unauthorized");
     }
 
     const { fileId } = await params;
+    if (!isValidFileId(fileId)) {
+        return invalidFileIdResponse();
+    }
 
     try {
-        const response = await serverAPIClient.get(`/documents/${fileId}`, {
-            headers: { Authorization: `Bearer ${token}` },
+        const response = await serverAPIClient.get(documentPath(fileId), {
+            headers: getAuthHeaders(token),
         });
-        return NextResponse.json(response.data);
+        return backendJsonResponse(response);
     } catch (error) {
-        console.error(`[file-storage/files] get ${fileId} error:`, error);
-        return NextResponse.json(
-            { error: "failed to fetch document" },
-            { status: 500 }
-        );
+        return errorResponse(error, "fetch document");
     }
 }
 
@@ -36,23 +62,26 @@ export async function PUT(
 ) {
     const token = getAuthToken(request);
     if (!token) {
-        return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+        return unauthorizedResponse("unauthorized");
     }
 
     const { fileId } = await params;
+    if (!isValidFileId(fileId)) {
+        return invalidFileIdResponse();
+    }
+
+    const { data, response: invalid } = await parseBody(updateDocumentSchema, request);
+    if (invalid) {
+        return invalid;
+    }
 
     try {
-        const body = await request.json().catch(() => ({}));
-        const response = await serverAPIClient.put(`/documents/${fileId}`, body, {
-            headers: { Authorization: `Bearer ${token}` },
+        const response = await serverAPIClient.put(documentPath(fileId), data, {
+            headers: getAuthHeaders(token),
         });
-        return NextResponse.json(response.data);
+        return backendJsonResponse(response);
     } catch (error) {
-        console.error(`[file-storage/files] put ${fileId} error:`, error);
-        return NextResponse.json(
-            { error: "failed to update document" },
-            { status: 500 }
-        );
+        return errorResponse(error, "update document");
     }
 }
 
@@ -62,21 +91,20 @@ export async function DELETE(
 ) {
     const token = getAuthToken(request);
     if (!token) {
-        return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+        return unauthorizedResponse("unauthorized");
     }
 
     const { fileId } = await params;
+    if (!isValidFileId(fileId)) {
+        return invalidFileIdResponse();
+    }
 
     try {
-        const response = await serverAPIClient.delete(`/documents/${fileId}`, {
-            headers: { Authorization: `Bearer ${token}` },
+        const response = await serverAPIClient.delete(documentPath(fileId), {
+            headers: getAuthHeaders(token),
         });
-        return NextResponse.json(response.data);
+        return backendJsonResponse(response);
     } catch (error) {
-        console.error(`[file-storage/files] delete ${fileId} error:`, error);
-        return NextResponse.json(
-            { error: "failed to delete document" },
-            { status: 500 }
-        );
+        return errorResponse(error, "delete document");
     }
 }

--- a/frontend/src/app/api/file-storage/files/route.ts
+++ b/frontend/src/app/api/file-storage/files/route.ts
@@ -1,34 +1,50 @@
 import { NextRequest, NextResponse } from "next/server";
-import { serverAPIClient } from "@/lib/api/server";
+import { z } from "zod";
 
-function getAuthToken(request: NextRequest): string | null {
-    return request.cookies.get("auth_token")?.value || null;
-}
+import { serverAPIClient } from "@/lib/api/server";
+import {
+    backendJsonResponse,
+    getAuthHeaders,
+    getAuthToken,
+    unauthorizedResponse,
+} from "@/lib/api/route-utils";
+// Deliberately the shared sanitizing errorResponse: the local
+// "@/lib/api/route-utils" binds errorResponse to legacy-message mode, which
+// forwards upstream error text (e.g. class-validator messages) to the
+// browser. File-storage mirrors mobile's sanitized error behaviour.
+import { errorResponse } from "@babyjamjam/shared/api";
+
+// Identity fields (orgId/uploadedBy) are deliberately NOT part of this
+// whitelist: the backend derives branch + uploader from the JWT
+// (@CurrentTenant), so client-supplied identity is spoofable noise and is
+// never forwarded. Only validated metadata crosses the proxy.
+const uploadMetadataSchema = z.object({
+    name: z.string().trim().min(1).max(255).optional(),
+    description: z.string().max(2000).optional(),
+    categoryId: z.string().trim().min(1).max(100).optional(),
+    tags: z.string().max(2000).optional(),
+});
 
 export async function GET(request: NextRequest) {
     try {
         const token = getAuthToken(request);
         if (!token) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            return unauthorizedResponse("Unauthorized");
         }
 
         const { searchParams } = new URL(request.url);
         const categoryId = searchParams.get("categoryId");
-        
+
         const params: Record<string, string> = {};
         if (categoryId) params.categoryId = categoryId;
 
         const response = await serverAPIClient.get("/documents", {
             params,
-            headers: { Authorization: `Bearer ${token}` },
+            headers: getAuthHeaders(token),
         });
-        return NextResponse.json(response.data);
+        return backendJsonResponse(response);
     } catch (error) {
-        console.error("[file-storage/documents] GET error:", error);
-        return NextResponse.json(
-            { error: "Failed to fetch documents" },
-            { status: 500 }
-        );
+        return errorResponse(error, "fetch documents");
     }
 }
 
@@ -36,7 +52,7 @@ export async function POST(request: NextRequest) {
     try {
         const token = getAuthToken(request);
         if (!token) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            return unauthorizedResponse("Unauthorized");
         }
 
         const formData = await request.formData();
@@ -55,43 +71,35 @@ export async function POST(request: NextRequest) {
         const blob = new Blob([buffer], { type: file.type });
         backendFormData.append("file", blob, file.name);
 
-        const name = formData.get("name");
-        const description = formData.get("description");
-        const categoryId = formData.get("categoryId");
-        const tags = formData.get("tags");
-        const orgId = formData.get("orgId");
-        const uploadedBy = formData.get("uploadedBy");
+        const metadataResult = uploadMetadataSchema.safeParse({
+            name: formData.get("name") ?? undefined,
+            description: formData.get("description") ?? undefined,
+            categoryId: formData.get("categoryId") ?? undefined,
+            tags: formData.get("tags") ?? undefined,
+        });
+        if (!metadataResult.success) {
+            return NextResponse.json(
+                { error: "Invalid upload metadata" },
+                { status: 400 }
+            );
+        }
 
-        if (name) backendFormData.append("name", name as string);
-        if (description) backendFormData.append("description", description as string);
-        if (categoryId) backendFormData.append("categoryId", categoryId as string);
-        if (tags) backendFormData.append("tags", tags as string);
-        if (orgId) backendFormData.append("orgId", orgId as string);
-        if (uploadedBy) backendFormData.append("uploadedBy", uploadedBy as string);
+        const { name, description, categoryId, tags } = metadataResult.data;
+        if (name) backendFormData.append("name", name);
+        if (description) backendFormData.append("description", description);
+        if (categoryId) backendFormData.append("categoryId", categoryId);
+        if (tags) backendFormData.append("tags", tags);
 
         const response = await serverAPIClient.post("/documents/upload", backendFormData, {
             timeout: 120000,
             headers: {
                 "Content-Type": undefined,
-                Authorization: `Bearer ${token}`,
+                ...getAuthHeaders(token),
             },
         });
 
-        return NextResponse.json(response.data, { status: 201 });
+        return backendJsonResponse(response);
     } catch (error) {
-        console.error("[file-storage/documents] POST error:", error);
-        if (error && typeof error === "object" && "response" in error) {
-            const axiosError = error as { response?: { status: number; data: unknown } };
-            if (axiosError.response) {
-                return NextResponse.json(
-                    axiosError.response.data || { error: "Upload failed" },
-                    { status: axiosError.response.status }
-                );
-            }
-        }
-        return NextResponse.json(
-            { error: "Failed to upload document" },
-            { status: 500 }
-        );
+        return errorResponse(error, "upload document");
     }
 }

--- a/frontend/src/hooks/use-documents.ts
+++ b/frontend/src/hooks/use-documents.ts
@@ -25,14 +25,15 @@ export interface Document {
     updatedAt: string;
 }
 
+// orgId/uploadedBy are deliberately absent: the backend derives both from the
+// JWT (@CurrentTenant), and the proxy strips them — sending them would only
+// earn a 400 from the backend's forbidNonWhitelisted pipe.
 export interface UploadDocumentParams {
     file: File;
     name?: string;
     description?: string;
     categoryId: string;
     tags?: string[];
-    orgId?: string;
-    uploadedBy?: string;
     onProgress?: (progress: number) => void;
 }
 
@@ -91,8 +92,6 @@ export function useUploadDocument() {
             description,
             categoryId,
             tags,
-            orgId,
-            uploadedBy,
             onProgress,
         }: UploadDocumentParams) => {
             const formData = new FormData();
@@ -101,8 +100,6 @@ export function useUploadDocument() {
             if (description) formData.append("description", description);
             formData.append("categoryId", categoryId);
             if (tags) formData.append("tags", JSON.stringify(tags));
-            if (orgId) formData.append("orgId", orgId);
-            if (uploadedBy) formData.append("uploadedBy", uploadedBy);
 
             const { data } = await api.post<Document>("/file-storage/files", formData, {
                 onUploadProgress: (progressEvent) => {

--- a/mobile/src/app/api/file-storage/__tests__/route.test.ts
+++ b/mobile/src/app/api/file-storage/__tests__/route.test.ts
@@ -215,6 +215,33 @@ describe("file-storage API routes", () => {
     expect(mockGet).not.toHaveBeenCalled();
   });
 
+  // The backend allowlists which stored types may render inline; nosniff is what
+  // stops a browser second-guessing that Content-Type. Dropping it at the proxy
+  // silently removes the guarantee for every mobile download.
+  it("passes the backend's download headers through, nosniff included", async () => {
+    mockGet.mockResolvedValueOnce({
+      status: 200,
+      data: new ArrayBuffer(8),
+      headers: {
+        "content-type": "application/pdf",
+        "content-disposition": "inline; filename=\"contract.pdf\"",
+        "x-content-type-options": "nosniff",
+      },
+    });
+
+    const response = await downloadFile(
+      createGetRequest("/api/file-storage/files/file_123/download"),
+      { params: Promise.resolve({ fileId: "file_123" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/pdf");
+    expect(response.headers.get("content-disposition")).toBe(
+      "inline; filename=\"contract.pdf\"",
+    );
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+  });
+
   describe("auth rejection", () => {
     function noAuthRequest(path: string, method = "GET"): NextRequest {
       return new NextRequest(`http://localhost${path}`, { method });

--- a/mobile/src/app/api/file-storage/files/[fileId]/download/route.ts
+++ b/mobile/src/app/api/file-storage/files/[fileId]/download/route.ts
@@ -40,13 +40,24 @@ export async function GET(
             responseType: "arraybuffer",
         });
 
+        // The backend decides Content-Type / Content-Disposition /
+        // X-Content-Type-Options; the proxy only copies them through and never
+        // invents its own values beyond the octet-stream/inline fallbacks.
+        // Dropping nosniff here would let a browser re-sniff a type the backend
+        // deliberately allowlisted for inline display.
+        const headers: Record<string, string> = {
+            "Content-Type": String(response.headers["content-type"] ?? "application/octet-stream"),
+            "Content-Disposition": String(response.headers["content-disposition"] ?? "inline"),
+            "Content-Length": String(response.data.byteLength),
+        };
+        const nosniff = response.headers["x-content-type-options"];
+        if (nosniff) {
+            headers["X-Content-Type-Options"] = String(nosniff);
+        }
+
         return new NextResponse(response.data, {
             status: response.status,
-            headers: {
-                "Content-Type": String(response.headers["content-type"] ?? "application/octet-stream"),
-                "Content-Disposition": String(response.headers["content-disposition"] ?? "inline"),
-                "Content-Length": String(response.data.byteLength),
-            },
+            headers,
         });
     } catch (error) {
         if (error && typeof error === "object" && "response" in error) {


### PR DESCRIPTION
Audit of the file storage subsystem — untouched since 2026-06-13 — turned up six real defects. This fixes four of them plus a latent data-migration bug. Three commits, one per area, reviewable independently.

## 1. Stored XSS through the inline download path

An uploaded file's `Content-Type` is whatever the browser said it was: multer forwards the multipart header verbatim and nothing sniffs the bytes. Download echoed it back with `Content-Disposition: inline`, served from the admin app's own origin, and neither frontend sets a CSP or `nosniff` anywhere.

The live route in is the desktop preview dialog's **인쇄** button — it renders for any non-HWP document (`shared-document-preview-dialog.tsx:594-606`) and its handler loads the inline URL into a same-origin, un-sandboxed iframe (`:520-523`). Upload `payload.html`, have a colleague print it, and it runs with their session. (The preview pane itself is gated to PDF/image, so it is not the vector — the print button is.)

Closed at the source rather than in the frontend. Only PDF and the raster types the preview actually renders may go out `inline`; everything else is forced to `attachment` + `application/octet-stream` regardless of the query param, and `nosniff` goes on every response so an allowlisted `Content-Type` cannot be re-sniffed into something executable. `image/svg+xml` is deliberately excluded — the UI matches `image/*` and SVG is scriptable.

The upload allowlist is defence in depth, not the control. That is why `application/octet-stream` stays permitted: the desktop dropzone validates only file size (its format label is cosmetic), and a `.hwp` on a machine without Hancom reports as octet-stream, so rejecting it would break the product's flagship format. Nothing outside the inline list is ever rendered, so a mislabelled upload can only be downloaded.

## 2. Upload leaked a storage object on every failed insert

Object was written before the row with no compensation. A claimed storage path, a stale `categoryId`, any transient DB error — each left a billed object no row references and no sweep job reclaims. Now compensated best-effort, with the original error always rethrown.

## 3. Korean filenames downloaded as gibberish

`encodeURIComponent` in the plain `filename` parameter, which browsers do not percent-decode, so 서류.pdf saved as `%EC%84%9C%EB%A5%98.pdf` — in a product where document names are Korean by default. Now the RFC 6266/5987 pair. The ASCII fallback still strips CR/LF and quotes, so the header stays injection-proof.

## 4. Desktop proxy was a pre-hardening fork of mobile's

Same endpoints, and mobile's routes were moved onto the shared helpers and hardened at some point. Desktop never caught up, and had **no test file at all** — which is why that hardening silently did not apply here. Four divergences: raw `fileId` interpolation into the upstream path; client-supplied `orgId`/`uploadedBy` forwarded; upstream error bodies returned verbatim (handing out class-validator field names on a 400); upload response forced to 201.

The identity forwarding was **not** a spoofing hole — `forbidNonWhitelisted` means the backend 400s and the controller reads both off the tenant anyway. It was a trap: the hook's public type still advertised the fields, so the first caller to fill them in would get an unexplainable 400 on desktop and success on mobile. Removed at both ends.

Worth knowing for later: the local `route-utils` wrapper binds `errorResponse` to `legacy-message` mode, which forwards upstream text verbatim. Importing it the conventional way would have quietly undone the sanitization, so these three routes take `errorResponse` from the shared package directly and say why inline.

Desktop's `HEAD` handler has no mobile equivalent and is **kept** — parity in one direction only.

## 5. A second branch could not upload anything

`document_category.value` was globally unique with no branch component, and the multi-tenancy backfill had assigned every category — including the eight global seed categories — to the first branch with `is_custom = true`. Branch #2 therefore sees an empty category list and cannot recreate "contract", because the global unique fires and surfaces as a bare 409 that reads as "you already have this" when an invisible other branch owns the name. `categoryId` is required on upload, so that branch cannot upload at all.

Now unique per branch, with the eight seed values restored to global scope and a partial unique index keeping those unique — Postgres does not constrain the NULL group in a composite unique, and Prisma cannot express a partial index, so it lives in the migration SQL with a note on the model.

## 6. The backfill script skipped documents

For `document` alone it read `where: { orgId: null }` while writing `branchId` — the legacy column filtering a different column's write. Any document that already had an `orgId` kept `branch_id = NULL`: invisible to every branch, objects still billed, storage paths blocked from reuse. Every other entity in that script uses a bare scan; `document` now matches.

## Read this before merging

**The migration re-runs on every push.** This repo does not use `prisma migrate deploy` — the patch workflow hardcodes `prisma db execute` per file and re-executes on every push to dev/preview/main, so the SQL is written to be run repeatedly. The remediation update is guarded by `NOT EXISTS` against a global twin: without that, a row created during the deploy window by app code predating the new `create()` guard would be flipped onto a value that already has a global, violate the partial index, and **brick the patch job in that environment permanently**. The step is added to all three jobs.

**`verify-documents-branch.sql` is deliberately not wired up.** If NULL-branch documents exist today, wiring it would fail the patch job in all three environments on every push. Wire it once this comes back zero:

```sql
SELECT count(*) FROM document WHERE branch_id IS NULL;
SELECT branch_id, is_custom, count(*) FROM document_category GROUP BY 1,2;
```

Those two queries also decide whether #5 and #6 are live incidents or dormant traps — I could not run them (no DB reachable from here).

**Check whether preview and production share a database** before promoting. If they do, landing this in preview applies the migration to production data.

## Not fixed

- `POST /documents` (metadata-only create) still trusts a client-supplied `mimetype`, `filesize` and `uploadedby`. Neither frontend calls it. Any row it creates is inert against #1 because the download side forces the disposition, but the audit trail is forgeable within a branch. Wants a decision: derive from the tenant, or delete the route.
- `GET /documents` is unpaginated and download buffers the whole file three times. Fine at current volume; streaming means changing the port signature.

## Verification

Every fix has a test that fails when the fix is reverted — verified by actually reverting each one, not asserted. I re-ran the two highest-consequence mutations independently: removing the inline forcing fails 2 tests, removing the compensating delete fails 2, disabling the global-category guard fails 1.

Backend 76 suites / 1231 passed, frontend 162 / 769, mobile 178 / 1027, type-check clean on all three, eslint clean.

One honest caveat carried up from the work: the "two branches can use the same value" case is a *schema* guarantee, and a unit test with mocked Prisma cannot revert SQL. Its evidence is a simulation of the old constraint, not a true mutation.
