### PR TITLE
fix(eformsign): stop reporting a finalize that never submitted

### DIFF
--- a/backend/application/services/eformsign.service.ts
+++ b/backend/application/services/eformsign.service.ts
@@ -24,6 +24,7 @@ import {
     EformsignApiError,
     extractEformsignVendorCode,
 } from "infrastructure/api/eformsign-api.error";
+import { normalizeEformsignStatusCode } from "domain/utils/eformsign-status-code";
 
 export interface EformsignTokenResponse {
     oauth_token: {
@@ -895,6 +896,25 @@ export class EformsignService {
                 }
             }),
         );
+    }
+
+    /**
+     * The document's current status at the vendor, normalized to a canonical
+     * code. When a headless run ends without a terminal SDK callback, eformsign
+     * — not the automation — is the authority on whether the step finished.
+     * Returns undefined when the response carries no recognizable status.
+     */
+    async fetchDocumentStatusCode(documentId: string, accessToken: string): Promise<string | undefined> {
+        const doc = await this.fetchStaffCompletionDocument(documentId, accessToken);
+        const rawStatus =
+            doc?.document?.document_status ??
+            doc?.document_status ??
+            doc?.status_type ??
+            doc?.status;
+        if (rawStatus === null || rawStatus === undefined || rawStatus === "") {
+            return undefined;
+        }
+        return normalizeEformsignStatusCode(rawStatus);
     }
 
     private async fetchStaffCompletionDocument(documentId: string, accessToken: string): Promise<any> {

--- a/backend/application/usecases/eformsign-doc/finalize-document-headless.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/finalize-document-headless.usecase.ts
@@ -4,6 +4,7 @@ import { EformsignHeadlessService } from "infrastructure/automation/eformsign-he
 import { EformsignHeadlessProgressService } from "application/services/eformsign-headless-progress.service";
 import type { EformsignHeadlessProgressStep } from "application/services/eformsign-headless-progress.service";
 import { GetEformsignAccessTokenUsecase } from "./get-eformsign-access-token.usecase";
+import { EFORMSIGN_COMPLETED_STATUS_CODES } from "domain/constants/eformsign-doc-status.constants";
 
 export interface FinalizeHeadlessParams {
     documentId: string;
@@ -19,7 +20,12 @@ export interface FinalizeHeadlessSuccess {
 export interface FinalizeHeadlessFailure {
     ok: false;
     reason: string;
-    fallbackHint: "iframe";
+    /**
+     * "iframe" reopens the editor so a human can finish the step. It is only
+     * safe once we know the step is genuinely unfinished — "manual_check" is
+     * for the runs where the vendor could not be asked.
+     */
+    fallbackHint: "iframe" | "manual_check";
     durationMs: number;
     failedStep?: EformsignHeadlessProgressStep;
 }
@@ -67,11 +73,29 @@ export class FinalizeDocumentHeadlessUsecase {
             });
 
             if (!result.ok) {
+                // The gate emits "creating" the moment it clicks 전송, so a failure
+                // at or after that step sits on an unknown side of the submit.
+                // Reopening the editor then can ask a human to re-approve a step
+                // eformsign already completed, so ask the vendor before guessing.
+                const sendWasAttempted =
+                    latestProgressStep === "creating" || latestProgressStep === "sent";
+                const settled = sendWasAttempted
+                    ? await this.readVendorOutcome(params.documentId, accessToken)
+                    : "pending";
+
+                if (settled === "completed") {
+                    this.logger.log(
+                        `Headless finalize for ${params.documentId} reported "${result.reason}" but eformsign shows the document completed; treating as success.`,
+                    );
+                    this.progressService.emit(params.progressId, "sent");
+                    return { ok: true, durationMs: result.durationMs };
+                }
+
                 this.progressService.emit(params.progressId, "failed", result.reason, latestProgressStep);
                 return {
                     ok: false,
                     reason: result.reason,
-                    fallbackHint: "iframe",
+                    fallbackHint: settled === "pending" ? "iframe" : "manual_check",
                     durationMs: result.durationMs,
                     failedStep: latestProgressStep,
                 };
@@ -89,6 +113,32 @@ export class FinalizeDocumentHeadlessUsecase {
                 durationMs: Date.now() - start,
                 failedStep: latestProgressStep,
             };
+        }
+    }
+
+    /**
+     * Whether eformsign considers the document finished. "unknown" is deliberately
+     * distinct from "pending": a status we could not read must not be reported as
+     * an unfinished step, because that is what sends a human back into the editor.
+     */
+    private async readVendorOutcome(
+        documentId: string,
+        accessToken: string,
+    ): Promise<"completed" | "pending" | "unknown"> {
+        try {
+            const statusCode = await this.eformsignService.fetchDocumentStatusCode(
+                documentId,
+                accessToken,
+            );
+            if (!statusCode) {
+                this.logger.warn(`eformsign returned no status for ${documentId} after a post-send failure.`);
+                return "unknown";
+            }
+            return EFORMSIGN_COMPLETED_STATUS_CODES.has(statusCode) ? "completed" : "pending";
+        } catch (error) {
+            const reason = error instanceof Error ? error.message : String(error);
+            this.logger.warn(`Could not read eformsign status for ${documentId}: ${reason}`);
+            return "unknown";
         }
     }
 }

--- a/backend/application/usecases/eformsign-doc/finalize-document-headless.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/finalize-document-headless.usecase.ts
@@ -101,6 +101,29 @@ export class FinalizeDocumentHeadlessUsecase {
                 };
             }
 
+            // A run that ended on the success latch stopped at the SDK callback
+            // without necessarily having clicked the popup 전송 that submits —
+            // exactly how a finalize once reported a completion eformsign never
+            // performed. The SDK's completion code is inferred, not documented,
+            // so this one path is settled by the vendor rather than by us.
+            if (result.gateOutcome === "success-latched") {
+                const settled = await this.readVendorOutcome(params.documentId, accessToken);
+                if (settled !== "completed") {
+                    const reason = "eformsign reported success without submitting the document";
+                    this.logger.warn(
+                        `Headless finalize for ${params.documentId}: ${reason} (vendor status: ${settled}).`,
+                    );
+                    this.progressService.emit(params.progressId, "failed", reason, latestProgressStep);
+                    return {
+                        ok: false,
+                        reason,
+                        fallbackHint: settled === "pending" ? "iframe" : "manual_check",
+                        durationMs: result.durationMs,
+                        failedStep: latestProgressStep,
+                    };
+                }
+            }
+
             return { ok: true, durationMs: result.durationMs };
         } catch (error) {
             const reason = error instanceof Error ? error.message : "unknown headless finalize error";

--- a/backend/infrastructure/automation/eformsign-creation-gates.ts
+++ b/backend/infrastructure/automation/eformsign-creation-gates.ts
@@ -78,6 +78,10 @@ export async function runEformsignCreationGates(
             await throwIfEformsignErrorLatched(page);
 
             if (await isSuccessLatched(page)) {
+                (logger as NestLogger).log?.(
+                    `[creation-gate] terminal success latched after ${Date.now() - startedAt}ms; ` +
+                        `lastAction: ${lastAction}`,
+                ) ?? console.log("[creation-gate] terminal success latched");
                 return "success-latched";
             }
 

--- a/backend/infrastructure/automation/eformsign-finalize-gates.ts
+++ b/backend/infrastructure/automation/eformsign-finalize-gates.ts
@@ -74,6 +74,12 @@ export async function runEformsignFinalizeGates(
             await throwIfEformsignErrorLatched(page);
 
             if (await isSuccessLatched(page)) {
+                // The one exit that used to leave no trace, which is why an
+                // incident here could only be reconstructed from log silence.
+                (logger as NestLogger).log?.(
+                    `[finalize-gate] terminal success latched after ${Date.now() - startedAt}ms; ` +
+                        `lastAction: ${lastAction}`,
+                ) ?? console.log("[finalize-gate] terminal success latched");
                 return "success-latched";
             }
 

--- a/backend/infrastructure/automation/eformsign-gate-utils.ts
+++ b/backend/infrastructure/automation/eformsign-gate-utils.ts
@@ -16,6 +16,13 @@ export const EFORMSIGN_READY_TEXT = "필수 입력 항목을 모두 작성했습
 // the loop fall back to the (now-blocked) top-level 전송.
 export const REQUEST_SEND_DIALOG_SELECTOR = "#requestWithInputCommentPopup";
 export const FINALIZE_REQUEST_SEND_DIALOG_SELECTOR = "#inputCommentPopup";
+// The only `code` an eformsign SDK success callback carries when the document
+// actually finished. The SDK fires that same callback for non-terminal events —
+// a top-level 전송 that merely opens the confirm popup is one — so latching on
+// the callback's arrival alone reports success for a send that never happened.
+// `frontend/src/hooks/useEformsign.ts` filters on the same value; the backend
+// keeps its own copy because it does not depend on @babyjamjam/shared.
+export const EFORMSIGN_SDK_COMPLETION_CODE = "-1";
 
 /**
  * Returns the first visible match in `locator`, or null if none are visible.
@@ -100,6 +107,26 @@ export async function readEformsignCallbackState(page: Page): Promise<EformsignC
     });
 }
 
+/**
+ * Every payload the SDK handed to its success callback, terminal or not. Only a
+ * completion-coded one latches `__eformsignSuccess`, so when a run ends without
+ * a terminal callback these are the only evidence of what the SDK did report.
+ */
+export async function readObservedSuccessCallbacks(page: Page): Promise<unknown[]> {
+    const observed = await page
+        .evaluate(() => {
+            const w = window as unknown as { __eformsignSuccessLog?: unknown[] };
+            return w.__eformsignSuccessLog ?? [];
+        })
+        .catch(() => []);
+    return Array.isArray(observed) ? observed : [];
+}
+
+export function formatObservedSuccessCallbacks(observed: readonly unknown[]): string {
+    if (!observed.length) return "none";
+    return observed.map((payload) => formatEformsignCallbackPayload(payload)).join(", ");
+}
+
 export async function throwIfEformsignErrorLatched(page: Page): Promise<void> {
     const state = await readEformsignCallbackState(page).catch(() => null);
     if (!state?.hasError) return;
@@ -173,9 +200,11 @@ export async function createGateErrorWithSnapshot(
 }
 
 /**
- * Watches `window.__eformsignSuccess`, set by the SDK success callback wired
- * in `buildEmbeddedSdkHtml`. Returns true once the dispatch is confirmed,
- * false if the timeout elapsed first.
+ * Watches `window.__eformsignSuccess`, which `buildEmbeddedSdkHtml` sets only
+ * for a success callback carrying `EFORMSIGN_SDK_COMPLETION_CODE`. A gate loop
+ * exits on this, so it must stay the *terminal* signal: latching on any success
+ * callback would let the loop stop before it clicked the popup 전송 that
+ * actually submits the document.
  */
 export async function isSuccessLatched(page: Page): Promise<boolean> {
     return page

--- a/backend/infrastructure/automation/eformsign-headless.service.ts
+++ b/backend/infrastructure/automation/eformsign-headless.service.ts
@@ -23,8 +23,15 @@ import { areE2EVendorStubsEnabled } from "infrastructure/vendor-stubs/e2e-vendor
  * Result envelope returned by the headless service. The frontend uses
  * `ok: false` + `reason` to fall back to the iframe path automatically.
  */
+/**
+ * How the gate loop ended. "request-send-clicked" means it clicked the popup
+ * 전송 that submits the document; "success-latched" means it stopped on the SDK
+ * callback instead, without necessarily having submitted anything.
+ */
+export type EformsignGateOutcome = "success-latched" | "request-send-clicked";
+
 export type HeadlessDispatchResult =
-    | { ok: true; durationMs: number; documentId?: string }
+    | { ok: true; durationMs: number; documentId?: string; gateOutcome?: EformsignGateOutcome }
     | { ok: false; reason: string; durationMs: number; documentId?: string };
 
 export interface DispatchCreationParams {
@@ -191,6 +198,7 @@ export class EformsignHeadlessService implements OnModuleDestroy {
             ok: true,
             durationMs: Date.now() - start,
             documentId: documentId ?? params.documentId,
+            gateOutcome,
         };
     }
 
@@ -216,6 +224,7 @@ export class EformsignHeadlessService implements OnModuleDestroy {
             ok: true,
             durationMs: Date.now() - start,
             documentId: documentId ?? params.documentId,
+            gateOutcome,
         };
     }
 

--- a/backend/infrastructure/automation/eformsign-headless.service.ts
+++ b/backend/infrastructure/automation/eformsign-headless.service.ts
@@ -11,8 +11,11 @@ import { runEformsignCreationGates } from "./eformsign-creation-gates";
 import { runEformsignFinalizeGates } from "./eformsign-finalize-gates";
 import type { EformsignHeadlessProgressStep } from "application/services/eformsign-headless-progress.service";
 import {
+    EFORMSIGN_SDK_COMPLETION_CODE,
     formatEformsignCallbackPayload,
+    formatObservedSuccessCallbacks,
     readEformsignCallbackState,
+    readObservedSuccessCallbacks,
 } from "./eformsign-gate-utils";
 import { areE2EVendorStubsEnabled } from "infrastructure/vendor-stubs/e2e-vendor-stubs";
 
@@ -174,7 +177,8 @@ export class EformsignHeadlessService implements OnModuleDestroy {
         await this.waitForEformsignIframe(page, "eformsign_iframe");
         params.onProgress?.("client-started");
 
-        await runEformsignCreationGates(page, eformsignFrame, this.logger, params.onProgress);
+        const gateOutcome = await runEformsignCreationGates(page, eformsignFrame, this.logger, params.onProgress);
+        this.logger.log(`[creation] gate sequence ended: ${gateOutcome}`);
 
         // The gate runner only confirms the click sequence completed; the
         // actual dispatch is acknowledged by the SDK success callback
@@ -202,7 +206,8 @@ export class EformsignHeadlessService implements OnModuleDestroy {
         await this.waitForEformsignIframe(page, "eformsign_finalize_iframe");
         params.onProgress?.("client-started");
 
-        await runEformsignFinalizeGates(page, eformsignFrame, this.logger, params.onProgress);
+        const gateOutcome = await runEformsignFinalizeGates(page, eformsignFrame, this.logger, params.onProgress);
+        this.logger.log(`[finalize] gate sequence ended: ${gateOutcome}`);
 
         const documentId = await this.waitForTerminalSdkCallback(page, 30_000);
         params.onProgress?.("sent");
@@ -215,25 +220,42 @@ export class EformsignHeadlessService implements OnModuleDestroy {
     }
 
     private async waitForTerminalSdkCallback(page: Page, timeoutMs: number): Promise<string | undefined> {
-        await page.waitForFunction(
-            () => {
-                const w = window as unknown as {
-                    __eformsignSuccess?: unknown;
-                    __eformsignError?: unknown;
-                };
-                return w.__eformsignSuccess !== undefined || w.__eformsignError !== undefined;
-            },
-            { timeout: timeoutMs },
-        );
+        try {
+            await page.waitForFunction(
+                () => {
+                    const w = window as unknown as {
+                        __eformsignSuccess?: unknown;
+                        __eformsignError?: unknown;
+                    };
+                    return w.__eformsignSuccess !== undefined || w.__eformsignError !== undefined;
+                },
+                { timeout: timeoutMs },
+            );
+        } catch {
+            // Non-terminal success callbacks are the expected shape of this
+            // timeout, and they are the only record of how far the SDK got —
+            // a bare Playwright timeout here left past incidents unexplainable.
+            throw new Error(
+                `eformsign SDK reported no terminal callback within ${timeoutMs}ms. ` +
+                    `Observed success callbacks: ${await this.describeObservedCallbacks(page)}`,
+            );
+        }
 
         const state = await readEformsignCallbackState(page);
         if (state.hasError) {
             throw new Error(`eformsign SDK error: ${formatEformsignCallbackPayload(state.error)}`);
         }
         if (!state.hasSuccess) {
-            throw new Error("eformsign SDK completed without a success callback");
+            throw new Error(
+                "eformsign SDK completed without a success callback. " +
+                    `Observed success callbacks: ${await this.describeObservedCallbacks(page)}`,
+            );
         }
         return this.readDocumentIdFromCallback(state.success);
+    }
+
+    private async describeObservedCallbacks(page: Page): Promise<string> {
+        return formatObservedSuccessCallbacks(await readObservedSuccessCallbacks(page));
     }
 
     private readDocumentIdFromCallback(payload: unknown): string | undefined {
@@ -323,7 +345,12 @@ export class EformsignHeadlessService implements OnModuleDestroy {
         sdk.document(
             option,
             "${iframeId}",
-            function (resp) { window.__eformsignSuccess = resp; },
+            function (resp) {
+                (window.__eformsignSuccessLog = window.__eformsignSuccessLog || []).push(resp);
+                if (resp && String(resp.code) === "${EFORMSIGN_SDK_COMPLETION_CODE}") {
+                    window.__eformsignSuccess = resp;
+                }
+            },
             function (resp) { window.__eformsignError = resp; },
             function (resp) { window.__eformsignAction = resp; }
         );

--- a/backend/interface/controllers/eformsign-doc.controller.ts
+++ b/backend/interface/controllers/eformsign-doc.controller.ts
@@ -286,12 +286,14 @@ export class EformsignDocController {
             progressId: dto.progressId,
         });
         if (!result.ok) {
-            this.logger.warn(`[finalize-headless] failed: ${result.reason}`);
+            this.logger.warn(
+                `[finalize-headless] failed: ${result.reason} (fallback: ${result.fallbackHint})`,
+            );
             return {
                 ok: false,
                 durationMs: result.durationMs,
                 reason: result.reason,
-                fallbackHint: "iframe",
+                fallbackHint: result.fallbackHint,
             };
         }
         return { ok: true, durationMs: result.durationMs };

--- a/backend/interface/dto/eformsign-doc.dto.ts
+++ b/backend/interface/dto/eformsign-doc.dto.ts
@@ -169,5 +169,5 @@ export interface FinalizeHeadlessResponseDto {
     ok: boolean;
     durationMs: number;
     reason?: string;
-    fallbackHint?: "iframe";
+    fallbackHint?: "iframe" | "manual_check";
 }

--- a/backend/test/services/eformsign-headless.service.spec.ts
+++ b/backend/test/services/eformsign-headless.service.spec.ts
@@ -83,6 +83,60 @@ describe("EformsignHeadlessService", () => {
         service = new EformsignHeadlessService({ get: configGetMock } as never);
     });
 
+    /**
+     * Pulls the SDK success callback out of the generated page and returns it
+     * bound to a stand-in `window`, so the assertions below exercise the source
+     * that actually ships to the browser rather than a restatement of it.
+     */
+    function extractSuccessCallback(html: string) {
+        const start = html.indexOf("function (resp) {");
+        expect(start).toBeGreaterThan(-1);
+        let depth = 0;
+        let end = start;
+        for (let index = html.indexOf("{", start); index < html.length; index += 1) {
+            if (html[index] === "{") depth += 1;
+            if (html[index] === "}") {
+                depth -= 1;
+                if (depth === 0) {
+                    end = index + 1;
+                    break;
+                }
+            }
+        }
+        const source = html.slice(start, end);
+        // eslint-disable-next-line @typescript-eslint/no-implied-eval
+        return new Function("window", `return (${source});`) as (
+            win: Record<string, unknown>,
+        ) => (resp: unknown) => void;
+    }
+
+    it("latches the SDK success callback only for the completion code", () => {
+        const html = (
+            service as unknown as {
+                buildEmbeddedSdkHtml: (option: Record<string, unknown>, iframeId: string) => string;
+            }
+        ).buildEmbeddedSdkHtml({ mode: { type: "02" } }, "eformsign_finalize_iframe");
+
+        const win: Record<string, unknown> = {};
+        const onSuccess = extractSuccessCallback(html)(win);
+
+        // eformsign fires this callback for non-terminal events too — the
+        // top-level 전송 that only opens the confirm popup is one. Latching on
+        // it reported a finalize as complete that eformsign never performed.
+        onSuccess({ code: "200", type: "document" });
+        expect(win["__eformsignSuccess"]).toBeUndefined();
+
+        onSuccess({ code: "-1", document_id: "doc-1" });
+        expect(win["__eformsignSuccess"]).toEqual({ code: "-1", document_id: "doc-1" });
+
+        // Both payloads stay on the diagnostic log so a run that never reaches a
+        // terminal callback can still say what the SDK did report.
+        expect(win["__eformsignSuccessLog"]).toEqual([
+            { code: "200", type: "document" },
+            { code: "-1", document_id: "doc-1" },
+        ]);
+    });
+
     it("dispatchCreation short-circuits vendor stubs without launching Chromium", async () => {
         configGetMock.mockImplementation((key: string) => key === "E2E_VENDOR_STUBS" ? "1" : undefined);
         const onProgress = jest.fn();
@@ -144,7 +198,11 @@ describe("EformsignHeadlessService", () => {
 
         expect(result.ok).toBe(false);
         if (!result.ok) {
-            expect(result.reason).toContain("Timeout");
+            // The bare Playwright timeout used to surface here and said nothing
+            // about what the SDK had reported, which is what made the finalize
+            // false-success incident unexplainable from logs alone.
+            expect(result.reason).toContain("no terminal callback");
+            expect(result.reason).toContain("Observed success callbacks");
         }
     });
 

--- a/backend/test/usecases/eformsign-doc/finalize-document-headless.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/finalize-document-headless.usecase.spec.ts
@@ -51,6 +51,82 @@ describe("FinalizeDocumentHeadlessUsecase", () => {
         });
     });
 
+    describe("when the run succeeds on the success latch", () => {
+        /**
+         * The latch exit stops at the SDK callback without necessarily having
+         * clicked the popup 전송 that submits. Since the callback's completion
+         * code is inferred rather than documented, this path must not be able to
+         * report a completion eformsign never performed.
+         */
+        function buildUsecase(gateOutcome: string | undefined, fetchDocumentStatusCode: jest.Mock) {
+            const eformsignService = {
+                generateStaffCompletionOptions: jest.fn().mockResolvedValue({ mode: { type: "02" } }),
+                fetchDocumentStatusCode,
+            };
+            const headlessService = {
+                dispatchFinalize: jest.fn().mockResolvedValue({
+                    ok: true,
+                    durationMs: 900,
+                    ...(gateOutcome ? { gateOutcome } : {}),
+                }),
+            };
+            const getAccessTokenUsecase = {
+                execute: jest.fn().mockResolvedValue({
+                    oauth_token: { access_token: "access-token", refresh_token: "refresh-token" },
+                }),
+            };
+
+            return new FinalizeDocumentHeadlessUsecase(
+                eformsignService as never,
+                headlessService as never,
+                getAccessTokenUsecase as never,
+                { emit: jest.fn() } as never,
+            );
+        }
+
+        it("rejects the run when eformsign has not actually completed the document", async () => {
+            // The incident shape: the SDK said success, the popup 전송 was never
+            // clicked, and the document sat at 070 (제공기관 검토) untouched.
+            const usecase = buildUsecase("success-latched", jest.fn().mockResolvedValue("070"));
+
+            await expect(usecase.execute({ documentId: "doc-1" })).resolves.toEqual(
+                expect.objectContaining({
+                    ok: false,
+                    reason: "eformsign reported success without submitting the document",
+                    fallbackHint: "iframe",
+                }),
+            );
+        });
+
+        it("accepts the run when eformsign confirms the document completed", async () => {
+            const usecase = buildUsecase("success-latched", jest.fn().mockResolvedValue("003"));
+
+            await expect(usecase.execute({ documentId: "doc-1" })).resolves.toEqual({
+                ok: true,
+                durationMs: 900,
+            });
+        });
+
+        it("asks for a manual check when the vendor status cannot be read", async () => {
+            const usecase = buildUsecase("success-latched", jest.fn().mockResolvedValue(undefined));
+
+            await expect(usecase.execute({ documentId: "doc-1" })).resolves.toEqual(
+                expect.objectContaining({ ok: false, fallbackHint: "manual_check" }),
+            );
+        });
+
+        it("trusts a run that clicked the popup 전송 without consulting the vendor", async () => {
+            const fetchDocumentStatusCode = jest.fn();
+            const usecase = buildUsecase("request-send-clicked", fetchDocumentStatusCode);
+
+            await expect(usecase.execute({ documentId: "doc-1" })).resolves.toEqual({
+                ok: true,
+                durationMs: 900,
+            });
+            expect(fetchDocumentStatusCode).not.toHaveBeenCalled();
+        });
+    });
+
     describe("when the run fails after 전송 was clicked", () => {
         /**
          * The gate emits "creating" on the 전송 click, so these runs sit on an

--- a/backend/test/usecases/eformsign-doc/finalize-document-headless.usecase.spec.ts
+++ b/backend/test/usecases/eformsign-doc/finalize-document-headless.usecase.spec.ts
@@ -50,4 +50,80 @@ describe("FinalizeDocumentHeadlessUsecase", () => {
             onProgress: expect.any(Function),
         });
     });
+
+    describe("when the run fails after 전송 was clicked", () => {
+        /**
+         * The gate emits "creating" on the 전송 click, so these runs sit on an
+         * unknown side of the submit. Which fallback they earn depends entirely
+         * on what eformsign says the document's status actually is.
+         */
+        function buildUsecase(fetchDocumentStatusCode: jest.Mock, reachedSend = true) {
+            const eformsignService = {
+                generateStaffCompletionOptions: jest.fn().mockResolvedValue({ mode: { type: "02" } }),
+                fetchDocumentStatusCode,
+            };
+            const headlessService = {
+                dispatchFinalize: jest.fn().mockImplementation(async ({ onProgress }) => {
+                    onProgress?.("client-started");
+                    if (reachedSend) onProgress?.("creating");
+                    return { ok: false, reason: "gate timeout", durationMs: 31_000 };
+                }),
+            };
+            const getAccessTokenUsecase = {
+                execute: jest.fn().mockResolvedValue({
+                    oauth_token: { access_token: "access-token", refresh_token: "refresh-token" },
+                }),
+            };
+            const progressService = { emit: jest.fn() };
+
+            return {
+                progressService,
+                usecase: new FinalizeDocumentHeadlessUsecase(
+                    eformsignService as never,
+                    headlessService as never,
+                    getAccessTokenUsecase as never,
+                    progressService as never,
+                ),
+            };
+        }
+
+        it("reports success when eformsign shows the document already completed", async () => {
+            // 072 = doc_accept_reviewer: the finalize landed, only the SDK
+            // callback went missing.
+            const { usecase, progressService } = buildUsecase(jest.fn().mockResolvedValue("072"));
+
+            await expect(usecase.execute({ documentId: "doc-1", progressId: "p-1" })).resolves.toEqual({
+                ok: true,
+                durationMs: 31_000,
+            });
+            expect(progressService.emit).toHaveBeenCalledWith("p-1", "sent");
+        });
+
+        it("asks for the iframe only when eformsign confirms the step is unfinished", async () => {
+            // 070 = doc_request_reviewer: still awaiting provider review.
+            const { usecase } = buildUsecase(jest.fn().mockResolvedValue("070"));
+
+            await expect(usecase.execute({ documentId: "doc-1" })).resolves.toEqual(
+                expect.objectContaining({ ok: false, fallbackHint: "iframe" }),
+            );
+        });
+
+        it("asks for a manual check when the vendor status cannot be read", async () => {
+            const { usecase } = buildUsecase(jest.fn().mockRejectedValue(new Error("502 Bad Gateway")));
+
+            await expect(usecase.execute({ documentId: "doc-1" })).resolves.toEqual(
+                expect.objectContaining({ ok: false, fallbackHint: "manual_check" }),
+            );
+        });
+
+        it("does not consult the vendor when the run never reached 전송", async () => {
+            const fetchDocumentStatusCode = jest.fn();
+            const { usecase } = buildUsecase(fetchDocumentStatusCode, false);
+
+            await expect(usecase.execute({ documentId: "doc-1" })).resolves.toEqual(
+                expect.objectContaining({ ok: false, fallbackHint: "iframe" }),
+            );
+            expect(fetchDocumentStatusCode).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/frontend/src/app/(protected)/contracts/page.tsx
+++ b/frontend/src/app/(protected)/contracts/page.tsx
@@ -1412,15 +1412,33 @@ function ContractDetail({
     mutationFn: async (endDate?: string): Promise<{ kind: "headless" } | { kind: "iframe"; option: EformsignDocumentOption }> => {
       // BJJ-90: try the backend-driven finalize first when the flag is on.
       if (isFeatureEnabled("headlessDispatch")) {
+        // Raised inside the try but acted on outside it: the catch below exists
+        // to turn transport failures into an iframe retry, and it would swallow
+        // this signal just as readily.
+        let manualCheckRequired = false;
         try {
           const progressId = finalizeProgressIdRef.current ?? undefined;
           const headless = await eformsignApi.finalizeHeadless(doc.id, endDate, progressId);
           if (headless.ok) {
             return { kind: "headless" };
           }
-          console.warn("[finalize] headless finalize ok=false, falling back to iframe", headless.reason);
+          manualCheckRequired = headless.fallbackHint === "manual_check";
+          console.warn(
+            "[finalize] headless finalize ok=false",
+            headless.reason,
+            headless.fallbackHint,
+          );
         } catch (headlessError) {
           console.warn("[finalize] headless finalize threw, falling back to iframe", headlessError);
+        }
+        // The backend asks for the iframe only once it has confirmed with
+        // eformsign that the step is still unfinished. When it could not
+        // confirm, reopening the editor would invite re-approval of a step that
+        // may already be done.
+        if (manualCheckRequired) {
+          throw new Error(
+            "완료 처리 결과를 확인하지 못했어요. eformsign에서 문서 상태를 확인한 뒤 다시 시도해 주세요.",
+          );
         }
       }
 

--- a/packages/shared/src/types/eformsign.ts
+++ b/packages/shared/src/types/eformsign.ts
@@ -320,7 +320,12 @@ export interface HeadlessFinalizeResponse {
   ok: boolean;
   durationMs: number;
   reason?: string;
-  fallbackHint?: "iframe";
+  /**
+   * "iframe" means the step is genuinely unfinished and reopening the editor is
+   * the recovery. "manual_check" means the vendor could not be asked, so the
+   * document must be verified in eformsign before anyone acts on it.
+   */
+  fallbackHint?: "iframe" | "manual_check";
 }
 
 export type FinalizeHeadlessResponse = HeadlessFinalizeResponse;


### PR DESCRIPTION
## 배경

송가연 계약서(`16327b4d…`)에서 "검토 완료 확인"이 완료됐다고 보고했지만 eformsign은 제공기관 검토 그대로였고, 화면도 새로고침 후 계속 "검토 필요"였습니다.

DB와 웹훅은 정상이었습니다 — eformsign이 전이하지 않았으니 완료 웹훅이 올 이유가 없었고, 화면은 DB를 정확히 반영한 것입니다. 거짓말을 한 건 완료 처리 그 자체입니다.

## 원인 (프로덕션 로그로 확정)

```
06:42:47  POST /eformsign-docs/finalize-headless  documentId=16327b4d…
06:42:57  [finalize-gate] clicked top-level 전송
          ← 이후 헤드리스 로그 완전 침묵
```

헤드리스가 `__eformsignSuccess`를 **아무 SDK success 콜백에나** 래치하고 있었습니다. eformsign은 완료가 아닌 이벤트에도 같은 콜백을 발화하며, 상위 전송(확인 팝업을 열 뿐인 버튼) 클릭이 그중 하나입니다. 게이트 루프가 버튼 탐색보다 먼저 `isSuccessLatched`를 검사하므로, **진짜 제출인 팝업 전송을 누르지 않은 채** `success-latched`로 빠져나와 `ok:true`를 반환했습니다. 그 탈출구는 로그를 하나도 남기지 않아 사고를 로그 침묵으로만 재구성해야 했습니다.

프론트 `useEformsign.ts:104`는 이미 `code === "-1"`로 거르고 있었습니다 — 그 필터의 존재가 SDK가 비완료 이벤트에도 발화한다는 증거입니다. 헤드리스에만 그 검사가 없었습니다.

## 변경

**1. 래치 판정** — 완료 코드일 때만 `__eformsignSuccess` 세팅. 관찰된 콜백은 전량 보존해서, 터미널 콜백 없이 끝난 실행의 에러가 SDK가 실제로 뭘 보고했는지 실어 나릅니다. `success-latched` 탈출과 게이트 결과를 로깅합니다.

**2. 폴백 정직화** — 전송 이후 실패는 미완료라고 가정하지 않고 벤더에 조회합니다. 완료면 콜백만 유실된 것이므로 성공, 미완료면 iframe, 조회 불가면 `manual_check`로 프론트가 에디터를 다시 열지 않고 안내합니다.

**3. 래치 성공의 벤더 대조** — `-1 == 완료`는 문서화된 사실이 아니라 프론트 필터와 테스트 목에서 추론한 값입니다. 추론이 틀렸다면 1번만으로는 사고가 재발합니다. 그래서 게이트가 `success-latched`로 끝난 실행만 성공 보고 전에 벤더 상태를 확인합니다. 팝업을 실제로 누른 실행은 종전대로 신뢰하므로 정상 경로에 벤더 호출이 늘지 않고 상태 반영 지연과 경합하지도 않습니다. **이로써 완료 코드의 의미가 무엇이든 이 증상은 도달 불가가 됩니다.**

## 검증

- backend / frontend / shared type-check 0 에러
- `test/services` + `test/usecases` 101 스위트 / 1224 테스트 통과 (origin/dev 병합 후 재실행)
- 신규 회귀 테스트는 **생성된 HTML의 실제 콜백을 추출·실행**해서 비완료 코드가 래치되지 않음을 검증합니다 — 재진술이 아니라 배포되는 소스를 봅니다
- 래치 성공 4케이스: 미완료→거부(이번 사고 모양), 완료→수락, 조회불가→manual_check, 팝업 클릭→벤더 조회 안 함

## 배포 후 확인 필요

실제 eformsign을 상대로는 아직 실행하지 않았습니다. 병합 후 계약서 생성 1건·완료 1건을 돌려 로그에 `gate sequence ended: request-send-clicked`가 찍히는지 확인해 주세요. `success-latched`가 찍힌다면 `-1` 추론이 틀렸다는 신호이며, 이제는 그게 조용히 지나가지 않고 로그와 벤더 대조 양쪽에 남습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RatgSUDvxqmoqkNMCN7hMb