### PR TITLE
fix: stop the contracts list refetching its way through the whole table

### DIFF
--- a/frontend/src/app/(protected)/contracts/page.test.tsx
+++ b/frontend/src/app/(protected)/contracts/page.test.tsx
@@ -17,3 +17,20 @@ describe("ContractsPage provider summaries", () => {
     expect(source).toContain('full: ["계약 종료일", "계약종료일", "endDate", "contractEndDate"]');
   });
 });
+
+describe("ContractsPage server-side search", () => {
+  // A guard against reintroduction, not a behaviour test. Filtering the server's
+  // pages client-side is what left hasNextPage describing the UNfiltered table,
+  // so the list kept pulling pages that were filtered away and never stopped.
+  // What the search actually sends is covered for real in
+  // src/hooks/__tests__/useInfiniteContracts.search.test.tsx, which drives the
+  // hook and asserts on the request; those tests fail when the fix is reverted.
+  //
+  // Asserting on source text cannot tell working code from a plausible string,
+  // so this file deliberately keeps only the absence check: it survives
+  // renames and formatting, and there is no way to satisfy it while still
+  // filtering.
+  it("no longer filters the server's pages client-side", () => {
+    expect(source).not.toContain("matchesDocumentSearch");
+  });
+});

--- a/frontend/src/app/(protected)/contracts/page.tsx
+++ b/frontend/src/app/(protected)/contracts/page.tsx
@@ -162,7 +162,6 @@ const ContractDocumentPreviewModal = dynamic(
   { ssr: false }
 );
 
-const EXCLUDED_CUSTOMER_NAMES: string[] = [];
 
 const TAB_ITEMS = [
   { label: "전체", value: "all" },
@@ -553,7 +552,6 @@ export default function ContractsPage() {
   } = useInfiniteContracts({
     enabled: canFetchDocuments,
     filterType,
-    excludedNames: EXCLUDED_CUSTOMER_NAMES,
     templateFilter,
     search: activeSearchQuery,
   });

--- a/frontend/src/app/(protected)/contracts/page.tsx
+++ b/frontend/src/app/(protected)/contracts/page.tsx
@@ -34,7 +34,7 @@ import { useInfiniteContracts } from "@/hooks/useInfiniteContracts";
 import { ServiceRecordHeaderCard } from "@/features/service-records/components/ServiceRecordHeaderCard";
 import { useClientServiceRecords } from "@/features/service-records/hooks/use-service-records";
 import type { EformsignDocument, EformsignDocumentOption } from "@/lib/eformsign/types";
-import { matchesDocumentSearch } from "@/lib/eformsign/contract-search";
+import { useDebounce } from "use-debounce";
 import {
   DocumentFilterType,
   contractStatusBadgeType,
@@ -520,6 +520,14 @@ export default function ContractsPage() {
   );
   const activeListTab = activeSection === "service-records" ? serviceRecordActiveTab : activeTab;
   const filterType: DocumentFilterType = activeListTab === "all" ? null : (activeListTab as DocumentFilterType);
+  // Search is applied server-side (chosung-aware), so each keystroke would be a
+  // request — debounce to one request per pause, matching mobile's
+  // useDebouncedValue(searchQuery.trim(), 300). Each surface debounces its own
+  // term so a section switch immediately uses that section's settled term.
+  const [debouncedSearchQuery] = useDebounce(searchQuery.trim(), 300);
+  const [debouncedServiceRecordSearchQuery] = useDebounce(serviceRecordSearchQuery.trim(), 300);
+  const activeSearchQuery =
+    activeSection === "service-records" ? debouncedServiceRecordSearchQuery : debouncedSearchQuery;
   const templateFilter = useMemo(
     () => serviceRecordTemplateIds.length > 0
       ? {
@@ -547,6 +555,7 @@ export default function ContractsPage() {
     filterType,
     excludedNames: EXCLUDED_CUSTOMER_NAMES,
     templateFilter,
+    search: activeSearchQuery,
   });
   // 전체 탭 StatsBar 카운터: 서버가 지점(인천=회사 전체) 상태 신호를 한 번 모아 내려주고
   // foldContractStats로 접는다. 무한 스크롤 목록과 분리되어, 스크롤하지 않아도 정확하다.
@@ -567,27 +576,20 @@ export default function ContractsPage() {
   const isStatsLoading = isBootstrappingAuth || isCountsLoading;
   const isServiceRecordListLoading = isInitialLoading;
 
-  // Use infinite scroll documents, with optional local search filter
-  const documents = useMemo(
-    () => infiniteDocuments.filter(
-      (doc) => matchesDocumentSearch(doc, searchQuery, resolveCustomerName(doc)),
-    ),
-    [infiniteDocuments, resolveCustomerName, searchQuery],
-  );
+  // Search happens server-side (it is part of the query key), so what the
+  // server returns is what renders — total_rows/hasNextPage describe the
+  // searched set and pagination stops when the matches run out.
+  const documents = infiniteDocuments;
 
   const serviceRecordDocuments = useMemo(() => {
     if (serviceRecordTemplateIds.length === 0) return [];
     return infiniteDocuments.filter(
-      (doc) =>
-        matchesDocumentStatusTab(doc, serviceRecordActiveTab) &&
-        matchesDocumentSearch(doc, serviceRecordSearchQuery, resolveCustomerName(doc)),
+      (doc) => matchesDocumentStatusTab(doc, serviceRecordActiveTab),
     );
   }, [
     serviceRecordTemplateIds,
     infiniteDocuments,
-    resolveCustomerName,
     serviceRecordActiveTab,
-    serviceRecordSearchQuery,
   ]);
 
   const stats = useMemo(

--- a/frontend/src/components/app/v3/ExpandableSearch.tsx
+++ b/frontend/src/components/app/v3/ExpandableSearch.tsx
@@ -107,7 +107,10 @@ export function ExpandableSearch({
           className={cn(
             "expandable-search-overlay-surface absolute right-0 top-0 flex h-[calc(40px*var(--glint-ui-scale,1))] items-start justify-start overflow-hidden rounded-[12px]",
             expanded
-              ? "bg-white shadow-sm"
+              // No border and no shadow: the expanded field sits on the panel
+              // header, and an outlined, raised box there reads as a separate
+              // surface floating over the list rather than part of the header.
+              ? "border-0 bg-white shadow-none"
               : "w-[calc(32px*var(--glint-ui-scale,1))] bg-transparent"
           )}
         >

--- a/frontend/src/components/app/v3/__tests__/ListPanel.test.tsx
+++ b/frontend/src/components/app/v3/__tests__/ListPanel.test.tsx
@@ -160,10 +160,12 @@ describe("ListPanel", () => {
     );
     expect(container.querySelector('[data-component="desktop_v3_expandable-search_overlay"]')).toHaveClass(
       "bg-white",
-      "shadow-sm",
+      "border-0",
+      "shadow-none",
     );
     expect(container.querySelector('[data-component="desktop_v3_expandable-search_overlay"]')).not.toHaveClass(
       "border",
+      "shadow-sm",
       "focus-within:ring-[3px]",
       "focus-within:ring-inset",
     );

--- a/frontend/src/hooks/__tests__/useInfiniteContracts.search.test.tsx
+++ b/frontend/src/hooks/__tests__/useInfiniteContracts.search.test.tsx
@@ -1,0 +1,163 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { eformsignApi } from "@/services/api";
+import {
+  infiniteContractsQueryKeys,
+  useInfiniteContracts,
+} from "../useInfiniteContracts";
+
+jest.mock("@/services/api", () => ({
+  eformsignApi: {
+    getAllDocuments: jest.fn(),
+    getInProgressDocuments: jest.fn(),
+    getCompletedDocuments: jest.fn(),
+    getExpiredDocuments: jest.fn(),
+  },
+}));
+
+const mockedApi = eformsignApi as jest.Mocked<typeof eformsignApi>;
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function wrapperFor(queryClient: QueryClient) {
+  return function QueryWrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function emptyPage() {
+  return { documents: [], total_rows: 0, limit: 20, skip: 0 };
+}
+
+describe("useInfiniteContracts — server-side search", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApi.getAllDocuments.mockResolvedValue(emptyPage() as never);
+    mockedApi.getInProgressDocuments.mockResolvedValue(emptyPage() as never);
+    mockedApi.getCompletedDocuments.mockResolvedValue(emptyPage() as never);
+    mockedApi.getExpiredDocuments.mockResolvedValue(emptyPage() as never);
+  });
+
+  // While the search was client-side, the server kept paginating the
+  // unfiltered table and hasNextPage never went false — the runaway load-more
+  // loop. Sending the term server-side is what makes the pagination metadata
+  // describe the searched set.
+  it("sends the search term to the All tab endpoint", async () => {
+    renderHook(
+      () => useInfiniteContracts({ filterType: null, search: "김현아" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(mockedApi.getAllDocuments).toHaveBeenCalled());
+
+    expect(mockedApi.getAllDocuments).toHaveBeenCalledWith(
+      expect.objectContaining({ search: "김현아" }),
+    );
+  });
+
+  it.each([
+    ["in-progress", () => mockedApi.getInProgressDocuments],
+    ["completed", () => mockedApi.getCompletedDocuments],
+    ["expired", () => mockedApi.getExpiredDocuments],
+  ] as const)(
+    "sends the search term to the %s endpoint",
+    async (filterType, getMock) => {
+      renderHook(
+        () => useInfiniteContracts({ filterType, search: "홍길동" }),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(getMock()).toHaveBeenCalled());
+
+      expect(getMock()).toHaveBeenCalledWith(
+        expect.objectContaining({ search: "홍길동" }),
+      );
+    },
+  );
+
+  it("trims the term before sending it", async () => {
+    renderHook(
+      () => useInfiniteContracts({ filterType: null, search: "  김현아  " }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(mockedApi.getAllDocuments).toHaveBeenCalled());
+
+    expect(mockedApi.getAllDocuments).toHaveBeenCalledWith(
+      expect.objectContaining({ search: "김현아" }),
+    );
+  });
+
+  it.each([
+    ["an omitted search", undefined],
+    ["an empty search", ""],
+    ["a whitespace-only search", "   "],
+  ])("sends no search param for %s", async (_description, search) => {
+    renderHook(
+      () => useInfiniteContracts({ filterType: null, search }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(mockedApi.getAllDocuments).toHaveBeenCalled());
+
+    expect(mockedApi.getAllDocuments.mock.calls[0][0]).not.toHaveProperty(
+      "search",
+    );
+  });
+
+  it("keys the cache by search term so two terms never share pages", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const { rerender } = renderHook(
+      ({ search }: { search: string }) =>
+        useInfiniteContracts({ filterType: null, search }),
+      { wrapper: wrapperFor(queryClient), initialProps: { search: "김" } },
+    );
+
+    await waitFor(() =>
+      expect(mockedApi.getAllDocuments).toHaveBeenCalledTimes(1),
+    );
+    expect(mockedApi.getAllDocuments).toHaveBeenLastCalledWith(
+      expect.objectContaining({ search: "김" }),
+    );
+
+    // Same normalized term (only whitespace differs) → same key, no refetch.
+    rerender({ search: "김 " });
+    await waitFor(() =>
+      expect(mockedApi.getAllDocuments).toHaveBeenCalledTimes(1),
+    );
+
+    // Different term → different key → its own fetch, not the cached "김" pages.
+    rerender({ search: "이" });
+    await waitFor(() =>
+      expect(mockedApi.getAllDocuments).toHaveBeenCalledTimes(2),
+    );
+    expect(mockedApi.getAllDocuments).toHaveBeenLastCalledWith(
+      expect.objectContaining({ search: "이" }),
+    );
+  });
+});
+
+describe("infiniteContractsQueryKeys — search segment", () => {
+  it("separates result sets for different search terms", () => {
+    const kim = infiniteContractsQueryKeys.documents(null, undefined, "김");
+    const lee = infiniteContractsQueryKeys.documents(null, undefined, "이");
+
+    expect(kim).not.toEqual(lee);
+  });
+
+  it("treats an omitted search and an empty search as the same key", () => {
+    expect(infiniteContractsQueryKeys.documents(null, undefined)).toEqual(
+      infiniteContractsQueryKeys.documents(null, undefined, ""),
+    );
+  });
+});

--- a/frontend/src/hooks/useInfiniteContracts.ts
+++ b/frontend/src/hooks/useInfiniteContracts.ts
@@ -6,11 +6,9 @@ import { eformsignApi } from "@/services/api";
 import { EformsignDocument, EformsignDocumentsResponse } from "@/lib/eformsign/types";
 import { eformsignQueryKeys } from "@/hooks/useEformsignDocuments";
 import { getStatusCategory, DocumentFilterType } from "@/lib/eformsign/status-codes";
-import { UNKNOWN_CUSTOMER_NAME, customerName } from "@/lib/eformsign/display-name";
 
 const PAGE_SIZE = 20;
 const EMPTY_DOCUMENTS: EformsignDocument[] = [];
-const EMPTY_EXCLUDED_NAMES: readonly string[] = [];
 const UNVERSIONED_SNAPSHOT_GENERATION = "<unversioned>";
 
 // Filter documents by actual status code. Used as a safety net for the merged
@@ -61,8 +59,6 @@ export interface DocumentTemplateFilter {
 interface UseInfiniteContractsOptions {
   enabled?: boolean;
   filterType?: DocumentFilterType;
-  /** Names to exclude from the results */
-  excludedNames?: readonly string[];
   templateFilter?: DocumentTemplateFilter;
   /**
    * Server-side search term (chosung-aware on the backend). Trimmed here;
@@ -102,7 +98,6 @@ export function getNextContractsPageParam(
 export function useInfiniteContracts({
   enabled = true,
   filterType = null,
-  excludedNames = EMPTY_EXCLUDED_NAMES,
   templateFilter,
   search,
 }: UseInfiniteContractsOptions = {}) {
@@ -214,25 +209,21 @@ export function useInfiniteContracts({
     return deduped;
   }, [query.data]);
 
-  const excludedNameSet = useMemo(() => new Set(excludedNames), [excludedNames]);
-
   const documents = useMemo(() => {
     if (fetchedDocuments.length === 0) return EMPTY_DOCUMENTS;
 
     // Server filters by status for per-status endpoints; this is a safety net
     // for the merged "전체" endpoint (which returns all statuses) and a no-op
     // for other tabs.
-    let docs = filterByActualStatus(fetchedDocuments, filterType);
-
-    if (excludedNameSet.size > 0) {
-      docs = docs.filter((doc) => {
-        const name = customerName(doc);
-        return name !== UNKNOWN_CUSTOMER_NAME && !excludedNameSet.has(name);
-      });
-    }
-
-    return sortByCreatedDate(docs);
-  }, [excludedNameSet, filterType, fetchedDocuments]);
+    //
+    // Nothing else may be filtered here. Dropping rows after the server has
+    // paginated leaves has_more describing a larger set than what renders, so
+    // the list keeps asking for pages that vanish on arrival and never settles
+    // — the same loop the client-side search caused. A customer-name exclusion
+    // list used to sit here; it was always empty, and if one is ever needed it
+    // belongs in the query, not after it.
+    return sortByCreatedDate(filterByActualStatus(fetchedDocuments, filterType));
+  }, [filterType, fetchedDocuments]);
 
   // Total reported by upstream eformsign for per-status tabs. Not meaningful
   // for the 전체 tab (it is the first page's deduped batch size).

--- a/frontend/src/hooks/useInfiniteContracts.ts
+++ b/frontend/src/hooks/useInfiniteContracts.ts
@@ -40,12 +40,16 @@ export const infiniteContractsQueryKeys = {
   documents: (
     status: DocumentFilterType,
     templateFilter?: DocumentTemplateFilter,
+    search?: string,
   ) => [
     ...eformsignQueryKeys.documents(),
     "infinite",
     status ?? "all",
     templateFilter?.templateMatch ?? "all-templates",
     templateFilter?.templateId ?? null,
+    // Search is part of the key so a new term never reuses another term's
+    // cached pages (which would render as the search silently not applying).
+    search || "",
   ] as const,
 };
 
@@ -60,6 +64,15 @@ interface UseInfiniteContractsOptions {
   /** Names to exclude from the results */
   excludedNames?: readonly string[];
   templateFilter?: DocumentTemplateFilter;
+  /**
+   * Server-side search term (chosung-aware on the backend). Trimmed here;
+   * an empty/whitespace value means "no search" and sends no param, so the
+   * unsearched list behaves exactly as before. With the search applied on the
+   * server, `total_rows`/`hasNextPage` describe the *filtered* set — the list
+   * stops paginating when the matches run out instead of walking the whole
+   * table client-side.
+   */
+  search?: string;
 }
 
 /**
@@ -91,16 +104,19 @@ export function useInfiniteContracts({
   filterType = null,
   excludedNames = EMPTY_EXCLUDED_NAMES,
   templateFilter,
+  search,
 }: UseInfiniteContractsOptions = {}) {
   const queryClient = useQueryClient();
   const templateId = templateFilter?.templateId;
   const templateMatch = templateFilter?.templateMatch;
+  const normalizedSearch = search?.trim() ?? "";
   const queryKey = useMemo(
     () => infiniteContractsQueryKeys.documents(
       filterType,
       templateId && templateMatch ? { templateId, templateMatch } : undefined,
+      normalizedSearch,
     ),
-    [filterType, templateId, templateMatch],
+    [filterType, templateId, templateMatch, normalizedSearch],
   );
   const query = useInfiniteQuery<EformsignDocumentsResponse>({
     queryKey,
@@ -111,6 +127,7 @@ export function useInfiniteContracts({
         limit: PAGE_SIZE,
         skip,
         ...(templateFilter ?? {}),
+        ...(normalizedSearch ? { search: normalizedSearch } : {}),
       };
       switch (filterType) {
         case "in-progress":

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -222,19 +222,19 @@ export const eformsignApi = {
     // Documents APIs - token is read from httpOnly cookie on server
     // Note: eformsign routes use /eformsign prefix to avoid conflict with file storage /documents
     // Unified endpoint - fetches all documents in single request (more efficient)
-    getAllDocuments: async (params?: { limit?: number; skip?: number; type?: string | null; templateId?: string; templateMatch?: "include" | "exclude"; excludeDeleted?: boolean }): Promise<EformsignDocumentsResponse> => {
+    getAllDocuments: async (params?: { limit?: number; skip?: number; type?: string | null; templateId?: string; templateMatch?: "include" | "exclude"; search?: string; excludeDeleted?: boolean }): Promise<EformsignDocumentsResponse> => {
         const { data } = await api.get('/eformsign/documents', { params });
         return data;
     },
-    getInProgressDocuments: async (params?: { limit?: number; skip?: number; templateId?: string; templateMatch?: "include" | "exclude" }): Promise<EformsignDocumentsResponse> => {
+    getInProgressDocuments: async (params?: { limit?: number; skip?: number; templateId?: string; templateMatch?: "include" | "exclude"; search?: string }): Promise<EformsignDocumentsResponse> => {
         const { data } = await api.get<EformsignApiListResponse>('/eformsign/documents/in-progress', { params });
         return normalizeDocumentListResponse(data, params);
     },
-    getCompletedDocuments: async (params?: { limit?: number; skip?: number; templateId?: string; templateMatch?: "include" | "exclude" }): Promise<EformsignDocumentsResponse> => {
+    getCompletedDocuments: async (params?: { limit?: number; skip?: number; templateId?: string; templateMatch?: "include" | "exclude"; search?: string }): Promise<EformsignDocumentsResponse> => {
         const { data } = await api.get<EformsignApiListResponse>('/eformsign/documents/completed', { params });
         return normalizeDocumentListResponse(data, params);
     },
-    getExpiredDocuments: async (params?: { limit?: number; skip?: number; templateId?: string; templateMatch?: "include" | "exclude" }): Promise<EformsignDocumentsResponse> => {
+    getExpiredDocuments: async (params?: { limit?: number; skip?: number; templateId?: string; templateMatch?: "include" | "exclude"; search?: string }): Promise<EformsignDocumentsResponse> => {
         const { data } = await api.get<EformsignApiListResponse>('/eformsign/documents/expired', { params });
         return normalizeDocumentListResponse(data, params);
     },

--- a/mobile/src/app/(shell)/contracts/page.tsx
+++ b/mobile/src/app/(shell)/contracts/page.tsx
@@ -161,7 +161,6 @@ type ContractStageItem = {
   time: string;
 };
 
-const EXCLUDED_CUSTOMER_NAMES: string[] = [];
 const CONTRACT_ROUTE_BODY_CLASS = "mobile-contracts-route";
 const FILTER_LABELS: FilterKey[] = ["전체", "서명 대기", "서명 완료", "검토 필요", "계약 완료", "기간 만료", "알 수 없음"];
 const CONTRACT_SECTIONS = [
@@ -2107,19 +2106,20 @@ export default function ContractsPage() {
     return undefined;
   }, [documentClientSummaryById, selectedDetailDoc?.id, selectedDoc?.id, selectedListDoc?.id]);
 
-  // 섹션·검색·삭제 필터는 서버가 페이지 slice 이전에 적용한다. 클라이언트에는
-  // 고객명 제외 목록(현재 비어 있음)만 안전망으로 남긴다.
+  // 섹션·검색·삭제 필터는 서버가 페이지 slice 이전에 적용한다.
+  //
+  // 서버가 페이지를 나눈 뒤에 행을 더 걷어내면 total_rows가 화면에 그려지는 수보다
+  // 커진 채로 남아, 목록이 도착하자마자 사라지는 페이지를 계속 요청하게 된다.
+  // 비어 있던 고객명 제외 목록을 여기서 걷어낸 이유다 — 제외가 필요해지면
+  // 조회 이후가 아니라 조회 조건에 넣어야 한다.
   const filteredDocuments = useMemo(() => {
-    const nameFiltered = displayDocuments.filter(
-      (doc) => !EXCLUDED_CUSTOMER_NAMES.includes(customerName(doc)),
-    );
     // 서명 완료/검토 필요 pills share the server's provider-review scope
     // ("in-progress"); the review-window split happens here on the client.
     if (activeFilter === "서명 완료" || activeFilter === "검토 필요") {
       const wantedCategory: ContractCategory = activeFilter === "서명 완료" ? "signed" : "in-progress";
-      return nameFiltered.filter((doc) => categorize(doc) === wantedCategory);
+      return displayDocuments.filter((doc) => categorize(doc) === wantedCategory);
     }
-    return nameFiltered;
+    return displayDocuments;
   }, [activeFilter, displayDocuments]);
 
   const filterItems = useMemo(() => {

--- a/mobile/src/app/(shell)/contracts/page.tsx
+++ b/mobile/src/app/(shell)/contracts/page.tsx
@@ -2112,15 +2112,13 @@ export default function ContractsPage() {
   // 커진 채로 남아, 목록이 도착하자마자 사라지는 페이지를 계속 요청하게 된다.
   // 비어 있던 고객명 제외 목록을 여기서 걷어낸 이유다 — 제외가 필요해지면
   // 조회 이후가 아니라 조회 조건에 넣어야 한다.
-  const filteredDocuments = useMemo(() => {
-    // 서명 완료/검토 필요 pills share the server's provider-review scope
-    // ("in-progress"); the review-window split happens here on the client.
-    if (activeFilter === "서명 완료" || activeFilter === "검토 필요") {
-      const wantedCategory: ContractCategory = activeFilter === "서명 완료" ? "signed" : "in-progress";
-      return displayDocuments.filter((doc) => categorize(doc) === wantedCategory);
-    }
-    return displayDocuments;
-  }, [activeFilter, displayDocuments]);
+  // 서명 완료/검토 필요는 서버의 provider-review 스코프를 공유하지만, 가르는 일은
+  // 서버가 이미 한다: displayStatus를 페이지 slice 전에 적용하므로(mirror-list
+  // service) 돌아온 행은 전부 해당 카테고리다. 여기서 한 번 더 거르면 행을 뺄 수만
+  // 있고 더할 수는 없어서, 서버가 센 total_rows보다 화면이 적어지는 쪽으로만
+  // 어긋난다. 특히 display_status가 없어 categorize가 폴백으로 검토 창을
+  // 브라우저 시계로 다시 계산할 때 서버 판정과 갈릴 수 있다.
+  const filteredDocuments = displayDocuments;
 
   const filterItems = useMemo(() => {
     if (isContractsLoading) {


### PR DESCRIPTION
Typing in the desktop contracts search left three skeleton rows and a spinner running indefinitely. Chasing that turned up a small family of the same mistake — filtering rows on the client *after* the server has paginated — so this fixes the cause and clears the other instances of the pattern. Split out of #489 (file storage hardening), which it has no files in common with.

## 1. Contract search walked the entire table on every keystroke

`useInfiniteContracts` was never given the search term. Search ran as a client-side filter over server-paginated pages, so `hasNextPage` kept describing the **unfiltered** table: the list stayed short, the sentinel stayed in view, `onLoadMore` fired again, the next page arrived and was filtered away, and it repeated until the whole table had been pulled. The visible symptom was the skeleton and spinner that never stop; the invisible one was a full table scan per search, with no debounce, per keystroke.

The backend already accepts `search` on all four list endpoints and matches chosung, and mobile has passed it through for a while — only the desktop wiring was missing. The term now goes into the query params **and the query key**; without the key a new term would reuse the previous term's cached pages and look like search silently not working. The client-side filter is gone from both search surfaces on the page (계약 목록 and 제공기록지). `total_rows`/`hasNextPage` now describe the searched set, so the loop ends because the server says there is no next page.

Debounced at 300ms to match mobile. The desktop never needed one because filtering was local.

**Two visible behaviour changes**, worth knowing before this ships:
- The server matches the document-derived customer name and the branch's recipient name, where the old client filter used the *linked client's* DB name. A client renamed after signing may now match differently.
- Search covers the whole table rather than only the pages already loaded. That is the point, but it surfaces rows that previously stayed hidden until you scrolled far enough.

## 2. Customer-name exclusion ran after pagination

Same shape, in three places: the desktop hook (via an `excludedNames` option), the mobile contracts page, and `DocumentsList.tsx`. It was never actually excluding anyone — both live pages passed an empty array, and the only populated copy lives in `DocumentsList.tsx`, which nothing renders. So this removes a trap rather than a feature: the machinery sat there waiting for someone to fill the array in and reintroduce the loop.

Removed from the hook (and with it the option, the Set, and the `display-name` import it was the only user of) and from both contract pages, each with a comment saying where an exclusion belongs if one is ever needed — in the query, not after it.

## 3. 서명 완료 / 검토 필요 split — not a defect, but the client pass is gone anyway

I first recorded this as a live instance of the same bug. **It was not**, and the third commit's message says so plainly. The mirror list service applies `displayStatus` *before* the caller slices a page, and `categorize()` defers to the `display_status` the backend stamps at serve time — client and server agreed, nothing was dropped, counts matched.

What is true is that re-filtering after pagination can only ever push the rendered count below `total_rows`. The one path where it actually diverges is the fallback: when `display_status` is absent, `categorize()` recomputes the review window against the **browser** clock while the server used its own, so a document sitting on the window boundary lands on different sides. Removing the client pass makes that unreachable and costs nothing, since every row the server returned already belongs to the requested category.

No backend change was needed anywhere in this PR.

## 4. Expandable search overlay: border and shadow removed

The expanded field sits on the list panel header, and an outlined raised box there reads as a separate surface floating over the list. Only the desktop component had anything to remove — mobile's already overrides the Input's default border with `border-none` plus inline `border`/`boxShadow: none`.

## Testing

The hook tests are the real coverage: they drive `useInfiniteContracts` and assert on the outgoing request, and **10 of them fail when the fix is reverted** (verified by reverting, not asserted). I re-ran that mutation independently — 6 failures on the search-specific suite alone.

The page-level tests here are deliberately thin. This repo has a habit of source-text assertions standing in for behaviour tests, and an earlier audit called that out; I dropped two the implementation added (they compared exact expression strings — brittle to renames, and satisfiable while the logic is inverted) and kept only the one that guards against reintroducing the client-side filter, with a comment saying what it is and is not.

frontend 162 suites / 754 tests · mobile 178 suites / 1027 tests · type-check clean on both · eslint 0 errors.

## Known, not fixed

`src/lib/eformsign/contract-search.ts` is now unused outside its own test. Left in place — other in-flight branches may reference it.
