### PR TITLE
fix: address main promotion review feedback

### DIFF
--- a/backend/application/services/pwa-notification-scheduler.service.ts
+++ b/backend/application/services/pwa-notification-scheduler.service.ts
@@ -9,14 +9,12 @@ import {
 } from "domain/repositories/message-trigger-job.repository.interface";
 import { MessageTriggerJobEntity } from "domain/entities/message-trigger-job.entity";
 import { MESSAGE_TRIGGER_TEMPLATE_CATALOG } from "domain/constants/message-trigger-catalog";
+import { SystemSettingService } from "./system-setting.service";
 
 const DAYS_THRESHOLD = 7;
 
-// Rolling 24-hour lookback for the "자동 전송 실패·취소" section, not a calendar day: both the
-// digest and the automated send run at 09:00 KST, so a calendar-day cut would report the prior
-// batch's failures a day late. A rolling window from one digest to the next covers exactly the
-// previous batch, with no gap and no double-report — which requires every branch in a run to
-// share one boundary; it is computed once, before the per-branch loop, rather than per branch.
+// Initial lookback for branches that do not have a successful digest watermark yet.
+// After the first successful run, each branch resumes from its persisted boundary.
 const UNDELIVERED_MESSAGES_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 // Sane upper bound on how many undelivered-message lines the digest email lists — matches the
@@ -53,19 +51,24 @@ export class PwaNotificationSchedulerService {
         private readonly branchRepository: IBranchRepository,
         @Inject(MESSAGE_TRIGGER_JOB_REPOSITORY)
         private readonly messageTriggerJobRepository: IMessageTriggerJobRepository,
+        private readonly systemSettingService: SystemSettingService,
     ) {}
 
     @Cron("0 9 * * *", { timeZone: "Asia/Seoul" })
     async sendDailySummaryNotifications(): Promise<void> {
         this.logger.log("[PWA Scheduler] Starting daily summary notifications...");
 
-        const undeliveredSince = new Date(Date.now() - UNDELIVERED_MESSAGES_WINDOW_MS);
+        const runStartedAt = new Date(Date.now());
         const branches = await this.branchRepository.findAllActive();
 
         for (const org of branches) {
             this.logger.log(`[PWA Scheduler] Processing org: ${org.name} (${org.id})`);
             try {
-                await this.sendBranchDigest(org.id, org.name, undeliveredSince);
+                const persistedWatermark = await this.systemSettingService
+                    .getPwaUndeliveredDigestWatermark(org.id);
+                const undeliveredSince = persistedWatermark
+                    ?? new Date(runStartedAt.getTime() - UNDELIVERED_MESSAGES_WINDOW_MS);
+                await this.sendBranchDigest(org.id, org.name, undeliveredSince, runStartedAt);
             } catch (error) {
                 this.logger.error(
                     `[PWA Scheduler] Failed to process branch ${org.id}`,
@@ -82,8 +85,13 @@ export class PwaNotificationSchedulerService {
      * notification service as a single digest — one in-app row, one push and one email
      * per branch user, rather than one send per condition (or per client).
      */
-    private async sendBranchDigest(branchId: string, branchName: string, undeliveredSince: Date): Promise<void> {
-        const [upcoming, ending, incompleteContracts, contractsNotSent, undeliveredMessages] = await Promise.all([
+    private async sendBranchDigest(
+        branchId: string,
+        branchName: string,
+        undeliveredSince: Date,
+        runStartedAt: Date,
+    ): Promise<void> {
+        const [upcoming, ending, incompleteContracts, contractsNotSent, undelivered] = await Promise.all([
             this.collect(branchId, "upcoming services", () =>
                 this.clientRepository.findStartingWithinDays(branchId, DAYS_THRESHOLD)),
             this.collect(branchId, "ending services", () =>
@@ -92,12 +100,7 @@ export class PwaNotificationSchedulerService {
                 this.clientRepository.findWithIncompleteContractsStartingWithinDays(branchId, DAYS_THRESHOLD)),
             this.collect(branchId, "contracts not sent", () =>
                 this.clientRepository.findWithoutContractSentStartingWithinDays(branchId, DAYS_THRESHOLD)),
-            this.collect(branchId, "undelivered messages", () =>
-                this.messageTriggerJobRepository.findRecentUndeliveredByBranch(
-                    branchId,
-                    undeliveredSince,
-                    UNDELIVERED_MESSAGES_LIMIT,
-                )),
+            this.collectUndeliveredMessages(branchId, undeliveredSince, runStartedAt),
         ]);
 
         const sections: DailyDigestSection[] = [];
@@ -147,20 +150,23 @@ export class PwaNotificationSchedulerService {
             });
         }
 
-        if (undeliveredMessages.length > 0) {
+        if (undelivered.total > 0) {
             sections.push({
                 key: "undeliveredMessages",
                 label: "자동 전송 실패·취소",
-                description: `어제 자동 전송 중 발송되지 못한 메시지가 ${undeliveredMessages.length}건 있어요. 필요하면 수동으로 발송해 주세요.`,
-                count: undeliveredMessages.length,
+                description: `이전 알림 이후 자동 전송 중 발송되지 못한 메시지가 ${undelivered.total}건 있어요. 필요하면 수동으로 발송해 주세요.`,
+                count: undelivered.total,
                 unit: "건",
                 url: "/messages",
-                details: undeliveredMessages.map((job) => this.formatUndeliveredMessageDetail(job)),
+                details: undelivered.items.map((job) => this.formatUndeliveredMessageDetail(job)),
             });
         }
 
         if (sections.length === 0) {
             this.logger.log(`[PWA Scheduler] Nothing to report for branch ${branchId}`);
+            if (undelivered.loaded) {
+                await this.systemSettingService.setPwaUndeliveredDigestWatermark(branchId, runStartedAt);
+            }
             return;
         }
 
@@ -174,11 +180,43 @@ export class PwaNotificationSchedulerService {
             this.logger.log(
                 `[PWA Scheduler] Daily digest for branch ${branchId}: ${sections.length} sections, ${result.sent} sent, ${result.failed} failed`,
             );
+            if (undelivered.loaded && result.sent > 0 && result.failed === 0) {
+                await this.systemSettingService.setPwaUndeliveredDigestWatermark(branchId, runStartedAt);
+            }
         } catch (error) {
             this.logger.error(
                 `[PWA Scheduler] Failed to send daily digest for branch ${branchId}`,
                 error instanceof Error ? error.stack : String(error),
             );
+        }
+    }
+
+    private async collectUndeliveredMessages(
+        branchId: string,
+        since: Date,
+        until: Date,
+    ): Promise<{ items: MessageTriggerJobEntity[]; total: number; loaded: boolean }> {
+        try {
+            const [items, total] = await Promise.all([
+                this.messageTriggerJobRepository.findRecentUndeliveredByBranch(
+                    branchId,
+                    since,
+                    until,
+                    UNDELIVERED_MESSAGES_LIMIT,
+                ),
+                this.messageTriggerJobRepository.countRecentUndeliveredByBranch(
+                    branchId,
+                    since,
+                    until,
+                ),
+            ]);
+            return { items, total, loaded: true };
+        } catch (error) {
+            this.logger.error(
+                `[PWA Scheduler] Failed to load undelivered messages for branch ${branchId}`,
+                error instanceof Error ? error.stack : String(error),
+            );
+            return { items: [], total: 0, loaded: false };
         }
     }
 

--- a/backend/application/services/system-setting.service.ts
+++ b/backend/application/services/system-setting.service.ts
@@ -32,6 +32,10 @@ export class SystemSettingService {
         return `branch:${branchId}:greeting_on_auto_registration`;
     }
 
+    private getPwaUndeliveredDigestWatermarkKey(branchId: string): string {
+        return `branch:${branchId}:pwa_undelivered_digest_watermark`;
+    }
+
     async getUserEmailNotificationsEnabled(userId: string): Promise<boolean> {
         const value = await this.getSettingUsecase.executeWithDefault(
             this.getUserEmailNotificationPreferenceKey(userId),
@@ -131,6 +135,25 @@ export class SystemSettingService {
         return this.updateSettingUsecase.execute(
             this.getGreetingOnAutoRegistrationKey(branchId),
             enabled ? "true" : "false"
+        );
+    }
+
+    async getPwaUndeliveredDigestWatermark(branchId: string): Promise<Date | null> {
+        const value = await this.getSettingUsecase.execute(
+            this.getPwaUndeliveredDigestWatermarkKey(branchId),
+        );
+        if (!value) return null;
+        const parsed = new Date(value);
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
+    }
+
+    async setPwaUndeliveredDigestWatermark(
+        branchId: string,
+        watermark: Date,
+    ): Promise<SystemSettingEntity> {
+        return this.updateSettingUsecase.execute(
+            this.getPwaUndeliveredDigestWatermarkKey(branchId),
+            watermark.toISOString(),
         );
     }
 

--- a/backend/application/usecases/eformsign-doc/dispatch-document-headless.usecase.ts
+++ b/backend/application/usecases/eformsign-doc/dispatch-document-headless.usecase.ts
@@ -198,10 +198,10 @@ export class DispatchDocumentHeadlessUsecase {
                 },
             });
 
-            // The gate runner emits "creating" only when it clicks (or ambiguously
-            // attempts) the confirmation popup's 전송. The first top-level 전송 only
-            // opens that popup and is safe to retry/fall back from. A failure at or
-            // after "creating" means eformsign may already hold the
+            // The gate runner emits "creating" whenever either top-level or popup
+            // 전송 may have submitted. Some templates submit directly from the
+            // top-level button, so neither send action is safe to retry. A failure
+            // at or after "creating" means eformsign may already hold the
             // document and only the SDK callback went missing. Those runs must not
             // report fallbackHint:"iframe" — that reopens the editor and a second
             // contract goes out. Only a failure that never reached the send button

--- a/backend/domain/repositories/message-trigger-job.repository.interface.ts
+++ b/backend/domain/repositories/message-trigger-job.repository.interface.ts
@@ -25,7 +25,7 @@ export interface IMessageTriggerJobRepository {
     ): Promise<MessageTriggerJobEntity[]>;
     /**
      * Terminal (failed or canceled) jobs for a branch whose terminal
-     * transition landed at or after `since` — `canceledAt` for a canceled
+     * transition landed in `[since, until)` — `canceledAt` for a canceled
      * row, `updatedAt` for a failed row (there is no dedicated failedAt
      * column; markFailed() always bumps updatedAt at the moment of
      * failure). Excludes rows the user canceled themselves
@@ -35,8 +35,14 @@ export interface IMessageTriggerJobRepository {
     findRecentUndeliveredByBranch(
         branchId: string,
         since: Date,
+        until: Date,
         limit: number,
     ): Promise<MessageTriggerJobEntity[]>;
+    countRecentUndeliveredByBranch(
+        branchId: string,
+        since: Date,
+        until: Date,
+    ): Promise<number>;
     findHistoryByBranch(
         branchId: string,
         limit?: number,

--- a/backend/infrastructure/automation/eformsign-creation-gates.ts
+++ b/backend/infrastructure/automation/eformsign-creation-gates.ts
@@ -27,9 +27,9 @@ const EFORMSIGN_CREATION_GATE_WAIT_TIMEOUT_MS = 70_000;
 // click. Kept separate from the wait budget on purpose: sharing one deadline let
 // a slow editor render starve the sequence, which needs only ~2s in practice.
 const EFORMSIGN_CREATION_GATE_ACTION_TIMEOUT_MS = 30_000;
-// The first top-level 전송 only opens a confirmation popup; it does not submit
-// the document. Give the popup 2 seconds, retry that safe pre-send click once,
-// then hand control to the visible iframe instead of idling for the full gate budget.
+// Older templates open a confirmation popup from top-level 전송, while newer
+// direct-send templates can submit immediately. Wait briefly for the popup,
+// but never click the same top-level action twice when its outcome is ambiguous.
 const EFORMSIGN_TOP_LEVEL_SEND_POPUP_WAIT_POLLS = 4;
 
 /**
@@ -52,10 +52,10 @@ export async function runEformsignCreationGates(
     let lastDiagnosticAt = startedAt;
     let firstActionAt: number | null = null;
     let topLevelSendAttempted = false;
-    let topLevelSendClickCount = 0;
     let topLevelSendPopupWaitPolls = 0;
     let ignoredPostTopLevelSuccessLogged = false;
     let preSendClickTimeoutCount = 0;
+    let sendAttemptedEmitted = false;
 
     const logMessage = (message: string): void => {
         const log = (logger as NestLogger).log;
@@ -89,6 +89,12 @@ export async function runEformsignCreationGates(
         if (infoInsertedEmitted) return;
         infoInsertedEmitted = true;
         onProgress?.("info-inserted");
+    };
+
+    const emitSendAttempted = () => {
+        if (sendAttemptedEmitted) return;
+        sendAttemptedEmitted = true;
+        onProgress?.("creating");
     };
 
     const tryPreSendClick = async (locator: Locator, action: string): Promise<boolean> => {
@@ -177,12 +183,12 @@ export async function runEformsignCreationGates(
                         "[creation-gate] popup 전송 click outcome is ambiguous; reconciling without retry";
                     logMessage(message);
                     emitInfoInserted();
-                    onProgress?.("creating");
+                    emitSendAttempted();
                     return "request-send-attempted";
                 }
                 logMessage("[creation-gate] clicked popup 전송");
                 emitInfoInserted();
-                onProgress?.("creating");
+                emitSendAttempted();
                 return "request-send-clicked";
             }
 
@@ -192,13 +198,13 @@ export async function runEformsignCreationGates(
             }
             const popupWaitExpired =
                 topLevelSendPopupWaitPolls >= EFORMSIGN_TOP_LEVEL_SEND_POPUP_WAIT_POLLS;
-            if (
-                popupWaitExpired
-                && topLevelSendClickCount >= EFORMSIGN_PRE_SEND_CLICK_TIMEOUT_LIMIT
-            ) {
-                throw new Error(
-                    "Pre-send eformsign creation confirmation popup timed out twice; opening iframe fallback",
+            if (popupWaitExpired) {
+                lastAction = "top-level 전송 may have submitted directly; reconciling";
+                logMessage(
+                    "[creation-gate] confirmation popup did not appear after top-level 전송; " +
+                        "reconciling without retry",
                 );
+                return "request-send-attempted";
             }
 
             const topLevelSendButton = requestSendDialogVisible
@@ -208,22 +214,19 @@ export async function runEformsignCreationGates(
             if (topLevelSendButton) {
                 const isFinalTopLevelSend = stampConfirmCount >= 3 || infoInsertedEmitted;
                 topLevelSendAttempted = true;
-                topLevelSendClickCount += 1;
                 topLevelSendPopupWaitPolls = 0;
+                if (isFinalTopLevelSend) {
+                    emitInfoInserted();
+                }
+                emitSendAttempted();
 
                 if (!(await tryClickGateLocator(topLevelSendButton))) {
                     lastAction = "top-level 전송 click outcome ambiguous; waiting for popup";
-                    if (isFinalTopLevelSend) {
-                        emitInfoInserted();
-                    }
                     noteAction(lastAction);
                     await page.waitForTimeout(EFORMSIGN_GATE_POLL_MS);
                     continue;
                 }
                 logMessage("[creation-gate] clicked top-level 전송");
-                if (isFinalTopLevelSend) {
-                    emitInfoInserted();
-                }
                 noteAction("clicked top-level 전송");
                 await page.waitForTimeout(250);
                 continue;

--- a/backend/infrastructure/automation/eformsign-headless.service.ts
+++ b/backend/infrastructure/automation/eformsign-headless.service.ts
@@ -224,8 +224,9 @@ export class EformsignHeadlessService implements OnModuleDestroy {
 
         // The gate runner only confirms the click sequence completed; the
         // actual dispatch is acknowledged by the SDK success callback
-        // (`__eformsignSuccess`). If that never fires, the document was not
-        // sent — surface that as ok=false so the frontend falls back.
+        // (`__eformsignSuccess`). If that never fires, surface ok=false; the
+        // caller uses the emitted creating progress to reconcile remotely
+        // instead of reopening mode:01.
         const documentId = await this.waitForTerminalSdkCallback(page, 30_000);
         params.onProgress?.("sent");
 

--- a/backend/infrastructure/database/repositories/sb.message-trigger-job.repository.ts
+++ b/backend/infrastructure/database/repositories/sb.message-trigger-job.repository.ts
@@ -254,7 +254,7 @@ export class SbMessageTriggerJobRepository implements IMessageTriggerJobReposito
 
     /**
      * Terminal jobs for a branch whose terminal transition landed at or
-     * after `since` — `canceledAt` for a canceled row, `updatedAt` for a
+     * in `[since, until)` — `canceledAt` for a canceled row, `updatedAt` for a
      * failed row (there is no dedicated failedAt column; markFailed()
      * always bumps updatedAt at the moment of failure). A row the user
      * canceled themselves (canceledByUser = true) is excluded: that cancel
@@ -263,6 +263,7 @@ export class SbMessageTriggerJobRepository implements IMessageTriggerJobReposito
     async findRecentUndeliveredByBranch(
         branchId: string,
         since: Date,
+        until: Date,
         limit: number,
     ): Promise<MessageTriggerJobEntity[]> {
         const rows = await this.prisma.message_trigger_job.findMany({
@@ -270,14 +271,31 @@ export class SbMessageTriggerJobRepository implements IMessageTriggerJobReposito
                 branchId,
                 canceledByUser: false,
                 OR: [
-                    { status: "canceled", canceledAt: { gte: since } },
-                    { status: "failed", updatedAt: { gte: since } },
+                    { status: "canceled", canceledAt: { gte: since, lt: until } },
+                    { status: "failed", updatedAt: { gte: since, lt: until } },
                 ],
             },
             orderBy: { updatedAt: "desc" },
             take: limit,
         });
         return rows.map((row) => this.toDomain(row));
+    }
+
+    async countRecentUndeliveredByBranch(
+        branchId: string,
+        since: Date,
+        until: Date,
+    ): Promise<number> {
+        return this.prisma.message_trigger_job.count({
+            where: {
+                branchId,
+                canceledByUser: false,
+                OR: [
+                    { status: "canceled", canceledAt: { gte: since, lt: until } },
+                    { status: "failed", updatedAt: { gte: since, lt: until } },
+                ],
+            },
+        });
     }
 
     async findHistoryByBranch(

--- a/backend/test/e2e/contract-headless.live.e2e.spec.ts
+++ b/backend/test/e2e/contract-headless.live.e2e.spec.ts
@@ -375,17 +375,9 @@ const buildContract = (
         );
 
         const fixtureStartedAt = Date.now();
-        let documentId: string | undefined;
-        for (let attempt = 1; attempt <= 3; attempt += 1) {
-            const fixtureResult = await headlessService.dispatchCreation({ documentOption });
-            documentId = fixtureResult.documentId
-                ?? await findRemoteByCustomer(customerName, fixtureStartedAt - 5_000);
-            if (documentId) break;
-            expect(fixtureResult).toEqual(expect.objectContaining({
-                ok: false,
-                reason: expect.stringContaining("confirmation popup timed out twice"),
-            }));
-        }
+        const fixtureResult = await headlessService.dispatchCreation({ documentOption });
+        const documentId = fixtureResult.documentId
+            ?? await findRemoteByCustomer(customerName, fixtureStartedAt - 5_000);
         expect(documentId).toBeTruthy();
         remoteDocumentIds.add(documentId!);
 

--- a/backend/test/repositories/sb.message-trigger-job.repository.spec.ts
+++ b/backend/test/repositories/sb.message-trigger-job.repository.spec.ts
@@ -121,6 +121,7 @@ describe("SbMessageTriggerJobRepository", () => {
         update: jest.fn(),
         findUnique: jest.fn(),
         findMany: jest.fn(),
+        count: jest.fn(),
         findFirst: jest.fn(),
         updateMany: jest.fn(),
     });
@@ -354,6 +355,7 @@ describe("SbMessageTriggerJobRepository", () => {
 
     it("findRecentUndeliveredByBranch scopes to branch and the failed/canceled since-window, newest first", async () => {
         const since = new Date("2026-07-08T00:00:00.000Z");
+        const until = new Date("2026-07-09T00:00:00.000Z");
         messageTriggerJobModel.findMany.mockResolvedValue([
             createRow({
                 id: "job-canceled",
@@ -370,7 +372,7 @@ describe("SbMessageTriggerJobRepository", () => {
             }),
         ]);
 
-        const result = await repository.findRecentUndeliveredByBranch("branch-1", since, 25);
+        const result = await repository.findRecentUndeliveredByBranch("branch-1", since, until, 25);
 
         // Deliberately scoped with objectContaining (not a canceledByUser
         // guard test — see the dedicated guard test below): branch scoping,
@@ -381,8 +383,8 @@ describe("SbMessageTriggerJobRepository", () => {
             where: expect.objectContaining({
                 branchId: "branch-1",
                 OR: [
-                    { status: "canceled", canceledAt: { gte: since } },
-                    { status: "failed", updatedAt: { gte: since } },
+                    { status: "canceled", canceledAt: { gte: since, lt: until } },
+                    { status: "failed", updatedAt: { gte: since, lt: until } },
                 ],
             }),
             orderBy: { updatedAt: "desc" },
@@ -395,9 +397,10 @@ describe("SbMessageTriggerJobRepository", () => {
 
     it("findRecentUndeliveredByBranch's guarded WHERE clause excludes a user-canceled row from the digest (canceledByUser guard)", async () => {
         const since = new Date("2026-07-08T00:00:00.000Z");
+        const until = new Date("2026-07-09T00:00:00.000Z");
         messageTriggerJobModel.findMany.mockResolvedValue([]);
 
-        await repository.findRecentUndeliveredByBranch("branch-1", since, 25);
+        await repository.findRecentUndeliveredByBranch("branch-1", since, until, 25);
 
         // Mutation-sensitive assertion, isolated from the shape test above:
         // a cancel the user pressed themselves must never be reported back
@@ -407,6 +410,26 @@ describe("SbMessageTriggerJobRepository", () => {
         // test above uses objectContaining and does not assert on this key).
         const [{ where }] = messageTriggerJobModel.findMany.mock.calls[0];
         expect(where.canceledByUser).toBe(false);
+    });
+
+    it("countRecentUndeliveredByBranch uses the same guarded half-open window", async () => {
+        const since = new Date("2026-07-08T00:00:00.000Z");
+        const until = new Date("2026-07-09T00:00:00.000Z");
+        messageTriggerJobModel.count.mockResolvedValue(73);
+
+        await expect(
+            repository.countRecentUndeliveredByBranch("branch-1", since, until),
+        ).resolves.toBe(73);
+        expect(messageTriggerJobModel.count).toHaveBeenCalledWith({
+            where: {
+                branchId: "branch-1",
+                canceledByUser: false,
+                OR: [
+                    { status: "canceled", canceledAt: { gte: since, lt: until } },
+                    { status: "failed", updatedAt: { gte: since, lt: until } },
+                ],
+            },
+        });
     });
 
     it("upsertPending falls back to findUnique when the guarded update matches no row (sent row stays immutable)", async () => {

--- a/backend/test/services/eformsign-creation-gates.spec.ts
+++ b/backend/test/services/eformsign-creation-gates.spec.ts
@@ -59,7 +59,7 @@ describe("runEformsignCreationGates", () => {
         expect(startButton.click).toHaveBeenCalledTimes(2);
     });
 
-    it("retries a missing confirmation popup once, then opens the iframe fallback", async () => {
+    it("treats a missing confirmation popup as an ambiguous direct send without clicking twice", async () => {
         const topLevelSendButton = visibleLocator();
         const requestSendDialog = visibleLocator({
             isVisible: jest.fn().mockResolvedValue(false),
@@ -83,11 +83,9 @@ describe("runEformsignCreationGates", () => {
 
         await expect(
             runEformsignCreationGates(page, eformsignFrame, console, onProgress),
-        ).rejects.toThrow(
-            "Pre-send eformsign creation confirmation popup timed out twice; opening iframe fallback",
-        );
-        expect(topLevelSendButton.click).toHaveBeenCalledTimes(2);
-        expect(onProgress).not.toHaveBeenCalledWith("creating");
+        ).resolves.toBe("request-send-attempted");
+        expect(topLevelSendButton.click).toHaveBeenCalledTimes(1);
+        expect(onProgress.mock.calls.map(([step]) => step)).toEqual(["creating"]);
     });
 
     it("treats a timed-out popup send click as attempted without clicking twice", async () => {

--- a/backend/test/services/pwa-notification-scheduler.service.spec.ts
+++ b/backend/test/services/pwa-notification-scheduler.service.spec.ts
@@ -3,6 +3,7 @@ import { DailyDigestSection, NotificationService } from "application/services/no
 import { IBranchRepository } from "domain/repositories/branch.repository.interface";
 import { IClientRepository } from "domain/repositories/client.repository.interface";
 import { IMessageTriggerJobRepository } from "domain/repositories/message-trigger-job.repository.interface";
+import { SystemSettingService } from "application/services/system-setting.service";
 import {
     MESSAGE_TRIGGER_TEMPLATE_CATALOG,
     MessageTriggerTemplateKey,
@@ -27,6 +28,11 @@ describe("PwaNotificationSchedulerService", () => {
     };
     const messageTriggerJobRepository = {
         findRecentUndeliveredByBranch: jest.fn(),
+        countRecentUndeliveredByBranch: jest.fn(),
+    };
+    const systemSettingService = {
+        getPwaUndeliveredDigestWatermark: jest.fn(),
+        setPwaUndeliveredDigestWatermark: jest.fn(),
     };
     let service: PwaNotificationSchedulerService;
 
@@ -42,6 +48,7 @@ describe("PwaNotificationSchedulerService", () => {
             clientRepository as unknown as IClientRepository,
             branchRepository as unknown as IBranchRepository,
             messageTriggerJobRepository as unknown as IMessageTriggerJobRepository,
+            systemSettingService as unknown as SystemSettingService,
         );
 
         branchRepository.findAllActive.mockResolvedValue([{ id: "branch-1", name: "인천점" }]);
@@ -67,6 +74,9 @@ describe("PwaNotificationSchedulerService", () => {
                 cancelReason: "24시간 경과로 취소",
             },
         ]);
+        messageTriggerJobRepository.countRecentUndeliveredByBranch.mockResolvedValue(1);
+        systemSettingService.getPwaUndeliveredDigestWatermark.mockResolvedValue(null);
+        systemSettingService.setPwaUndeliveredDigestWatermark.mockResolvedValue(undefined);
         notificationService.sendDailyDigestToBranchUsers.mockResolvedValue({ sent: 2, failed: 0 });
     });
 
@@ -124,7 +134,7 @@ describe("PwaNotificationSchedulerService", () => {
             {
                 key: "undeliveredMessages",
                 label: "자동 전송 실패·취소",
-                description: "어제 자동 전송 중 발송되지 못한 메시지가 1건 있어요. 필요하면 수동으로 발송해 주세요.",
+                description: "이전 알림 이후 자동 전송 중 발송되지 못한 메시지가 1건 있어요. 필요하면 수동으로 발송해 주세요.",
                 count: 1,
                 unit: "건",
                 url: "/messages",
@@ -139,6 +149,7 @@ describe("PwaNotificationSchedulerService", () => {
         clientRepository.findWithIncompleteContractsStartingWithinDays.mockResolvedValue([]);
         clientRepository.findWithoutContractSentStartingWithinDays.mockResolvedValue([]);
         messageTriggerJobRepository.findRecentUndeliveredByBranch.mockResolvedValue([]);
+        messageTriggerJobRepository.countRecentUndeliveredByBranch.mockResolvedValue(0);
 
         await service.sendDailySummaryNotifications();
 
@@ -207,8 +218,20 @@ describe("PwaNotificationSchedulerService", () => {
         await expect(service.sendDailySummaryNotifications()).resolves.toBeUndefined();
 
         expect(sendBranchDigestSpy).toHaveBeenCalledTimes(2);
-        expect(sendBranchDigestSpy).toHaveBeenNthCalledWith(1, "branch-1", "인천점", expect.any(Date));
-        expect(sendBranchDigestSpy).toHaveBeenNthCalledWith(2, "branch-2", "부천점", expect.any(Date));
+        expect(sendBranchDigestSpy).toHaveBeenNthCalledWith(
+            1,
+            "branch-1",
+            "인천점",
+            expect.any(Date),
+            expect.any(Date),
+        );
+        expect(sendBranchDigestSpy).toHaveBeenNthCalledWith(
+            2,
+            "branch-2",
+            "부천점",
+            expect.any(Date),
+            expect.any(Date),
+        );
     });
 
     describe("undelivered-messages section (자동 전송 실패·취소)", () => {
@@ -225,6 +248,7 @@ describe("PwaNotificationSchedulerService", () => {
                     cancelReason: "Provider disabled or delivery failed",
                 },
             ]);
+            messageTriggerJobRepository.countRecentUndeliveredByBranch.mockResolvedValue(2);
 
             await service.sendDailySummaryNotifications();
 
@@ -233,7 +257,7 @@ describe("PwaNotificationSchedulerService", () => {
             expect(section).toEqual({
                 key: "undeliveredMessages",
                 label: "자동 전송 실패·취소",
-                description: "어제 자동 전송 중 발송되지 못한 메시지가 2건 있어요. 필요하면 수동으로 발송해 주세요.",
+                description: "이전 알림 이후 자동 전송 중 발송되지 못한 메시지가 2건 있어요. 필요하면 수동으로 발송해 주세요.",
                 count: 2,
                 unit: "건",
                 url: "/messages",
@@ -242,6 +266,25 @@ describe("PwaNotificationSchedulerService", () => {
                     `박민수 · ${undeliveredMessageLabel(MessageTriggerTemplateKey.CLIENT_WELCOME)} — Provider disabled or delivery failed`,
                 ],
             });
+        });
+
+        it("should preserve the total count while capping rendered details at 50", async () => {
+            messageTriggerJobRepository.findRecentUndeliveredByBranch.mockResolvedValue(
+                Array.from({ length: 50 }, (_, index) => ({
+                    payload: { recipientName: `이용자 ${index + 1}` },
+                    templateKey: MessageTriggerTemplateKey.SERVICE_INFO,
+                    cancelReason: "발송 실패",
+                })),
+            );
+            messageTriggerJobRepository.countRecentUndeliveredByBranch.mockResolvedValue(73);
+
+            await service.sendDailySummaryNotifications();
+
+            const [, , sections] = digestCall();
+            const section = sections.find((candidate) => candidate.key === "undeliveredMessages");
+            expect(section?.count).toBe(73);
+            expect(section?.description).toContain("73건");
+            expect(section?.details).toHaveLength(50);
         });
 
         it("should fall back to 사용자 when a job's payload is missing a recipient name", async () => {
@@ -281,6 +324,7 @@ describe("PwaNotificationSchedulerService", () => {
 
         it("should omit the section when the query returns no rows, without inflating the digest section count", async () => {
             messageTriggerJobRepository.findRecentUndeliveredByBranch.mockResolvedValue([]);
+            messageTriggerJobRepository.countRecentUndeliveredByBranch.mockResolvedValue(0);
 
             await service.sendDailySummaryNotifications();
 
@@ -295,14 +339,59 @@ describe("PwaNotificationSchedulerService", () => {
             const after = Date.now();
 
             expect(messageTriggerJobRepository.findRecentUndeliveredByBranch).toHaveBeenCalledTimes(1);
-            const [branchId, since, limit] = messageTriggerJobRepository.findRecentUndeliveredByBranch.mock
-                .calls[0] as [string, Date, number];
+            const [branchId, since, , limit] = messageTriggerJobRepository.findRecentUndeliveredByBranch.mock
+                .calls[0] as [string, Date, Date, number];
             expect(branchId).toBe("branch-1");
             expect(limit).toBe(50);
 
             const windowMs = 24 * 60 * 60 * 1000;
             expect(since.getTime()).toBeGreaterThanOrEqual(before - windowMs);
             expect(since.getTime()).toBeLessThanOrEqual(after - windowMs);
+        });
+
+        it("should resume from the persisted branch watermark and advance it only after a successful digest", async () => {
+            const previousWatermark = new Date("2026-08-09T00:00:00.000Z");
+            const runStartedAt = new Date("2026-08-12T00:00:00.000Z");
+            jest.spyOn(Date, "now").mockReturnValue(runStartedAt.getTime());
+            systemSettingService.getPwaUndeliveredDigestWatermark.mockResolvedValue(previousWatermark);
+
+            await service.sendDailySummaryNotifications();
+
+            expect(messageTriggerJobRepository.findRecentUndeliveredByBranch).toHaveBeenCalledWith(
+                "branch-1",
+                previousWatermark,
+                runStartedAt,
+                50,
+            );
+            expect(messageTriggerJobRepository.countRecentUndeliveredByBranch).toHaveBeenCalledWith(
+                "branch-1",
+                previousWatermark,
+                runStartedAt,
+            );
+            expect(systemSettingService.setPwaUndeliveredDigestWatermark).toHaveBeenCalledWith(
+                "branch-1",
+                runStartedAt,
+            );
+        });
+
+        it("should retain the previous watermark when digest delivery fails", async () => {
+            notificationService.sendDailyDigestToBranchUsers.mockRejectedValue(new Error("smtp down"));
+
+            await service.sendDailySummaryNotifications();
+
+            expect(systemSettingService.setPwaUndeliveredDigestWatermark).not.toHaveBeenCalled();
+        });
+
+        it("should retain the previous watermark when digest delivery is only partially successful", async () => {
+            notificationService.sendDailyDigestToBranchUsers.mockResolvedValue({
+                sent: 1,
+                skipped: 0,
+                failed: 1,
+            });
+
+            await service.sendDailySummaryNotifications();
+
+            expect(systemSettingService.setPwaUndeliveredDigestWatermark).not.toHaveBeenCalled();
         });
 
         it("should use the exact same since boundary for every branch in one run, not a fresh one per branch", async () => {
@@ -326,8 +415,8 @@ describe("PwaNotificationSchedulerService", () => {
 
             const calls = messageTriggerJobRepository.findRecentUndeliveredByBranch.mock.calls;
             expect(calls).toHaveLength(2);
-            const [, sinceBranch1] = calls[0] as [string, Date, number];
-            const [, sinceBranch2] = calls[1] as [string, Date, number];
+            const [, sinceBranch1] = calls[0] as [string, Date, Date, number];
+            const [, sinceBranch2] = calls[1] as [string, Date, Date, number];
             expect(sinceBranch1.getTime()).toBe(sinceBranch2.getTime());
         });
 
@@ -344,6 +433,7 @@ describe("PwaNotificationSchedulerService", () => {
                 "incompleteContracts",
                 "contractsNotSent",
             ]);
+            expect(systemSettingService.setPwaUndeliveredDigestWatermark).not.toHaveBeenCalled();
         });
     });
 });

--- a/backend/test/services/system-setting.service.spec.ts
+++ b/backend/test/services/system-setting.service.spec.ts
@@ -211,4 +211,41 @@ describe("SystemSettingService", () => {
             expect(getResult).toBe(true);
         });
     });
+
+    describe("PWA undelivered digest watermark", () => {
+        it("should read a valid branch-scoped ISO timestamp", async () => {
+            getSettingUsecase.execute.mockResolvedValue("2026-08-11T00:00:00.000Z");
+
+            await expect(service.getPwaUndeliveredDigestWatermark("branch-1")).resolves.toEqual(
+                new Date("2026-08-11T00:00:00.000Z"),
+            );
+            expect(getSettingUsecase.execute).toHaveBeenCalledWith(
+                "branch:branch-1:pwa_undelivered_digest_watermark",
+            );
+        });
+
+        it("should fail open to the initial window when the stored timestamp is invalid", async () => {
+            getSettingUsecase.execute.mockResolvedValue("not-a-date");
+
+            await expect(service.getPwaUndeliveredDigestWatermark("branch-1")).resolves.toBeNull();
+        });
+
+        it("should persist the watermark as an ISO timestamp", async () => {
+            const watermark = new Date("2026-08-12T00:00:00.000Z");
+            const entity = new SystemSettingEntity(
+                "branch:branch-1:pwa_undelivered_digest_watermark",
+                watermark.toISOString(),
+                watermark,
+            );
+            updateSettingUsecase.execute.mockResolvedValue(entity);
+
+            await expect(
+                service.setPwaUndeliveredDigestWatermark("branch-1", watermark),
+            ).resolves.toBe(entity);
+            expect(updateSettingUsecase.execute).toHaveBeenCalledWith(
+                "branch:branch-1:pwa_undelivered_digest_watermark",
+                watermark.toISOString(),
+            );
+        });
+    });
 });


### PR DESCRIPTION
## Summary\n\n- avoid duplicate eformsign sends when direct-send templates omit the confirmation popup\n- report exact undelivered-message totals while limiting digest detail rows\n- persist per-branch digest watermarks so missed scheduler runs are recovered safely\n- add regression coverage for direct-send reconciliation, exact counts, durable boundaries, and partial failures\n\n## Verification\n\n- focused backend tests: 68 passed\n- expanded affected backend tests: 111 passed\n- backend type-check: passed\n- backend lint: passed (existing warnings only)\n- backend build: passed\n- full backend tests: 230 suites / 2,956 tests passed; existing Vercel Gemini live gateway suite has 7 empty-response failures\n- pnpm audit: 2 moderate vulnerabilities, no high/critical vulnerabilities\n